### PR TITLE
Add catalog for common configs and metrics in metadata

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -1,9 +1,2058 @@
 # This file is generated and should not be manually edited.
 # The structure and contents are a work in progress and subject to change.
+# Common metrics and configurations are collected in the top-level `definitions` catalog;
+# each module references them by id via `metric_refs` and `configuration_refs`.
 # For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468
 
-file_format: 0.5
+file_format: 0.6
 
+definitions:
+  configurations:
+    common.controller-telemetry.enabled:
+      name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+      declarative_name: java.common.controller_telemetry/development.enabled
+      description: Enables the creation of experimental controller spans.
+      type: boolean
+      default: false
+    common.db.query-sanitization.enabled:
+      name: otel.instrumentation.common.db.query-sanitization.enabled
+      declarative_name: java.common.db.query_sanitization.enabled
+      description: Enables query sanitization for database queries.
+      type: boolean
+      default: true
+    common.peer-service-mapping:
+      name: otel.instrumentation.common.peer-service-mapping
+      declarative_name: java.common.service_peer_mapping
+      description: Used to specify a mapping from host names or IP addresses to peer
+        services.
+      type: map
+      default: ''
+      declarative_type: structured_list
+      declarative_schema:
+        type: object
+        required:
+        - peer
+        - service_name
+        properties:
+          peer:
+            type: string
+            description: Host name or IP address to match against.
+          service_name:
+            type: string
+            description: Peer service name to record for matching peers.
+    http.client.capture-request-headers:
+      name: otel.instrumentation.http.client.capture-request-headers
+      declarative_name: general.http.client.request_captured_headers
+      description: List of HTTP request headers to capture in HTTP client telemetry.
+      type: list
+      default: ''
+    http.client.capture-response-headers:
+      name: otel.instrumentation.http.client.capture-response-headers
+      declarative_name: general.http.client.response_captured_headers
+      description: List of HTTP response headers to capture in HTTP client telemetry.
+      type: list
+      default: ''
+    http.client.emit-experimental-telemetry:
+      name: otel.instrumentation.http.client.emit-experimental-telemetry
+      declarative_name: java.common.http.client.emit_experimental_telemetry/development
+      description: Enable the capture of experimental HTTP client telemetry. Adds
+        the `http.request.body.size` and `http.response.body.size` attributes to spans,
+        and records `http.client.request.size` and `http.client.response.size` metrics.
+      type: boolean
+      default: false
+    http.known-methods:
+      name: otel.instrumentation.http.known-methods
+      declarative_name: java.common.http.known_methods
+      description: Configures the instrumentation to recognize an alternative set
+        of HTTP request methods. All other methods will be treated as `_OTHER`.
+      type: list
+      default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+    http.server.capture-request-headers:
+      name: otel.instrumentation.http.server.capture-request-headers
+      declarative_name: general.http.server.request_captured_headers
+      description: List of HTTP request headers to capture in HTTP server telemetry.
+      type: list
+      default: ''
+    http.server.capture-response-headers:
+      name: otel.instrumentation.http.server.capture-response-headers
+      declarative_name: general.http.server.response_captured_headers
+      description: List of HTTP response headers to capture in HTTP server telemetry.
+      type: list
+      default: ''
+    http.server.emit-experimental-telemetry:
+      name: otel.instrumentation.http.server.emit-experimental-telemetry
+      declarative_name: java.common.http.server.emit_experimental_telemetry/development
+      description: Enable the capture of experimental HTTP server telemetry. Adds
+        the `http.request.body.size` and `http.response.body.size` attributes to spans,
+        and records `http.server.request.size` and `http.server.response.size` metrics.
+      type: boolean
+      default: false
+    java.common.http.client.url_template_rules:
+      declarative_name: java.common.http.client.url_template_rules
+      description: |
+        Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+      type: list
+      default: ''
+      declarative_type: structured_list
+      declarative_schema:
+        type: object
+        required:
+        - pattern
+        - template
+        properties:
+          pattern:
+            type: string
+            description: Regular expression matched against the request URL.
+          template:
+            type: string
+            description: Template used to derive the low-cardinality route.
+          override:
+            type: boolean
+            description: Whether this rule overrides an already-applied template.
+            default: false
+    messaging.capture-headers:
+      name: otel.instrumentation.messaging.experimental.capture-headers
+      declarative_name: java.common.messaging.capture_headers/development
+      description: A comma-separated list of header names to capture as span attributes.
+      type: list
+      default: ''
+    otel.experimental.javascript-snippet-ad834761:
+      name: otel.experimental.javascript-snippet
+      declarative_name: java.servlet.javascript_snippet/development
+      description: Experimental setting to inject a JavaScript snippet into HTML responses
+        after the opening `<head>` tag.
+      type: string
+      default: ''
+    otel.experimental.javascript-snippet-cfa9f908:
+      name: otel.experimental.javascript-snippet
+      declarative_name: java.servlet.javascript_snippet/development
+      description: Experimental setting to inject a JavaScript snippet into HTML responses
+        after the opening `<head>` tag.
+      type: string
+      default: ''
+      examples:
+      - <script type="text/javascript">console.log('test')</script>
+    otel.instrumentation.apache-elasticjob.experimental-span-attributes:
+      name: otel.instrumentation.apache-elasticjob.experimental-span-attributes
+      declarative_name: java.apache_elasticjob.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `job.system`, `scheduling.apache-elasticjob.job.name`, `scheduling.apache-elasticjob.task.id`, `scheduling.apache-elasticjob.sharding.item.index`, `scheduling.apache-elasticjob.sharding.total.count`, `scheduling.apache-elasticjob.sharding.item.parameter`, and `scheduling.apache-elasticjob.job.type`.
+      type: boolean
+      default: false
+    otel.instrumentation.apache-shenyu.experimental-span-attributes:
+      name: otel.instrumentation.apache-shenyu.experimental-span-attributes
+      declarative_name: java.apache_shenyu.experimental_span_attributes/development
+      description: |
+        Enables experimental `apache-shenyu.meta.` prefixed span attributes `app-name`, `service-name`, `context-path`, `param-types`, `id`, `method-name`, `rpc-type`, `path` and `rpc-ext`.
+      type: boolean
+      default: false
+    otel.instrumentation.aws-lambda.flush-timeout:
+      name: otel.instrumentation.aws-lambda.flush-timeout
+      declarative_name: java.aws_lambda.flush_timeout
+      description: Flush timeout in milliseconds.
+      type: int
+      default: 10000
+    otel.instrumentation.aws-sdk.experimental-record-individual-http-error:
+      name: otel.instrumentation.aws-sdk.experimental-record-individual-http-error
+      declarative_name: java.aws_sdk.record_individual_http_error/development
+      description: Determines whether errors returned by each individual HTTP request
+        should be recorded as events for the SDK span.
+      type: boolean
+      default: false
+    otel.instrumentation.aws-sdk.experimental-span-attributes-0c4c01de:
+      name: otel.instrumentation.aws-sdk.experimental-span-attributes
+      declarative_name: java.aws_sdk.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `aws.agent`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
+      type: boolean
+      default: false
+    otel.instrumentation.aws-sdk.experimental-span-attributes-f30ad240:
+      name: otel.instrumentation.aws-sdk.experimental-span-attributes
+      declarative_name: java.aws_sdk.experimental_span_attributes/development
+      description: |
+        Enables the experimental span attributes `aws.agent`, `aws.queue.name`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
+      type: boolean
+      default: false
+    otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging:
+      name: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
+      declarative_name: java.aws_sdk.use_propagator_for_messaging/development
+      description: Determines whether the configured TextMapPropagator should be used
+        to inject into supported messaging attributes (for SQS).
+      type: boolean
+      default: false
+    otel.instrumentation.camel.experimental-span-attributes:
+      name: otel.instrumentation.camel.experimental-span-attributes
+      declarative_name: java.camel.experimental_span_attributes/development
+      description: |
+        Enable the capture of experimental `camel.uri`, `camel.kafka.partitionKey`, `camel.kafka.key` and `camel.kafka.offset` span attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.cassandra.query-sanitization.enabled:
+      name: otel.instrumentation.cassandra.query-sanitization.enabled
+      declarative_name: java.cassandra.query_sanitization.enabled
+      description: |
+        Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+      type: boolean
+      default: true
+    otel.instrumentation.common.enduser.id.enabled:
+      name: otel.instrumentation.common.enduser.id.enabled
+      declarative_name: java.common.enduser.id.enabled
+      description: Enables capturing the enduser.id attribute. This property and the
+        associated attribute are not supported when v3 preview is enabled.
+      type: boolean
+      default: false
+    otel.instrumentation.common.enduser.role.enabled:
+      name: otel.instrumentation.common.enduser.role.enabled
+      declarative_name: java.common.enduser.role.enabled
+      description: Enables capturing the enduser.role attribute. This property and
+        the associated attribute are not supported when v3 preview is enabled.
+      type: boolean
+      default: false
+    otel.instrumentation.common.enduser.scope.enabled:
+      name: otel.instrumentation.common.enduser.scope.enabled
+      declarative_name: java.common.enduser.scope.enabled
+      description: Enables capturing the enduser.scope attribute when v3 preview is
+        not enabled. This property is not honored when v3 preview is enabled.
+      type: boolean
+      default: false
+    otel.instrumentation.common.experimental.view-telemetry.enabled:
+      name: otel.instrumentation.common.experimental.view-telemetry.enabled
+      declarative_name: java.common.view_telemetry/development.enabled
+      description: Enables the creation of experimental view spans.
+      type: boolean
+      default: false
+    otel.instrumentation.common.logging.span-id-key:
+      name: otel.instrumentation.common.logging.span-id-key
+      declarative_name: java.common.logging.span_id_key
+      description: |
+        Specifies the key name used to store the span ID in the logging context.
+      type: string
+      default: span_id
+    otel.instrumentation.common.logging.trace-flags-key:
+      name: otel.instrumentation.common.logging.trace-flags-key
+      declarative_name: java.common.logging.trace_flags_key
+      description: |
+        Specifies the key name used to store the trace flags in the logging context.
+      type: string
+      default: trace_flags
+    otel.instrumentation.common.logging.trace-id-key:
+      name: otel.instrumentation.common.logging.trace-id-key
+      declarative_name: java.common.logging.trace_id_key
+      description: |
+        Specifies the key name used to store the trace ID in the logging context.
+      type: string
+      default: trace_id
+    otel.instrumentation.common.mdc.resource-attributes:
+      name: otel.instrumentation.common.mdc.resource-attributes
+      declarative_name: java.common.mdc.resource_attributes
+      description: |
+        Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
+      type: list
+      default: ''
+    otel.instrumentation.common.user.name.enabled:
+      name: otel.instrumentation.common.user.name.enabled
+      declarative_name: java.common.user.name.enabled
+      description: Enables capturing the user.name attribute when v3 preview is enabled.
+        This property and the associated attribute are not supported when v3 preview
+        is disabled.
+      type: boolean
+      default: false
+    otel.instrumentation.common.user.roles.enabled:
+      name: otel.instrumentation.common.user.roles.enabled
+      declarative_name: java.common.user.roles.enabled
+      description: Enables capturing the user.roles attribute when v3 preview is enabled.
+        This property and the associated attribute are not supported when v3 preview
+        is disabled.
+      type: boolean
+      default: false
+    otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e:
+      name: otel.instrumentation.couchbase.experimental-span-attributes
+      declarative_name: java.couchbase.experimental_span_attributes/development
+      description: Enables experimental span attributes emitted from the underlying
+        Couchbase library.
+      type: boolean
+      default: false
+    otel.instrumentation.couchbase.experimental-span-attributes-a850037a:
+      name: otel.instrumentation.couchbase.experimental-span-attributes
+      declarative_name: java.couchbase.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.dropwizard-metrics.enabled:
+      name: otel.instrumentation.dropwizard-metrics.enabled
+      declarative_name: java.dropwizard_metrics.enabled
+      description: Enables the dropwizard metrics instrumentation.
+      type: boolean
+      default: false
+    otel.instrumentation.elasticsearch.capture-search-query:
+      name: otel.instrumentation.elasticsearch.capture-search-query
+      declarative_name: java.elasticsearch.capture_search_query
+      description: |
+        Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
+      type: boolean
+      default: false
+    otel.instrumentation.elasticsearch.experimental-span-attributes-4728abdb:
+      name: otel.instrumentation.elasticsearch.experimental-span-attributes
+      declarative_name: java.elasticsearch.experimental_span_attributes/development
+      description: |
+        Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.search.types`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.broadcast.failed`, `elasticsearch.shard.broadcast.successful`, `elasticsearch.shard.broadcast.total`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.elasticsearch.experimental-span-attributes-df937525:
+      name: otel.instrumentation.elasticsearch.experimental-span-attributes
+      declarative_name: java.elasticsearch.experimental_span_attributes/development
+      description: |
+        Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.elasticsearch.experimental-span-attributes-ee0c671a:
+      name: otel.instrumentation.elasticsearch.experimental-span-attributes
+      declarative_name: java.elasticsearch.experimental_span_attributes/development
+      description: |
+        Enable the capture of the experimental span attributes `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version`.
+      type: boolean
+      default: false
+    otel.instrumentation.executors.include:
+      name: otel.instrumentation.executors.include
+      declarative_name: java.executors.include
+      description: List of Executor subclasses to be instrumented.
+      type: list
+      default: ''
+      examples:
+      - com.example.CustomExecutor
+      - com.example.ExecutorOne,com.example.ExecutorTwo
+    otel.instrumentation.executors.include-all:
+      name: otel.instrumentation.executors.include-all
+      declarative_name: java.executors.include_all
+      description: Whether to instrument all classes that implement the Executor interface.
+      type: boolean
+      default: false
+    otel.instrumentation.external-annotations.exclude-methods:
+      name: otel.instrumentation.external-annotations.exclude-methods
+      declarative_name: java.external_annotations.exclude_methods
+      description: All methods to be excluded from auto-instrumentation by annotation-based
+        advices.
+      type: string
+      default: ''
+      examples:
+      - com.example.MyClass[method1,method2]
+      - com.example.MyClass[method1];com.example.OtherClass[method2]
+    otel.instrumentation.external-annotations.include:
+      name: otel.instrumentation.external-annotations.include
+      declarative_name: java.external_annotations.include
+      description: Semicolon-separated list of annotation class names to instrument.
+      type: list
+      default: ''
+      examples:
+      - com.example.Trace
+      - com.example.Trace;com.example.OtherTrace
+    otel.instrumentation.genai.capture-message-content-274e53a8:
+      name: otel.instrumentation.genai.capture-message-content
+      declarative_name: java.common.gen_ai.capture_message_content
+      description: |
+        Enables including the full content of user and assistant messages in emitted log events. Note that full content can have data privacy and size concerns, and care should be taken when enabling this.
+      type: boolean
+      default: false
+    otel.instrumentation.genai.capture-message-content-ceb072e9:
+      name: otel.instrumentation.genai.capture-message-content
+      declarative_name: java.common.gen_ai.capture_message_content
+      description: |
+        Determines whether Generative AI events include full content of user and assistant messages. Note that full content can have data privacy and size concerns and care should be taken when enabling this
+      type: boolean
+      default: false
+    otel.instrumentation.graphql.capture-query:
+      name: otel.instrumentation.graphql.capture-query
+      declarative_name: java.graphql.capture_query
+      description: Whether to capture the query in `graphql.document` span attribute.
+      type: boolean
+      default: true
+    otel.instrumentation.graphql.data-fetcher.enabled:
+      name: otel.instrumentation.graphql.data-fetcher.enabled
+      declarative_name: java.graphql.data_fetcher.enabled
+      description: Enables span generation for data fetchers.
+      type: boolean
+      default: false
+    otel.instrumentation.graphql.operation-name-in-span-name.enabled:
+      name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
+      declarative_name: java.graphql.operation_name_in_span_name.enabled
+      description: |
+        Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
+      type: boolean
+      default: false
+    otel.instrumentation.graphql.query-sanitization.enabled:
+      name: otel.instrumentation.graphql.query-sanitization.enabled
+      declarative_name: java.graphql.query_sanitization.enabled
+      description: Enables sanitization of sensitive information from queries so they
+        aren't added as span attributes.
+      type: boolean
+      default: true
+    otel.instrumentation.graphql.trivial-data-fetcher.enabled:
+      name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
+      declarative_name: java.graphql.trivial_data_fetcher.enabled
+      description: Whether to create spans for trivial data fetchers. A trivial data
+        fetcher is one that simply maps data from an object to a field.
+      type: boolean
+      default: false
+    otel.instrumentation.grpc.capture-metadata.client.request:
+      name: otel.instrumentation.grpc.capture-metadata.client.request
+      declarative_name: java.grpc.capture_metadata.client.request
+      description: |
+        A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes.
+      type: list
+      default: ''
+      examples:
+      - custom-request-header
+      - my-metadata-key,another-metadata-key
+    otel.instrumentation.grpc.capture-metadata.server.request:
+      name: otel.instrumentation.grpc.capture-metadata.server.request
+      declarative_name: java.grpc.capture_metadata.server.request
+      description: |
+        A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes.
+      type: list
+      default: ''
+    otel.instrumentation.grpc.emit-message-events:
+      name: otel.instrumentation.grpc.emit-message-events
+      declarative_name: java.grpc.emit_message_events
+      description: Determines whether to emit a span event for each individual message
+        received and sent.
+      type: boolean
+      default: true
+    otel.instrumentation.grpc.experimental-span-attributes:
+      name: otel.instrumentation.grpc.experimental-span-attributes
+      declarative_name: java.grpc.experimental_span_attributes/development
+      description: |
+        Enable the capture of experimental span attributes `grpc.received.message_count`, `grpc.sent.message_count` and `grpc.canceled`.
+      type: boolean
+      default: false
+    otel.instrumentation.guava.experimental-span-attributes:
+      name: otel.instrumentation.guava.experimental-span-attributes
+      declarative_name: java.guava.experimental_span_attributes/development
+      description: Enables experimental span attribute `guava.canceled` for cancelled
+        operations.
+      type: boolean
+      default: false
+    otel.instrumentation.hibernate.experimental-span-attributes:
+      name: otel.instrumentation.hibernate.experimental-span-attributes
+      declarative_name: java.hibernate.experimental_span_attributes/development
+      description: Enables the experimental `hibernate.session_id` span attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.hystrix.experimental-span-attributes:
+      name: otel.instrumentation.hystrix.experimental-span-attributes
+      declarative_name: java.hystrix.experimental_span_attributes/development
+      description: Enables capturing the experimental `hystrix.command`, `hystrix.circuit_open`
+        and `hystrix.group` span attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.java-util-logging.experimental-log-attributes:
+      name: otel.instrumentation.java-util-logging.experimental-log-attributes
+      declarative_name: java.java_util_logging.experimental_log_attributes/development
+      description: Enables capturing the experimental `thread.name` and `thread.id`
+        log attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.java-util-logging.experimental.capture-arguments:
+      name: otel.instrumentation.java-util-logging.experimental.capture-arguments
+      declarative_name: java.java_util_logging.capture_arguments/development
+      description: Enables the capture of the log message arguments.
+      type: boolean
+      default: false
+    otel.instrumentation.java-util-logging.experimental.capture-template:
+      name: otel.instrumentation.java-util-logging.experimental.capture-template
+      declarative_name: java.java_util_logging.capture_template/development
+      description: Enables the capture of the log message template (if arguments are
+        provided).
+      type: boolean
+      default: false
+    otel.instrumentation.jaxrs.experimental-span-attributes:
+      name: otel.instrumentation.jaxrs.experimental-span-attributes
+      declarative_name: java.jaxrs.experimental_span_attributes/development
+      description: Enables the experimental `jaxrs.canceled` span attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.jboss-logmanager.experimental-log-attributes:
+      name: otel.instrumentation.jboss-logmanager.experimental-log-attributes
+      declarative_name: java.jboss_logmanager.experimental_log_attributes/development
+      description: |
+        Enables the capture of experimental log attributes, including thread name and thread ID.
+      type: boolean
+      default: false
+    otel.instrumentation.jboss-logmanager.experimental.capture-arguments:
+      name: otel.instrumentation.jboss-logmanager.experimental.capture-arguments
+      declarative_name: java.jboss_logmanager.capture_arguments/development
+      description: |
+        Enables the capture of the log message arguments.
+      type: boolean
+      default: false
+    otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes:
+      name: otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
+      declarative_name: java.jboss_logmanager.capture_mdc_attributes/development
+      description: |
+        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+      type: list
+      default: ''
+      examples:
+      - custom-mdc-key
+      - key1,key2,key3
+    otel.instrumentation.jboss-logmanager.experimental.capture-template:
+      name: otel.instrumentation.jboss-logmanager.experimental.capture-template
+      declarative_name: java.jboss_logmanager.capture_template/development
+      description: |
+        Enables the capture of the log message template (if arguments are provided).
+      type: boolean
+      default: false
+    otel.instrumentation.jdbc-datasource.enabled:
+      name: otel.instrumentation.jdbc-datasource.enabled
+      declarative_name: java.jdbc_datasource.enabled
+      description: Enables instrumentation of JDBC datasource connections.
+      type: boolean
+      default: false
+    otel.instrumentation.jdbc.experimental.capture-query-parameters:
+      name: otel.instrumentation.jdbc.experimental.capture-query-parameters
+      declarative_name: java.jdbc.capture_query_parameters/development
+      description: |
+        Sets whether the query parameters should be captured as span attributes named <code>db.query.parameter.&lt;key&gt;</code>. Enabling this option disables the statement sanitization.<p>WARNING: captured query parameters may contain sensitive information such as passwords, personally identifiable information or protected health info.
+      type: boolean
+      default: false
+    otel.instrumentation.jdbc.experimental.sqlcommenter.enabled:
+      name: otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
+      declarative_name: java.jdbc.sqlcommenter/development.enabled
+      description: |
+        Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance. Consult with database experts before enabling.
+      type: boolean
+      default: false
+    otel.instrumentation.jdbc.experimental.transaction.enabled:
+      name: otel.instrumentation.jdbc.experimental.transaction.enabled
+      declarative_name: java.jdbc.transaction/development.enabled
+      description: Enables experimental instrumentation to create spans for COMMIT
+        and ROLLBACK operations.
+      type: boolean
+      default: false
+    otel.instrumentation.jdbc.query-sanitization.enabled:
+      name: otel.instrumentation.jdbc.query-sanitization.enabled
+      declarative_name: java.jdbc.query_sanitization.enabled
+      description: Enables query sanitization for database queries. Takes precedence
+        over otel.instrumentation.common.db.query-sanitization.enabled.
+      type: boolean
+      default: true
+    otel.instrumentation.jsp.experimental-span-attributes:
+      name: otel.instrumentation.jsp.experimental-span-attributes
+      declarative_name: java.jsp.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `jsp.forwardOrigin`, `jsp.requestURL`, `jsp.compiler`, and `jsp.classFQCN`.
+      type: boolean
+      default: false
+    otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4:
+      name: otel.instrumentation.kafka.experimental-span-attributes
+      declarative_name: java.kafka.experimental_span_attributes/development
+      description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
+        and `messaging.kafka.bootstrap.servers`.
+      type: boolean
+      default: false
+    otel.instrumentation.kafka.experimental-span-attributes-6596b308:
+      name: otel.instrumentation.kafka.experimental-span-attributes
+      declarative_name: java.kafka.experimental_span_attributes/development
+      description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`
+        and `messaging.kafka.bootstrap.servers`.
+      type: boolean
+      default: false
+    otel.instrumentation.kafka.experimental-span-attributes-956cabd8:
+      name: otel.instrumentation.kafka.experimental-span-attributes
+      declarative_name: java.kafka.experimental_span_attributes/development
+      description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
+      type: boolean
+      default: false
+    otel.instrumentation.kafka.producer-propagation.enabled:
+      name: otel.instrumentation.kafka.producer-propagation.enabled
+      declarative_name: java.kafka.producer_propagation.enabled
+      description: Enable context propagation for Kafka message producers.
+      type: boolean
+      default: true
+    otel.instrumentation.kubernetes-client.experimental-span-attributes:
+      name: otel.instrumentation.kubernetes-client.experimental-span-attributes
+      declarative_name: java.kubernetes_client.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `kubernetes-client.namespace` and `kubernetes-client.name` for Kubernetes API requests.
+      type: boolean
+      default: false
+    otel.instrumentation.lettuce.connection-telemetry.enabled:
+      name: otel.instrumentation.lettuce.connection-telemetry.enabled
+      declarative_name: java.lettuce.connection_telemetry.enabled
+      description: Enables connection telemetry spans for Redis connections.
+      type: boolean
+      default: false
+    otel.instrumentation.lettuce.experimental-span-attributes-48d10623:
+      name: otel.instrumentation.lettuce.experimental-span-attributes
+      declarative_name: java.lettuce.experimental_span_attributes/development
+      description: Enables experimental span attribute `lettuce.command.cancelled`.
+      type: boolean
+      default: false
+    otel.instrumentation.lettuce.experimental-span-attributes-f6bf8fef:
+      name: otel.instrumentation.lettuce.experimental-span-attributes
+      declarative_name: java.lettuce.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `lettuce.command.cancelled` and `lettuce.command.results.count`.
+      type: boolean
+      default: false
+    otel.instrumentation.lettuce.experimental.command-encoding-events.enabled:
+      name: otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
+      declarative_name: java.lettuce.command_encoding_events/development.enabled
+      description: Enables capturing `redis.encode.start` and `redis.encode.end` span
+        events.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental-log-attributes:
+      name: otel.instrumentation.log4j-appender.experimental-log-attributes
+      declarative_name: java.log4j_appender.experimental_log_attributes/development
+      description: |
+        Enables the capture of experimental log attributes, including thread name and thread ID.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental.capture-arguments:
+      name: otel.instrumentation.log4j-appender.experimental.capture-arguments
+      declarative_name: java.log4j_appender.capture_arguments/development
+      description: |
+        Enables the capture of the log message arguments.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental.capture-code-attributes:
+      name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
+      declarative_name: java.log4j_appender.capture_code_attributes/development
+      description: |
+        Enables the capture of code location attributes, including file path, class name, method name, and line number.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes:
+      name: otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
+      declarative_name: java.log4j_appender.capture_map_message_attributes/development
+      description: |
+        Enables the capture of attributes from Log4j MapMessage instances.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental.capture-marker-attribute:
+      name: otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
+      declarative_name: java.log4j_appender.capture_marker_attribute/development
+      description: |
+        Enables the capture of the Log4j marker attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-436113d6:
+      name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
+      declarative_name: java.log4j_appender.capture_mdc_attributes/development
+      description: |
+        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+      type: list
+      default: ''
+      examples:
+      - custom-mdc-key
+      - key1,key2,key3
+    otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-e8e19d91:
+      name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
+      declarative_name: java.log4j_appender.capture_mdc_attributes/development
+      description: |
+        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+      type: list
+      default: ''
+      examples:
+      - '*'
+      - key1,key2
+    otel.instrumentation.log4j-appender.experimental.capture-template:
+      name: otel.instrumentation.log4j-appender.experimental.capture-template
+      declarative_name: java.log4j_appender.capture_template/development
+      description: |
+        Enables the capture of the log message template (if arguments are provided).
+      type: boolean
+      default: false
+    otel.instrumentation.log4j-context-data.add-baggage:
+      name: otel.instrumentation.log4j-context-data.add-baggage
+      declarative_name: java.log4j_context_data.add_baggage
+      description: |
+        Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental-log-attributes:
+      name: otel.instrumentation.logback-appender.experimental-log-attributes
+      declarative_name: java.logback_appender.experimental_log_attributes/development
+      description: |
+        Enables the capture of experimental log attributes, including thread name and thread ID.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-arguments:
+      name: otel.instrumentation.logback-appender.experimental.capture-arguments
+      declarative_name: java.logback_appender.capture_arguments/development
+      description: |
+        Enables the capture of log message arguments as separate attributes.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-code-attributes:
+      name: otel.instrumentation.logback-appender.experimental.capture-code-attributes
+      declarative_name: java.logback_appender.capture_code_attributes/development
+      description: |
+        Enables the capture of code location attributes, including file path, class name, method name, and line number.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes:
+      name: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
+      declarative_name: java.logback_appender.capture_key_value_pair_attributes/development
+      description: |
+        Enables the capture of attributes from Logback key-value pairs.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes:
+      name: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
+      declarative_name: java.logback_appender.capture_logger_context_attributes/development
+      description: |
+        Enables the capture of attributes from the Logback logger context.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes:
+      name: otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
+      declarative_name: java.logback_appender.capture_logstash_marker_attributes/development
+      description: |
+        Enables the capture of attributes from Logstash markers.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments:
+      name: otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
+      declarative_name: java.logback_appender.capture_logstash_structured_arguments/development
+      description: |
+        Enables the capture of attributes from Logstash structured arguments.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-marker-attribute:
+      name: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
+      declarative_name: java.logback_appender.capture_marker_attribute/development
+      description: |
+        Enables the capture of the Logback marker attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-appender.experimental.capture-mdc-attributes:
+      name: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
+      declarative_name: java.logback_appender.capture_mdc_attributes/development
+      description: |
+        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+      type: list
+      default: ''
+      examples:
+      - custom-mdc-key
+      - key1,key2,key3
+    otel.instrumentation.logback-appender.experimental.capture-template:
+      name: otel.instrumentation.logback-appender.experimental.capture-template
+      declarative_name: java.logback_appender.capture_template/development
+      description: |
+        Enables the capture of the log message template before parameter substitution.
+      type: boolean
+      default: false
+    otel.instrumentation.logback-mdc.add-baggage:
+      name: otel.instrumentation.logback-mdc.add-baggage
+      declarative_name: java.logback_mdc.add_baggage
+      description: |
+        Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
+      type: boolean
+      default: false
+    otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6:
+      name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+      declarative_name: java.common.messaging.receive_telemetry/development.enabled
+      description: |
+        Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+      type: boolean
+      default: false
+    otel.instrumentation.messaging.experimental.receive-telemetry.enabled-59c44ca8:
+      name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+      declarative_name: java.common.messaging.receive_telemetry/development.enabled
+      description: |
+        Enables the creation of consumer spans on messaging receive operations. These spans will measure the time between receiving a message and the consumer processing that message.
+      type: boolean
+      default: false
+    otel.instrumentation.methods.include:
+      name: otel.instrumentation.methods.include
+      declarative_name: java.methods.include
+      description: Semicolon-separated list of fully qualified class and method patterns
+        to instrument.
+      type: list
+      default: ''
+      examples:
+      - com.example.MyClass[method1]
+      - com.example.MyClass[method1,method2];com.example.OtherClass[call]
+    otel.instrumentation.micrometer.base-time-unit:
+      name: otel.instrumentation.micrometer.base-time-unit
+      declarative_name: java.micrometer.base_time_unit
+      description: |
+        Sets the base time unit for the OpenTelemetry MeterRegistry. Supported values: ns, us, ms, s, min, h, d.
+      type: string
+      default: s
+      examples:
+      - ns
+      - milliseconds
+    otel.instrumentation.micrometer.histogram-gauges.enabled:
+      name: otel.instrumentation.micrometer.histogram-gauges.enabled
+      declarative_name: java.micrometer.histogram_gauges.enabled
+      description: |
+        Enables gauge-based Micrometer histograms for DistributionSummary and Timer instruments.
+      type: boolean
+      default: false
+    otel.instrumentation.micrometer.prometheus-mode.enabled:
+      name: otel.instrumentation.micrometer.prometheus-mode.enabled
+      declarative_name: java.micrometer.prometheus_mode.enabled
+      description: |
+        Simulates the behavior of Micrometer's PrometheusMeterRegistry. The instruments will be renamed to match Micrometer instrument naming, and the base time unit will be set to seconds.
+      type: boolean
+      default: false
+    otel.instrumentation.mongo.query-sanitization.enabled:
+      name: otel.instrumentation.mongo.query-sanitization.enabled
+      declarative_name: java.mongo.query_sanitization.enabled
+      description: |
+        Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+      type: boolean
+      default: true
+    otel.instrumentation.netty.connection-telemetry.enabled:
+      name: otel.instrumentation.netty.connection-telemetry.enabled
+      declarative_name: java.netty.connection_telemetry.enabled
+      description: Enable the creation of Connect and DNS spans.
+      type: boolean
+      default: false
+    otel.instrumentation.netty.ssl-telemetry.enabled:
+      name: otel.instrumentation.netty.ssl-telemetry.enabled
+      declarative_name: java.netty.ssl_telemetry.enabled
+      description: Enable SSL telemetry.
+      type: boolean
+      default: false
+    otel.instrumentation.opensearch.capture-search-query:
+      name: otel.instrumentation.opensearch.capture-search-query
+      declarative_name: java.opensearch.capture_search_query
+      description: |
+        Enable the capture of sanitized search query bodies. Search queries may contain personal or sensitive information.
+      type: boolean
+      default: true
+    otel.instrumentation.opentelemetry-annotations.exclude-methods:
+      name: otel.instrumentation.opentelemetry-annotations.exclude-methods
+      declarative_name: java.opentelemetry_extension_annotations.exclude_methods
+      description: All methods to be excluded from auto-instrumentation by annotation-based
+        advices.
+      type: string
+      default: ''
+      examples:
+      - com.example.MyClass[method1,method2]
+      - com.example.MyClass[method1];com.example.OtherClass[method2]
+    otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods:
+      name: otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
+      declarative_name: java.opentelemetry_instrumentation_annotations.exclude_methods
+      description: All methods to be excluded from auto-instrumentation by annotation-based
+        advices.
+      type: string
+      default: ''
+      examples:
+      - com.example.MyClass[method1,method2]
+      - com.example.MyClass[method1];com.example.OtherClass[method2]
+    otel.instrumentation.oshi.experimental-metrics.enabled:
+      name: otel.instrumentation.oshi.experimental-metrics.enabled
+      declarative_name: java.oshi.experimental_metrics/development.enabled
+      description: Enable the experimental `runtime.java.memory` and `runtime.java.cpu_time`
+        metrics.
+      type: boolean
+      default: false
+    otel.instrumentation.powerjob.experimental-span-attributes:
+      name: otel.instrumentation.powerjob.experimental-span-attributes
+      declarative_name: java.powerjob.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `job.system`, `scheduling.powerjob.job.id`, `scheduling.powerjob.job.param`, `scheduling.powerjob.job.instance.param`, and `scheduling.powerjob.job.type`.
+      type: boolean
+      default: false
+    otel.instrumentation.pulsar.experimental-span-attributes-1d77bf4d:
+      name: otel.instrumentation.pulsar.experimental-span-attributes
+      declarative_name: java.pulsar.experimental_span_attributes/development
+      description: |
+        Enables capturing experimental span attribute `messaging.pulsar.message.type` on PRODUCER spans.
+      type: boolean
+      default: false
+    otel.instrumentation.pulsar.experimental-span-attributes-5ac8c0d9:
+      name: otel.instrumentation.pulsar.experimental-span-attributes
+      declarative_name: java.pulsar.experimental_span_attributes/development
+      description: |
+        Enables the experimental span attribute `messaging.pulsar.message.type` for producer spans.
+      type: boolean
+      default: false
+    otel.instrumentation.quartz.experimental-span-attributes:
+      name: otel.instrumentation.quartz.experimental-span-attributes
+      declarative_name: java.quartz.experimental_span_attributes/development
+      description: Enables the experimental `job.system` span attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled:
+      name: otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
+      declarative_name: java.r2dbc.sqlcommenter/development.enabled
+      description: |
+        Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance.
+      type: boolean
+      default: false
+    otel.instrumentation.r2dbc.query-sanitization.enabled:
+      name: otel.instrumentation.r2dbc.query-sanitization.enabled
+      declarative_name: java.r2dbc.query_sanitization.enabled
+      description: |
+        Enables query sanitization for database queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+      type: boolean
+      default: true
+    otel.instrumentation.rabbitmq.experimental-span-attributes:
+      name: otel.instrumentation.rabbitmq.experimental-span-attributes
+      declarative_name: java.rabbitmq.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `rabbitmq.command`, `rabbitmq.delivery_mode`, `rabbitmq.queue`, and `rabbitmq.record.queue_time_ms`.
+      type: boolean
+      default: false
+    otel.instrumentation.reactor-netty.connection-telemetry.enabled:
+      name: otel.instrumentation.reactor-netty.connection-telemetry.enabled
+      declarative_name: java.reactor_netty.connection_telemetry.enabled
+      description: Enables the creation of Connect and DNS spans.
+      type: boolean
+      default: false
+    otel.instrumentation.reactor.experimental-span-attributes:
+      name: otel.instrumentation.reactor.experimental-span-attributes
+      declarative_name: java.reactor.experimental_span_attributes/development
+      description: |
+        Enables the capture of the experimental `reactor.canceled` attribute on spans when reactive streams are cancelled.
+      type: boolean
+      default: false
+    otel.instrumentation.resources.experimental.process-command-attributes.enabled:
+      name: otel.instrumentation.resources.experimental.process-command-attributes.enabled
+      description: |
+        Enables capture of process command-line resource attributes when v3 preview suppresses them by default.
+      type: boolean
+      default: false
+    otel.instrumentation.rocketmq-client.experimental-span-attributes:
+      name: otel.instrumentation.rocketmq-client.experimental-span-attributes
+      declarative_name: java.rocketmq_client.experimental_span_attributes/development
+      description: |
+        Enables capturing experimental span attributes `messaging.rocketmq.message.tag`, `messaging.rocketmq.broker_address`, `messaging.rocketmq.send_result`, `messaging.rocketmq.queue_id`, and `messaging.rocketmq.queue_offset`.
+      type: boolean
+      default: false
+    otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics:
+      name: otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
+      declarative_name: java.runtime_telemetry.emit_experimental_jfr_metrics/development
+      description: |
+        Enables the capture of experimental JFR-based JVM runtime metrics on Java 17+.
+      type: boolean
+      default: false
+    otel.instrumentation.runtime-telemetry.emit-experimental-metrics:
+      name: otel.instrumentation.runtime-telemetry.emit-experimental-metrics
+      declarative_name: java.runtime_telemetry.emit_experimental_metrics/development
+      description: Enables the capture of experimental JMX-based JVM runtime metrics.
+      type: boolean
+      default: false
+    otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled:
+      name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
+      declarative_name: java.runtime_telemetry.package_emitter/development.enabled
+      description: Enables creating events for JAR libraries used by the application.
+      type: boolean
+      default: false
+    otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second:
+      name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
+      declarative_name: java.runtime_telemetry.package_emitter/development.jars_per_second
+      description: The number of JAR files processed per second by the package emitter.
+      type: int
+      default: 10
+    otel.instrumentation.runtime-telemetry.experimental.prefer-jfr:
+      name: otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
+      declarative_name: java.runtime_telemetry.prefer_jfr/development
+      description: |
+        Prefer JFR over JMX for metrics available from both sources, on Java 17+. When enabled, overlapping metrics are collected via JFR and the corresponding JMX metrics are suppressed.
+      type: boolean
+      default: false
+    otel.instrumentation.rxjava.experimental-span-attributes:
+      name: otel.instrumentation.rxjava.experimental-span-attributes
+      declarative_name: java.rxjava.experimental_span_attributes/development
+      description: |
+        Enables the experimental span attribute `rxjava.canceled`.
+      type: boolean
+      default: false
+    otel.instrumentation.servlet.experimental-span-attributes:
+      name: otel.instrumentation.servlet.experimental-span-attributes
+      declarative_name: java.servlet.experimental_span_attributes/development
+      description: Enables capturing the experimental `servlet.timeout` span attribute.
+      type: boolean
+      default: false
+    otel.instrumentation.servlet.experimental.capture-request-parameters:
+      name: otel.instrumentation.servlet.experimental.capture-request-parameters
+      declarative_name: java.servlet.capture_request_parameters/development
+      description: List of request parameter names to capture as span attributes.
+      type: list
+      default: ''
+    otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled:
+      name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+      declarative_name: java.servlet.trace_id_request_attribute/development.enabled
+      description: Enables adding the trace ID and span ID as request attributes for
+        downstream servlet access.
+      type: boolean
+      default: true
+    otel.instrumentation.spring-batch.experimental-span-attributes:
+      name: otel.instrumentation.spring-batch.experimental-span-attributes
+      declarative_name: java.spring_batch.experimental_span_attributes/development
+      description: Adds the experimental attribute `job.system` to spans.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-batch.experimental.chunk.new-trace:
+      name: otel.instrumentation.spring-batch.experimental.chunk.new-trace
+      declarative_name: java.spring_batch.chunk/development.new_trace
+      description: When enabled, a new root span will be created for each chunk processing.
+        Please note that this may lead to a high number of spans being created.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-batch.item.enabled:
+      name: otel.instrumentation.spring-batch.item.enabled
+      declarative_name: java.spring_batch.item.enabled
+      description: When enabled, spans will be created for each item processed. Please
+        note that this may lead to a high number of spans being created.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-cloud-gateway.experimental-span-attributes:
+      name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+      declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
+      description: |
+        Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-integration.global-channel-interceptor-patterns:
+      name: otel.instrumentation.spring-integration.global-channel-interceptor-patterns
+      declarative_name: java.spring_integration.global_channel_interceptor_patterns
+      description: A list of Spring channel name patterns that will be intercepted.
+      type: list
+      default: '*'
+    otel.instrumentation.spring-integration.producer.enabled:
+      name: otel.instrumentation.spring-integration.producer.enabled
+      declarative_name: java.spring_integration.producer.enabled
+      description: |
+        Create producer spans when messages are sent to an output channel. Enable when you're using a messaging library that doesn't have its own instrumentation for generating producer spans. Note that the detection of output channels only works for Spring Cloud Stream `DirectWithAttributesChannel`.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-scheduling.experimental-span-attributes:
+      name: otel.instrumentation.spring-scheduling.experimental-span-attributes
+      declarative_name: java.spring_scheduling.experimental_span_attributes/development
+      description: Adds the experimental span attribute `job.system` with the value
+        `spring_scheduling`.
+      type: boolean
+      default: false
+    otel.instrumentation.spring-security.enduser.role.granted-authority-prefix:
+      name: otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
+      declarative_name: java.spring_security.enduser.role.granted_authority_prefix
+      description: Prefix of granted authorities identifying roles to capture in the
+        `enduser.role` semantic attribute. This property is not honored when v3 preview
+        is enabled; use the `user.roles` variant instead.
+      type: string
+      default: ROLE_
+    otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix:
+      name: otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
+      declarative_name: java.spring_security.enduser.scope.granted_authority_prefix
+      description: Prefix of granted authorities identifying scopes to capture in
+        the `enduser.scope` semantic attribute. This property and the associated attribute
+        are not supported when v3 preview is enabled.
+      type: string
+      default: SCOPE_
+    otel.instrumentation.spring-security.user.roles.granted-authority-prefix:
+      name: otel.instrumentation.spring-security.user.roles.granted-authority-prefix
+      declarative_name: java.spring_security.user.roles.granted_authority_prefix
+      description: Prefix of granted authorities identifying roles to capture in the
+        `user.roles` semantic attribute when v3 preview is enabled. This property
+        is not honored when v3 preview is disabled; use the `enduser.role` variant
+        instead.
+      type: string
+      default: ROLE_
+    otel.instrumentation.spring-webmvc.experimental-span-attributes:
+      name: otel.instrumentation.spring-webmvc.experimental-span-attributes
+      declarative_name: java.spring_webmvc.experimental_span_attributes/development
+      description: |
+        Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
+      type: boolean
+      default: false
+    otel.instrumentation.spymemcached.experimental-span-attributes:
+      name: otel.instrumentation.spymemcached.experimental-span-attributes
+      declarative_name: java.spymemcached.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `spymemcached.result` and `spymemcached.command.cancelled`.
+      type: boolean
+      default: false
+    otel.instrumentation.twilio.experimental-span-attributes:
+      name: otel.instrumentation.twilio.experimental-span-attributes
+      declarative_name: java.twilio.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `twilio.type`, `twilio.account`, `twilio.sid`, `twilio.parentSid`, and `twilio.status`.
+      type: boolean
+      default: false
+    otel.instrumentation.xxl-job.experimental-span-attributes:
+      name: otel.instrumentation.xxl-job.experimental-span-attributes
+      declarative_name: java.xxl_job.experimental_span_attributes/development
+      description: |
+        Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
+      type: boolean
+      default: false
+    otel.jmx.config:
+      name: otel.jmx.config
+      declarative_name: java.jmx.config
+      description: List of paths to JMX metric definition YAML files.
+      type: list
+      default: ''
+    otel.jmx.discovery.delay:
+      name: otel.jmx.discovery.delay
+      declarative_name: java.jmx.discovery.delay
+      description: Time in milliseconds between JMX MBean detection attempts.
+      type: int
+      default: 60000
+    otel.jmx.enabled:
+      name: otel.jmx.enabled
+      declarative_name: java.jmx.enabled
+      description: Enables collection of JMX metrics.
+      type: boolean
+      default: true
+    otel.jmx.target.system:
+      name: otel.jmx.target.system
+      declarative_name: java.jmx.target.system
+      description: List of predefined JMX target systems to collect metrics for.
+      type: list
+      default: ''
+    otel.semconv-stability.opt-in:
+      name: otel.semconv-stability.opt-in
+      declarative_name: general.semconv_stability.opt_in
+      description: |
+        Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
+      type: list
+      default: ''
+    sanitization.url.sensitive-query-parameters:
+      name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+      declarative_name: general.sanitization.url.sensitive_query_parameters/development
+      description: List of URL query parameter names whose values are redacted in
+        URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+      type: list
+      default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  metrics:
+    db.client.connection.count-2e6ba9b7:
+      name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    db.client.connection.create_time-4f586679:
+      name: db.client.connection.create_time
+      description: The time it took to create a new connection.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.idle.max-b95e4f5c:
+      name: db.client.connection.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.idle.min-73bdafbc:
+      name: db.client.connection.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.max-c7917942:
+      name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.pending_requests-a0f41111:
+      name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.timeouts-d2dbfa58:
+      name: db.client.connection.timeouts
+      description: The number of connection timeouts that have occurred trying to
+        obtain a connection from the pool.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{timeout}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.use_time-a06760eb:
+      name: db.client.connection.use_time
+      description: The time between borrowing a connection and returning it to the
+        pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connection.wait_time-40a55682:
+      name: db.client.connection.wait_time
+      description: The time it took to obtain an open connection from the pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    db.client.connections.create_time-6f641171:
+      name: db.client.connections.create_time
+      description: The time it took to create a new connection.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.idle.max-f9946dd5:
+      name: db.client.connections.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.idle.min-f04d4083:
+      name: db.client.connections.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.max-ddde65fe:
+      name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.pending_requests-a0698f55:
+      name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.timeouts-b32b8a2b:
+      name: db.client.connections.timeouts
+      description: The number of connection timeouts that have occurred trying to
+        obtain a connection from the pool.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{timeouts}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.usage-5ef1d5ef:
+      name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
+    db.client.connections.use_time-cb3aefff:
+      name: db.client.connections.use_time
+      description: The time between borrowing a connection and returning it to the
+        pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.connections.wait_time-e6bdd10e:
+      name: db.client.connections.wait_time
+      description: The time it took to obtain an open connection from the pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
+    db.client.operation.duration-32559b79:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-39ae058b:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+    db.client.operation.duration-4f486dc3:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-55295033:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+    db.client.operation.duration-7714cbf7:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+    db.client.operation.duration-88382861:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-8ae2b8ce:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-bfd9d23c:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-d4212042:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    db.client.operation.duration-e36c6087:
+      name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    failsafe.circuit_breaker.execution.count-9271cf8d:
+      name: failsafe.circuit_breaker.execution.count
+      description: Count of circuit breaker executions.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.circuit_breaker.name
+        type: STRING
+      - name: failsafe.circuit_breaker.outcome
+        type: STRING
+    failsafe.circuit_breaker.state_change.count-09bbffb6:
+      name: failsafe.circuit_breaker.state_change.count
+      description: Count of circuit breaker state changes.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.circuit_breaker.name
+        type: STRING
+      - name: failsafe.circuit_breaker.state
+        type: STRING
+    failsafe.retry_policy.attempts-cc34346c:
+      name: failsafe.retry_policy.attempts
+      description: Number of attempts for each execution.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{attempt}'
+      attributes:
+      - name: failsafe.retry_policy.name
+        type: STRING
+      - name: failsafe.retry_policy.outcome
+        type: STRING
+    failsafe.retry_policy.execution.count-d01cba44:
+      name: failsafe.retry_policy.execution.count
+      description: Count of execution attempts processed by the retry policy, where
+        one execution represents the total number of attempts.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.retry_policy.name
+        type: STRING
+      - name: failsafe.retry_policy.outcome
+        type: STRING
+    gen_ai.client.operation.duration-32ef946d:
+      name: gen_ai.client.operation.duration
+      description: GenAI operation duration.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.response.model
+        type: STRING
+    gen_ai.client.operation.duration-d420df10:
+      name: gen_ai.client.operation.duration
+      description: GenAI operation duration.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+    gen_ai.client.token.usage-9c41606c:
+      name: gen_ai.client.token.usage
+      description: Measures number of input and output tokens used.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{token}'
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.token.type
+        type: STRING
+    gen_ai.client.token.usage-c5ff244f:
+      name: gen_ai.client.token.usage
+      description: Measures number of input and output tokens used.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{token}'
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.response.model
+        type: STRING
+      - name: gen_ai.token.type
+        type: STRING
+    http.client.request.duration-98bb5f3b:
+      name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    http.client.request.duration-a64b5297:
+      name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    http.server.active_requests-2c1402e2:
+      name: http.server.active_requests
+      description: Number of active HTTP server requests.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    http.server.request.duration-1f6f63ed:
+      name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    http.server.request.duration-2311bdb1:
+      name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    http.server.request.duration-639e2d0b:
+      name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    http.server.response.body.size-9ece7062:
+      name: http.server.response.body.size
+      description: Size of HTTP server response bodies.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    iceberg.scan.data_files.count-7869922f:
+      name: iceberg.scan.data_files.count
+      description: The number of data files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.data_files.size-25d28777:
+      name: iceberg.scan.data_files.size
+      description: The total size of all scanned data files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.data_manifests.count-91f2a926:
+      name: iceberg.scan.data_manifests.count
+      description: The number of data manifests.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.delete_files.count-2ce39a8f:
+      name: iceberg.scan.delete_files.count
+      description: The number of delete files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.delete_file.type
+        type: STRING
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.delete_files.size-c63edff8:
+      name: iceberg.scan.delete_files.size
+      description: The total size of all scanned delete files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.delete_manifests.count-304a613c:
+      name: iceberg.scan.delete_manifests.count
+      description: The number of delete manifests.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    iceberg.scan.planning.duration-6654a71a:
+      name: iceberg.scan.planning.duration
+      description: The total duration needed to plan the scan.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    messaging.publish.duration-05731f17:
+      name: messaging.publish.duration
+      description: Measures the duration of publish operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    messaging.receive.duration-4b4a91de:
+      name: messaging.receive.duration
+      description: Measures the duration of receive operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    messaging.receive.messages-2499c5ac:
+      name: messaging.receive.messages
+      description: Measures the number of received messages.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{message}'
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.client.call.duration-7381532d:
+      name: rpc.client.call.duration
+      description: Measures the duration of outbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.response.status_code
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.client.duration-599bf562:
+      name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.client.request.size-0d8f967b:
+      name: rpc.client.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.client.response.size-d0124e0e:
+      name: rpc.client.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.server.call.duration-1e979856:
+      name: rpc.server.call.duration
+      description: Measures the duration of inbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.response.status_code
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.server.duration-83a39fb3:
+      name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.server.request.size-75ef4f8e:
+      name: rpc.server.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    rpc.server.response.size-fb45af0b:
+      name: rpc.server.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    runtime.java.cpu_time-ac10c23f:
+      name: runtime.java.cpu_time
+      description: Runtime Java CPU time
+      instrument: gauge
+      data_type: LONG_GAUGE
+      unit: ms
+      attributes:
+      - name: type
+        type: STRING
+    runtime.java.memory-2a143889:
+      name: runtime.java.memory
+      description: Runtime Java memory
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: type
+        type: STRING
+    system.disk.io-58ee1ced:
+      name: system.disk.io
+      description: System disk IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    system.disk.operations-cf678806:
+      name: system.disk.operations
+      description: System disk operations
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{operations}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    system.memory.usage-11625112:
+      name: system.memory.usage
+      description: System memory usage
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: state
+        type: STRING
+    system.memory.utilization-677660f3:
+      name: system.memory.utilization
+      description: System memory utilization
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes:
+      - name: state
+        type: STRING
+    system.network.errors-0d1e8b98:
+      name: system.network.errors
+      description: System network errors
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{errors}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    system.network.io-518133c1:
+      name: system.network.io
+      description: System network IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    system.network.packets-6d263c01:
+      name: system.network.packets
+      description: System network packets
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{packets}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
 libraries:
 - name: activej-http-6.0
   display_name: ActiveJ
@@ -21,46 +2070,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.activej:activej-http:[6.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -103,6 +2121,10 @@ libraries:
   - com.typesafe.akka:akka-actor_2.11:[2.3,)
   - com.typesafe.akka:akka-actor_2.12:[2.3,)
   - com.typesafe.akka:akka-actor_2.13:[2.3,)
+- name: akka-actor-fork-join-2.5
+  source_path: instrumentation/akka/akka-actor-fork-join-2.5
+  scope:
+    name: io.opentelemetry.akka-actor-fork-join-2.5
 - name: akka-actor-forkjoin-2.5
   display_name: Akka Actors
   description: This instrumentation provides context propagation for the Akka Fork-Join
@@ -140,127 +2162,22 @@ libraries:
   - com.typesafe.akka:akka-http_2.11:[10,)
   - com.typesafe.akka:akka-http_2.12:[10,)
   - com.typesafe.akka:akka-http_2.13:[10,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -307,39 +2224,9 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -399,105 +2286,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.alibaba:druid:(,)
-  configurations:
-  - name: otel.semconv-stability.opt-in
-    declarative_name: general.semconv_stability.opt_in
-    description: |
-      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.semconv-stability.opt-in
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.idle.max-f9946dd5
+    - db.client.connections.idle.min-f04d4083
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.pending_requests-a0698f55
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.idle.max-b95e4f5c
+    - db.client.connection.idle.min-73bdafbc
+    - db.client.connection.max-c7917942
+    - db.client.connection.pending_requests-a0f41111
 - name: apache-dbcp-2.0
   display_name: Apache DBCP
   description: |
@@ -513,88 +2318,21 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.commons:commons-dbcp2:[2,)
-  configurations:
-  - name: otel.semconv-stability.opt-in
-    declarative_name: general.semconv_stability.opt_in
-    description: |
-      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.semconv-stability.opt-in
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.idle.max-f9946dd5
+    - db.client.connections.idle.min-f04d4083
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.idle.max-b95e4f5c
+    - db.client.connection.idle.min-73bdafbc
+    - db.client.connection.max-c7917942
 - name: apache-dubbo-2.7
   display_name: Apache Dubbo
   description: |
@@ -611,133 +2349,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.dubbo:dubbo:[2.7,)
-  configurations:
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  telemetry:
-  - when: default
-    metrics:
-    - name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: peer.service
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - span_kind: SERVER
-      attributes:
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-  - when: otel.semconv-stability.opt-in=rpc,service.peer
-    metrics:
-    - name: rpc.client.call.duration
-      description: Measures the duration of outbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.call.duration
-      description: Measures the duration of inbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-    - span_kind: SERVER
-      attributes:
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
+  configuration_refs:
+  - common.peer-service-mapping
 - name: apache-elasticjob-3.0
   display_name: Apache ElasticJob
   description: This instrumentation enables spans for Apache ElasticJob job executions.
@@ -748,13 +2361,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.shardingsphere.elasticjob:elasticjob-lite-core:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.apache-elasticjob.experimental-span-attributes
-    declarative_name: java.apache_elasticjob.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `job.system`, `scheduling.apache-elasticjob.job.name`, `scheduling.apache-elasticjob.task.id`, `scheduling.apache-elasticjob.sharding.item.index`, `scheduling.apache-elasticjob.sharding.total.count`, `scheduling.apache-elasticjob.sharding.item.parameter`, and `scheduling.apache-elasticjob.job.type`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.apache-elasticjob.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -801,95 +2409,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.httpcomponents:httpasyncclient:[4.1,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -912,23 +2443,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -965,95 +2481,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - commons-httpclient:commons-httpclient:[2.0,4.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1074,23 +2513,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1126,95 +2550,18 @@ libraries:
   javaagent_target_versions:
   - io.dropwizard:dropwizard-client:(,3.0.0)
   - org.apache.httpcomponents:httpclient:[4.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1237,23 +2584,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1290,23 +2622,8 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1343,95 +2660,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.httpcomponents.client5:httpclient5:[5.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1454,23 +2694,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1507,23 +2732,8 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1558,13 +2768,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.shenyu:shenyu-web:[2.4.0,)
-  configurations:
-  - name: otel.instrumentation.apache-shenyu.experimental-span-attributes
-    declarative_name: java.apache_shenyu.experimental_span_attributes/development
-    description: |
-      Enables experimental `apache-shenyu.meta.` prefixed span attributes `app-name`, `service-name`, `context-path`, `param-types`, `id`, `method-name`, `rpc-type`, `path` and `rpc-ext`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.apache-shenyu.experimental-span-attributes
 - name: armeria-1.3
   display_name: Armeria
   description: |
@@ -1585,127 +2790,22 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.linecorp.armeria:armeria:[1.3.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1760,39 +2860,9 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -1929,93 +2999,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.ning:async-http-client:[1.8.0,1.9.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2036,21 +3031,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2085,93 +3067,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.ning:async-http-client:[1.9.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2192,21 +3099,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2241,95 +3135,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.asynchttpclient:async-http-client:[2.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2356,23 +3173,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2427,12 +3229,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.amazonaws:aws-lambda-java-core:[1.0.0,)
-  configurations:
-  - name: otel.instrumentation.aws-lambda.flush-timeout
-    declarative_name: java.aws_lambda.flush_timeout
-    description: Flush timeout in milliseconds.
-    type: int
-    default: 10000
+  configuration_refs:
+  - otel.instrumentation.aws-lambda.flush-timeout
   telemetry:
   - when: default
     spans:
@@ -2454,18 +3252,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.amazonaws:aws-lambda-java-core:[1.0.0,)
-  configurations:
-  - name: otel.instrumentation.aws-lambda.flush-timeout
-    declarative_name: java.aws_lambda.flush_timeout
-    description: Flush timeout in milliseconds.
-    type: int
-    default: 10000
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - otel.instrumentation.aws-lambda.flush-timeout
   telemetry:
   - when: default
     spans:
@@ -2501,12 +3290,8 @@ libraries:
   scope:
     name: io.opentelemetry.aws-lambda-events-3.11
   has_standalone_library: true
-  configurations:
-  - name: otel.instrumentation.aws-lambda.flush-timeout
-    declarative_name: java.aws_lambda.flush_timeout
-    description: Flush timeout in milliseconds.
-    type: int
-    default: 10000
+  configuration_refs:
+  - otel.instrumentation.aws-lambda.flush-timeout
   telemetry:
   - when: default
     spans:
@@ -2558,24 +3343,10 @@ libraries:
   javaagent_target_versions:
   - com.amazonaws:aws-java-sdk-core:[1.10.33,)
   - com.amazonaws:aws-java-sdk-sqs:[1.10.33,)
-  configurations:
-  - name: otel.instrumentation.aws-sdk.experimental-span-attributes
-    declarative_name: java.aws_sdk.experimental_span_attributes/development
-    description: |
-      Enables the experimental span attributes `aws.agent`, `aws.queue.name`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: Allows configuring headers to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.aws-sdk.experimental-span-attributes-f30ad240
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: default
     spans:
@@ -2583,33 +3354,7 @@ libraries:
       attributes:
       - name: aws.agent
         type: STRING
-      - name: aws.dynamodb.table_names
-        type: STRING_ARRAY
-      - name: aws.kinesis.stream_name
-        type: STRING
-      - name: aws.lambda.function.arn
-        type: STRING
-      - name: aws.lambda.function.name
-        type: STRING
-      - name: aws.lambda.resource_mapping.id
-        type: STRING
-      - name: aws.queue.name
-        type: STRING
-      - name: aws.request_id
-        type: STRING
       - name: aws.s3.bucket
-        type: STRING
-      - name: aws.sns.topic.arn
-        type: STRING
-      - name: aws.sqs.queue.url
-        type: STRING
-      - name: aws.step_functions.activity.arn
-        type: STRING
-      - name: aws.step_functions.state_machine.arn
-        type: STRING
-      - name: db.operation
-        type: STRING
-      - name: db.system
         type: STRING
       - name: error.type
         type: STRING
@@ -2617,189 +3362,6 @@ libraries:
         type: STRING
       - name: http.response.status_code
         type: LONG
-      - name: messaging.destination.name
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: CONSUMER
-      attributes:
-      - name: aws.agent
-        type: STRING
-      - name: aws.request_id
-        type: STRING
-      - name: aws.sqs.queue.url
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: messaging.batch.message_count
-        type: LONG
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.message.id
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: PRODUCER
-      attributes:
-      - name: aws.agent
-        type: STRING
-      - name: aws.request_id
-        type: STRING
-      - name: aws.sqs.queue.url
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.message.id
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: aws.agent
-        type: STRING
-      - name: aws.dynamodb.table_names
-        type: STRING_ARRAY
-      - name: aws.kinesis.stream_name
-        type: STRING
-      - name: aws.lambda.function.arn
-        type: STRING
-      - name: aws.lambda.function.name
-        type: STRING
-      - name: aws.lambda.resource_mapping.id
-        type: STRING
-      - name: aws.queue.name
-        type: STRING
-      - name: aws.request_id
-        type: STRING
-      - name: aws.s3.bucket
-        type: STRING
-      - name: aws.sns.topic.arn
-        type: STRING
-      - name: aws.sqs.queue.url
-        type: STRING
-      - name: aws.step_functions.activity.arn
-        type: STRING
-      - name: aws.step_functions.state_machine.arn
-        type: STRING
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: messaging.destination.name
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: CONSUMER
-      attributes:
-      - name: aws.agent
-        type: STRING
-      - name: aws.request_id
-        type: STRING
-      - name: aws.sqs.queue.url
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.message.id
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
       - name: network.protocol.version
         type: STRING
       - name: rpc.method
@@ -2837,71 +3399,18 @@ libraries:
   - software.amazon.awssdk:lambda:[2.17.0,)
   - software.amazon.awssdk:sns:[2.2.0,)
   - software.amazon.awssdk:sqs:[2.2.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: Allows configuring headers to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.aws-sdk.experimental-span-attributes
-    declarative_name: java.aws_sdk.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `aws.agent`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
-    declarative_name: java.aws_sdk.use_propagator_for_messaging/development
-    description: Determines whether the configured TextMapPropagator should be used
-      to inject into supported messaging attributes (for SQS).
-    type: boolean
-    default: false
-  - name: otel.instrumentation.genai.capture-message-content
-    declarative_name: java.common.gen_ai.capture_message_content
-    description: |
-      Determines whether Generative AI events include full content of user and assistant messages. Note that full content can have data privacy and size concerns and care should be taken when enabling this
-    type: boolean
-    default: false
-  - name: otel.instrumentation.aws-sdk.experimental-record-individual-http-error
-    declarative_name: java.aws_sdk.record_individual_http_error/development
-    description: Determines whether errors returned by each individual HTTP request
-      should be recorded as events for the SDK span.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.aws-sdk.experimental-record-individual-http-error
+  - otel.instrumentation.aws-sdk.experimental-span-attributes-0c4c01de
+  - otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
+  - otel.instrumentation.genai.capture-message-content-ceb072e9
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: default
-    metrics:
-    - name: gen_ai.client.operation.duration
-      description: GenAI operation duration.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-    - name: gen_ai.client.token.usage
-      description: Measures number of input and output tokens used.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{token}'
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.token.type
-        type: STRING
+    metric_refs:
+    - gen_ai.client.operation.duration-d420df10
+    - gen_ai.client.token.usage-9c41606c
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3058,19 +3567,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3122,10 +3620,6 @@ libraries:
         type: STRING
       - name: aws.step_functions.state_machine.arn
         type: STRING
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.system.name
@@ -3282,48 +3776,13 @@ libraries:
   - com.mchange:c3p0:(,)
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.pending_requests-a0698f55
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.pending_requests-a0f41111
 - name: camel-2.20
   display_name: Apache Camel
   description: |
@@ -3342,13 +3801,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.camel:camel-core:[2.19,3)
-  configurations:
-  - name: otel.instrumentation.camel.experimental-span-attributes
-    declarative_name: java.camel.experimental_span_attributes/development
-    description: |
-      Enable the capture of experimental `camel.uri`, `camel.kafka.partitionKey`, `camel.kafka.key` and `camel.kafka.offset` span attributes.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.camel.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -3500,18 +3954,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.datastax.cassandra:cassandra-driver-core:[3.0,4.0)
-  configurations:
-  - name: otel.instrumentation.cassandra.query-sanitization.enabled
-    declarative_name: java.cassandra.query_sanitization.enabled
-    description: |
-      Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.cassandra.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -3538,39 +3983,12 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-88382861
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.collection.name
-        type: STRING
       - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -3600,12 +4018,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.datastax.oss:java-driver-core:[4.0,4.4)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -3644,29 +4058,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-88382861
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3682,13 +4075,7 @@ libraries:
         type: BOOLEAN
       - name: cassandra.speculative_execution.count
         type: LONG
-      - name: db.collection.name
-        type: STRING
       - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -3720,18 +4107,9 @@ libraries:
   javaagent_target_versions:
   - com.datastax.oss:java-driver-core:[4.4,)
   - org.apache.cassandra:java-driver-core:(,)
-  configurations:
-  - name: otel.instrumentation.cassandra.query-sanitization.enabled
-    declarative_name: java.cassandra.query_sanitization.enabled
-    description: |
-      Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.cassandra.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -3770,29 +4148,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-88382861
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3808,13 +4165,7 @@ libraries:
         type: BOOLEAN
       - name: cassandra.speculative_execution.count
         type: LONG
-      - name: db.collection.name
-        type: STRING
       - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -3844,12 +4195,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.clickhouse:clickhouse-client:[0.5.0,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -3868,23 +4215,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3916,12 +4248,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.clickhouse:client-v2:[0.6.4,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -3940,23 +4268,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3988,18 +4301,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[2,3)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.couchbase.experimental-span-attributes-a850037a
   telemetry:
   - when: default
     spans:
@@ -4014,17 +4318,8 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4052,18 +4347,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[2.6.0,3)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.couchbase.experimental-span-attributes-a850037a
   telemetry:
   - when: default
     spans:
@@ -4106,21 +4392,8 @@ libraries:
       - name: network.type
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-7714cbf7
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4153,13 +4426,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.1,3.1.6)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying
-      Couchbase library.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
   telemetry:
   - when: default
     spans:
@@ -4193,48 +4461,6 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.couchbase.local_id
-        type: STRING
-      - name: db.couchbase.operation_id
-        type: LONG
-      - name: db.couchbase.scope
-        type: STRING
-      - name: db.couchbase.server_duration
-        type: LONG
-      - name: db.couchbase.service
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
 - name: couchbase-3.1.6
   display_name: Couchbase Client
   description: |
@@ -4250,13 +4476,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.1.6,3.2.0)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying
-      Couchbase library.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
   telemetry:
   - when: default
     spans:
@@ -4292,50 +4513,6 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.couchbase.local_id
-        type: STRING
-      - name: db.couchbase.operation_id
-        type: LONG
-      - name: db.couchbase.retries
-        type: LONG
-      - name: db.couchbase.scope
-        type: STRING
-      - name: db.couchbase.server_duration
-        type: LONG
-      - name: db.couchbase.service
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
 - name: couchbase-3.2
   display_name: Couchbase Client
   description: |
@@ -4351,13 +4528,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.2.0,3.4.0)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying
-      Couchbase library.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
   telemetry:
   - when: default
     spans:
@@ -4395,52 +4567,6 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.couchbase.document_id
-        type: STRING
-      - name: db.couchbase.local_id
-        type: STRING
-      - name: db.couchbase.operation_id
-        type: LONG
-      - name: db.couchbase.retries
-        type: LONG
-      - name: db.couchbase.scope
-        type: STRING
-      - name: db.couchbase.server_duration
-        type: LONG
-      - name: db.couchbase.service
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
 - name: couchbase-3.4
   display_name: Couchbase Client
   description: |
@@ -4456,13 +4582,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.4.0,)
-  configurations:
-  - name: otel.instrumentation.couchbase.experimental-span-attributes
-    declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying
-      Couchbase library.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
   telemetry:
   - when: default
     spans:
@@ -4500,52 +4621,6 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.couchbase.document_id
-        type: STRING
-      - name: db.couchbase.local_id
-        type: STRING
-      - name: db.couchbase.operation_id
-        type: LONG
-      - name: db.couchbase.retries
-        type: LONG
-      - name: db.couchbase.scope
-        type: STRING
-      - name: db.couchbase.server_duration
-        type: LONG
-      - name: db.couchbase.service
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
 - name: dropwizard-metrics-4.0
   display_name: Dropwizard Metrics
   description: |
@@ -4559,12 +4634,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.dropwizard.metrics:metrics-core:[4.0.0,)
-  configurations:
-  - name: otel.instrumentation.dropwizard-metrics.enabled
-    declarative_name: java.dropwizard_metrics.enabled
-    description: Enables the dropwizard metrics instrumentation.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.dropwizard-metrics.enabled
 - name: dropwizard-views-0.7
   display_name: Dropwizard Views
   description: |
@@ -4578,12 +4649,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.dropwizard:dropwizard-views:(,3.0.0)
-  configurations:
-  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    declarative_name: java.common.view_telemetry/development.enabled
-    description: Enables the creation of experimental view spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.common.experimental.view-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -4601,62 +4668,6 @@ libraries:
   javaagent_target_versions:
   - co.elastic.clients:elasticsearch-java:[7.16,7.17.20)
   - co.elastic.clients:elasticsearch-java:[8.0.0,8.10)
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.elasticsearch.path_parts.id
-        type: STRING
-      - name: db.elasticsearch.path_parts.index
-        type: STRING
-      - name: db.operation
-        type: STRING
-      - name: db.system
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.elasticsearch.path_parts.id
-        type: STRING
-      - name: db.elasticsearch.path_parts.index
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
 - name: elasticsearch-rest-5.0
   display_name: Elasticsearch REST Client
   description: This instrumentation enables database client spans and database client
@@ -4672,19 +4683,9 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[5.0,6.4)
   - org.elasticsearch.client:rest:[5.0,6.4)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.capture-search-query
-    declarative_name: java.elasticsearch.capture_search_query
-    description: |
-      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - otel.instrumentation.elasticsearch.capture-search-query
   telemetry:
   - when: default
     spans:
@@ -4701,19 +4702,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-4f486dc3
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4741,19 +4731,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[6.4,7.0)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.capture-search-query
-    declarative_name: java.elasticsearch.capture_search_query
-    description: |
-      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - otel.instrumentation.elasticsearch.capture-search-query
   telemetry:
   - when: default
     spans:
@@ -4770,19 +4750,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-4f486dc3
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4811,19 +4780,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[7.0,)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.capture-search-query
-    declarative_name: java.elasticsearch.capture_search_query
-    description: |
-      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - otel.instrumentation.elasticsearch.capture-search-query
   telemetry:
   - when: default
     spans:
@@ -4840,19 +4799,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-4f486dc3
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4881,13 +4829,8 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[5.0.0,5.3.0)
   - org.elasticsearch:elasticsearch:[5.0.0,5.3.0)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
-    declarative_name: java.elasticsearch.experimental_span_attributes/development
-    description: |
-      Enable the capture of the experimental span attributes `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.elasticsearch.experimental-span-attributes-ee0c671a
   telemetry:
   - when: default
     spans:
@@ -4936,17 +4879,8 @@ libraries:
       - name: network.peer.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4975,13 +4909,8 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[5.3.0,6.0.0)
   - org.elasticsearch:elasticsearch:[5.3.0,6.0.0)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
-    declarative_name: java.elasticsearch.experimental_span_attributes/development
-    description: |
-      Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.search.types`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.broadcast.failed`, `elasticsearch.shard.broadcast.successful`, `elasticsearch.shard.broadcast.total`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.elasticsearch.experimental-span-attributes-4728abdb
   telemetry:
   - when: default
     spans:
@@ -5040,17 +4969,8 @@ libraries:
       - name: network.peer.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5079,13 +4999,8 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[6.0.0,)
   - org.elasticsearch:elasticsearch:[6.0.0,8.0.0)
-  configurations:
-  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
-    declarative_name: java.elasticsearch.experimental_span_attributes/development
-    description: |
-      Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.elasticsearch.experimental-span-attributes-df937525
   telemetry:
   - when: default
     spans:
@@ -5140,17 +5055,8 @@ libraries:
       - name: network.type
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5177,20 +5083,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.executors.include
-    declarative_name: java.executors.include
-    description: List of Executor subclasses to be instrumented.
-    type: list
-    default: ''
-    examples:
-    - com.example.CustomExecutor
-    - com.example.ExecutorOne,com.example.ExecutorTwo
-  - name: otel.instrumentation.executors.include-all
-    declarative_name: java.executors.include_all
-    description: Whether to instrument all classes that implement the Executor interface.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.executors.include
+  - otel.instrumentation.executors.include-all
 - name: failsafe-3.0
   display_name: Failsafe
   description: This standalone instrumentation enables metrics for Failsafe circuit
@@ -5202,48 +5097,11 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: failsafe.circuit_breaker.execution.count
-      description: Count of circuit breaker executions.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.circuit_breaker.name
-        type: STRING
-      - name: failsafe.circuit_breaker.outcome
-        type: STRING
-    - name: failsafe.circuit_breaker.state_change.count
-      description: Count of circuit breaker state changes.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.circuit_breaker.name
-        type: STRING
-      - name: failsafe.circuit_breaker.state
-        type: STRING
-    - name: failsafe.retry_policy.attempts
-      description: Number of attempts for each execution.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{attempt}'
-      attributes:
-      - name: failsafe.retry_policy.name
-        type: STRING
-      - name: failsafe.retry_policy.outcome
-        type: STRING
-    - name: failsafe.retry_policy.execution.count
-      description: Count of execution attempts processed by the retry policy, where
-        one execution represents the total number of attempts.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.retry_policy.name
-        type: STRING
-      - name: failsafe.retry_policy.outcome
-        type: STRING
+    metric_refs:
+    - failsafe.circuit_breaker.execution.count-9271cf8d
+    - failsafe.circuit_breaker.state_change.count-09bbffb6
+    - failsafe.retry_policy.attempts-cc34346c
+    - failsafe.retry_policy.execution.count-d01cba44
 - name: finagle-http-23.11
   display_name: Finagle HTTP
   description: |
@@ -5273,12 +5131,8 @@ libraries:
   javaagent_target_versions:
   - com.twitter:finatra-http_2.11:[2.9.0,]
   - com.twitter:finatra-http_2.12:[2.9.0,]
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -5302,12 +5156,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.geode:geode-core:[1.4.0,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -5322,23 +5172,12 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-39ae058b
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.collection.name
+      - name: db.namespace
         type: STRING
       - name: db.operation.name
         type: STRING
@@ -5361,93 +5200,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.google.http-client:google-http-client:[1.19.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5465,39 +5229,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
 - name: grails-3.0
   display_name: Grails
   description: |
@@ -5512,12 +5243,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.grails:grails-web-url-mappings:[3.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -5540,24 +5267,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.graphql-java:graphql-java:[12,20)
-  configurations:
-  - name: otel.instrumentation.graphql.capture-query
-    declarative_name: java.graphql.capture_query
-    description: Whether to capture the query in `graphql.document` span attribute.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.graphql.query-sanitization.enabled
-    declarative_name: java.graphql.query_sanitization.enabled
-    description: Enables sanitization of sensitive information from queries so they
-      aren't added as span attributes.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
-    declarative_name: java.graphql.operation_name_in_span_name.enabled
-    description: |
-      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.graphql.capture-query
+  - otel.instrumentation.graphql.operation-name-in-span-name.enabled
+  - otel.instrumentation.graphql.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -5582,35 +5295,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.graphql-java:graphql-java:[20,)
-  configurations:
-  - name: otel.instrumentation.graphql.capture-query
-    declarative_name: java.graphql.capture_query
-    description: Whether to capture the query in `graphql.document` span attribute.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.graphql.query-sanitization.enabled
-    declarative_name: java.graphql.query_sanitization.enabled
-    description: Enables sanitization of sensitive information from queries so they
-      aren't added as span attributes.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
-    declarative_name: java.graphql.operation_name_in_span_name.enabled
-    description: |
-      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.graphql.data-fetcher.enabled
-    declarative_name: java.graphql.data_fetcher.enabled
-    description: Enables span generation for data fetchers.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
-    declarative_name: java.graphql.trivial_data_fetcher.enabled
-    description: Whether to create spans for trivial data fetchers. A trivial data
-      fetcher is one that simply maps data from an object to a field.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.graphql.capture-query
+  - otel.instrumentation.graphql.data-fetcher.enabled
+  - otel.instrumentation.graphql.operation-name-in-span-name.enabled
+  - otel.instrumentation.graphql.query-sanitization.enabled
+  - otel.instrumentation.graphql.trivial-data-fetcher.enabled
   telemetry:
   - when: default
     spans:
@@ -5651,46 +5341,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish.grizzly:grizzly-http:[2.3,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -5739,151 +5398,20 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.grpc:grpc-core:[1.6.0,)
-  configurations:
-  - name: otel.instrumentation.grpc.emit-message-events
-    declarative_name: java.grpc.emit_message_events
-    description: Determines whether to emit a span event for each individual message
-      received and sent.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.grpc.experimental-span-attributes
-    declarative_name: java.grpc.experimental_span_attributes/development
-    description: |
-      Enable the capture of experimental span attributes `grpc.received.message_count`, `grpc.sent.message_count` and `grpc.canceled`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.grpc.capture-metadata.client.request
-    declarative_name: java.grpc.capture_metadata.client.request
-    description: |
-      A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes.
-    type: list
-    default: ''
-    examples:
-    - custom-request-header
-    - my-metadata-key,another-metadata-key
-  - name: otel.instrumentation.grpc.capture-metadata.server.request
-    declarative_name: java.grpc.capture_metadata.server.request
-    description: |
-      A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.instrumentation.grpc.capture-metadata.client.request
+  - otel.instrumentation.grpc.capture-metadata.server.request
+  - otel.instrumentation.grpc.emit-message-events
+  - otel.instrumentation.grpc.experimental-span-attributes
   telemetry:
   - when: default
-    metrics:
-    - name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.client.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.client.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - rpc.client.duration-599bf562
+    - rpc.client.request.size-0d8f967b
+    - rpc.client.response.size-d0124e0e
+    - rpc.server.duration-83a39fb3
+    - rpc.server.request.size-75ef4f8e
+    - rpc.server.response.size-fb45af0b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5920,121 +5448,13 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.instrumentation.grpc.experimental-span-attributes=true
-    metrics:
-    - name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.client.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.client.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - rpc.client.duration-599bf562
+    - rpc.client.request.size-0d8f967b
+    - rpc.client.response.size-d0124e0e
+    - rpc.server.duration-83a39fb3
+    - rpc.server.request.size-75ef4f8e
+    - rpc.server.response.size-fb45af0b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6079,39 +5499,9 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=rpc
-    metrics:
-    - name: rpc.client.call.duration
-      description: Measures the duration of outbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.response.status_code
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.call.duration
-      description: Measures the duration of inbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.response.status_code
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - rpc.client.call.duration-7381532d
+    - rpc.server.call.duration-1e979856
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6161,13 +5551,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.google.guava:guava:[10.0,]
-  configurations:
-  - name: otel.instrumentation.guava.experimental-span-attributes
-    declarative_name: java.guava.experimental_span_attributes/development
-    description: Enables experimental span attribute `guava.canceled` for cancelled
-      operations.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.guava.experimental-span-attributes
 - name: gwt-2.0
   display_name: GWT
   description: This instrumentation enables RPC server spans for GWT RPC requests.
@@ -6205,7 +5590,7 @@ libraries:
     name: io.opentelemetry.hbase-client-1.4
   has_javaagent: true
   javaagent_target_versions:
-  - org.apache.hbase:hbase-client:[1.4.0, 2.0.0)
+  - org.apache.hbase:hbase-client:[1.4.0,2.0.0)
 - name: hbase-client-2.0
   display_name: HBase Client
   description: |
@@ -6220,62 +5605,6 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.hbase:hbase-client:[2.0.0, 2.5.0)
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.name
-        type: STRING
-      - name: db.operation
-        type: STRING
-      - name: db.system
-        type: STRING
-      - name: db.user
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
 - name: helidon-4.3
   display_name: Helidon
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -6295,48 +5624,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.helidon.webserver:helidon-webserver:[4.3.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -6378,23 +5674,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[3.3.0.GA,4.0.0.Final)
-  configurations:
-  - name: otel.instrumentation.hibernate.experimental-span-attributes
-    declarative_name: java.hibernate.experimental_span_attributes/development
-    description: Enables the experimental `hibernate.session_id` span attribute.
-    type: boolean
-    default: false
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: INTERNAL
-      attributes: []
-  - when: otel.instrumentation.hibernate.experimental-span-attributes=true
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: hibernate.session_id
-        type: STRING
+  configuration_refs:
+  - otel.instrumentation.hibernate.experimental-span-attributes
 - name: hibernate-4.0
   display_name: Hibernate
   description: This instrumentation enables spans for Hibernate ORM operations.
@@ -6405,12 +5686,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[4.0.0.Final,6)
-  configurations:
-  - name: otel.instrumentation.hibernate.experimental-span-attributes
-    declarative_name: java.hibernate.experimental_span_attributes/development
-    description: Enables the experimental `hibernate.session_id` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.hibernate.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -6433,17 +5710,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate.orm:hibernate-core:[6.0.0.Final,)
-  configurations:
-  - name: otel.instrumentation.hibernate.experimental-span-attributes
-    declarative_name: java.hibernate.experimental_span_attributes/development
-    description: Enables the experimental `hibernate.session_id` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.hibernate.experimental-span-attributes
   telemetry:
-  - when: default
-    spans:
-    - span_kind: INTERNAL
-      attributes: []
   - when: otel.instrumentation.hibernate.experimental-span-attributes=true
     spans:
     - span_kind: INTERNAL
@@ -6460,12 +5729,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[4.3.0.Final,)
-  configurations:
-  - name: otel.instrumentation.hibernate.experimental-span-attributes
-    declarative_name: java.hibernate.experimental_span_attributes/development
-    description: Enables the experimental `hibernate.session_id` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.hibernate.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -6505,148 +5770,25 @@ libraries:
   - com.zaxxer:HikariCP:[3.0.0,)
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.create_time
-      description: The time it took to create a new connection.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.timeouts
-      description: The number of connection timeouts that have occurred trying to
-        obtain a connection from the pool.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{timeouts}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
-    - name: db.client.connections.use_time
-      description: The time between borrowing a connection and returning it to the
-        pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.wait_time
-      description: The time it took to obtain an open connection from the pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connections.create_time-6f641171
+    - db.client.connections.idle.min-f04d4083
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.pending_requests-a0698f55
+    - db.client.connections.timeouts-b32b8a2b
+    - db.client.connections.usage-5ef1d5ef
+    - db.client.connections.use_time-cb3aefff
+    - db.client.connections.wait_time-e6bdd10e
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.create_time
-      description: The time it took to create a new connection.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.timeouts
-      description: The number of connection timeouts that have occurred trying to
-        obtain a connection from the pool.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{timeout}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.use_time
-      description: The time between borrowing a connection and returning it to the
-        pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.wait_time
-      description: The time it took to obtain an open connection from the pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.create_time-4f586679
+    - db.client.connection.idle.min-73bdafbc
+    - db.client.connection.max-c7917942
+    - db.client.connection.pending_requests-a0f41111
+    - db.client.connection.timeouts-d2dbfa58
+    - db.client.connection.use_time-a06760eb
+    - db.client.connection.wait_time-40a55682
 - name: http-url-connection
   display_name: HttpURLConnection
   description: |
@@ -6662,132 +5804,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
-  - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6818,13 +5846,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.netflix.hystrix:hystrix-core:[1.4.0,)
-  configurations:
-  - name: otel.instrumentation.hystrix.experimental-span-attributes
-    declarative_name: java.hystrix.experimental_span_attributes/development
-    description: Enables capturing the experimental `hystrix.command`, `hystrix.circuit_open`
-      and `hystrix.group` span attributes.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.hystrix.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -6851,87 +5874,14 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: iceberg.scan.data_files.count
-      description: The number of data files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.data_files.size
-      description: The total size of all scanned data files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.data_manifests.count
-      description: The number of data manifests.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.delete_files.count
-      description: The number of delete files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.delete_file.type
-        type: STRING
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.delete_files.size
-      description: The total size of all scanned delete files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.delete_manifests.count
-      description: The number of delete manifests.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    - name: iceberg.scan.planning.duration
-      description: The total duration needed to plan the scan.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
+    metric_refs:
+    - iceberg.scan.data_files.count-7869922f
+    - iceberg.scan.data_files.size-25d28777
+    - iceberg.scan.data_manifests.count-91f2a926
+    - iceberg.scan.delete_files.count-2ce39a8f
+    - iceberg.scan.delete_files.size-c63edff8
+    - iceberg.scan.delete_manifests.count-304a613c
+    - iceberg.scan.planning.duration-6654a71a
 - name: influxdb-2.4
   display_name: InfluxDB Client
   description: This instrumentation enables database client spans and metrics for
@@ -6946,12 +5896,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.influxdb:influxdb-java:[2.4,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables or disables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -6970,23 +5916,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7021,95 +5952,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 11+
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7131,45 +5985,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
 - name: java-http-server
   display_name: Java HTTP Server
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -7186,67 +6001,16 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -7289,13 +6053,10 @@ libraries:
   scope:
     name: io.opentelemetry.java-util-logging
   has_javaagent: true
-  configurations:
-  - name: otel.instrumentation.java-util-logging.experimental-log-attributes
-    declarative_name: java.java_util_logging.experimental_log_attributes/development
-    description: Enables capturing the experimental `thread.name` and `thread.id`
-      log attributes.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.java-util-logging.experimental-log-attributes
+  - otel.instrumentation.java-util-logging.experimental.capture-arguments
+  - otel.instrumentation.java-util-logging.experimental.capture-template
 - name: javalin-5.0
   display_name: Javalin
   description: This instrumentation enriches existing HTTP server spans with route
@@ -7339,12 +6100,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.ws.rs:jsr311-api:[0.5,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7369,17 +6126,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.ws.rs:javax.ws.rs-api:[,]
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7404,17 +6153,9 @@ libraries:
   javaagent_target_versions:
   - org.apache.cxf:cxf-rt-frontend-jaxrs:[3.2,4)
   - org.apache.tomee:openejb-cxf-rs:(8,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7449,17 +6190,9 @@ libraries:
   javaagent_target_versions:
   - org.glassfish.jersey.containers:jersey-container-servlet:[2.0,3.0.0)
   - org.glassfish.jersey.core:jersey-server:[2.0,3.0.0)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7494,17 +6227,9 @@ libraries:
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-jaxrs:[3.0.0.Final,3.1.0.Final)
   - org.jboss.resteasy:resteasy-jaxrs:[3.5.0.Final,4)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7539,17 +6264,9 @@ libraries:
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-core:[4.0.0.Final,6)
   - org.jboss.resteasy:resteasy-jaxrs:[3.1.0.Final,3.5.0.Final)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7584,17 +6301,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.ws.rs:jakarta.ws.rs-api:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7619,17 +6328,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish.jersey.core:jersey-server:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -7664,17 +6365,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-core:[6.0.0.Final,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jaxrs.experimental-span-attributes
-    declarative_name: java.jaxrs.experimental_span_attributes/development
-    description: Enables the experimental `jaxrs.canceled` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.jaxrs.experimental-span-attributes
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7707,12 +6400,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.xml.ws:jaxws-api:[2.0,]
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7736,12 +6425,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.axis2:axis2-jaxws:[1.6.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7761,12 +6446,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.cxf:cxf-rt-frontend-jaxws:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
 - name: jaxws-2.0-metro-2.2
   display_name: Metro JAX-WS
   description: |
@@ -7781,12 +6462,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.sun.xml.ws:jaxws-rt:[2.2,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+- name: jaxws-cxf-3.0
+  source_path: instrumentation/jaxws/jaxws-cxf-3.0
+  scope:
+    name: io.opentelemetry.jaxws-cxf-3.0
+  telemetry:
+  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+    spans:
+    - span_kind: INTERNAL
+      attributes: []
 - name: jaxws-jws-api-1.1
   display_name: JWS API
   description: |
@@ -7801,12 +6487,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.jws:javax.jws-api:[1.1,]
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7816,6 +6498,15 @@ libraries:
         type: STRING
       - name: code.namespace
         type: STRING
+- name: jaxws-metro-2.2
+  source_path: instrumentation/jaxws/jaxws-metro-2.2
+  scope:
+    name: io.opentelemetry.jaxws-metro-2.2
+  telemetry:
+  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+    spans:
+    - span_kind: INTERNAL
+      attributes: []
 - name: jboss-logmanager-appender-1.1
   display_name: JBoss Log Manager
   description: |
@@ -7829,22 +6520,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jboss.logmanager:jboss-logmanager:[1.1.0.GA,)
-  configurations:
-  - name: otel.instrumentation.jboss-logmanager.experimental-log-attributes
-    declarative_name: java.jboss_logmanager.experimental_log_attributes/development
-    description: |
-      Enables the capture of experimental log attributes, including thread name and thread ID.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
-    declarative_name: java.jboss_logmanager.capture_mdc_attributes/development
-    description: |
-      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-    type: list
-    default: ''
-    examples:
-    - custom-mdc-key
-    - key1,key2,key3
+  configuration_refs:
+  - otel.instrumentation.jboss-logmanager.experimental-log-attributes
+  - otel.instrumentation.jboss-logmanager.experimental.capture-arguments
+  - otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
+  - otel.instrumentation.jboss-logmanager.experimental.capture-template
 - name: jboss-logmanager-mdc-1.1
   display_name: JBoss Log Manager
   description: |
@@ -7871,144 +6551,14 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.jdbc.query-sanitization.enabled
-    declarative_name: java.jdbc.query_sanitization.enabled
-    description: Enables query sanitization for database queries. Takes precedence
-      over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.jdbc.experimental.transaction.enabled
-    declarative_name: java.jdbc.transaction/development.enabled
-    description: Enables experimental instrumentation to create spans for COMMIT and
-      ROLLBACK operations.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
-    declarative_name: java.jdbc.sqlcommenter/development.enabled
-    description: |
-      Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance. Consult with database experts before enabling.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.jdbc.experimental.capture-query-parameters
-    declarative_name: java.jdbc.capture_query_parameters/development
-    description: |
-      Sets whether the query parameters should be captured as span attributes named <code>db.query.parameter.&lt;key&gt;</code>. Enabling this option disables the statement sanitization.<p>WARNING: captured query parameters may contain sensitive information such as passwords, personally identifiable information or protected health info.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jdbc-datasource.enabled
-    declarative_name: java.jdbc_datasource.enabled
-    description: Enables instrumentation of JDBC datasource connections.
-    type: boolean
-    default: false
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.connection_string
-        type: STRING
-      - name: db.name
-        type: STRING
-      - name: db.operation
-        type: STRING
-      - name: db.sql.table
-        type: STRING
-      - name: db.statement
-        type: STRING
-      - name: db.system
-        type: STRING
-      - name: db.user
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-    - span_kind: INTERNAL
-      attributes:
-      - name: code.function
-        type: STRING
-      - name: code.namespace
-        type: STRING
-      - name: db.connection_string
-        type: STRING
-      - name: db.name
-        type: STRING
-      - name: db.system
-        type: STRING
-      - name: db.user
-        type: STRING
-  - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.query.text
-        type: STRING
-      - name: db.stored_procedure.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: service.peer.name
-        type: STRING
-    - span_kind: INTERNAL
-      attributes:
-      - name: code.function
-        type: STRING
-      - name: code.namespace
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.system.name
-        type: STRING
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
+  - otel.instrumentation.jdbc-datasource.enabled
+  - otel.instrumentation.jdbc.experimental.capture-query-parameters
+  - otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
+  - otel.instrumentation.jdbc.experimental.transaction.enabled
+  - otel.instrumentation.jdbc.query-sanitization.enabled
 - name: jedis-1.4
   display_name: Jedis
   description: This instrumentation enables database client spans and database client
@@ -8023,31 +6573,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[1.4.0,2.0.0)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
   telemetry:
   - when: default
     spans:
@@ -8066,21 +6594,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-32559b79
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8110,68 +6625,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[2.0.0,3.0.0)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: structured_list
-    default: ''
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation
-        type: STRING
-      - name: db.statement
-        type: STRING
-      - name: db.system
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.text
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
 - name: jedis-3.0
   display_name: Jedis
   description: This instrumentation enables database client spans and database client
@@ -8186,31 +6642,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[3.0.0,4)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
   telemetry:
   - when: default
     spans:
@@ -8235,30 +6669,11 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-bfd9d23c
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -8289,12 +6704,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[4.0.0-beta1,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -8312,39 +6723,12 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-7714cbf7
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -8354,10 +6738,6 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
         type: LONG
 - name: jetty-8.0
   display_name: Eclipse Jetty
@@ -8376,46 +6756,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[8.0.0.v20110901,11)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -8463,46 +6812,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[11, 12)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -8550,46 +6868,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[12,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -8637,95 +6924,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-client:[9.2,10)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8748,23 +6958,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8803,95 +6998,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-client:[12,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8914,23 +7032,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8966,12 +7069,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.jfinal:jfinal:[3.2,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -8996,19 +7095,9 @@ libraries:
   - jakarta.jms:jakarta.jms-api:(,3)
   - javax.jms:javax.jms-api:(,)
   - javax.jms:jms-api:(,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -9050,19 +7139,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.jms:jakarta.jms-api:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -9103,95 +7182,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jodd:jodd-http:[4.1.1,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9213,45 +7215,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
 - name: jsf-mojarra-1.2
   display_name: Eclipse Mojarra
   description: |
@@ -9269,12 +7232,8 @@ libraries:
   - javax.faces:jsf-impl:[1.2,2)
   - org.glassfish:jakarta.faces:[2.3.9,3)
   - org.glassfish:javax.faces:[2.0.7,3)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9294,12 +7253,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish:jakarta.faces:[3,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9318,12 +7273,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.myfaces.core:myfaces-impl:[1.2,3)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9343,12 +7294,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.myfaces.core:myfaces-impl:[3,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9367,18 +7314,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat:tomcat-jasper:[7.0.19,10)
-  configurations:
-  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    declarative_name: java.common.view_telemetry/development.enabled
-    description: Enables the creation of experimental view spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.jsp.experimental-span-attributes
-    declarative_name: java.jsp.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `jsp.forwardOrigin`, `jsp.requestURL`, `jsp.compiler`, and `jsp.classFQCN`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.common.experimental.view-telemetry.enabled
+  - otel.instrumentation.jsp.experimental-span-attributes
   telemetry:
   - when: otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -9409,164 +7347,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.kafka:kafka-clients:[0.11.0.0,)
-  configurations:
-  - name: otel.instrumentation.kafka.producer-propagation.enabled
-    declarative_name: java.kafka.producer_propagation.enabled
-    description: Enable context propagation for Kafka message producers.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.kafka.experimental-span-attributes
-    declarative_name: java.kafka.experimental_span_attributes/development
-    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
-      and `messaging.kafka.bootstrap.servers`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CONSUMER
-      attributes:
-      - name: messaging.batch.message_count
-        type: LONG
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.consumer.group
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.offset
-        type: LONG
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.message.body.size
-        type: LONG
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-    - span_kind: PRODUCER
-      attributes:
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.offset
-        type: LONG
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-  - when: otel.instrumentation.kafka.experimental-span-attributes=true
-    spans:
-    - span_kind: CONSUMER
-      attributes:
-      - name: kafka.record.queue_time_ms
-        type: LONG
-      - name: messaging.batch.message_count
-        type: LONG
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.consumer.group
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.offset
-        type: LONG
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.message.body.size
-        type: LONG
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-    - span_kind: PRODUCER
-      attributes:
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.bootstrap.servers
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.offset
-        type: LONG
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-  - when: otel.semconv-stability.opt-in=messaging
-    spans:
-    - span_kind: CONSUMER
-      attributes:
-      - name: messaging.batch.message_count
-        type: LONG
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.kafka.offset
-        type: LONG
-      - name: messaging.message.body.size
-        type: LONG
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-    - span_kind: PRODUCER
-      attributes:
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.tombstone
-        type: BOOLEAN
-      - name: messaging.kafka.offset
-        type: LONG
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
+  - otel.instrumentation.kafka.producer-propagation.enabled
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
 - name: kafka-clients-2.6
   display_name: Apache Kafka Client
   description: This standalone instrumentation enables messaging spans for Kafka producers
@@ -9663,24 +7448,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.kafka:kafka-streams:[0.11.0.0,)
-  configurations:
-  - name: otel.instrumentation.kafka.experimental-span-attributes
-    declarative_name: java.kafka.experimental_span_attributes/development
-    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
-      and `messaging.kafka.bootstrap.servers`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: default
     spans:
@@ -9771,23 +7542,8 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -9860,127 +7616,22 @@ libraries:
   javaagent_target_versions:
   - io.ktor:ktor-client-core:[2.0.0,3.0.0)
   - io.ktor:ktor-server-core:[2.0.0,3.0.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10073,127 +7724,22 @@ libraries:
   javaagent_target_versions:
   - io.ktor:ktor-client-core:[3.0.0,)
   - io.ktor:ktor-server-core:[3.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10246,65 +7792,11 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.instrumentation.http.server.emit-experimental-telemetry=true
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.active_requests
-      description: Number of active HTTP server requests.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    - name: http.server.response.body.size
-      description: Size of HTTP server response bodies.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.active_requests-2c1402e2
+    - http.server.request.duration-1f6f63ed
+    - http.server.response.body.size-9ece7062
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10371,99 +7863,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.kubernetes:client-java-api:[7.0.0,)
-  configurations:
-  - name: otel.instrumentation.kubernetes-client.experimental-span-attributes
-    declarative_name: java.kubernetes_client.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `kubernetes-client.namespace` and `kubernetes-client.name` for Kubernetes API requests.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - otel.instrumentation.kubernetes-client.experimental-span-attributes
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10482,21 +7894,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.instrumentation.kubernetes-client.experimental-span-attributes=true
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10518,39 +7917,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
 - name: lettuce-4.0
   display_name: Lettuce
   description: |
@@ -10565,36 +7931,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - biz.paluch.redis:lettuce:[4.0.Final,)
-  configurations:
-  - name: otel.instrumentation.lettuce.connection-telemetry.enabled
-    declarative_name: java.lettuce.connection_telemetry.enabled
-    description: Enables connection telemetry spans for Redis connections.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.lettuce.experimental-span-attributes
-    declarative_name: java.lettuce.experimental_span_attributes/development
-    description: Enables experimental span attribute `lettuce.command.cancelled`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.peer-service-mapping
+  - otel.instrumentation.lettuce.connection-telemetry.enabled
+  - otel.instrumentation.lettuce.experimental-span-attributes-48d10623
   telemetry:
   - when: default
     spans:
@@ -10627,22 +7967,11 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.system.name
@@ -10669,42 +7998,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.lettuce:lettuce-core:[5.0.0.RELEASE,5.1.0.RELEASE)
-  configurations:
-  - name: otel.instrumentation.lettuce.connection-telemetry.enabled
-    declarative_name: java.lettuce.connection_telemetry.enabled
-    description: Enables connection telemetry spans for Redis connections.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.lettuce.experimental-span-attributes
-    declarative_name: java.lettuce.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `lettuce.command.cancelled` and `lettuce.command.results.count`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
+  - otel.instrumentation.lettuce.connection-telemetry.enabled
+  - otel.instrumentation.lettuce.experimental-span-attributes-f6bf8fef
   telemetry:
   - when: default
     spans:
@@ -10715,37 +8013,6 @@ libraries:
       - name: db.statement
         type: STRING
       - name: db.system
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-  - when: otel.instrumentation.common.v3-preview=true
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation.batch.size
-        type: LONG
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.text
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: error.type
         type: STRING
       - name: peer.service
         type: STRING
@@ -10774,22 +8041,11 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -10819,18 +8075,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.lettuce:lettuce-core:[5.1.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
-    declarative_name: java.lettuce.command_encoding_events/development.enabled
-    description: Enables capturing `redis.encode.start` and `redis.encode.end` span
-      events.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
   telemetry:
   - when: default
     spans:
@@ -10854,45 +8101,6 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
-  - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.text
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
 - name: liberty-20.0
   display_name: Liberty
   description: |
@@ -10905,39 +8113,13 @@ libraries:
   scope:
     name: io.opentelemetry.liberty-20.0
   has_javaagent: true
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
 - name: liberty-dispatcher-20.0
   display_name: Liberty
   description: |
@@ -10950,29 +8132,11 @@ libraries:
   scope:
     name: io.opentelemetry.liberty-dispatcher-20.0
   has_javaagent: true
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
 - name: log4j-appender-1.2
   display_name: Log4j
   description: |
@@ -10986,28 +8150,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - log4j:log4j:[1.2,)
-  configurations:
-  - name: otel.instrumentation.log4j-appender.experimental-log-attributes
-    declarative_name: java.log4j_appender.experimental_log_attributes/development
-    description: |
-      Enables the capture of experimental log attributes, including thread name and thread ID.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
-    declarative_name: java.log4j_appender.capture_mdc_attributes/development
-    description: |
-      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-    type: list
-    default: ''
-    examples:
-    - custom-mdc-key
-    - key1,key2,key3
-  - name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
-    declarative_name: java.log4j_appender.capture_code_attributes/development
-    description: |
-      Enables the capture of code location attributes, including file path, class name, method name, and line number.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.log4j-appender.experimental-log-attributes
+  - otel.instrumentation.log4j-appender.experimental.capture-code-attributes
+  - otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-436113d6
 - name: log4j-appender-2.17
   display_name: Log4j
   description: |
@@ -11022,40 +8168,14 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.0,)
-  configurations:
-  - name: otel.instrumentation.log4j-appender.experimental-log-attributes
-    declarative_name: java.log4j_appender.experimental_log_attributes/development
-    description: |
-      Enables the capture of experimental log attributes, including thread name and thread ID.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
-    declarative_name: java.log4j_appender.capture_code_attributes/development
-    description: |
-      Enables the capture of code location attributes, including file path, class name, method name, and line number.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
-    declarative_name: java.log4j_appender.capture_map_message_attributes/development
-    description: |
-      Enables the capture of attributes from Log4j MapMessage instances.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
-    declarative_name: java.log4j_appender.capture_marker_attribute/development
-    description: |
-      Enables the capture of the Log4j marker attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
-    declarative_name: java.log4j_appender.capture_mdc_attributes/development
-    description: |
-      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-    type: list
-    default: ''
-    examples:
-    - '*'
-    - key1,key2
+  configuration_refs:
+  - otel.instrumentation.log4j-appender.experimental-log-attributes
+  - otel.instrumentation.log4j-appender.experimental.capture-arguments
+  - otel.instrumentation.log4j-appender.experimental.capture-code-attributes
+  - otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
+  - otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
+  - otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-e8e19d91
+  - otel.instrumentation.log4j-appender.experimental.capture-template
 - name: log4j-context-data-2.7
   display_name: Log4j
   description: |
@@ -11067,37 +8187,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.7,2.17.0)
-  configurations:
-  - name: otel.instrumentation.log4j-context-data.add-baggage
-    declarative_name: java.log4j_context_data.add_baggage
-    description: |
-      Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.logging.trace-id-key
-    declarative_name: java.common.logging.trace_id_key
-    description: |
-      Specifies the key name used to store the trace ID in the logging context.
-    type: string
-    default: trace_id
-  - name: otel.instrumentation.common.logging.span-id-key
-    declarative_name: java.common.logging.span_id_key
-    description: |
-      Specifies the key name used to store the span ID in the logging context.
-    type: string
-    default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags-key
-    declarative_name: java.common.logging.trace_flags_key
-    description: |
-      Specifies the key name used to store the trace flags in the logging context.
-    type: string
-    default: trace_flags
-  - name: otel.instrumentation.common.mdc.resource-attributes
-    declarative_name: java.common.mdc.resource_attributes
-    description: |
-      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.instrumentation.common.logging.span-id-key
+  - otel.instrumentation.common.logging.trace-flags-key
+  - otel.instrumentation.common.logging.trace-id-key
+  - otel.instrumentation.common.mdc.resource-attributes
+  - otel.instrumentation.log4j-context-data.add-baggage
 - name: log4j-context-data-2.17
   display_name: Log4j
   description: |
@@ -11109,37 +8204,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.17.0,)
-  configurations:
-  - name: otel.instrumentation.log4j-context-data.add-baggage
-    declarative_name: java.log4j_context_data.add_baggage
-    description: |
-      Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.logging.trace-id-key
-    declarative_name: java.common.logging.trace_id_key
-    description: |
-      Specifies the key name used to store the trace ID in the logging context.
-    type: string
-    default: trace_id
-  - name: otel.instrumentation.common.logging.span-id-key
-    declarative_name: java.common.logging.span_id_key
-    description: |
-      Specifies the key name used to store the span ID in the logging context.
-    type: string
-    default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags-key
-    declarative_name: java.common.logging.trace_flags_key
-    description: |
-      Specifies the key name used to store the trace flags in the logging context.
-    type: string
-    default: trace_flags
-  - name: otel.instrumentation.common.mdc.resource-attributes
-    declarative_name: java.common.mdc.resource_attributes
-    description: |
-      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.instrumentation.common.logging.span-id-key
+  - otel.instrumentation.common.logging.trace-flags-key
+  - otel.instrumentation.common.logging.trace-id-key
+  - otel.instrumentation.common.mdc.resource-attributes
+  - otel.instrumentation.log4j-context-data.add-baggage
 - name: log4j-mdc-1.2
   display_name: Log4j
   description: |
@@ -11151,31 +8221,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - log4j:log4j:[1.2,)
-  configurations:
-  - name: otel.instrumentation.common.logging.trace-id-key
-    declarative_name: java.common.logging.trace_id_key
-    description: |
-      Specifies the key name used to store the trace ID in the logging context.
-    type: string
-    default: trace_id
-  - name: otel.instrumentation.common.logging.span-id-key
-    declarative_name: java.common.logging.span_id_key
-    description: |
-      Specifies the key name used to store the span ID in the logging context.
-    type: string
-    default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags-key
-    declarative_name: java.common.logging.trace_flags_key
-    description: |
-      Specifies the key name used to store the trace flags in the logging context.
-    type: string
-    default: trace_flags
-  - name: otel.instrumentation.common.mdc.resource-attributes
-    declarative_name: java.common.mdc.resource_attributes
-    description: |
-      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.instrumentation.common.logging.span-id-key
+  - otel.instrumentation.common.logging.trace-flags-key
+  - otel.instrumentation.common.logging.trace-id-key
+  - otel.instrumentation.common.mdc.resource-attributes
 - name: logback-appender-1.0
   display_name: Logback
   description: |
@@ -11190,70 +8240,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - ch.qos.logback:logback-classic:[0.9.16,)
-  configurations:
-  - name: otel.instrumentation.logback-appender.experimental-log-attributes
-    declarative_name: java.logback_appender.experimental_log_attributes/development
-    description: |
-      Enables the capture of experimental log attributes, including thread name and thread ID.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-code-attributes
-    declarative_name: java.logback_appender.capture_code_attributes/development
-    description: |
-      Enables the capture of code location attributes, including file path, class name, method name, and line number.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
-    declarative_name: java.logback_appender.capture_marker_attribute/development
-    description: |
-      Enables the capture of the Logback marker attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
-    declarative_name: java.logback_appender.capture_key_value_pair_attributes/development
-    description: |
-      Enables the capture of attributes from Logback key-value pairs.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
-    declarative_name: java.logback_appender.capture_logger_context_attributes/development
-    description: |
-      Enables the capture of attributes from the Logback logger context.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-template
-    declarative_name: java.logback_appender.capture_template/development
-    description: |
-      Enables the capture of the log message template before parameter substitution.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-arguments
-    declarative_name: java.logback_appender.capture_arguments/development
-    description: |
-      Enables the capture of log message arguments as separate attributes.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
-    declarative_name: java.logback_appender.capture_logstash_marker_attributes/development
-    description: |
-      Enables the capture of attributes from Logstash markers.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
-    declarative_name: java.logback_appender.capture_logstash_structured_arguments/development
-    description: |
-      Enables the capture of attributes from Logstash structured arguments.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
-    declarative_name: java.logback_appender.capture_mdc_attributes/development
-    description: |
-      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-    type: list
-    default: ''
-    examples:
-    - custom-mdc-key
-    - key1,key2,key3
+  configuration_refs:
+  - otel.instrumentation.logback-appender.experimental-log-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-arguments
+  - otel.instrumentation.logback-appender.experimental.capture-code-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
+  - otel.instrumentation.logback-appender.experimental.capture-marker-attribute
+  - otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
+  - otel.instrumentation.logback-appender.experimental.capture-template
 - name: logback-mdc-1.0
   display_name: Logback
   description: |
@@ -11266,37 +8263,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - ch.qos.logback:logback-classic:[1.0.0,1.2.3]
-  configurations:
-  - name: otel.instrumentation.logback-mdc.add-baggage
-    declarative_name: java.logback_mdc.add_baggage
-    description: |
-      Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.logging.trace-id-key
-    declarative_name: java.common.logging.trace_id_key
-    description: |
-      Specifies the key name used to store the trace ID in the logging context.
-    type: string
-    default: trace_id
-  - name: otel.instrumentation.common.logging.span-id-key
-    declarative_name: java.common.logging.span_id_key
-    description: |
-      Specifies the key name used to store the span ID in the logging context.
-    type: string
-    default: span_id
-  - name: otel.instrumentation.common.logging.trace-flags-key
-    declarative_name: java.common.logging.trace_flags_key
-    description: |
-      Specifies the key name used to store the trace flags in the logging context.
-    type: string
-    default: trace_flags
-  - name: otel.instrumentation.common.mdc.resource-attributes
-    declarative_name: java.common.mdc.resource_attributes
-    description: |
-      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.instrumentation.common.logging.span-id-key
+  - otel.instrumentation.common.logging.trace-flags-key
+  - otel.instrumentation.common.logging.trace-id-key
+  - otel.instrumentation.common.mdc.resource-attributes
+  - otel.instrumentation.logback-mdc.add-baggage
 - name: micrometer-1.5
   display_name: Micrometer
   description: |
@@ -11310,28 +8282,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.micrometer:micrometer-core:[1.5.0,)
-  configurations:
-  - name: otel.instrumentation.micrometer.prometheus-mode.enabled
-    declarative_name: java.micrometer.prometheus_mode.enabled
-    description: |
-      Simulates the behavior of Micrometer's PrometheusMeterRegistry. The instruments will be renamed to match Micrometer instrument naming, and the base time unit will be set to seconds.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.micrometer.base-time-unit
-    declarative_name: java.micrometer.base_time_unit
-    description: |
-      Sets the base time unit for the OpenTelemetry MeterRegistry. Supported values: ns, us, ms, s, min, h, d.
-    type: string
-    default: s
-    examples:
-    - ns
-    - milliseconds
-  - name: otel.instrumentation.micrometer.histogram-gauges.enabled
-    declarative_name: java.micrometer.histogram_gauges.enabled
-    description: |
-      Enables gauge-based Micrometer histograms for DistributionSummary and Timer instruments.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.micrometer.base-time-unit
+  - otel.instrumentation.micrometer.histogram-gauges.enabled
+  - otel.instrumentation.micrometer.prometheus-mode.enabled
 - name: mongo-3.1
   display_name: MongoDB Driver
   description: |
@@ -11347,18 +8301,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongo-java-driver:[3.1,)
-  configurations:
-  - name: otel.instrumentation.mongo.query-sanitization.enabled
-    declarative_name: java.mongo.query_sanitization.enabled
-    description: |
-      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.mongo.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -11381,25 +8326,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-e36c6087
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11432,18 +8360,9 @@ libraries:
   javaagent_target_versions:
   - org.mongodb:mongo-java-driver:[3.7, 4.0)
   - org.mongodb:mongodb-driver-core:[3.7, 4.0)
-  configurations:
-  - name: otel.instrumentation.mongo.query-sanitization.enabled
-    declarative_name: java.mongo.query_sanitization.enabled
-    description: |
-      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.mongo.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -11466,25 +8385,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-e36c6087
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11516,18 +8418,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongodb-driver-core:[4.0,)
-  configurations:
-  - name: otel.instrumentation.mongo.query-sanitization.enabled
-    declarative_name: java.mongo.query_sanitization.enabled
-    description: |
-      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.mongo.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -11550,25 +8443,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-e36c6087
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11600,18 +8476,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongodb-driver-async:[3.3,)
-  configurations:
-  - name: otel.instrumentation.mongo.query-sanitization.enabled
-    declarative_name: java.mongo.query_sanitization.enabled
-    description: |
-      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - otel.instrumentation.mongo.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -11634,25 +8501,8 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-e36c6087
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11704,13 +8554,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.nats:jnats:[2.17.2,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
   telemetry:
   - when: default
     spans:
@@ -11759,125 +8604,22 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.netty:netty:[3.8.0.Final,4)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11901,93 +8643,6 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: SERVER
-      attributes:
-      - name: client.address
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.path
-        type: STRING
-      - name: url.query
-        type: STRING
-      - name: url.scheme
-        type: STRING
-      - name: user_agent.original
-        type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
       - name: url.full
         type: STRING
     - span_kind: SERVER
@@ -12033,282 +8688,23 @@ libraries:
   source_path: instrumentation/netty/netty-4.0
   scope:
     name: io.opentelemetry.netty-4.0
-    schema_url: https://opentelemetry.io/schemas/1.41.0
   has_javaagent: true
   javaagent_target_versions:
   - io.netty:netty-all:[4.0.0.Final,4.1.0.Final)
   - io.netty:netty-codec-http:[4.0.0.Final,4.1.0.Final)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.netty.connection-telemetry.enabled
-    declarative_name: java.netty.connection_telemetry.enabled
-    description: Enable the creation of Connect and DNS spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.netty.ssl-telemetry.enabled
-    declarative_name: java.netty.ssl_telemetry.enabled
-    description: Enable SSL telemetry.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
-  telemetry:
-  - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: SERVER
-      attributes:
-      - name: client.address
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.path
-        type: STRING
-      - name: url.query
-        type: STRING
-      - name: url.scheme
-        type: STRING
-      - name: user_agent.original
-        type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
-    - span_kind: SERVER
-      attributes:
-      - name: client.address
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.path
-        type: STRING
-      - name: url.query
-        type: STRING
-      - name: url.scheme
-        type: STRING
-      - name: user_agent.original
-        type: STRING
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - otel.instrumentation.netty.connection-telemetry.enabled
+  - otel.instrumentation.netty.ssl-telemetry.enabled
+  - sanitization.url.sensitive-query-parameters
 - name: netty-4.1
   display_name: Netty HTTP codec
   description: |
@@ -12328,222 +8724,24 @@ libraries:
   javaagent_target_versions:
   - io.netty:netty-all:[4.1.0.Final,5.0.0)
   - io.netty:netty-codec-http:[4.1.0.Final,5.0.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.netty.connection-telemetry.enabled
-    declarative_name: java.netty.connection_telemetry.enabled
-    description: Enable the creation of Connect and DNS spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.netty.ssl-telemetry.enabled
-    declarative_name: java.netty.ssl_telemetry.enabled
-    description: Enable SSL telemetry.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - otel.instrumentation.netty.connection-telemetry.enabled
+  - otel.instrumentation.netty.ssl-telemetry.enabled
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: peer.service
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.full
-        type: STRING
-    - span_kind: SERVER
-      attributes:
-      - name: client.address
-        type: STRING
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: url.path
-        type: STRING
-      - name: url.query
-        type: STRING
-      - name: url.scheme
-        type: STRING
-      - name: user_agent.original
-        type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12565,8 +8763,6 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
-      - name: service.peer.name
-        type: STRING
       - name: url.full
         type: STRING
     - span_kind: SERVER
@@ -12613,95 +8809,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.squareup.okhttp:okhttp:[2.2,3)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12724,23 +8843,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12778,95 +8882,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.squareup.okhttp3:okhttp:[3.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12895,23 +8922,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12954,46 +8966,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.openai:openai-java:[1.1.0,3)
-  configurations:
-  - name: otel.instrumentation.genai.capture-message-content
-    declarative_name: java.common.gen_ai.capture_message_content
-    description: |
-      Enables including the full content of user and assistant messages in emitted log events. Note that full content can have data privacy and size concerns, and care should be taken when enabling this.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.genai.capture-message-content-274e53a8
   telemetry:
   - when: default
-    metrics:
-    - name: gen_ai.client.operation.duration
-      description: GenAI operation duration.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.response.model
-        type: STRING
-    - name: gen_ai.client.token.usage
-      description: Measures number of input and output tokens used.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{token}'
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.response.model
-        type: STRING
-      - name: gen_ai.token.type
-        type: STRING
+    metric_refs:
+    - gen_ai.client.operation.duration-32ef946d
+    - gen_ai.client.token.usage-c5ff244f
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13056,45 +9035,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.opensearch.client:opensearch-java:[3.0,)
-  configurations:
-  - name: otel.instrumentation.opensearch.capture-search-query
-    declarative_name: java.opensearch.capture_search_query
-    description: |
-      Enable the capture of sanitized search query bodies. Search queries may contain personal or sensitive information.
-    type: boolean
-    default: true
-  telemetry:
-  - when: default
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation
-        type: STRING
-      - name: db.statement
-        type: STRING
-      - name: db.system
-        type: STRING
-  - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.query.text
-        type: STRING
-      - name: db.system.name
-        type: STRING
+  configuration_refs:
+  - otel.instrumentation.opensearch.capture-search-query
 - name: opensearch-rest-1.0
   display_name: OpenSearch REST Client
   description: |
@@ -13122,17 +9064,8 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13169,17 +9102,8 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13189,6 +9113,14 @@ libraries:
         type: STRING
       - name: db.system.name
         type: STRING
+- name: opentelemetry-api-1.52
+  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.52
+  scope:
+    name: io.opentelemetry.opentelemetry-api-1.52
+- name: opentelemetry-instrumentation-api
+  source_path: instrumentation/opentelemetry-instrumentation-api
+  scope:
+    name: io.opentelemetry.opentelemetry-instrumentation-api
 - name: oracle-ucp-11.2
   display_name: Oracle UCP
   description: |
@@ -13205,64 +9137,15 @@ libraries:
   - com.oracle.database.jdbc:ucp:[,)
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.pending_requests-a0698f55
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.max-c7917942
+    - db.client.connection.pending_requests-a0f41111
 - name: oshi-5.0
   display_name: OSHI
   description: |
@@ -13277,166 +9160,33 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.github.oshi:oshi-core:[5.0.0,)
-  configurations:
-  - name: otel.instrumentation.oshi.experimental-metrics.enabled
-    declarative_name: java.oshi.experimental_metrics/development.enabled
-    description: Enable the experimental `runtime.java.memory` and `runtime.java.cpu_time`
-      metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.oshi.experimental-metrics.enabled
   telemetry:
   - when: default
-    metrics:
-    - name: system.disk.io
-      description: System disk IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.disk.operations
-      description: System disk operations
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{operations}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.memory.usage
-      description: System memory usage
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: state
-        type: STRING
-    - name: system.memory.utilization
-      description: System memory utilization
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes:
-      - name: state
-        type: STRING
-    - name: system.network.errors
-      description: System network errors
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{errors}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.network.io
-      description: System network IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.network.packets
-      description: System network packets
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{packets}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
+    metric_refs:
+    - system.disk.io-58ee1ced
+    - system.disk.operations-cf678806
+    - system.memory.usage-11625112
+    - system.memory.utilization-677660f3
+    - system.network.errors-0d1e8b98
+    - system.network.io-518133c1
+    - system.network.packets-6d263c01
   - when: otel.instrumentation.oshi.experimental-metrics.enabled=true
-    metrics:
-    - name: runtime.java.cpu_time
-      description: Runtime Java CPU time
-      instrument: gauge
-      data_type: LONG_GAUGE
-      unit: ms
-      attributes:
-      - name: type
-        type: STRING
-    - name: runtime.java.memory
-      description: Runtime Java memory
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: type
-        type: STRING
-    - name: system.disk.io
-      description: System disk IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.disk.operations
-      description: System disk operations
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{operations}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.memory.usage
-      description: System memory usage
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: state
-        type: STRING
-    - name: system.memory.utilization
-      description: System memory utilization
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes:
-      - name: state
-        type: STRING
-    - name: system.network.errors
-      description: System network errors
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{errors}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.network.io
-      description: System network IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    - name: system.network.packets
-      description: System network packets
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{packets}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
+    metric_refs:
+    - runtime.java.cpu_time-ac10c23f
+    - runtime.java.memory-2a143889
+    - system.disk.io-58ee1ced
+    - system.disk.operations-cf678806
+    - system.memory.usage-11625112
+    - system.memory.utilization-677660f3
+    - system.network.errors-0d1e8b98
+    - system.network.io-518133c1
+    - system.network.packets-6d263c01
+- name: payara
+  source_path: instrumentation/payara
+  scope:
+    name: io.opentelemetry.payara
 - name: payara-5.2020
   display_name: Payara
   description: |
@@ -13486,127 +9236,22 @@ libraries:
   - org.apache.pekko:pekko-http_2.12:[1.0,)
   - org.apache.pekko:pekko-http_2.13:[1.0,)
   - org.apache.pekko:pekko-http_3:[1.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-a64b5297
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13666,12 +9311,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.typesafe.play:play_2.11:[2.4.0,2.6)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -13694,12 +9335,8 @@ libraries:
   - com.typesafe.play:play_2.12:[2.6.0,)
   - com.typesafe.play:play_2.13:[2.6.0,)
   - org.playframework:play_3:[2.6.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -13721,93 +9358,18 @@ libraries:
   javaagent_target_versions:
   - com.typesafe.play:play-ahc-ws-standalone_2.11:[1.0.0,2.0.0)
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[1.0.0,2.0.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13848,93 +9410,18 @@ libraries:
   - com.typesafe.play:play-ahc-ws-standalone_2.11:[2.0.0,]
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[2.0.0,2.1.0)
   - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.0.6,2.1.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -13975,93 +9462,18 @@ libraries:
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[2.1.0,]
   - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.1.0,]
   - org.playframework:play-ahc-ws-standalone_3:[3.0.0,]
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -14095,13 +9507,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - tech.powerjob:powerjob-worker:[4.0.0,)
-  configurations:
-  - name: otel.instrumentation.powerjob.experimental-span-attributes
-    declarative_name: java.powerjob.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `job.system`, `scheduling.powerjob.job.id`, `scheduling.powerjob.job.param`, `scheduling.powerjob.job.instance.param`, and `scheduling.powerjob.job.type`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.powerjob.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -14127,12 +9534,6 @@ libraries:
         type: STRING
       - name: scheduling.powerjob.job.type
         type: STRING
-  - when: otel.semconv-stability.opt-in=code
-    spans:
-    - span_kind: INTERNAL
-      attributes:
-      - name: code.function.name
-        type: STRING
 - name: pulsar-2.8
   display_name: Apache Pulsar Client
   description: |
@@ -14146,76 +9547,16 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.pulsar:pulsar-client:[2.8.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
-  - name: otel.instrumentation.pulsar.experimental-span-attributes
-    declarative_name: java.pulsar.experimental_span_attributes/development
-    description: |
-      Enables the experimental span attribute `messaging.pulsar.message.type` for producer spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  - otel.instrumentation.pulsar.experimental-span-attributes-5ac8c0d9
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
-    metrics:
-    - name: messaging.publish.duration
-      description: Measures the duration of publish operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: messaging.receive.duration
-      description: Measures the duration of receive operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: messaging.receive.messages
-      description: Measures the number of received messages.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{message}'
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - messaging.publish.duration-05731f17
+    - messaging.receive.duration-4b4a91de
+    - messaging.receive.messages-2499c5ac
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -14256,55 +9597,10 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.instrumentation.pulsar.experimental-span-attributes=true
-    metrics:
-    - name: messaging.publish.duration
-      description: Measures the duration of publish operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: messaging.receive.duration
-      description: Measures the duration of receive operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: messaging.receive.messages
-      description: Measures the number of received messages.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{message}'
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - messaging.publish.duration-05731f17
+    - messaging.receive.duration-4b4a91de
+    - messaging.receive.messages-2499c5ac
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -14346,6 +9642,10 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
+- name: quarkus-resteasy-reactive
+  source_path: instrumentation/quarkus-resteasy-reactive
+  scope:
+    name: io.opentelemetry.quarkus-resteasy-reactive
 - name: quarkus-resteasy-reactive-1.11
   display_name: Quarkus RESTEasy Reactive
   description: |
@@ -14371,12 +9671,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.quartz-scheduler:quartz:[2.0.0,)
-  configurations:
-  - name: otel.instrumentation.quartz.experimental-span-attributes
-    declarative_name: java.quartz.experimental_span_attributes/development
-    description: Enables the experimental `job.system` span attribute.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.quartz.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -14411,43 +9707,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.r2dbc:r2dbc-spi:[0.9.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.r2dbc.query-sanitization.enabled
-    declarative_name: java.r2dbc.query_sanitization.enabled
-    description: |
-      Enables query sanitization for database queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
-    declarative_name: java.r2dbc.sqlcommenter/development.enabled
-    description: |
-      Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
+  - otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
+  - otel.instrumentation.r2dbc.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -14474,37 +9738,18 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.query.summary
         type: STRING
       - name: db.query.text
         type: STRING
       - name: db.system.name
-        type: STRING
-      - name: error.type
         type: STRING
       - name: server.address
         type: STRING
@@ -14525,24 +9770,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.rabbitmq:amqp-client:[2.7.0,)
-  configurations:
-  - name: otel.instrumentation.rabbitmq.experimental-span-attributes
-    declarative_name: java.rabbitmq.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `rabbitmq.command`, `rabbitmq.delivery_mode`, `rabbitmq.queue`, and `rabbitmq.record.queue_time_ms`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables the creation of consumer spans on messaging receive operations. These spans will measure the time between receiving a message and the consumer processing that message.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: List of messaging headers to capture.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-59c44ca8
+  - otel.instrumentation.rabbitmq.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -14666,14 +9897,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.ratpack:ratpack-core:[1.4.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
-  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+  - when: otel.semconv-stability.opt-in=service.peer
     spans:
     - span_kind: INTERNAL
       attributes: []
@@ -14698,130 +9925,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.ratpack:ratpack-core:[1.7.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: CLIENT
       attributes:
@@ -14870,21 +9990,8 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -14906,43 +10013,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
-      - name: url.full
-        type: STRING
 - name: reactor-3.1
   display_name: Reactor
   description: |
@@ -14957,13 +10027,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.projectreactor:reactor-core:[3.1.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.reactor.experimental-span-attributes
-    declarative_name: java.reactor.experimental_span_attributes/development
-    description: |
-      Enables the capture of the experimental `reactor.canceled` attribute on spans when reactive streams are cancelled.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.reactor.experimental-span-attributes
 - name: reactor-3.4
   display_name: Reactor
   description: |
@@ -14990,24 +10055,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.projectreactor.kafka:reactor-kafka:[1.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
-  - name: otel.instrumentation.kafka.experimental-span-attributes
-    declarative_name: java.kafka.experimental_span_attributes/development
-    description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.kafka.experimental-span-attributes-956cabd8
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.kafka.experimental-span-attributes=true
     spans:
@@ -15080,100 +10131,19 @@ libraries:
   javaagent_target_versions:
   - io.projectreactor.netty:reactor-netty-http:[1.0.0,)
   - io.projectreactor.netty:reactor-netty:[1.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.reactor-netty.connection-telemetry.enabled
-    declarative_name: java.reactor_netty.connection_telemetry.enabled
-    description: Enables the creation of Connect and DNS spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - otel.instrumentation.reactor-netty.connection-telemetry.enabled
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -15199,51 +10169,6 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
-      - name: url.full
-        type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: http.request.method
-        type: STRING
-      - name: http.request.method_original
-        type: STRING
-      - name: http.request.resend_count
-        type: LONG
-      - name: http.response.status_code
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-      - name: service.peer.name
-        type: STRING
       - name: url.full
         type: STRING
 - name: rediscala-1.8
@@ -15275,39 +10200,16 @@ libraries:
         type: STRING
       - name: db.system
         type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-55295033
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.system.name
         type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
 - name: redisson-3.0
   display_name: Redisson
   description: This instrumentation enables database client spans and database client
@@ -15339,35 +10241,12 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-7714cbf7
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -15377,10 +10256,6 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
         type: LONG
 - name: redisson-3.17
   display_name: Redisson
@@ -15413,35 +10288,12 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-7714cbf7
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -15451,10 +10303,6 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
         type: LONG
 - name: resources
   display_name: Resource Detectors
@@ -15466,12 +10314,8 @@ libraries:
   scope:
     name: io.opentelemetry.resources
   has_standalone_library: true
-  configurations:
-  - name: otel.instrumentation.resources.experimental.process-command-attributes.enabled
-    description: |
-      Enables capture of process command-line resource attributes when v3 preview suppresses them by default.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.resources.experimental.process-command-attributes.enabled
 - name: restlet-1.1
   display_name: Restlet
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -15490,48 +10334,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.restlet:org.restlet:[1.1.0, 1.2-M1)
-  configurations:
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -15583,48 +10394,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.restlet.jse:org.restlet:[2.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -15705,19 +10483,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.rocketmq:rocketmq-client:[4.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
-  - name: otel.instrumentation.rocketmq-client.experimental-span-attributes
-    declarative_name: java.rocketmq_client.experimental_span_attributes/development
-    description: |
-      Enables capturing experimental span attributes `messaging.rocketmq.message.tag`, `messaging.rocketmq.broker_address`, `messaging.rocketmq.send_result`, `messaging.rocketmq.queue_id`, and `messaging.rocketmq.queue_offset`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.rocketmq-client.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -15794,19 +10562,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.rocketmq:rocketmq-client-java:[5.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: |
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -15868,447 +10626,20 @@ libraries:
     name: io.opentelemetry.runtime-telemetry
   has_standalone_library: true
   has_javaagent: true
-  configurations:
-  - name: otel.instrumentation.runtime-telemetry.emit-experimental-metrics
-    declarative_name: java.runtime_telemetry.emit_experimental_metrics/development
-    description: Enables the capture of experimental JMX-based JVM runtime metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
-    declarative_name: java.runtime_telemetry.emit_experimental_jfr_metrics/development
-    description: |
-      Enables the capture of experimental JFR-based JVM runtime metrics on Java 17+.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
-    declarative_name: java.runtime_telemetry.prefer_jfr/development
-    description: |
-      Prefer JFR over JMX for metrics available from both sources, on Java 17+. When enabled, overlapping metrics are collected via JFR and the corresponding JMX metrics are suppressed.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
-    declarative_name: java.runtime_telemetry.package_emitter/development.enabled
-    description: Enables creating events for JAR libraries used by the application.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
-    declarative_name: java.runtime_telemetry.package_emitter/development.jars_per_second
-    description: The number of JAR files processed per second by the package emitter.
-    type: int
-    default: 10
-  telemetry:
-  - when: Java17
-    metrics:
-    - name: jvm.buffer.count
-      description: Number of buffers in the pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{buffer}'
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.buffer.memory.limit
-      description: Measure of total memory capacity of buffers.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.buffer.memory.used
-      description: Measure of memory used by buffers.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.class.count
-      description: Number of classes currently loaded.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.loaded
-      description: Number of classes loaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.unloaded
-      description: Number of classes unloaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.cpu.count
-      description: Number of processors available to the Java virtual machine.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{cpu}'
-      attributes: []
-    - name: jvm.cpu.longlock
-      description: Long lock times
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes: []
-    - name: jvm.cpu.recent_utilization
-      description: Recent CPU utilization for the process as reported by the JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes: []
-    - name: jvm.cpu.time
-      description: CPU time used by the process as reported by the JVM.
-      instrument: counter
-      data_type: DOUBLE_SUM
-      unit: s
-      attributes: []
-    - name: jvm.gc.duration
-      description: Duration of JVM garbage collection actions.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: jvm.gc.action
-        type: STRING
-      - name: jvm.gc.name
-        type: STRING
-    - name: jvm.memory.committed
-      description: Measure of memory committed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.init
-      description: Measure of initial memory requested.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.limit
-      description: Measure of max obtainable memory.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used
-      description: Measure of memory used.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used_after_last_gc
-      description: Measure of memory used, as measured after the most recent garbage
-        collection event on this pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.system.cpu.utilization
-      description: Recent CPU utilization for the whole system as reported by the
-        JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes: []
-    - name: jvm.thread.count
-      description: Number of executing platform threads.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{thread}'
-      attributes:
-      - name: jvm.thread.daemon
-        type: BOOLEAN
-      - name: jvm.thread.state
-        type: STRING
-  - when: Java21
-    metrics:
-    - name: jvm.class.count
-      description: Number of classes currently loaded.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.loaded
-      description: Number of classes loaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.unloaded
-      description: Number of classes unloaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.cpu.count
-      description: Number of processors available to the Java virtual machine.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{cpu}'
-      attributes: []
-    - name: jvm.cpu.recent_utilization
-      description: Recent CPU utilization for the process as reported by the JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes: []
-    - name: jvm.cpu.time
-      description: CPU time used by the process as reported by the JVM.
-      instrument: counter
-      data_type: DOUBLE_SUM
-      unit: s
-      attributes: []
-    - name: jvm.gc.duration
-      description: Duration of JVM garbage collection actions.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: jvm.gc.action
-        type: STRING
-      - name: jvm.gc.name
-        type: STRING
-    - name: jvm.memory.committed
-      description: Measure of memory committed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.limit
-      description: Measure of max obtainable memory.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used
-      description: Measure of memory used.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used_after_last_gc
-      description: Measure of memory used, as measured after the most recent garbage
-        collection event on this pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.thread.count
-      description: Number of executing platform threads.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{thread}'
-      attributes:
-      - name: jvm.thread.daemon
-        type: BOOLEAN
-      - name: jvm.thread.state
-        type: STRING
-    - name: jvm.thread.virtual.pinned
-      description: Duration of virtual thread pinning.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes: []
-  - when: default
-    metrics:
-    - name: jvm.buffer.count
-      description: Number of buffers in the pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{buffer}'
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.buffer.memory.limit
-      description: Measure of total memory capacity of buffers.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.buffer.memory.used
-      description: Measure of memory used by buffers.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.buffer.pool.name
-        type: STRING
-    - name: jvm.class.count
-      description: Number of classes currently loaded.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.loaded
-      description: Number of classes loaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.class.unloaded
-      description: Number of classes unloaded since JVM start.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{class}'
-      attributes: []
-    - name: jvm.cpu.count
-      description: Number of processors available to the Java virtual machine.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{cpu}'
-      attributes: []
-    - name: jvm.cpu.recent_utilization
-      description: Recent CPU utilization for the process as reported by the JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes: []
-    - name: jvm.cpu.time
-      description: CPU time used by the process as reported by the JVM.
-      instrument: counter
-      data_type: DOUBLE_SUM
-      unit: s
-      attributes: []
-    - name: jvm.file_descriptor.count
-      description: Number of open file descriptors as reported by the JVM.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{file_descriptor}'
-      attributes: []
-    - name: jvm.file_descriptor.limit
-      description: Measure of max open file descriptors as reported by the JVM.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{file_descriptor}'
-      attributes: []
-    - name: jvm.gc.duration
-      description: Duration of JVM garbage collection actions.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: jvm.gc.action
-        type: STRING
-      - name: jvm.gc.cause
-        type: STRING
-      - name: jvm.gc.name
-        type: STRING
-    - name: jvm.memory.committed
-      description: Measure of memory committed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.init
-      description: Measure of initial memory requested.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.limit
-      description: Measure of max obtainable memory.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used
-      description: Measure of memory used.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.memory.used_after_last_gc
-      description: Measure of memory used, as measured after the most recent garbage
-        collection event on this pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: jvm.memory.pool.name
-        type: STRING
-      - name: jvm.memory.type
-        type: STRING
-    - name: jvm.system.cpu.load_1m
-      description: Average CPU load of the whole system for the last minute as reported
-        by the JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '{run_queue_item}'
-      attributes: []
-    - name: jvm.system.cpu.utilization
-      description: Recent CPU utilization for the whole system as reported by the
-        JVM.
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes: []
-    - name: jvm.thread.count
-      description: Number of executing platform threads.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{thread}'
-      attributes:
-      - name: jvm.thread.daemon
-        type: BOOLEAN
-      - name: jvm.thread.state
-        type: STRING
+  configuration_refs:
+  - otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
+  - otel.instrumentation.runtime-telemetry.emit-experimental-metrics
+  - otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
+  - otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
+  - otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
+- name: runtime-telemetry-java17
+  source_path: instrumentation/runtime-telemetry/runtime-telemetry-java17
+  scope:
+    name: io.opentelemetry.runtime-telemetry-java17
+- name: runtime-telemetry-java8
+  source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
+  scope:
+    name: io.opentelemetry.runtime-telemetry-java8
 - name: rxjava-2.0
   display_name: RxJava
   description: |
@@ -16323,13 +10654,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava2:rxjava:[2.0.6,)
-  configurations:
-  - name: otel.instrumentation.rxjava.experimental-span-attributes
-    declarative_name: java.rxjava.experimental_span_attributes/development
-    description: |
-      Enables the experimental span attribute `rxjava.canceled`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.rxjava.experimental-span-attributes
 - name: rxjava-3.0
   display_name: RxJava
   description: |
@@ -16344,13 +10670,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava3:rxjava:[3.0.0,3.1.0]
-  configurations:
-  - name: otel.instrumentation.rxjava.experimental-span-attributes
-    declarative_name: java.rxjava.experimental_span_attributes/development
-    description: |
-      Enables the experimental span attribute `rxjava.canceled`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.rxjava.experimental-span-attributes
 - name: rxjava-3.1.1
   display_name: RxJava
   description: |
@@ -16365,13 +10686,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava3:rxjava:[3.1.1,)
-  configurations:
-  - name: otel.instrumentation.rxjava.experimental-span-attributes
-    declarative_name: java.rxjava.experimental_span_attributes/development
-    description: |
-      Enables the experimental span attribute `rxjava.canceled`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.rxjava.experimental-span-attributes
+- name: scala-fork-join-2.8
+  source_path: instrumentation/scala-fork-join-2.8
+  scope:
+    name: io.opentelemetry.scala-fork-join-2.8
 - name: scala-forkjoin-2.8
   display_name: Scala ForkJoinPool
   description: |
@@ -16400,46 +10720,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.servlet:servlet-api:[2.2, 3.0)
-  configurations:
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
-    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
-    description: Enables adding the trace ID and span ID as request attributes for
-      downstream servlet access.
-    type: boolean
-    default: true
-  - name: otel.experimental.javascript-snippet
-    declarative_name: java.servlet.javascript_snippet/development
-    description: Experimental setting to inject a JavaScript snippet into HTML responses
-      after the opening `<head>` tag.
-    type: string
-    default: ''
+  configuration_refs:
+  - otel.experimental.javascript-snippet-ad834761
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -16493,50 +10782,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.servlet:javax.servlet-api:[3.0,)
-  configurations:
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
-    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
-    description: Enables adding the trace ID and span ID as request attributes for
-      downstream servlet access.
-    type: boolean
-    default: true
-  - name: otel.experimental.javascript-snippet
-    declarative_name: java.servlet.javascript_snippet/development
-    description: Experimental setting to inject a JavaScript snippet into HTML responses
-      after the opening `<head>` tag.
-    type: string
-    default: ''
-    examples:
-    - <script type="text/javascript">console.log('test')</script>
+  configuration_refs:
+  - otel.experimental.javascript-snippet-cfa9f908
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -16594,48 +10848,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.servlet:jakarta.servlet-api:[5.0.0,)
-  configurations:
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
-    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
-    description: Enables adding the trace ID and span ID as request attributes for
-      downstream servlet access.
-    type: boolean
-    default: true
-  - name: otel.experimental.javascript-snippet
-    declarative_name: java.servlet.javascript_snippet/development
-    description: Experimental setting to inject a JavaScript snippet into HTML responses
-      after the opening `<head>` tag.
-    type: string
-    default: ''
+  configuration_refs:
+  - otel.experimental.javascript-snippet-ad834761
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
   telemetry:
   - when: otel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -16692,80 +10913,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.alipay.sofa:sofa-rpc-all:[5.4.0,)
-  configurations:
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  telemetry:
-  - when: default
-    metrics:
-    - name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: peer.service
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - span_kind: SERVER
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
+  configuration_refs:
+  - common.peer-service-mapping
 - name: spark-2.3
   display_name: Spark Web Framework
   description: |
@@ -16791,24 +10940,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.batch:spring-batch-core:[3.0.0.RELEASE,5)
-  configurations:
-  - name: otel.instrumentation.spring-batch.experimental-span-attributes
-    declarative_name: java.spring_batch.experimental_span_attributes/development
-    description: Adds the experimental attribute `job.system` to spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.spring-batch.experimental.chunk.new-trace
-    declarative_name: java.spring_batch.chunk/development.new_trace
-    description: When enabled, a new root span will be created for each chunk processing.
-      Please note that this may lead to a high number of spans being created.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.spring-batch.item.enabled
-    declarative_name: java.spring_batch.item.enabled
-    description: When enabled, spans will be created for each item processed. Please
-      note that this may lead to a high number of spans being created.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.spring-batch.experimental-span-attributes
+  - otel.instrumentation.spring-batch.experimental.chunk.new-trace
+  - otel.instrumentation.spring-batch.item.enabled
   telemetry:
   - when: default
     spans:
@@ -16878,13 +11013,8 @@ libraries:
   javaagent_target_versions:
   - org.springframework.cloud:spring-cloud-starter-gateway-server-webflux:[4.3.0,)
   - org.springframework.cloud:spring-cloud-starter-gateway:[2.0.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
-    declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
-    description: |
-      Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
 - name: spring-cloud-gateway-webmvc-4.3
   display_name: Spring Cloud Gateway Server WebMVC
   description: |
@@ -16897,13 +11027,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc:[4.3.0,)
-  configurations:
-  - name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
-    declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
-    description: |
-      Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
 - name: spring-core-2.0
   display_name: Spring Core
   description: |
@@ -16930,7 +11055,7 @@ libraries:
   - org.springframework.data:spring-data-commons:[1.8.0.RELEASE,)
   - org.springframework:spring-aop:[1.2,)
   telemetry:
-  - when: default
+  - when: otel.semconv-stability.opt-in=database
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -16950,23 +11075,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.integration:spring-integration-core:[4.1.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.spring-integration.producer.enabled
-    declarative_name: java.spring_integration.producer.enabled
-    description: |
-      Create producer spans when messages are sent to an output channel. Enable when you're using a messaging library that doesn't have its own instrumentation for generating producer spans. Note that the detection of output channels only works for Spring Cloud Stream `DirectWithAttributesChannel`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.spring-integration.global-channel-interceptor-patterns
-    declarative_name: java.spring_integration.global_channel_interceptor_patterns
-    description: A list of Spring channel name patterns that will be intercepted.
-    type: list
-    default: '*'
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.spring-integration.global-channel-interceptor-patterns
+  - otel.instrumentation.spring-integration.producer.enabled
   telemetry:
   - when: default
     spans:
@@ -16997,18 +11109,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-jms:[2.0,6)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -17036,18 +11139,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-jms:[6.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -17075,55 +11169,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.kafka:spring-kafka:[2.7.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.kafka.experimental-span-attributes
-    declarative_name: java.kafka.experimental_span_attributes/development
-    description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`
-      and `messaging.kafka.bootstrap.servers`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.kafka.experimental-span-attributes-6596b308
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
-  - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
+  - when: default
     spans:
     - span_kind: CONSUMER
       attributes:
-      - name: messaging.batch.message_count
-        type: LONG
-      - name: messaging.client_id
-        type: STRING
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.destination.partition.id
-        type: STRING
-      - name: messaging.kafka.consumer.group
-        type: STRING
-      - name: messaging.kafka.message.key
-        type: STRING
-      - name: messaging.kafka.message.offset
-        type: LONG
-      - name: messaging.message.body.size
-        type: LONG
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-  - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true
-    spans:
-    - span_kind: CONSUMER
-      attributes:
-      - name: kafka.record.queue_time_ms
-        type: LONG
       - name: messaging.batch.message_count
         type: LONG
       - name: messaging.client_id
@@ -17158,24 +11212,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.pulsar:spring-pulsar:[1.0.0,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.pulsar.experimental-span-attributes
-    declarative_name: java.pulsar.experimental_span_attributes/development
-    description: |
-      Enables capturing experimental span attribute `messaging.pulsar.message.type` on PRODUCER spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  - otel.instrumentation.pulsar.experimental-span-attributes-1d77bf4d
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -17204,12 +11244,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.amqp:spring-rabbit:(,)
-  configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - messaging.capture-headers
   telemetry:
   - when: default
     spans:
@@ -17266,13 +11302,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-context:[3.1.0.RELEASE,]
-  configurations:
-  - name: otel.instrumentation.spring-scheduling.experimental-span-attributes
-    declarative_name: java.spring_scheduling.experimental_span_attributes/development
-    description: Adds the experimental span attribute `job.system` with the value
-      `spring_scheduling`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.spring-scheduling.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -17306,60 +11337,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.security:spring-security-config:[6.0.0,]
-  configurations:
-  - name: otel.instrumentation.common.enduser.id.enabled
-    declarative_name: java.common.enduser.id.enabled
-    description: Enables capturing the enduser.id attribute. This property and the
-      associated attribute are not supported when v3 preview is enabled.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.enduser.role.enabled
-    declarative_name: java.common.enduser.role.enabled
-    description: Enables capturing the enduser.role attribute. This property and the
-      associated attribute are not supported when v3 preview is enabled.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.enduser.scope.enabled
-    declarative_name: java.common.enduser.scope.enabled
-    description: Enables capturing the enduser.scope attribute when v3 preview is
-      not enabled. This property is not honored when v3 preview is enabled.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.user.name.enabled
-    declarative_name: java.common.user.name.enabled
-    description: Enables capturing the user.name attribute when v3 preview is enabled.
-      This property and the associated attribute are not supported when v3 preview
-      is disabled.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.user.roles.enabled
-    declarative_name: java.common.user.roles.enabled
-    description: Enables capturing the user.roles attribute when v3 preview is enabled.
-      This property and the associated attribute are not supported when v3 preview
-      is disabled.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
-    declarative_name: java.spring_security.enduser.role.granted_authority_prefix
-    description: Prefix of granted authorities identifying roles to capture in the
-      `enduser.role` semantic attribute. This property is not honored when v3 preview
-      is enabled; use the `user.roles` variant instead.
-    type: string
-    default: ROLE_
-  - name: otel.instrumentation.spring-security.user.roles.granted-authority-prefix
-    declarative_name: java.spring_security.user.roles.granted_authority_prefix
-    description: Prefix of granted authorities identifying roles to capture in the
-      `user.roles` semantic attribute when v3 preview is enabled. This property is
-      not honored when v3 preview is disabled; use the `enduser.role` variant instead.
-    type: string
-    default: ROLE_
-  - name: otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
-    declarative_name: java.spring_security.enduser.scope.granted_authority_prefix
-    description: Prefix of granted authorities identifying scopes to capture in the
-      `enduser.scope` semantic attribute. This property and the associated attribute
-      are not supported when v3 preview is enabled.
-    type: string
-    default: SCOPE_
+  configuration_refs:
+  - otel.instrumentation.common.enduser.id.enabled
+  - otel.instrumentation.common.enduser.role.enabled
+  - otel.instrumentation.common.enduser.scope.enabled
+  - otel.instrumentation.common.user.name.enabled
+  - otel.instrumentation.common.user.roles.enabled
+  - otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
+  - otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
+  - otel.instrumentation.spring-security.user.roles.granted-authority-prefix
 - name: spring-web-3.1
   display_name: Spring Web
   description: |
@@ -17375,21 +11361,8 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17406,21 +11379,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17450,35 +11410,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-web:[6.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enables the capture of experimental HTTP client telemetry, including URL template as the span name.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
+  configuration_refs:
+  - http.client.emit-experimental-telemetry
+  - java.common.http.client.url_template_rules
 - name: spring-webflux-5.0
   display_name: Spring WebFlux
   description: |
@@ -17496,29 +11430,12 @@ libraries:
   - io.projectreactor.ipc:reactor-netty:[0.7.0.RELEASE,)
   - io.projectreactor.netty:reactor-netty:[0.8.0.RELEASE,)
   - org.springframework:spring-webflux:[5.0.0.RELEASE,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
-  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+  - when: default
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17536,6 +11453,8 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+    spans:
     - span_kind: INTERNAL
       attributes:
       - name: code.function
@@ -17543,21 +11462,16 @@ libraries:
       - name: code.namespace
         type: STRING
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
+    spans:
+    - span_kind: INTERNAL
       attributes:
-      - name: http.request.method
+      - name: code.function
         type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
+      - name: code.namespace
         type: STRING
-      - name: server.port
-        type: LONG
+  - when: otel.semconv-stability.opt-in=service.peer
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17574,12 +11488,6 @@ libraries:
       - name: service.peer.name
         type: STRING
       - name: url.full
-        type: STRING
-    - span_kind: INTERNAL
-      attributes:
-      - name: code.function
-        type: STRING
-      - name: code.namespace
         type: STRING
 - name: spring-webflux-5.3
   display_name: Spring WebFlux
@@ -17598,35 +11506,9 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
+    - http.server.request.duration-2311bdb1
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17671,35 +11553,9 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
+    - http.server.request.duration-2311bdb1
     spans:
     - span_kind: CLIENT
       attributes:
@@ -17758,23 +11614,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-webmvc:[3.1.0.RELEASE,6)
-  configurations:
-  - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
-    declarative_name: java.spring_webmvc.experimental_span_attributes/development
-    description: |
-      Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    declarative_name: java.common.view_telemetry/development.enabled
-    description: Enables the creation of experimental view spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.common.experimental.view-telemetry.enabled
+  - otel.instrumentation.spring-webmvc.experimental-span-attributes
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -17811,23 +11654,8 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -17878,23 +11706,10 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-webmvc:[6.0.0,)
-  configurations:
-  - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
-    declarative_name: java.spring_webmvc.experimental_span_attributes/development
-    description: |
-      Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
-    declarative_name: java.common.view_telemetry/development.enabled
-    description: Enables the creation of experimental view spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
+  - otel.instrumentation.common.experimental.view-telemetry.enabled
+  - otel.instrumentation.spring-webmvc.experimental-span-attributes
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -17928,12 +11743,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.ws:spring-ws-core:[2.0.0.RELEASE,]
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -17957,13 +11768,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - net.spy:spymemcached:[2.12.0,)
-  configurations:
-  - name: otel.instrumentation.spymemcached.experimental-span-attributes
-    declarative_name: java.spymemcached.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `spymemcached.result` and `spymemcached.command.cancelled`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.spymemcached.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -17994,21 +11800,8 @@ libraries:
       - name: spymemcached.result
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-32559b79
     spans:
     - span_kind: CLIENT
       attributes:
@@ -18036,12 +11829,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.struts:struts2-core:[2.1.0,7)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -18066,12 +11855,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.struts:struts2-core:[7.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -18095,12 +11880,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tapestry:tapestry-core:[5.4.0,)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -18123,157 +11904,6 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.thrift:libthrift:[0.13.0,)
-  telemetry:
-  - when: default
-    metrics:
-    - name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - span_kind: SERVER
-      attributes:
-      - name: network.local.address
-        type: STRING
-      - name: network.local.port
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-  - when: otel.semconv-stability.opt-in=rpc
-    metrics:
-    - name: rpc.client.call.duration
-      description: Measures the duration of outbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - name: rpc.server.call.duration
-      description: Measures the duration of inbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    spans:
-    - span_kind: CLIENT
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    - span_kind: SERVER
-      attributes:
-      - name: error.type
-        type: STRING
-      - name: network.local.address
-        type: STRING
-      - name: network.local.port
-        type: LONG
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: network.type
-        type: STRING
-      - name: rpc.method
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
 - name: tomcat-7.0
   display_name: Apache Tomcat
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -18291,58 +11921,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat.embed:tomcat-embed-core:[7.0.4, 10)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -18393,58 +11982,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat.embed:tomcat-embed-core:[10,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental-span-attributes
-    declarative_name: java.servlet.experimental_span_attributes/development
-    description: Enables capturing the experimental `servlet.timeout` span attribute.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
-    declarative_name: java.servlet.capture_request_parameters/development
-    description: List of request parameter names to capture as span attributes.
-    type: list
-    default: ''
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
+  - otel.instrumentation.servlet.experimental-span-attributes
+  - otel.instrumentation.servlet.experimental.capture-request-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-1f6f63ed
     spans:
     - span_kind: SERVER
       attributes:
@@ -18491,105 +12039,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat:tomcat-jdbc:[8.5.0,)
-  configurations:
-  - name: otel.semconv-stability.opt-in
-    declarative_name: general.semconv_stability.opt_in
-    description: |
-      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.semconv-stability.opt-in
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.idle.max-f9946dd5
+    - db.client.connections.idle.min-f04d4083
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.pending_requests-a0698f55
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    - name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.idle.max-b95e4f5c
+    - db.client.connection.idle.min-73bdafbc
+    - db.client.connection.max-c7917942
+    - db.client.connection.pending_requests-a0f41111
 - name: twilio-6.6
   display_name: Twilio
   description: |
@@ -18601,13 +12067,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.twilio.sdk:twilio:(,8.0.0)
-  configurations:
-  - name: otel.instrumentation.twilio.experimental-span-attributes
-    declarative_name: java.twilio.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `twilio.type`, `twilio.account`, `twilio.sid`, `twilio.parentSid`, and `twilio.status`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.twilio.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -18640,46 +12101,15 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.undertow:undertow-core:[1.4.0.Final,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  configuration_refs:
+  - http.known-methods
+  - http.server.capture-request-headers
+  - http.server.capture-response-headers
+  - http.server.emit-experimental-telemetry
   telemetry:
   - when: default
-    metrics:
-    - name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
+    metric_refs:
+    - http.server.request.duration-639e2d0b
     spans:
     - span_kind: SERVER
       attributes:
@@ -18726,12 +12156,8 @@ libraries:
   javaagent_target_versions:
   - com.vaadin:flow-server:[2.2.0,3)
   - com.vaadin:flow-server:[3.1.0,25.0.0)
-  configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  configuration_refs:
+  - common.controller-telemetry.enabled
 - name: vertx-http-client-3.0
   display_name: Vert.x HTTP Client
   description: |
@@ -18747,93 +12173,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[3.0.0,4.0.0)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -18852,21 +12203,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-98bb5f3b
     spans:
     - span_kind: CLIENT
       attributes:
@@ -18899,95 +12237,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[4.0.0,5)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -19014,23 +12275,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -19072,95 +12318,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[5.0.0,)
-  configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: |
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
-    type: list
-    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ''
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: |
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
-    type: boolean
-    default: false
-  - declarative_name: java.common.http.client.url_template_rules
-    description: |
-      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-    type: list
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - pattern
-      - template
-      properties:
-        pattern:
-          type: string
-          description: Regular expression matched against the request URL.
-        template:
-          type: string
-          description: Template used to derive the low-cardinality route.
-        override:
-          type: boolean
-          description: Whether this rule overrides an already-applied template.
-          default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL
-      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  configuration_refs:
+  - common.peer-service-mapping
+  - http.client.capture-request-headers
+  - http.client.capture-response-headers
+  - http.client.emit-experimental-telemetry
+  - http.known-methods
+  - java.common.http.client.url_template_rules
+  - sanitization.url.sensitive-query-parameters
   telemetry:
   - when: default
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -19187,23 +12356,8 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metrics:
-    - name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - http.client.request.duration-a64b5297
     spans:
     - span_kind: CLIENT
       attributes:
@@ -19243,29 +12397,11 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-kafka-client:[3.5.1,)
-  configurations:
-  - name: otel.instrumentation.kafka.producer-propagation.enabled
-    declarative_name: java.kafka.producer_propagation.enabled
-    description: Enable context propagation for Kafka message producers.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.kafka.experimental-span-attributes
-    declarative_name: java.kafka.experimental_span_attributes/development
-    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
-      and `messaging.kafka.bootstrap.servers`.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
-  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-    declarative_name: java.common.messaging.receive_telemetry/development.enabled
-    description: |
-      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-    type: boolean
-    default: false
+  configuration_refs:
+  - messaging.capture-headers
+  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
+  - otel.instrumentation.kafka.producer-propagation.enabled
+  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -19327,31 +12463,9 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-redis-client:[4.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer
-      services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-      - peer
-      - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  configuration_refs:
+  - common.db.query-sanitization.enabled
+  - common.peer-service-mapping
   telemetry:
   - when: default
     spans:
@@ -19376,34 +12490,13 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-8ae2b8ce
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -19447,12 +12540,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-sql-client:[4.0.0,5)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -19475,30 +12564,13 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.query.summary
         type: STRING
       - name: db.query.text
@@ -19528,12 +12600,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-sql-client:[5.0.0,)
-  configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  configuration_refs:
+  - common.db.query-sanitization.enabled
   telemetry:
   - when: default
     spans:
@@ -19556,30 +12624,13 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metrics:
-    - name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
+    metric_refs:
+    - db.client.operation.duration-d4212042
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
-      - name: db.operation.batch.size
-        type: LONG
       - name: db.query.summary
         type: STRING
       - name: db.query.text
@@ -19623,47 +12674,13 @@ libraries:
   - org.vibur:vibur-dbcp:[11.0,)
   telemetry:
   - when: default
-    metrics:
-    - name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    - name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
+    metric_refs:
+    - db.client.connections.max-ddde65fe
+    - db.client.connections.usage-5ef1d5ef
   - when: otel.semconv-stability.opt-in=database
-    metrics:
-    - name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    - name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
+    metric_refs:
+    - db.client.connection.count-2e6ba9b7
+    - db.client.connection.max-c7917942
 - name: wicket-8.0
   display_name: Apache Wicket
   description: |
@@ -19687,13 +12704,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[1.9.2, 2.1.2)
-  configurations:
-  - name: otel.instrumentation.xxl-job.experimental-span-attributes
-    declarative_name: java.xxl_job.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.xxl-job.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -19727,13 +12739,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[2.1.2,2.3.0)
-  configurations:
-  - name: otel.instrumentation.xxl-job.experimental-span-attributes
-    declarative_name: java.xxl_job.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.xxl-job.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -19767,13 +12774,8 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[2.3.0,)
-  configurations:
-  - name: otel.instrumentation.xxl-job.experimental-span-attributes
-    declarative_name: java.xxl_job.experimental_span_attributes/development
-    description: |
-      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
-    type: boolean
-    default: false
+  configuration_refs:
+  - otel.instrumentation.xxl-job.experimental-span-attributes
   telemetry:
   - when: default
     spans:
@@ -19839,24 +12841,9 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.external-annotations.include
-    declarative_name: java.external_annotations.include
-    description: Semicolon-separated list of annotation class names to instrument.
-    type: list
-    default: ''
-    examples:
-    - com.example.Trace
-    - com.example.Trace;com.example.OtherTrace
-  - name: otel.instrumentation.external-annotations.exclude-methods
-    declarative_name: java.external_annotations.exclude_methods
-    description: All methods to be excluded from auto-instrumentation by annotation-based
-      advices.
-    type: string
-    default: ''
-    examples:
-    - com.example.MyClass[method1,method2]
-    - com.example.MyClass[method1];com.example.OtherClass[method2]
+  configuration_refs:
+  - otel.instrumentation.external-annotations.exclude-methods
+  - otel.instrumentation.external-annotations.include
 - name: jmx-metrics
   display_name: JMX Metrics
   description: |
@@ -19866,27 +12853,11 @@ custom:
     name: io.opentelemetry.jmx-metrics
   has_standalone_library: true
   has_javaagent: true
-  configurations:
-  - name: otel.jmx.enabled
-    declarative_name: java.jmx.enabled
-    description: Enables collection of JMX metrics.
-    type: boolean
-    default: true
-  - name: otel.jmx.config
-    declarative_name: java.jmx.config
-    description: List of paths to JMX metric definition YAML files.
-    type: list
-    default: ''
-  - name: otel.jmx.discovery.delay
-    declarative_name: java.jmx.discovery.delay
-    description: Time in milliseconds between JMX MBean detection attempts.
-    type: int
-    default: 60000
-  - name: otel.jmx.target.system
-    declarative_name: java.jmx.target.system
-    description: List of predefined JMX target systems to collect metrics for.
-    type: list
-    default: ''
+  configuration_refs:
+  - otel.jmx.config
+  - otel.jmx.discovery.delay
+  - otel.jmx.enabled
+  - otel.jmx.target.system
 - name: methods
   display_name: Methods
   description: |
@@ -19897,16 +12868,8 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configurations:
-  - name: otel.instrumentation.methods.include
-    declarative_name: java.methods.include
-    description: Semicolon-separated list of fully qualified class and method patterns
-      to instrument.
-    type: list
-    default: ''
-    examples:
-    - com.example.MyClass[method1]
-    - com.example.MyClass[method1,method2];com.example.OtherClass[call]
+  configuration_refs:
+  - otel.instrumentation.methods.include
 - name: opentelemetry-extension-annotations-1.0
   display_name: OpenTelemetry Extension Annotations
   description: |
@@ -19917,16 +12880,8 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - io.opentelemetry:opentelemetry-extension-annotations:[0.16.0,)
-  configurations:
-  - name: otel.instrumentation.opentelemetry-annotations.exclude-methods
-    declarative_name: java.opentelemetry_extension_annotations.exclude_methods
-    description: All methods to be excluded from auto-instrumentation by annotation-based
-      advices.
-    type: string
-    default: ''
-    examples:
-    - com.example.MyClass[method1,method2]
-    - com.example.MyClass[method1];com.example.OtherClass[method2]
+  configuration_refs:
+  - otel.instrumentation.opentelemetry-annotations.exclude-methods
 - name: opentelemetry-instrumentation-annotations-1.16
   display_name: OpenTelemetry Instrumentation Annotations
   description: |
@@ -19937,13 +12892,5 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - io.opentelemetry:opentelemetry-instrumentation-annotations:(,)
-  configurations:
-  - name: otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
-    declarative_name: java.opentelemetry_instrumentation_annotations.exclude_methods
-    description: All methods to be excluded from auto-instrumentation by annotation-based
-      advices.
-    type: string
-    default: ''
-    examples:
-    - com.example.MyClass[method1,method2]
-    - com.example.MyClass[method1];com.example.OtherClass[method2]
+  configuration_refs:
+  - otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -1,2058 +1,9 @@
 # This file is generated and should not be manually edited.
 # The structure and contents are a work in progress and subject to change.
-# Common metrics and configurations are collected in the top-level `definitions` catalog;
-# each module references them by id via `metric_refs` and `configuration_refs`.
 # For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468
 
-file_format: 0.6
+file_format: 0.5
 
-definitions:
-  configurations:
-    common.controller-telemetry.enabled:
-      name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-      declarative_name: java.common.controller_telemetry/development.enabled
-      description: Enables the creation of experimental controller spans.
-      type: boolean
-      default: false
-    common.db.query-sanitization.enabled:
-      name: otel.instrumentation.common.db.query-sanitization.enabled
-      declarative_name: java.common.db.query_sanitization.enabled
-      description: Enables query sanitization for database queries.
-      type: boolean
-      default: true
-    common.peer-service-mapping:
-      name: otel.instrumentation.common.peer-service-mapping
-      declarative_name: java.common.service_peer_mapping
-      description: Used to specify a mapping from host names or IP addresses to peer
-        services.
-      type: map
-      default: ''
-      declarative_type: structured_list
-      declarative_schema:
-        type: object
-        required:
-        - peer
-        - service_name
-        properties:
-          peer:
-            type: string
-            description: Host name or IP address to match against.
-          service_name:
-            type: string
-            description: Peer service name to record for matching peers.
-    http.client.capture-request-headers:
-      name: otel.instrumentation.http.client.capture-request-headers
-      declarative_name: general.http.client.request_captured_headers
-      description: List of HTTP request headers to capture in HTTP client telemetry.
-      type: list
-      default: ''
-    http.client.capture-response-headers:
-      name: otel.instrumentation.http.client.capture-response-headers
-      declarative_name: general.http.client.response_captured_headers
-      description: List of HTTP response headers to capture in HTTP client telemetry.
-      type: list
-      default: ''
-    http.client.emit-experimental-telemetry:
-      name: otel.instrumentation.http.client.emit-experimental-telemetry
-      declarative_name: java.common.http.client.emit_experimental_telemetry/development
-      description: Enable the capture of experimental HTTP client telemetry. Adds
-        the `http.request.body.size` and `http.response.body.size` attributes to spans,
-        and records `http.client.request.size` and `http.client.response.size` metrics.
-      type: boolean
-      default: false
-    http.known-methods:
-      name: otel.instrumentation.http.known-methods
-      declarative_name: java.common.http.known_methods
-      description: Configures the instrumentation to recognize an alternative set
-        of HTTP request methods. All other methods will be treated as `_OTHER`.
-      type: list
-      default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
-    http.server.capture-request-headers:
-      name: otel.instrumentation.http.server.capture-request-headers
-      declarative_name: general.http.server.request_captured_headers
-      description: List of HTTP request headers to capture in HTTP server telemetry.
-      type: list
-      default: ''
-    http.server.capture-response-headers:
-      name: otel.instrumentation.http.server.capture-response-headers
-      declarative_name: general.http.server.response_captured_headers
-      description: List of HTTP response headers to capture in HTTP server telemetry.
-      type: list
-      default: ''
-    http.server.emit-experimental-telemetry:
-      name: otel.instrumentation.http.server.emit-experimental-telemetry
-      declarative_name: java.common.http.server.emit_experimental_telemetry/development
-      description: Enable the capture of experimental HTTP server telemetry. Adds
-        the `http.request.body.size` and `http.response.body.size` attributes to spans,
-        and records `http.server.request.size` and `http.server.response.size` metrics.
-      type: boolean
-      default: false
-    java.common.http.client.url_template_rules:
-      declarative_name: java.common.http.client.url_template_rules
-      description: |
-        Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
-      type: list
-      default: ''
-      declarative_type: structured_list
-      declarative_schema:
-        type: object
-        required:
-        - pattern
-        - template
-        properties:
-          pattern:
-            type: string
-            description: Regular expression matched against the request URL.
-          template:
-            type: string
-            description: Template used to derive the low-cardinality route.
-          override:
-            type: boolean
-            description: Whether this rule overrides an already-applied template.
-            default: false
-    messaging.capture-headers:
-      name: otel.instrumentation.messaging.experimental.capture-headers
-      declarative_name: java.common.messaging.capture_headers/development
-      description: A comma-separated list of header names to capture as span attributes.
-      type: list
-      default: ''
-    otel.experimental.javascript-snippet-ad834761:
-      name: otel.experimental.javascript-snippet
-      declarative_name: java.servlet.javascript_snippet/development
-      description: Experimental setting to inject a JavaScript snippet into HTML responses
-        after the opening `<head>` tag.
-      type: string
-      default: ''
-    otel.experimental.javascript-snippet-cfa9f908:
-      name: otel.experimental.javascript-snippet
-      declarative_name: java.servlet.javascript_snippet/development
-      description: Experimental setting to inject a JavaScript snippet into HTML responses
-        after the opening `<head>` tag.
-      type: string
-      default: ''
-      examples:
-      - <script type="text/javascript">console.log('test')</script>
-    otel.instrumentation.apache-elasticjob.experimental-span-attributes:
-      name: otel.instrumentation.apache-elasticjob.experimental-span-attributes
-      declarative_name: java.apache_elasticjob.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `job.system`, `scheduling.apache-elasticjob.job.name`, `scheduling.apache-elasticjob.task.id`, `scheduling.apache-elasticjob.sharding.item.index`, `scheduling.apache-elasticjob.sharding.total.count`, `scheduling.apache-elasticjob.sharding.item.parameter`, and `scheduling.apache-elasticjob.job.type`.
-      type: boolean
-      default: false
-    otel.instrumentation.apache-shenyu.experimental-span-attributes:
-      name: otel.instrumentation.apache-shenyu.experimental-span-attributes
-      declarative_name: java.apache_shenyu.experimental_span_attributes/development
-      description: |
-        Enables experimental `apache-shenyu.meta.` prefixed span attributes `app-name`, `service-name`, `context-path`, `param-types`, `id`, `method-name`, `rpc-type`, `path` and `rpc-ext`.
-      type: boolean
-      default: false
-    otel.instrumentation.aws-lambda.flush-timeout:
-      name: otel.instrumentation.aws-lambda.flush-timeout
-      declarative_name: java.aws_lambda.flush_timeout
-      description: Flush timeout in milliseconds.
-      type: int
-      default: 10000
-    otel.instrumentation.aws-sdk.experimental-record-individual-http-error:
-      name: otel.instrumentation.aws-sdk.experimental-record-individual-http-error
-      declarative_name: java.aws_sdk.record_individual_http_error/development
-      description: Determines whether errors returned by each individual HTTP request
-        should be recorded as events for the SDK span.
-      type: boolean
-      default: false
-    otel.instrumentation.aws-sdk.experimental-span-attributes-0c4c01de:
-      name: otel.instrumentation.aws-sdk.experimental-span-attributes
-      declarative_name: java.aws_sdk.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `aws.agent`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
-      type: boolean
-      default: false
-    otel.instrumentation.aws-sdk.experimental-span-attributes-f30ad240:
-      name: otel.instrumentation.aws-sdk.experimental-span-attributes
-      declarative_name: java.aws_sdk.experimental_span_attributes/development
-      description: |
-        Enables the experimental span attributes `aws.agent`, `aws.queue.name`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
-      type: boolean
-      default: false
-    otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging:
-      name: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
-      declarative_name: java.aws_sdk.use_propagator_for_messaging/development
-      description: Determines whether the configured TextMapPropagator should be used
-        to inject into supported messaging attributes (for SQS).
-      type: boolean
-      default: false
-    otel.instrumentation.camel.experimental-span-attributes:
-      name: otel.instrumentation.camel.experimental-span-attributes
-      declarative_name: java.camel.experimental_span_attributes/development
-      description: |
-        Enable the capture of experimental `camel.uri`, `camel.kafka.partitionKey`, `camel.kafka.key` and `camel.kafka.offset` span attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.cassandra.query-sanitization.enabled:
-      name: otel.instrumentation.cassandra.query-sanitization.enabled
-      declarative_name: java.cassandra.query_sanitization.enabled
-      description: |
-        Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-      type: boolean
-      default: true
-    otel.instrumentation.common.enduser.id.enabled:
-      name: otel.instrumentation.common.enduser.id.enabled
-      declarative_name: java.common.enduser.id.enabled
-      description: Enables capturing the enduser.id attribute. This property and the
-        associated attribute are not supported when v3 preview is enabled.
-      type: boolean
-      default: false
-    otel.instrumentation.common.enduser.role.enabled:
-      name: otel.instrumentation.common.enduser.role.enabled
-      declarative_name: java.common.enduser.role.enabled
-      description: Enables capturing the enduser.role attribute. This property and
-        the associated attribute are not supported when v3 preview is enabled.
-      type: boolean
-      default: false
-    otel.instrumentation.common.enduser.scope.enabled:
-      name: otel.instrumentation.common.enduser.scope.enabled
-      declarative_name: java.common.enduser.scope.enabled
-      description: Enables capturing the enduser.scope attribute when v3 preview is
-        not enabled. This property is not honored when v3 preview is enabled.
-      type: boolean
-      default: false
-    otel.instrumentation.common.experimental.view-telemetry.enabled:
-      name: otel.instrumentation.common.experimental.view-telemetry.enabled
-      declarative_name: java.common.view_telemetry/development.enabled
-      description: Enables the creation of experimental view spans.
-      type: boolean
-      default: false
-    otel.instrumentation.common.logging.span-id-key:
-      name: otel.instrumentation.common.logging.span-id-key
-      declarative_name: java.common.logging.span_id_key
-      description: |
-        Specifies the key name used to store the span ID in the logging context.
-      type: string
-      default: span_id
-    otel.instrumentation.common.logging.trace-flags-key:
-      name: otel.instrumentation.common.logging.trace-flags-key
-      declarative_name: java.common.logging.trace_flags_key
-      description: |
-        Specifies the key name used to store the trace flags in the logging context.
-      type: string
-      default: trace_flags
-    otel.instrumentation.common.logging.trace-id-key:
-      name: otel.instrumentation.common.logging.trace-id-key
-      declarative_name: java.common.logging.trace_id_key
-      description: |
-        Specifies the key name used to store the trace ID in the logging context.
-      type: string
-      default: trace_id
-    otel.instrumentation.common.mdc.resource-attributes:
-      name: otel.instrumentation.common.mdc.resource-attributes
-      declarative_name: java.common.mdc.resource_attributes
-      description: |
-        Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
-      type: list
-      default: ''
-    otel.instrumentation.common.user.name.enabled:
-      name: otel.instrumentation.common.user.name.enabled
-      declarative_name: java.common.user.name.enabled
-      description: Enables capturing the user.name attribute when v3 preview is enabled.
-        This property and the associated attribute are not supported when v3 preview
-        is disabled.
-      type: boolean
-      default: false
-    otel.instrumentation.common.user.roles.enabled:
-      name: otel.instrumentation.common.user.roles.enabled
-      declarative_name: java.common.user.roles.enabled
-      description: Enables capturing the user.roles attribute when v3 preview is enabled.
-        This property and the associated attribute are not supported when v3 preview
-        is disabled.
-      type: boolean
-      default: false
-    otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e:
-      name: otel.instrumentation.couchbase.experimental-span-attributes
-      declarative_name: java.couchbase.experimental_span_attributes/development
-      description: Enables experimental span attributes emitted from the underlying
-        Couchbase library.
-      type: boolean
-      default: false
-    otel.instrumentation.couchbase.experimental-span-attributes-a850037a:
-      name: otel.instrumentation.couchbase.experimental-span-attributes
-      declarative_name: java.couchbase.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.dropwizard-metrics.enabled:
-      name: otel.instrumentation.dropwizard-metrics.enabled
-      declarative_name: java.dropwizard_metrics.enabled
-      description: Enables the dropwizard metrics instrumentation.
-      type: boolean
-      default: false
-    otel.instrumentation.elasticsearch.capture-search-query:
-      name: otel.instrumentation.elasticsearch.capture-search-query
-      declarative_name: java.elasticsearch.capture_search_query
-      description: |
-        Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
-      type: boolean
-      default: false
-    otel.instrumentation.elasticsearch.experimental-span-attributes-4728abdb:
-      name: otel.instrumentation.elasticsearch.experimental-span-attributes
-      declarative_name: java.elasticsearch.experimental_span_attributes/development
-      description: |
-        Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.search.types`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.broadcast.failed`, `elasticsearch.shard.broadcast.successful`, `elasticsearch.shard.broadcast.total`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.elasticsearch.experimental-span-attributes-df937525:
-      name: otel.instrumentation.elasticsearch.experimental-span-attributes
-      declarative_name: java.elasticsearch.experimental_span_attributes/development
-      description: |
-        Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.elasticsearch.experimental-span-attributes-ee0c671a:
-      name: otel.instrumentation.elasticsearch.experimental-span-attributes
-      declarative_name: java.elasticsearch.experimental_span_attributes/development
-      description: |
-        Enable the capture of the experimental span attributes `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version`.
-      type: boolean
-      default: false
-    otel.instrumentation.executors.include:
-      name: otel.instrumentation.executors.include
-      declarative_name: java.executors.include
-      description: List of Executor subclasses to be instrumented.
-      type: list
-      default: ''
-      examples:
-      - com.example.CustomExecutor
-      - com.example.ExecutorOne,com.example.ExecutorTwo
-    otel.instrumentation.executors.include-all:
-      name: otel.instrumentation.executors.include-all
-      declarative_name: java.executors.include_all
-      description: Whether to instrument all classes that implement the Executor interface.
-      type: boolean
-      default: false
-    otel.instrumentation.external-annotations.exclude-methods:
-      name: otel.instrumentation.external-annotations.exclude-methods
-      declarative_name: java.external_annotations.exclude_methods
-      description: All methods to be excluded from auto-instrumentation by annotation-based
-        advices.
-      type: string
-      default: ''
-      examples:
-      - com.example.MyClass[method1,method2]
-      - com.example.MyClass[method1];com.example.OtherClass[method2]
-    otel.instrumentation.external-annotations.include:
-      name: otel.instrumentation.external-annotations.include
-      declarative_name: java.external_annotations.include
-      description: Semicolon-separated list of annotation class names to instrument.
-      type: list
-      default: ''
-      examples:
-      - com.example.Trace
-      - com.example.Trace;com.example.OtherTrace
-    otel.instrumentation.genai.capture-message-content-274e53a8:
-      name: otel.instrumentation.genai.capture-message-content
-      declarative_name: java.common.gen_ai.capture_message_content
-      description: |
-        Enables including the full content of user and assistant messages in emitted log events. Note that full content can have data privacy and size concerns, and care should be taken when enabling this.
-      type: boolean
-      default: false
-    otel.instrumentation.genai.capture-message-content-ceb072e9:
-      name: otel.instrumentation.genai.capture-message-content
-      declarative_name: java.common.gen_ai.capture_message_content
-      description: |
-        Determines whether Generative AI events include full content of user and assistant messages. Note that full content can have data privacy and size concerns and care should be taken when enabling this
-      type: boolean
-      default: false
-    otel.instrumentation.graphql.capture-query:
-      name: otel.instrumentation.graphql.capture-query
-      declarative_name: java.graphql.capture_query
-      description: Whether to capture the query in `graphql.document` span attribute.
-      type: boolean
-      default: true
-    otel.instrumentation.graphql.data-fetcher.enabled:
-      name: otel.instrumentation.graphql.data-fetcher.enabled
-      declarative_name: java.graphql.data_fetcher.enabled
-      description: Enables span generation for data fetchers.
-      type: boolean
-      default: false
-    otel.instrumentation.graphql.operation-name-in-span-name.enabled:
-      name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
-      declarative_name: java.graphql.operation_name_in_span_name.enabled
-      description: |
-        Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
-      type: boolean
-      default: false
-    otel.instrumentation.graphql.query-sanitization.enabled:
-      name: otel.instrumentation.graphql.query-sanitization.enabled
-      declarative_name: java.graphql.query_sanitization.enabled
-      description: Enables sanitization of sensitive information from queries so they
-        aren't added as span attributes.
-      type: boolean
-      default: true
-    otel.instrumentation.graphql.trivial-data-fetcher.enabled:
-      name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
-      declarative_name: java.graphql.trivial_data_fetcher.enabled
-      description: Whether to create spans for trivial data fetchers. A trivial data
-        fetcher is one that simply maps data from an object to a field.
-      type: boolean
-      default: false
-    otel.instrumentation.grpc.capture-metadata.client.request:
-      name: otel.instrumentation.grpc.capture-metadata.client.request
-      declarative_name: java.grpc.capture_metadata.client.request
-      description: |
-        A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes.
-      type: list
-      default: ''
-      examples:
-      - custom-request-header
-      - my-metadata-key,another-metadata-key
-    otel.instrumentation.grpc.capture-metadata.server.request:
-      name: otel.instrumentation.grpc.capture-metadata.server.request
-      declarative_name: java.grpc.capture_metadata.server.request
-      description: |
-        A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes.
-      type: list
-      default: ''
-    otel.instrumentation.grpc.emit-message-events:
-      name: otel.instrumentation.grpc.emit-message-events
-      declarative_name: java.grpc.emit_message_events
-      description: Determines whether to emit a span event for each individual message
-        received and sent.
-      type: boolean
-      default: true
-    otel.instrumentation.grpc.experimental-span-attributes:
-      name: otel.instrumentation.grpc.experimental-span-attributes
-      declarative_name: java.grpc.experimental_span_attributes/development
-      description: |
-        Enable the capture of experimental span attributes `grpc.received.message_count`, `grpc.sent.message_count` and `grpc.canceled`.
-      type: boolean
-      default: false
-    otel.instrumentation.guava.experimental-span-attributes:
-      name: otel.instrumentation.guava.experimental-span-attributes
-      declarative_name: java.guava.experimental_span_attributes/development
-      description: Enables experimental span attribute `guava.canceled` for cancelled
-        operations.
-      type: boolean
-      default: false
-    otel.instrumentation.hibernate.experimental-span-attributes:
-      name: otel.instrumentation.hibernate.experimental-span-attributes
-      declarative_name: java.hibernate.experimental_span_attributes/development
-      description: Enables the experimental `hibernate.session_id` span attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.hystrix.experimental-span-attributes:
-      name: otel.instrumentation.hystrix.experimental-span-attributes
-      declarative_name: java.hystrix.experimental_span_attributes/development
-      description: Enables capturing the experimental `hystrix.command`, `hystrix.circuit_open`
-        and `hystrix.group` span attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.java-util-logging.experimental-log-attributes:
-      name: otel.instrumentation.java-util-logging.experimental-log-attributes
-      declarative_name: java.java_util_logging.experimental_log_attributes/development
-      description: Enables capturing the experimental `thread.name` and `thread.id`
-        log attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.java-util-logging.experimental.capture-arguments:
-      name: otel.instrumentation.java-util-logging.experimental.capture-arguments
-      declarative_name: java.java_util_logging.capture_arguments/development
-      description: Enables the capture of the log message arguments.
-      type: boolean
-      default: false
-    otel.instrumentation.java-util-logging.experimental.capture-template:
-      name: otel.instrumentation.java-util-logging.experimental.capture-template
-      declarative_name: java.java_util_logging.capture_template/development
-      description: Enables the capture of the log message template (if arguments are
-        provided).
-      type: boolean
-      default: false
-    otel.instrumentation.jaxrs.experimental-span-attributes:
-      name: otel.instrumentation.jaxrs.experimental-span-attributes
-      declarative_name: java.jaxrs.experimental_span_attributes/development
-      description: Enables the experimental `jaxrs.canceled` span attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.jboss-logmanager.experimental-log-attributes:
-      name: otel.instrumentation.jboss-logmanager.experimental-log-attributes
-      declarative_name: java.jboss_logmanager.experimental_log_attributes/development
-      description: |
-        Enables the capture of experimental log attributes, including thread name and thread ID.
-      type: boolean
-      default: false
-    otel.instrumentation.jboss-logmanager.experimental.capture-arguments:
-      name: otel.instrumentation.jboss-logmanager.experimental.capture-arguments
-      declarative_name: java.jboss_logmanager.capture_arguments/development
-      description: |
-        Enables the capture of the log message arguments.
-      type: boolean
-      default: false
-    otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes:
-      name: otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
-      declarative_name: java.jboss_logmanager.capture_mdc_attributes/development
-      description: |
-        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-      type: list
-      default: ''
-      examples:
-      - custom-mdc-key
-      - key1,key2,key3
-    otel.instrumentation.jboss-logmanager.experimental.capture-template:
-      name: otel.instrumentation.jboss-logmanager.experimental.capture-template
-      declarative_name: java.jboss_logmanager.capture_template/development
-      description: |
-        Enables the capture of the log message template (if arguments are provided).
-      type: boolean
-      default: false
-    otel.instrumentation.jdbc-datasource.enabled:
-      name: otel.instrumentation.jdbc-datasource.enabled
-      declarative_name: java.jdbc_datasource.enabled
-      description: Enables instrumentation of JDBC datasource connections.
-      type: boolean
-      default: false
-    otel.instrumentation.jdbc.experimental.capture-query-parameters:
-      name: otel.instrumentation.jdbc.experimental.capture-query-parameters
-      declarative_name: java.jdbc.capture_query_parameters/development
-      description: |
-        Sets whether the query parameters should be captured as span attributes named <code>db.query.parameter.&lt;key&gt;</code>. Enabling this option disables the statement sanitization.<p>WARNING: captured query parameters may contain sensitive information such as passwords, personally identifiable information or protected health info.
-      type: boolean
-      default: false
-    otel.instrumentation.jdbc.experimental.sqlcommenter.enabled:
-      name: otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
-      declarative_name: java.jdbc.sqlcommenter/development.enabled
-      description: |
-        Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance. Consult with database experts before enabling.
-      type: boolean
-      default: false
-    otel.instrumentation.jdbc.experimental.transaction.enabled:
-      name: otel.instrumentation.jdbc.experimental.transaction.enabled
-      declarative_name: java.jdbc.transaction/development.enabled
-      description: Enables experimental instrumentation to create spans for COMMIT
-        and ROLLBACK operations.
-      type: boolean
-      default: false
-    otel.instrumentation.jdbc.query-sanitization.enabled:
-      name: otel.instrumentation.jdbc.query-sanitization.enabled
-      declarative_name: java.jdbc.query_sanitization.enabled
-      description: Enables query sanitization for database queries. Takes precedence
-        over otel.instrumentation.common.db.query-sanitization.enabled.
-      type: boolean
-      default: true
-    otel.instrumentation.jsp.experimental-span-attributes:
-      name: otel.instrumentation.jsp.experimental-span-attributes
-      declarative_name: java.jsp.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `jsp.forwardOrigin`, `jsp.requestURL`, `jsp.compiler`, and `jsp.classFQCN`.
-      type: boolean
-      default: false
-    otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4:
-      name: otel.instrumentation.kafka.experimental-span-attributes
-      declarative_name: java.kafka.experimental_span_attributes/development
-      description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
-        and `messaging.kafka.bootstrap.servers`.
-      type: boolean
-      default: false
-    otel.instrumentation.kafka.experimental-span-attributes-6596b308:
-      name: otel.instrumentation.kafka.experimental-span-attributes
-      declarative_name: java.kafka.experimental_span_attributes/development
-      description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`
-        and `messaging.kafka.bootstrap.servers`.
-      type: boolean
-      default: false
-    otel.instrumentation.kafka.experimental-span-attributes-956cabd8:
-      name: otel.instrumentation.kafka.experimental-span-attributes
-      declarative_name: java.kafka.experimental_span_attributes/development
-      description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
-      type: boolean
-      default: false
-    otel.instrumentation.kafka.producer-propagation.enabled:
-      name: otel.instrumentation.kafka.producer-propagation.enabled
-      declarative_name: java.kafka.producer_propagation.enabled
-      description: Enable context propagation for Kafka message producers.
-      type: boolean
-      default: true
-    otel.instrumentation.kubernetes-client.experimental-span-attributes:
-      name: otel.instrumentation.kubernetes-client.experimental-span-attributes
-      declarative_name: java.kubernetes_client.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `kubernetes-client.namespace` and `kubernetes-client.name` for Kubernetes API requests.
-      type: boolean
-      default: false
-    otel.instrumentation.lettuce.connection-telemetry.enabled:
-      name: otel.instrumentation.lettuce.connection-telemetry.enabled
-      declarative_name: java.lettuce.connection_telemetry.enabled
-      description: Enables connection telemetry spans for Redis connections.
-      type: boolean
-      default: false
-    otel.instrumentation.lettuce.experimental-span-attributes-48d10623:
-      name: otel.instrumentation.lettuce.experimental-span-attributes
-      declarative_name: java.lettuce.experimental_span_attributes/development
-      description: Enables experimental span attribute `lettuce.command.cancelled`.
-      type: boolean
-      default: false
-    otel.instrumentation.lettuce.experimental-span-attributes-f6bf8fef:
-      name: otel.instrumentation.lettuce.experimental-span-attributes
-      declarative_name: java.lettuce.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `lettuce.command.cancelled` and `lettuce.command.results.count`.
-      type: boolean
-      default: false
-    otel.instrumentation.lettuce.experimental.command-encoding-events.enabled:
-      name: otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
-      declarative_name: java.lettuce.command_encoding_events/development.enabled
-      description: Enables capturing `redis.encode.start` and `redis.encode.end` span
-        events.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental-log-attributes:
-      name: otel.instrumentation.log4j-appender.experimental-log-attributes
-      declarative_name: java.log4j_appender.experimental_log_attributes/development
-      description: |
-        Enables the capture of experimental log attributes, including thread name and thread ID.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental.capture-arguments:
-      name: otel.instrumentation.log4j-appender.experimental.capture-arguments
-      declarative_name: java.log4j_appender.capture_arguments/development
-      description: |
-        Enables the capture of the log message arguments.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental.capture-code-attributes:
-      name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
-      declarative_name: java.log4j_appender.capture_code_attributes/development
-      description: |
-        Enables the capture of code location attributes, including file path, class name, method name, and line number.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes:
-      name: otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
-      declarative_name: java.log4j_appender.capture_map_message_attributes/development
-      description: |
-        Enables the capture of attributes from Log4j MapMessage instances.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental.capture-marker-attribute:
-      name: otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
-      declarative_name: java.log4j_appender.capture_marker_attribute/development
-      description: |
-        Enables the capture of the Log4j marker attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-436113d6:
-      name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
-      declarative_name: java.log4j_appender.capture_mdc_attributes/development
-      description: |
-        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-      type: list
-      default: ''
-      examples:
-      - custom-mdc-key
-      - key1,key2,key3
-    otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-e8e19d91:
-      name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
-      declarative_name: java.log4j_appender.capture_mdc_attributes/development
-      description: |
-        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-      type: list
-      default: ''
-      examples:
-      - '*'
-      - key1,key2
-    otel.instrumentation.log4j-appender.experimental.capture-template:
-      name: otel.instrumentation.log4j-appender.experimental.capture-template
-      declarative_name: java.log4j_appender.capture_template/development
-      description: |
-        Enables the capture of the log message template (if arguments are provided).
-      type: boolean
-      default: false
-    otel.instrumentation.log4j-context-data.add-baggage:
-      name: otel.instrumentation.log4j-context-data.add-baggage
-      declarative_name: java.log4j_context_data.add_baggage
-      description: |
-        Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental-log-attributes:
-      name: otel.instrumentation.logback-appender.experimental-log-attributes
-      declarative_name: java.logback_appender.experimental_log_attributes/development
-      description: |
-        Enables the capture of experimental log attributes, including thread name and thread ID.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-arguments:
-      name: otel.instrumentation.logback-appender.experimental.capture-arguments
-      declarative_name: java.logback_appender.capture_arguments/development
-      description: |
-        Enables the capture of log message arguments as separate attributes.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-code-attributes:
-      name: otel.instrumentation.logback-appender.experimental.capture-code-attributes
-      declarative_name: java.logback_appender.capture_code_attributes/development
-      description: |
-        Enables the capture of code location attributes, including file path, class name, method name, and line number.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes:
-      name: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
-      declarative_name: java.logback_appender.capture_key_value_pair_attributes/development
-      description: |
-        Enables the capture of attributes from Logback key-value pairs.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes:
-      name: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
-      declarative_name: java.logback_appender.capture_logger_context_attributes/development
-      description: |
-        Enables the capture of attributes from the Logback logger context.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes:
-      name: otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
-      declarative_name: java.logback_appender.capture_logstash_marker_attributes/development
-      description: |
-        Enables the capture of attributes from Logstash markers.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments:
-      name: otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
-      declarative_name: java.logback_appender.capture_logstash_structured_arguments/development
-      description: |
-        Enables the capture of attributes from Logstash structured arguments.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-marker-attribute:
-      name: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
-      declarative_name: java.logback_appender.capture_marker_attribute/development
-      description: |
-        Enables the capture of the Logback marker attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-appender.experimental.capture-mdc-attributes:
-      name: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
-      declarative_name: java.logback_appender.capture_mdc_attributes/development
-      description: |
-        Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
-      type: list
-      default: ''
-      examples:
-      - custom-mdc-key
-      - key1,key2,key3
-    otel.instrumentation.logback-appender.experimental.capture-template:
-      name: otel.instrumentation.logback-appender.experimental.capture-template
-      declarative_name: java.logback_appender.capture_template/development
-      description: |
-        Enables the capture of the log message template before parameter substitution.
-      type: boolean
-      default: false
-    otel.instrumentation.logback-mdc.add-baggage:
-      name: otel.instrumentation.logback-mdc.add-baggage
-      declarative_name: java.logback_mdc.add_baggage
-      description: |
-        Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
-      type: boolean
-      default: false
-    otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6:
-      name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-      declarative_name: java.common.messaging.receive_telemetry/development.enabled
-      description: |
-        Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
-      type: boolean
-      default: false
-    otel.instrumentation.messaging.experimental.receive-telemetry.enabled-59c44ca8:
-      name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
-      declarative_name: java.common.messaging.receive_telemetry/development.enabled
-      description: |
-        Enables the creation of consumer spans on messaging receive operations. These spans will measure the time between receiving a message and the consumer processing that message.
-      type: boolean
-      default: false
-    otel.instrumentation.methods.include:
-      name: otel.instrumentation.methods.include
-      declarative_name: java.methods.include
-      description: Semicolon-separated list of fully qualified class and method patterns
-        to instrument.
-      type: list
-      default: ''
-      examples:
-      - com.example.MyClass[method1]
-      - com.example.MyClass[method1,method2];com.example.OtherClass[call]
-    otel.instrumentation.micrometer.base-time-unit:
-      name: otel.instrumentation.micrometer.base-time-unit
-      declarative_name: java.micrometer.base_time_unit
-      description: |
-        Sets the base time unit for the OpenTelemetry MeterRegistry. Supported values: ns, us, ms, s, min, h, d.
-      type: string
-      default: s
-      examples:
-      - ns
-      - milliseconds
-    otel.instrumentation.micrometer.histogram-gauges.enabled:
-      name: otel.instrumentation.micrometer.histogram-gauges.enabled
-      declarative_name: java.micrometer.histogram_gauges.enabled
-      description: |
-        Enables gauge-based Micrometer histograms for DistributionSummary and Timer instruments.
-      type: boolean
-      default: false
-    otel.instrumentation.micrometer.prometheus-mode.enabled:
-      name: otel.instrumentation.micrometer.prometheus-mode.enabled
-      declarative_name: java.micrometer.prometheus_mode.enabled
-      description: |
-        Simulates the behavior of Micrometer's PrometheusMeterRegistry. The instruments will be renamed to match Micrometer instrument naming, and the base time unit will be set to seconds.
-      type: boolean
-      default: false
-    otel.instrumentation.mongo.query-sanitization.enabled:
-      name: otel.instrumentation.mongo.query-sanitization.enabled
-      declarative_name: java.mongo.query_sanitization.enabled
-      description: |
-        Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-      type: boolean
-      default: true
-    otel.instrumentation.netty.connection-telemetry.enabled:
-      name: otel.instrumentation.netty.connection-telemetry.enabled
-      declarative_name: java.netty.connection_telemetry.enabled
-      description: Enable the creation of Connect and DNS spans.
-      type: boolean
-      default: false
-    otel.instrumentation.netty.ssl-telemetry.enabled:
-      name: otel.instrumentation.netty.ssl-telemetry.enabled
-      declarative_name: java.netty.ssl_telemetry.enabled
-      description: Enable SSL telemetry.
-      type: boolean
-      default: false
-    otel.instrumentation.opensearch.capture-search-query:
-      name: otel.instrumentation.opensearch.capture-search-query
-      declarative_name: java.opensearch.capture_search_query
-      description: |
-        Enable the capture of sanitized search query bodies. Search queries may contain personal or sensitive information.
-      type: boolean
-      default: true
-    otel.instrumentation.opentelemetry-annotations.exclude-methods:
-      name: otel.instrumentation.opentelemetry-annotations.exclude-methods
-      declarative_name: java.opentelemetry_extension_annotations.exclude_methods
-      description: All methods to be excluded from auto-instrumentation by annotation-based
-        advices.
-      type: string
-      default: ''
-      examples:
-      - com.example.MyClass[method1,method2]
-      - com.example.MyClass[method1];com.example.OtherClass[method2]
-    otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods:
-      name: otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
-      declarative_name: java.opentelemetry_instrumentation_annotations.exclude_methods
-      description: All methods to be excluded from auto-instrumentation by annotation-based
-        advices.
-      type: string
-      default: ''
-      examples:
-      - com.example.MyClass[method1,method2]
-      - com.example.MyClass[method1];com.example.OtherClass[method2]
-    otel.instrumentation.oshi.experimental-metrics.enabled:
-      name: otel.instrumentation.oshi.experimental-metrics.enabled
-      declarative_name: java.oshi.experimental_metrics/development.enabled
-      description: Enable the experimental `runtime.java.memory` and `runtime.java.cpu_time`
-        metrics.
-      type: boolean
-      default: false
-    otel.instrumentation.powerjob.experimental-span-attributes:
-      name: otel.instrumentation.powerjob.experimental-span-attributes
-      declarative_name: java.powerjob.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `job.system`, `scheduling.powerjob.job.id`, `scheduling.powerjob.job.param`, `scheduling.powerjob.job.instance.param`, and `scheduling.powerjob.job.type`.
-      type: boolean
-      default: false
-    otel.instrumentation.pulsar.experimental-span-attributes-1d77bf4d:
-      name: otel.instrumentation.pulsar.experimental-span-attributes
-      declarative_name: java.pulsar.experimental_span_attributes/development
-      description: |
-        Enables capturing experimental span attribute `messaging.pulsar.message.type` on PRODUCER spans.
-      type: boolean
-      default: false
-    otel.instrumentation.pulsar.experimental-span-attributes-5ac8c0d9:
-      name: otel.instrumentation.pulsar.experimental-span-attributes
-      declarative_name: java.pulsar.experimental_span_attributes/development
-      description: |
-        Enables the experimental span attribute `messaging.pulsar.message.type` for producer spans.
-      type: boolean
-      default: false
-    otel.instrumentation.quartz.experimental-span-attributes:
-      name: otel.instrumentation.quartz.experimental-span-attributes
-      declarative_name: java.quartz.experimental_span_attributes/development
-      description: Enables the experimental `job.system` span attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled:
-      name: otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
-      declarative_name: java.r2dbc.sqlcommenter/development.enabled
-      description: |
-        Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance.
-      type: boolean
-      default: false
-    otel.instrumentation.r2dbc.query-sanitization.enabled:
-      name: otel.instrumentation.r2dbc.query-sanitization.enabled
-      declarative_name: java.r2dbc.query_sanitization.enabled
-      description: |
-        Enables query sanitization for database queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
-      type: boolean
-      default: true
-    otel.instrumentation.rabbitmq.experimental-span-attributes:
-      name: otel.instrumentation.rabbitmq.experimental-span-attributes
-      declarative_name: java.rabbitmq.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `rabbitmq.command`, `rabbitmq.delivery_mode`, `rabbitmq.queue`, and `rabbitmq.record.queue_time_ms`.
-      type: boolean
-      default: false
-    otel.instrumentation.reactor-netty.connection-telemetry.enabled:
-      name: otel.instrumentation.reactor-netty.connection-telemetry.enabled
-      declarative_name: java.reactor_netty.connection_telemetry.enabled
-      description: Enables the creation of Connect and DNS spans.
-      type: boolean
-      default: false
-    otel.instrumentation.reactor.experimental-span-attributes:
-      name: otel.instrumentation.reactor.experimental-span-attributes
-      declarative_name: java.reactor.experimental_span_attributes/development
-      description: |
-        Enables the capture of the experimental `reactor.canceled` attribute on spans when reactive streams are cancelled.
-      type: boolean
-      default: false
-    otel.instrumentation.resources.experimental.process-command-attributes.enabled:
-      name: otel.instrumentation.resources.experimental.process-command-attributes.enabled
-      description: |
-        Enables capture of process command-line resource attributes when v3 preview suppresses them by default.
-      type: boolean
-      default: false
-    otel.instrumentation.rocketmq-client.experimental-span-attributes:
-      name: otel.instrumentation.rocketmq-client.experimental-span-attributes
-      declarative_name: java.rocketmq_client.experimental_span_attributes/development
-      description: |
-        Enables capturing experimental span attributes `messaging.rocketmq.message.tag`, `messaging.rocketmq.broker_address`, `messaging.rocketmq.send_result`, `messaging.rocketmq.queue_id`, and `messaging.rocketmq.queue_offset`.
-      type: boolean
-      default: false
-    otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics:
-      name: otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
-      declarative_name: java.runtime_telemetry.emit_experimental_jfr_metrics/development
-      description: |
-        Enables the capture of experimental JFR-based JVM runtime metrics on Java 17+.
-      type: boolean
-      default: false
-    otel.instrumentation.runtime-telemetry.emit-experimental-metrics:
-      name: otel.instrumentation.runtime-telemetry.emit-experimental-metrics
-      declarative_name: java.runtime_telemetry.emit_experimental_metrics/development
-      description: Enables the capture of experimental JMX-based JVM runtime metrics.
-      type: boolean
-      default: false
-    otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled:
-      name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
-      declarative_name: java.runtime_telemetry.package_emitter/development.enabled
-      description: Enables creating events for JAR libraries used by the application.
-      type: boolean
-      default: false
-    otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second:
-      name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
-      declarative_name: java.runtime_telemetry.package_emitter/development.jars_per_second
-      description: The number of JAR files processed per second by the package emitter.
-      type: int
-      default: 10
-    otel.instrumentation.runtime-telemetry.experimental.prefer-jfr:
-      name: otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
-      declarative_name: java.runtime_telemetry.prefer_jfr/development
-      description: |
-        Prefer JFR over JMX for metrics available from both sources, on Java 17+. When enabled, overlapping metrics are collected via JFR and the corresponding JMX metrics are suppressed.
-      type: boolean
-      default: false
-    otel.instrumentation.rxjava.experimental-span-attributes:
-      name: otel.instrumentation.rxjava.experimental-span-attributes
-      declarative_name: java.rxjava.experimental_span_attributes/development
-      description: |
-        Enables the experimental span attribute `rxjava.canceled`.
-      type: boolean
-      default: false
-    otel.instrumentation.servlet.experimental-span-attributes:
-      name: otel.instrumentation.servlet.experimental-span-attributes
-      declarative_name: java.servlet.experimental_span_attributes/development
-      description: Enables capturing the experimental `servlet.timeout` span attribute.
-      type: boolean
-      default: false
-    otel.instrumentation.servlet.experimental.capture-request-parameters:
-      name: otel.instrumentation.servlet.experimental.capture-request-parameters
-      declarative_name: java.servlet.capture_request_parameters/development
-      description: List of request parameter names to capture as span attributes.
-      type: list
-      default: ''
-    otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled:
-      name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
-      declarative_name: java.servlet.trace_id_request_attribute/development.enabled
-      description: Enables adding the trace ID and span ID as request attributes for
-        downstream servlet access.
-      type: boolean
-      default: true
-    otel.instrumentation.spring-batch.experimental-span-attributes:
-      name: otel.instrumentation.spring-batch.experimental-span-attributes
-      declarative_name: java.spring_batch.experimental_span_attributes/development
-      description: Adds the experimental attribute `job.system` to spans.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-batch.experimental.chunk.new-trace:
-      name: otel.instrumentation.spring-batch.experimental.chunk.new-trace
-      declarative_name: java.spring_batch.chunk/development.new_trace
-      description: When enabled, a new root span will be created for each chunk processing.
-        Please note that this may lead to a high number of spans being created.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-batch.item.enabled:
-      name: otel.instrumentation.spring-batch.item.enabled
-      declarative_name: java.spring_batch.item.enabled
-      description: When enabled, spans will be created for each item processed. Please
-        note that this may lead to a high number of spans being created.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-cloud-gateway.experimental-span-attributes:
-      name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
-      declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
-      description: |
-        Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-integration.global-channel-interceptor-patterns:
-      name: otel.instrumentation.spring-integration.global-channel-interceptor-patterns
-      declarative_name: java.spring_integration.global_channel_interceptor_patterns
-      description: A list of Spring channel name patterns that will be intercepted.
-      type: list
-      default: '*'
-    otel.instrumentation.spring-integration.producer.enabled:
-      name: otel.instrumentation.spring-integration.producer.enabled
-      declarative_name: java.spring_integration.producer.enabled
-      description: |
-        Create producer spans when messages are sent to an output channel. Enable when you're using a messaging library that doesn't have its own instrumentation for generating producer spans. Note that the detection of output channels only works for Spring Cloud Stream `DirectWithAttributesChannel`.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-scheduling.experimental-span-attributes:
-      name: otel.instrumentation.spring-scheduling.experimental-span-attributes
-      declarative_name: java.spring_scheduling.experimental_span_attributes/development
-      description: Adds the experimental span attribute `job.system` with the value
-        `spring_scheduling`.
-      type: boolean
-      default: false
-    otel.instrumentation.spring-security.enduser.role.granted-authority-prefix:
-      name: otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
-      declarative_name: java.spring_security.enduser.role.granted_authority_prefix
-      description: Prefix of granted authorities identifying roles to capture in the
-        `enduser.role` semantic attribute. This property is not honored when v3 preview
-        is enabled; use the `user.roles` variant instead.
-      type: string
-      default: ROLE_
-    otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix:
-      name: otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
-      declarative_name: java.spring_security.enduser.scope.granted_authority_prefix
-      description: Prefix of granted authorities identifying scopes to capture in
-        the `enduser.scope` semantic attribute. This property and the associated attribute
-        are not supported when v3 preview is enabled.
-      type: string
-      default: SCOPE_
-    otel.instrumentation.spring-security.user.roles.granted-authority-prefix:
-      name: otel.instrumentation.spring-security.user.roles.granted-authority-prefix
-      declarative_name: java.spring_security.user.roles.granted_authority_prefix
-      description: Prefix of granted authorities identifying roles to capture in the
-        `user.roles` semantic attribute when v3 preview is enabled. This property
-        is not honored when v3 preview is disabled; use the `enduser.role` variant
-        instead.
-      type: string
-      default: ROLE_
-    otel.instrumentation.spring-webmvc.experimental-span-attributes:
-      name: otel.instrumentation.spring-webmvc.experimental-span-attributes
-      declarative_name: java.spring_webmvc.experimental_span_attributes/development
-      description: |
-        Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
-      type: boolean
-      default: false
-    otel.instrumentation.spymemcached.experimental-span-attributes:
-      name: otel.instrumentation.spymemcached.experimental-span-attributes
-      declarative_name: java.spymemcached.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `spymemcached.result` and `spymemcached.command.cancelled`.
-      type: boolean
-      default: false
-    otel.instrumentation.twilio.experimental-span-attributes:
-      name: otel.instrumentation.twilio.experimental-span-attributes
-      declarative_name: java.twilio.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `twilio.type`, `twilio.account`, `twilio.sid`, `twilio.parentSid`, and `twilio.status`.
-      type: boolean
-      default: false
-    otel.instrumentation.xxl-job.experimental-span-attributes:
-      name: otel.instrumentation.xxl-job.experimental-span-attributes
-      declarative_name: java.xxl_job.experimental_span_attributes/development
-      description: |
-        Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
-      type: boolean
-      default: false
-    otel.jmx.config:
-      name: otel.jmx.config
-      declarative_name: java.jmx.config
-      description: List of paths to JMX metric definition YAML files.
-      type: list
-      default: ''
-    otel.jmx.discovery.delay:
-      name: otel.jmx.discovery.delay
-      declarative_name: java.jmx.discovery.delay
-      description: Time in milliseconds between JMX MBean detection attempts.
-      type: int
-      default: 60000
-    otel.jmx.enabled:
-      name: otel.jmx.enabled
-      declarative_name: java.jmx.enabled
-      description: Enables collection of JMX metrics.
-      type: boolean
-      default: true
-    otel.jmx.target.system:
-      name: otel.jmx.target.system
-      declarative_name: java.jmx.target.system
-      description: List of predefined JMX target systems to collect metrics for.
-      type: list
-      default: ''
-    otel.semconv-stability.opt-in:
-      name: otel.semconv-stability.opt-in
-      declarative_name: general.semconv_stability.opt_in
-      description: |
-        Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
-      type: list
-      default: ''
-    sanitization.url.sensitive-query-parameters:
-      name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-      declarative_name: general.sanitization.url.sensitive_query_parameters/development
-      description: List of URL query parameter names whose values are redacted in
-        URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-      type: list
-      default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
-  metrics:
-    db.client.connection.count-2e6ba9b7:
-      name: db.client.connection.count
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-      - name: db.client.connection.state
-        type: STRING
-    db.client.connection.create_time-4f586679:
-      name: db.client.connection.create_time
-      description: The time it took to create a new connection.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.idle.max-b95e4f5c:
-      name: db.client.connection.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.idle.min-73bdafbc:
-      name: db.client.connection.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.max-c7917942:
-      name: db.client.connection.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connection}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.pending_requests-a0f41111:
-      name: db.client.connection.pending_requests
-      description: The number of current pending requests for an open connection.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{request}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.timeouts-d2dbfa58:
-      name: db.client.connection.timeouts
-      description: The number of connection timeouts that have occurred trying to
-        obtain a connection from the pool.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{timeout}'
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.use_time-a06760eb:
-      name: db.client.connection.use_time
-      description: The time between borrowing a connection and returning it to the
-        pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connection.wait_time-40a55682:
-      name: db.client.connection.wait_time
-      description: The time it took to obtain an open connection from the pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.client.connection.pool.name
-        type: STRING
-    db.client.connections.create_time-6f641171:
-      name: db.client.connections.create_time
-      description: The time it took to create a new connection.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.idle.max-f9946dd5:
-      name: db.client.connections.idle.max
-      description: The maximum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.idle.min-f04d4083:
-      name: db.client.connections.idle.min
-      description: The minimum number of idle open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.max-ddde65fe:
-      name: db.client.connections.max
-      description: The maximum number of open connections allowed.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.pending_requests-a0698f55:
-      name: db.client.connections.pending_requests
-      description: The number of pending requests for an open connection, cumulative
-        for the entire pool.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.timeouts-b32b8a2b:
-      name: db.client.connections.timeouts
-      description: The number of connection timeouts that have occurred trying to
-        obtain a connection from the pool.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{timeouts}'
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.usage-5ef1d5ef:
-      name: db.client.connections.usage
-      description: The number of connections that are currently in state described
-        by the state attribute.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{connections}'
-      attributes:
-      - name: pool.name
-        type: STRING
-      - name: state
-        type: STRING
-    db.client.connections.use_time-cb3aefff:
-      name: db.client.connections.use_time
-      description: The time between borrowing a connection and returning it to the
-        pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.connections.wait_time-e6bdd10e:
-      name: db.client.connections.wait_time
-      description: The time it took to obtain an open connection from the pool.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: pool.name
-        type: STRING
-    db.client.operation.duration-32559b79:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-39ae058b:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-    db.client.operation.duration-4f486dc3:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-55295033:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-    db.client.operation.duration-7714cbf7:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-    db.client.operation.duration-88382861:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-8ae2b8ce:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-bfd9d23c:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: network.peer.address
-        type: STRING
-      - name: network.peer.port
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-d4212042:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.namespace
-        type: STRING
-      - name: db.query.summary
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    db.client.operation.duration-e36c6087:
-      name: db.client.operation.duration
-      description: Duration of database client operations.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: db.collection.name
-        type: STRING
-      - name: db.namespace
-        type: STRING
-      - name: db.operation.name
-        type: STRING
-      - name: db.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    failsafe.circuit_breaker.execution.count-9271cf8d:
-      name: failsafe.circuit_breaker.execution.count
-      description: Count of circuit breaker executions.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.circuit_breaker.name
-        type: STRING
-      - name: failsafe.circuit_breaker.outcome
-        type: STRING
-    failsafe.circuit_breaker.state_change.count-09bbffb6:
-      name: failsafe.circuit_breaker.state_change.count
-      description: Count of circuit breaker state changes.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.circuit_breaker.name
-        type: STRING
-      - name: failsafe.circuit_breaker.state
-        type: STRING
-    failsafe.retry_policy.attempts-cc34346c:
-      name: failsafe.retry_policy.attempts
-      description: Number of attempts for each execution.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{attempt}'
-      attributes:
-      - name: failsafe.retry_policy.name
-        type: STRING
-      - name: failsafe.retry_policy.outcome
-        type: STRING
-    failsafe.retry_policy.execution.count-d01cba44:
-      name: failsafe.retry_policy.execution.count
-      description: Count of execution attempts processed by the retry policy, where
-        one execution represents the total number of attempts.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{execution}'
-      attributes:
-      - name: failsafe.retry_policy.name
-        type: STRING
-      - name: failsafe.retry_policy.outcome
-        type: STRING
-    gen_ai.client.operation.duration-32ef946d:
-      name: gen_ai.client.operation.duration
-      description: GenAI operation duration.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.response.model
-        type: STRING
-    gen_ai.client.operation.duration-d420df10:
-      name: gen_ai.client.operation.duration
-      description: GenAI operation duration.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-    gen_ai.client.token.usage-9c41606c:
-      name: gen_ai.client.token.usage
-      description: Measures number of input and output tokens used.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{token}'
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.token.type
-        type: STRING
-    gen_ai.client.token.usage-c5ff244f:
-      name: gen_ai.client.token.usage
-      description: Measures number of input and output tokens used.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: '{token}'
-      attributes:
-      - name: gen_ai.operation.name
-        type: STRING
-      - name: gen_ai.provider.name
-        type: STRING
-      - name: gen_ai.request.model
-        type: STRING
-      - name: gen_ai.response.model
-        type: STRING
-      - name: gen_ai.token.type
-        type: STRING
-    http.client.request.duration-98bb5f3b:
-      name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    http.client.request.duration-a64b5297:
-      name: http.client.request.duration
-      description: Duration of HTTP client requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    http.server.active_requests-2c1402e2:
-      name: http.server.active_requests
-      description: Number of active HTTP server requests.
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: '{requests}'
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    http.server.request.duration-1f6f63ed:
-      name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    http.server.request.duration-2311bdb1:
-      name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    http.server.request.duration-639e2d0b:
-      name: http.server.request.duration
-      description: Duration of HTTP server requests.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    http.server.response.body.size-9ece7062:
-      name: http.server.response.body.size
-      description: Size of HTTP server response bodies.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: http.request.method
-        type: STRING
-      - name: http.response.status_code
-        type: LONG
-      - name: http.route
-        type: STRING
-      - name: network.protocol.version
-        type: STRING
-      - name: url.scheme
-        type: STRING
-    iceberg.scan.data_files.count-7869922f:
-      name: iceberg.scan.data_files.count
-      description: The number of data files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.data_files.size-25d28777:
-      name: iceberg.scan.data_files.size
-      description: The total size of all scanned data files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.data_manifests.count-91f2a926:
-      name: iceberg.scan.data_manifests.count
-      description: The number of data manifests.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.delete_files.count-2ce39a8f:
-      name: iceberg.scan.delete_files.count
-      description: The number of delete files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.delete_file.type
-        type: STRING
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.delete_files.size-c63edff8:
-      name: iceberg.scan.delete_files.size
-      description: The total size of all scanned delete files.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.delete_manifests.count-304a613c:
-      name: iceberg.scan.delete_manifests.count
-      description: The number of delete manifests.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{file}'
-      attributes:
-      - name: iceberg.scan.state
-        type: STRING
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    iceberg.scan.planning.duration-6654a71a:
-      name: iceberg.scan.planning.duration
-      description: The total duration needed to plan the scan.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: iceberg.schema.id
-        type: LONG
-      - name: iceberg.table.name
-        type: STRING
-    messaging.publish.duration-05731f17:
-      name: messaging.publish.duration
-      description: Measures the duration of publish operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    messaging.receive.duration-4b4a91de:
-      name: messaging.receive.duration
-      description: Measures the duration of receive operation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    messaging.receive.messages-2499c5ac:
-      name: messaging.receive.messages
-      description: Measures the number of received messages.
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{message}'
-      attributes:
-      - name: messaging.destination.name
-        type: STRING
-      - name: messaging.operation
-        type: STRING
-      - name: messaging.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.client.call.duration-7381532d:
-      name: rpc.client.call.duration
-      description: Measures the duration of outbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.response.status_code
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.client.duration-599bf562:
-      name: rpc.client.duration
-      description: The duration of an outbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.client.request.size-0d8f967b:
-      name: rpc.client.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.client.response.size-d0124e0e:
-      name: rpc.client.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.server.call.duration-1e979856:
-      name: rpc.server.call.duration
-      description: Measures the duration of inbound remote procedure calls (RPC).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: s
-      attributes:
-      - name: rpc.method
-        type: STRING
-      - name: rpc.response.status_code
-        type: STRING
-      - name: rpc.system.name
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.server.duration-83a39fb3:
-      name: rpc.server.duration
-      description: The duration of an inbound RPC invocation.
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: ms
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.server.request.size-75ef4f8e:
-      name: rpc.server.request.size
-      description: Measures the size of RPC request messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    rpc.server.response.size-fb45af0b:
-      name: rpc.server.response.size
-      description: Measures the size of RPC response messages (uncompressed).
-      instrument: histogram
-      data_type: HISTOGRAM
-      unit: By
-      attributes:
-      - name: network.type
-        type: STRING
-      - name: rpc.grpc.status_code
-        type: LONG
-      - name: rpc.method
-        type: STRING
-      - name: rpc.service
-        type: STRING
-      - name: rpc.system
-        type: STRING
-      - name: server.address
-        type: STRING
-      - name: server.port
-        type: LONG
-    runtime.java.cpu_time-ac10c23f:
-      name: runtime.java.cpu_time
-      description: Runtime Java CPU time
-      instrument: gauge
-      data_type: LONG_GAUGE
-      unit: ms
-      attributes:
-      - name: type
-        type: STRING
-    runtime.java.memory-2a143889:
-      name: runtime.java.memory
-      description: Runtime Java memory
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: type
-        type: STRING
-    system.disk.io-58ee1ced:
-      name: system.disk.io
-      description: System disk IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    system.disk.operations-cf678806:
-      name: system.disk.operations
-      description: System disk operations
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{operations}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    system.memory.usage-11625112:
-      name: system.memory.usage
-      description: System memory usage
-      instrument: updowncounter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: state
-        type: STRING
-    system.memory.utilization-677660f3:
-      name: system.memory.utilization
-      description: System memory utilization
-      instrument: gauge
-      data_type: DOUBLE_GAUGE
-      unit: '1'
-      attributes:
-      - name: state
-        type: STRING
-    system.network.errors-0d1e8b98:
-      name: system.network.errors
-      description: System network errors
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{errors}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    system.network.io-518133c1:
-      name: system.network.io
-      description: System network IO
-      instrument: counter
-      data_type: LONG_SUM
-      unit: By
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
-    system.network.packets-6d263c01:
-      name: system.network.packets
-      description: System network packets
-      instrument: counter
-      data_type: LONG_SUM
-      unit: '{packets}'
-      attributes:
-      - name: device
-        type: STRING
-      - name: direction
-        type: STRING
 libraries:
 - name: activej-http-6.0
   display_name: ActiveJ
@@ -2070,15 +21,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.activej:activej-http:[6.0,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -2121,10 +103,6 @@ libraries:
   - com.typesafe.akka:akka-actor_2.11:[2.3,)
   - com.typesafe.akka:akka-actor_2.12:[2.3,)
   - com.typesafe.akka:akka-actor_2.13:[2.3,)
-- name: akka-actor-fork-join-2.5
-  source_path: instrumentation/akka/akka-actor-fork-join-2.5
-  scope:
-    name: io.opentelemetry.akka-actor-fork-join-2.5
 - name: akka-actor-forkjoin-2.5
   display_name: Akka Actors
   description: This instrumentation provides context propagation for the Akka Fork-Join
@@ -2162,22 +140,127 @@ libraries:
   - com.typesafe.akka:akka-http_2.11:[10,)
   - com.typesafe.akka:akka-http_2.12:[10,)
   - com.typesafe.akka:akka-http_2.13:[10,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2224,9 +307,39 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2286,23 +399,105 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.alibaba:druid:(,)
-  configuration_refs:
-  - otel.semconv-stability.opt-in
+  configurations:
+  - name: otel.semconv-stability.opt-in
+    declarative_name: general.semconv_stability.opt_in
+    description: |
+      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.idle.max-f9946dd5
-    - db.client.connections.idle.min-f04d4083
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.pending_requests-a0698f55
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.idle.max-b95e4f5c
-    - db.client.connection.idle.min-73bdafbc
-    - db.client.connection.max-c7917942
-    - db.client.connection.pending_requests-a0f41111
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: apache-dbcp-2.0
   display_name: Apache DBCP
   description: |
@@ -2318,21 +513,88 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.commons:commons-dbcp2:[2,)
-  configuration_refs:
-  - otel.semconv-stability.opt-in
+  configurations:
+  - name: otel.semconv-stability.opt-in
+    declarative_name: general.semconv_stability.opt_in
+    description: |
+      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.idle.max-f9946dd5
-    - db.client.connections.idle.min-f04d4083
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.idle.max-b95e4f5c
-    - db.client.connection.idle.min-73bdafbc
-    - db.client.connection.max-c7917942
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: apache-dubbo-2.7
   display_name: Apache Dubbo
   description: |
@@ -2349,8 +611,133 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.dubbo:dubbo:[2.7,)
-  configuration_refs:
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  telemetry:
+  - when: default
+    metrics:
+    - name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: peer.service
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - span_kind: SERVER
+      attributes:
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+  - when: otel.semconv-stability.opt-in=rpc,service.peer
+    metrics:
+    - name: rpc.client.call.duration
+      description: Measures the duration of outbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.call.duration
+      description: Measures the duration of inbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+    - span_kind: SERVER
+      attributes:
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
 - name: apache-elasticjob-3.0
   display_name: Apache ElasticJob
   description: This instrumentation enables spans for Apache ElasticJob job executions.
@@ -2361,8 +748,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.shardingsphere.elasticjob:elasticjob-lite-core:[3.0.0,)
-  configuration_refs:
-  - otel.instrumentation.apache-elasticjob.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.apache-elasticjob.experimental-span-attributes
+    declarative_name: java.apache_elasticjob.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `job.system`, `scheduling.apache-elasticjob.job.name`, `scheduling.apache-elasticjob.task.id`, `scheduling.apache-elasticjob.sharding.item.index`, `scheduling.apache-elasticjob.sharding.total.count`, `scheduling.apache-elasticjob.sharding.item.parameter`, and `scheduling.apache-elasticjob.job.type`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -2409,18 +801,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.httpcomponents:httpasyncclient:[4.1,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2443,8 +912,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2481,18 +965,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - commons-httpclient:commons-httpclient:[2.0,4.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2513,8 +1074,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2550,18 +1126,95 @@ libraries:
   javaagent_target_versions:
   - io.dropwizard:dropwizard-client:(,3.0.0)
   - org.apache.httpcomponents:httpclient:[4.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2584,8 +1237,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2622,8 +1290,23 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2660,18 +1343,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.httpcomponents.client5:httpclient5:[5.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2694,8 +1454,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2732,8 +1507,23 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2768,8 +1558,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.shenyu:shenyu-web:[2.4.0,)
-  configuration_refs:
-  - otel.instrumentation.apache-shenyu.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.apache-shenyu.experimental-span-attributes
+    declarative_name: java.apache_shenyu.experimental_span_attributes/development
+    description: |
+      Enables experimental `apache-shenyu.meta.` prefixed span attributes `app-name`, `service-name`, `context-path`, `param-types`, `id`, `method-name`, `rpc-type`, `path` and `rpc-ext`.
+    type: boolean
+    default: false
 - name: armeria-1.3
   display_name: Armeria
   description: |
@@ -2790,22 +1585,127 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.linecorp.armeria:armeria:[1.3.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2860,9 +1760,39 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -2999,18 +1929,93 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.ning:async-http-client:[1.8.0,1.9.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3031,8 +2036,21 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3067,18 +2085,93 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.ning:async-http-client:[1.9.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3099,8 +2192,21 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3135,18 +2241,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.asynchttpclient:async-http-client:[2.0.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3173,8 +2356,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3229,8 +2427,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.amazonaws:aws-lambda-java-core:[1.0.0,)
-  configuration_refs:
-  - otel.instrumentation.aws-lambda.flush-timeout
+  configurations:
+  - name: otel.instrumentation.aws-lambda.flush-timeout
+    declarative_name: java.aws_lambda.flush_timeout
+    description: Flush timeout in milliseconds.
+    type: int
+    default: 10000
   telemetry:
   - when: default
     spans:
@@ -3252,9 +2454,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.amazonaws:aws-lambda-java-core:[1.0.0,)
-  configuration_refs:
-  - http.known-methods
-  - otel.instrumentation.aws-lambda.flush-timeout
+  configurations:
+  - name: otel.instrumentation.aws-lambda.flush-timeout
+    declarative_name: java.aws_lambda.flush_timeout
+    description: Flush timeout in milliseconds.
+    type: int
+    default: 10000
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
     spans:
@@ -3290,8 +2501,12 @@ libraries:
   scope:
     name: io.opentelemetry.aws-lambda-events-3.11
   has_standalone_library: true
-  configuration_refs:
-  - otel.instrumentation.aws-lambda.flush-timeout
+  configurations:
+  - name: otel.instrumentation.aws-lambda.flush-timeout
+    declarative_name: java.aws_lambda.flush_timeout
+    description: Flush timeout in milliseconds.
+    type: int
+    default: 10000
   telemetry:
   - when: default
     spans:
@@ -3343,10 +2558,24 @@ libraries:
   javaagent_target_versions:
   - com.amazonaws:aws-java-sdk-core:[1.10.33,)
   - com.amazonaws:aws-java-sdk-sqs:[1.10.33,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.aws-sdk.experimental-span-attributes-f30ad240
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.aws-sdk.experimental-span-attributes
+    declarative_name: java.aws_sdk.experimental_span_attributes/development
+    description: |
+      Enables the experimental span attributes `aws.agent`, `aws.queue.name`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: Allows configuring headers to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
     spans:
@@ -3354,7 +2583,33 @@ libraries:
       attributes:
       - name: aws.agent
         type: STRING
+      - name: aws.dynamodb.table_names
+        type: STRING_ARRAY
+      - name: aws.kinesis.stream_name
+        type: STRING
+      - name: aws.lambda.function.arn
+        type: STRING
+      - name: aws.lambda.function.name
+        type: STRING
+      - name: aws.lambda.resource_mapping.id
+        type: STRING
+      - name: aws.queue.name
+        type: STRING
+      - name: aws.request_id
+        type: STRING
       - name: aws.s3.bucket
+        type: STRING
+      - name: aws.sns.topic.arn
+        type: STRING
+      - name: aws.sqs.queue.url
+        type: STRING
+      - name: aws.step_functions.activity.arn
+        type: STRING
+      - name: aws.step_functions.state_machine.arn
+        type: STRING
+      - name: db.operation
+        type: STRING
+      - name: db.system
         type: STRING
       - name: error.type
         type: STRING
@@ -3362,6 +2617,189 @@ libraries:
         type: STRING
       - name: http.response.status_code
         type: LONG
+      - name: messaging.destination.name
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+    - span_kind: CONSUMER
+      attributes:
+      - name: aws.agent
+        type: STRING
+      - name: aws.request_id
+        type: STRING
+      - name: aws.sqs.queue.url
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: messaging.batch.message_count
+        type: LONG
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.message.id
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+    - span_kind: PRODUCER
+      attributes:
+      - name: aws.agent
+        type: STRING
+      - name: aws.request_id
+        type: STRING
+      - name: aws.sqs.queue.url
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.message.id
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: aws.agent
+        type: STRING
+      - name: aws.dynamodb.table_names
+        type: STRING_ARRAY
+      - name: aws.kinesis.stream_name
+        type: STRING
+      - name: aws.lambda.function.arn
+        type: STRING
+      - name: aws.lambda.function.name
+        type: STRING
+      - name: aws.lambda.resource_mapping.id
+        type: STRING
+      - name: aws.queue.name
+        type: STRING
+      - name: aws.request_id
+        type: STRING
+      - name: aws.s3.bucket
+        type: STRING
+      - name: aws.sns.topic.arn
+        type: STRING
+      - name: aws.sqs.queue.url
+        type: STRING
+      - name: aws.step_functions.activity.arn
+        type: STRING
+      - name: aws.step_functions.state_machine.arn
+        type: STRING
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: messaging.destination.name
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+    - span_kind: CONSUMER
+      attributes:
+      - name: aws.agent
+        type: STRING
+      - name: aws.request_id
+        type: STRING
+      - name: aws.sqs.queue.url
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.message.id
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
       - name: network.protocol.version
         type: STRING
       - name: rpc.method
@@ -3399,18 +2837,71 @@ libraries:
   - software.amazon.awssdk:lambda:[2.17.0,)
   - software.amazon.awssdk:sns:[2.2.0,)
   - software.amazon.awssdk:sqs:[2.2.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.aws-sdk.experimental-record-individual-http-error
-  - otel.instrumentation.aws-sdk.experimental-span-attributes-0c4c01de
-  - otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
-  - otel.instrumentation.genai.capture-message-content-ceb072e9
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: Allows configuring headers to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.aws-sdk.experimental-span-attributes
+    declarative_name: java.aws_sdk.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `aws.agent`, `aws.lambda.function.arn` and `aws.lambda.function.name` for AWS SDK instrumentation.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
+    declarative_name: java.aws_sdk.use_propagator_for_messaging/development
+    description: Determines whether the configured TextMapPropagator should be used
+      to inject into supported messaging attributes (for SQS).
+    type: boolean
+    default: false
+  - name: otel.instrumentation.genai.capture-message-content
+    declarative_name: java.common.gen_ai.capture_message_content
+    description: |
+      Determines whether Generative AI events include full content of user and assistant messages. Note that full content can have data privacy and size concerns and care should be taken when enabling this
+    type: boolean
+    default: false
+  - name: otel.instrumentation.aws-sdk.experimental-record-individual-http-error
+    declarative_name: java.aws_sdk.record_individual_http_error/development
+    description: Determines whether errors returned by each individual HTTP request
+      should be recorded as events for the SDK span.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - gen_ai.client.operation.duration-d420df10
-    - gen_ai.client.token.usage-9c41606c
+    metrics:
+    - name: gen_ai.client.operation.duration
+      description: GenAI operation duration.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+    - name: gen_ai.client.token.usage
+      description: Measures number of input and output tokens used.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{token}'
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.token.type
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3567,8 +3058,19 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -3620,6 +3122,10 @@ libraries:
         type: STRING
       - name: aws.step_functions.state_machine.arn
         type: STRING
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.system.name
@@ -3776,13 +3282,48 @@ libraries:
   - com.mchange:c3p0:(,)
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.pending_requests-a0698f55
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.pending_requests-a0f41111
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: camel-2.20
   display_name: Apache Camel
   description: |
@@ -3801,8 +3342,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.camel:camel-core:[2.19,3)
-  configuration_refs:
-  - otel.instrumentation.camel.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.camel.experimental-span-attributes
+    declarative_name: java.camel.experimental_span_attributes/development
+    description: |
+      Enable the capture of experimental `camel.uri`, `camel.kafka.partitionKey`, `camel.kafka.key` and `camel.kafka.offset` span attributes.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -3954,9 +3500,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.datastax.cassandra:cassandra-driver-core:[3.0,4.0)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.cassandra.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.cassandra.query-sanitization.enabled
+    declarative_name: java.cassandra.query_sanitization.enabled
+    description: |
+      Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -3983,12 +3538,39 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-88382861
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.collection.name
+        type: STRING
       - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -4018,8 +3600,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.datastax.oss:java-driver-core:[4.0,4.4)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4058,8 +3644,29 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-88382861
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4075,7 +3682,13 @@ libraries:
         type: BOOLEAN
       - name: cassandra.speculative_execution.count
         type: LONG
+      - name: db.collection.name
+        type: STRING
       - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -4107,9 +3720,18 @@ libraries:
   javaagent_target_versions:
   - com.datastax.oss:java-driver-core:[4.4,)
   - org.apache.cassandra:java-driver-core:(,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.cassandra.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.cassandra.query-sanitization.enabled
+    declarative_name: java.cassandra.query_sanitization.enabled
+    description: |
+      Enables query sanitization for Cassandra queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4148,8 +3770,29 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-88382861
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4165,7 +3808,13 @@ libraries:
         type: BOOLEAN
       - name: cassandra.speculative_execution.count
         type: LONG
+      - name: db.collection.name
+        type: STRING
       - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
         type: STRING
       - name: db.query.summary
         type: STRING
@@ -4195,8 +3844,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.clickhouse:clickhouse-client:[0.5.0,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4215,8 +3868,23 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-d4212042
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4248,8 +3916,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.clickhouse:client-v2:[0.6.4,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4268,8 +3940,23 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-d4212042
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4301,9 +3988,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[2,3)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.couchbase.experimental-span-attributes-a850037a
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4318,8 +4014,17 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4347,9 +4052,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[2.6.0,3)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.couchbase.experimental-span-attributes-a850037a
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `couchbase.operation_id` and `couchbase.local.address`. Different operation types receive different experimental attributes.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -4392,8 +4106,21 @@ libraries:
       - name: network.type
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-7714cbf7
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4426,8 +4153,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.1,3.1.6)
-  configuration_refs:
-  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: Enables experimental span attributes emitted from the underlying
+      Couchbase library.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4461,6 +4193,48 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.couchbase.local_id
+        type: STRING
+      - name: db.couchbase.operation_id
+        type: LONG
+      - name: db.couchbase.scope
+        type: STRING
+      - name: db.couchbase.server_duration
+        type: LONG
+      - name: db.couchbase.service
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
 - name: couchbase-3.1.6
   display_name: Couchbase Client
   description: |
@@ -4476,8 +4250,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.1.6,3.2.0)
-  configuration_refs:
-  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: Enables experimental span attributes emitted from the underlying
+      Couchbase library.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4513,6 +4292,50 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.couchbase.local_id
+        type: STRING
+      - name: db.couchbase.operation_id
+        type: LONG
+      - name: db.couchbase.retries
+        type: LONG
+      - name: db.couchbase.scope
+        type: STRING
+      - name: db.couchbase.server_duration
+        type: LONG
+      - name: db.couchbase.service
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
 - name: couchbase-3.2
   display_name: Couchbase Client
   description: |
@@ -4528,8 +4351,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.2.0,3.4.0)
-  configuration_refs:
-  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: Enables experimental span attributes emitted from the underlying
+      Couchbase library.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4567,6 +4395,52 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.couchbase.document_id
+        type: STRING
+      - name: db.couchbase.local_id
+        type: STRING
+      - name: db.couchbase.operation_id
+        type: LONG
+      - name: db.couchbase.retries
+        type: LONG
+      - name: db.couchbase.scope
+        type: STRING
+      - name: db.couchbase.server_duration
+        type: LONG
+      - name: db.couchbase.service
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
 - name: couchbase-3.4
   display_name: Couchbase Client
   description: |
@@ -4582,8 +4456,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.couchbase.client:java-client:[3.4.0,)
-  configuration_refs:
-  - otel.instrumentation.couchbase.experimental-span-attributes-6c36d22e
+  configurations:
+  - name: otel.instrumentation.couchbase.experimental-span-attributes
+    declarative_name: java.couchbase.experimental_span_attributes/development
+    description: Enables experimental span attributes emitted from the underlying
+      Couchbase library.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4621,6 +4500,52 @@ libraries:
         type: LONG
       - name: net.transport
         type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database,otel.instrumentation.couchbase.experimental-span-attributes=true
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.couchbase.document_id
+        type: STRING
+      - name: db.couchbase.local_id
+        type: STRING
+      - name: db.couchbase.operation_id
+        type: LONG
+      - name: db.couchbase.retries
+        type: LONG
+      - name: db.couchbase.scope
+        type: STRING
+      - name: db.couchbase.server_duration
+        type: LONG
+      - name: db.couchbase.service
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
 - name: dropwizard-metrics-4.0
   display_name: Dropwizard Metrics
   description: |
@@ -4634,8 +4559,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.dropwizard.metrics:metrics-core:[4.0.0,)
-  configuration_refs:
-  - otel.instrumentation.dropwizard-metrics.enabled
+  configurations:
+  - name: otel.instrumentation.dropwizard-metrics.enabled
+    declarative_name: java.dropwizard_metrics.enabled
+    description: Enables the dropwizard metrics instrumentation.
+    type: boolean
+    default: false
 - name: dropwizard-views-0.7
   display_name: Dropwizard Views
   description: |
@@ -4649,8 +4578,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.dropwizard:dropwizard-views:(,3.0.0)
-  configuration_refs:
-  - otel.instrumentation.common.experimental.view-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
+    declarative_name: java.common.view_telemetry/development.enabled
+    description: Enables the creation of experimental view spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -4668,6 +4601,62 @@ libraries:
   javaagent_target_versions:
   - co.elastic.clients:elasticsearch-java:[7.16,7.17.20)
   - co.elastic.clients:elasticsearch-java:[8.0.0,8.10)
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.elasticsearch.path_parts.id
+        type: STRING
+      - name: db.elasticsearch.path_parts.index
+        type: STRING
+      - name: db.operation
+        type: STRING
+      - name: db.system
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.elasticsearch.path_parts.id
+        type: STRING
+      - name: db.elasticsearch.path_parts.index
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
 - name: elasticsearch-rest-5.0
   display_name: Elasticsearch REST Client
   description: This instrumentation enables database client spans and database client
@@ -4683,9 +4672,19 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[5.0,6.4)
   - org.elasticsearch.client:rest:[5.0,6.4)
-  configuration_refs:
-  - http.known-methods
-  - otel.instrumentation.elasticsearch.capture-search-query
+  configurations:
+  - name: otel.instrumentation.elasticsearch.capture-search-query
+    declarative_name: java.elasticsearch.capture_search_query
+    description: |
+      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
     spans:
@@ -4702,8 +4701,19 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-4f486dc3
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4731,9 +4741,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[6.4,7.0)
-  configuration_refs:
-  - http.known-methods
-  - otel.instrumentation.elasticsearch.capture-search-query
+  configurations:
+  - name: otel.instrumentation.elasticsearch.capture-search-query
+    declarative_name: java.elasticsearch.capture_search_query
+    description: |
+      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
     spans:
@@ -4750,8 +4770,19 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-4f486dc3
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4780,9 +4811,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.elasticsearch.client:elasticsearch-rest-client:[7.0,)
-  configuration_refs:
-  - http.known-methods
-  - otel.instrumentation.elasticsearch.capture-search-query
+  configurations:
+  - name: otel.instrumentation.elasticsearch.capture-search-query
+    declarative_name: java.elasticsearch.capture_search_query
+    description: |
+      Enable the capture of search query bodies. It is important to note that Elasticsearch queries may contain personal or sensitive information.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
     spans:
@@ -4799,8 +4840,19 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-4f486dc3
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4829,8 +4881,13 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[5.0.0,5.3.0)
   - org.elasticsearch:elasticsearch:[5.0.0,5.3.0)
-  configuration_refs:
-  - otel.instrumentation.elasticsearch.experimental-span-attributes-ee0c671a
+  configurations:
+  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
+    declarative_name: java.elasticsearch.experimental_span_attributes/development
+    description: |
+      Enable the capture of the experimental span attributes `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4879,8 +4936,17 @@ libraries:
       - name: network.peer.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4909,8 +4975,13 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[5.3.0,6.0.0)
   - org.elasticsearch:elasticsearch:[5.3.0,6.0.0)
-  configuration_refs:
-  - otel.instrumentation.elasticsearch.experimental-span-attributes-4728abdb
+  configurations:
+  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
+    declarative_name: java.elasticsearch.experimental_span_attributes/development
+    description: |
+      Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.search.types`, `elasticsearch.request.write.routing`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.broadcast.failed`, `elasticsearch.shard.broadcast.successful`, `elasticsearch.shard.broadcast.total`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -4969,8 +5040,17 @@ libraries:
       - name: network.peer.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -4999,8 +5079,13 @@ libraries:
   javaagent_target_versions:
   - org.elasticsearch.client:transport:[6.0.0,)
   - org.elasticsearch:elasticsearch:[6.0.0,8.0.0)
-  configuration_refs:
-  - otel.instrumentation.elasticsearch.experimental-span-attributes-df937525
+  configurations:
+  - name: otel.instrumentation.elasticsearch.experimental-span-attributes
+    declarative_name: java.elasticsearch.experimental_span_attributes/development
+    description: |
+      Enable the capture of `elasticsearch.action`, `elasticsearch.id`, `elasticsearch.request`, `elasticsearch.request.indices`, `elasticsearch.request.write.type`, `elasticsearch.request.write.version`, `elasticsearch.response.status`, `elasticsearch.shard.replication.failed`, `elasticsearch.shard.replication.successful`, `elasticsearch.shard.replication.total`, `elasticsearch.type`, and `elasticsearch.version` experimental span attributes.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5055,8 +5140,17 @@ libraries:
       - name: network.type
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5083,9 +5177,20 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - otel.instrumentation.executors.include
-  - otel.instrumentation.executors.include-all
+  configurations:
+  - name: otel.instrumentation.executors.include
+    declarative_name: java.executors.include
+    description: List of Executor subclasses to be instrumented.
+    type: list
+    default: ''
+    examples:
+    - com.example.CustomExecutor
+    - com.example.ExecutorOne,com.example.ExecutorTwo
+  - name: otel.instrumentation.executors.include-all
+    declarative_name: java.executors.include_all
+    description: Whether to instrument all classes that implement the Executor interface.
+    type: boolean
+    default: false
 - name: failsafe-3.0
   display_name: Failsafe
   description: This standalone instrumentation enables metrics for Failsafe circuit
@@ -5097,11 +5202,48 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - failsafe.circuit_breaker.execution.count-9271cf8d
-    - failsafe.circuit_breaker.state_change.count-09bbffb6
-    - failsafe.retry_policy.attempts-cc34346c
-    - failsafe.retry_policy.execution.count-d01cba44
+    metrics:
+    - name: failsafe.circuit_breaker.execution.count
+      description: Count of circuit breaker executions.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.circuit_breaker.name
+        type: STRING
+      - name: failsafe.circuit_breaker.outcome
+        type: STRING
+    - name: failsafe.circuit_breaker.state_change.count
+      description: Count of circuit breaker state changes.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.circuit_breaker.name
+        type: STRING
+      - name: failsafe.circuit_breaker.state
+        type: STRING
+    - name: failsafe.retry_policy.attempts
+      description: Number of attempts for each execution.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{attempt}'
+      attributes:
+      - name: failsafe.retry_policy.name
+        type: STRING
+      - name: failsafe.retry_policy.outcome
+        type: STRING
+    - name: failsafe.retry_policy.execution.count
+      description: Count of execution attempts processed by the retry policy, where
+        one execution represents the total number of attempts.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{execution}'
+      attributes:
+      - name: failsafe.retry_policy.name
+        type: STRING
+      - name: failsafe.retry_policy.outcome
+        type: STRING
 - name: finagle-http-23.11
   display_name: Finagle HTTP
   description: |
@@ -5131,8 +5273,12 @@ libraries:
   javaagent_target_versions:
   - com.twitter:finatra-http_2.11:[2.9.0,]
   - com.twitter:finatra-http_2.12:[2.9.0,]
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -5156,8 +5302,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.geode:geode-core:[1.4.0,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -5172,12 +5322,23 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-39ae058b
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
-      - name: db.namespace
+      - name: db.collection.name
         type: STRING
       - name: db.operation.name
         type: STRING
@@ -5200,18 +5361,93 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.google.http-client:google-http-client:[1.19.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5229,6 +5465,39 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
 - name: grails-3.0
   display_name: Grails
   description: |
@@ -5243,8 +5512,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.grails:grails-web-url-mappings:[3.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -5267,10 +5540,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.graphql-java:graphql-java:[12,20)
-  configuration_refs:
-  - otel.instrumentation.graphql.capture-query
-  - otel.instrumentation.graphql.operation-name-in-span-name.enabled
-  - otel.instrumentation.graphql.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.graphql.capture-query
+    declarative_name: java.graphql.capture_query
+    description: Whether to capture the query in `graphql.document` span attribute.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.query-sanitization.enabled
+    declarative_name: java.graphql.query_sanitization.enabled
+    description: Enables sanitization of sensitive information from queries so they
+      aren't added as span attributes.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
+    declarative_name: java.graphql.operation_name_in_span_name.enabled
+    description: |
+      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5295,12 +5582,35 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.graphql-java:graphql-java:[20,)
-  configuration_refs:
-  - otel.instrumentation.graphql.capture-query
-  - otel.instrumentation.graphql.data-fetcher.enabled
-  - otel.instrumentation.graphql.operation-name-in-span-name.enabled
-  - otel.instrumentation.graphql.query-sanitization.enabled
-  - otel.instrumentation.graphql.trivial-data-fetcher.enabled
+  configurations:
+  - name: otel.instrumentation.graphql.capture-query
+    declarative_name: java.graphql.capture_query
+    description: Whether to capture the query in `graphql.document` span attribute.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.query-sanitization.enabled
+    declarative_name: java.graphql.query_sanitization.enabled
+    description: Enables sanitization of sensitive information from queries so they
+      aren't added as span attributes.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.graphql.operation-name-in-span-name.enabled
+    declarative_name: java.graphql.operation_name_in_span_name.enabled
+    description: |
+      Whether GraphQL operation name is added to the span name. WARNING: The GraphQL operation name is provided by the client and can have high cardinality. Use only when the server is not exposed to malicious clients.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.graphql.data-fetcher.enabled
+    declarative_name: java.graphql.data_fetcher.enabled
+    description: Enables span generation for data fetchers.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.graphql.trivial-data-fetcher.enabled
+    declarative_name: java.graphql.trivial_data_fetcher.enabled
+    description: Whether to create spans for trivial data fetchers. A trivial data
+      fetcher is one that simply maps data from an object to a field.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5341,15 +5651,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish.grizzly:grizzly-http:[2.3,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -5398,20 +5739,151 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.grpc:grpc-core:[1.6.0,)
-  configuration_refs:
-  - otel.instrumentation.grpc.capture-metadata.client.request
-  - otel.instrumentation.grpc.capture-metadata.server.request
-  - otel.instrumentation.grpc.emit-message-events
-  - otel.instrumentation.grpc.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.grpc.emit-message-events
+    declarative_name: java.grpc.emit_message_events
+    description: Determines whether to emit a span event for each individual message
+      received and sent.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.grpc.experimental-span-attributes
+    declarative_name: java.grpc.experimental_span_attributes/development
+    description: |
+      Enable the capture of experimental span attributes `grpc.received.message_count`, `grpc.sent.message_count` and `grpc.canceled`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.grpc.capture-metadata.client.request
+    declarative_name: java.grpc.capture_metadata.client.request
+    description: |
+      A comma-separated list of request metadata keys. gRPC client instrumentation will capture metadata values corresponding to configured keys as span attributes.
+    type: list
+    default: ''
+    examples:
+    - custom-request-header
+    - my-metadata-key,another-metadata-key
+  - name: otel.instrumentation.grpc.capture-metadata.server.request
+    declarative_name: java.grpc.capture_metadata.server.request
+    description: |
+      A comma-separated list of request metadata keys. gRPC server instrumentation will capture metadata values corresponding to configured keys as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - rpc.client.duration-599bf562
-    - rpc.client.request.size-0d8f967b
-    - rpc.client.response.size-d0124e0e
-    - rpc.server.duration-83a39fb3
-    - rpc.server.request.size-75ef4f8e
-    - rpc.server.response.size-fb45af0b
+    metrics:
+    - name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.client.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.client.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5448,13 +5920,121 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.instrumentation.grpc.experimental-span-attributes=true
-    metric_refs:
-    - rpc.client.duration-599bf562
-    - rpc.client.request.size-0d8f967b
-    - rpc.client.response.size-d0124e0e
-    - rpc.server.duration-83a39fb3
-    - rpc.server.request.size-75ef4f8e
-    - rpc.server.response.size-fb45af0b
+    metrics:
+    - name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.client.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.client.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.request.size
+      description: Measures the size of RPC request messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.response.size
+      description: Measures the size of RPC response messages (uncompressed).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.grpc.status_code
+        type: LONG
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5499,9 +6079,39 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=rpc
-    metric_refs:
-    - rpc.client.call.duration-7381532d
-    - rpc.server.call.duration-1e979856
+    metrics:
+    - name: rpc.client.call.duration
+      description: Measures the duration of outbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.response.status_code
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.call.duration
+      description: Measures the duration of inbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.response.status_code
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5551,8 +6161,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.google.guava:guava:[10.0,]
-  configuration_refs:
-  - otel.instrumentation.guava.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.guava.experimental-span-attributes
+    declarative_name: java.guava.experimental_span_attributes/development
+    description: Enables experimental span attribute `guava.canceled` for cancelled
+      operations.
+    type: boolean
+    default: false
 - name: gwt-2.0
   display_name: GWT
   description: This instrumentation enables RPC server spans for GWT RPC requests.
@@ -5590,7 +6205,7 @@ libraries:
     name: io.opentelemetry.hbase-client-1.4
   has_javaagent: true
   javaagent_target_versions:
-  - org.apache.hbase:hbase-client:[1.4.0,2.0.0)
+  - org.apache.hbase:hbase-client:[1.4.0, 2.0.0)
 - name: hbase-client-2.0
   display_name: HBase Client
   description: |
@@ -5605,6 +6220,62 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.hbase:hbase-client:[2.0.0, 2.5.0)
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.name
+        type: STRING
+      - name: db.operation
+        type: STRING
+      - name: db.system
+        type: STRING
+      - name: db.user
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
 - name: helidon-4.3
   display_name: Helidon
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -5624,15 +6295,48 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.helidon.webserver:helidon-webserver:[4.3.0,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -5674,8 +6378,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[3.3.0.GA,4.0.0.Final)
-  configuration_refs:
-  - otel.instrumentation.hibernate.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.hibernate.experimental-span-attributes
+    declarative_name: java.hibernate.experimental_span_attributes/development
+    description: Enables the experimental `hibernate.session_id` span attribute.
+    type: boolean
+    default: false
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: INTERNAL
+      attributes: []
+  - when: otel.instrumentation.hibernate.experimental-span-attributes=true
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: hibernate.session_id
+        type: STRING
 - name: hibernate-4.0
   display_name: Hibernate
   description: This instrumentation enables spans for Hibernate ORM operations.
@@ -5686,8 +6405,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[4.0.0.Final,6)
-  configuration_refs:
-  - otel.instrumentation.hibernate.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.hibernate.experimental-span-attributes
+    declarative_name: java.hibernate.experimental_span_attributes/development
+    description: Enables the experimental `hibernate.session_id` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5710,9 +6433,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate.orm:hibernate-core:[6.0.0.Final,)
-  configuration_refs:
-  - otel.instrumentation.hibernate.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.hibernate.experimental-span-attributes
+    declarative_name: java.hibernate.experimental_span_attributes/development
+    description: Enables the experimental `hibernate.session_id` span attribute.
+    type: boolean
+    default: false
   telemetry:
+  - when: default
+    spans:
+    - span_kind: INTERNAL
+      attributes: []
   - when: otel.instrumentation.hibernate.experimental-span-attributes=true
     spans:
     - span_kind: INTERNAL
@@ -5729,8 +6460,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.hibernate:hibernate-core:[4.3.0.Final,)
-  configuration_refs:
-  - otel.instrumentation.hibernate.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.hibernate.experimental-span-attributes
+    declarative_name: java.hibernate.experimental_span_attributes/development
+    description: Enables the experimental `hibernate.session_id` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5770,25 +6505,148 @@ libraries:
   - com.zaxxer:HikariCP:[3.0.0,)
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.create_time-6f641171
-    - db.client.connections.idle.min-f04d4083
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.pending_requests-a0698f55
-    - db.client.connections.timeouts-b32b8a2b
-    - db.client.connections.usage-5ef1d5ef
-    - db.client.connections.use_time-cb3aefff
-    - db.client.connections.wait_time-e6bdd10e
+    metrics:
+    - name: db.client.connections.create_time
+      description: The time it took to create a new connection.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.timeouts
+      description: The number of connection timeouts that have occurred trying to
+        obtain a connection from the pool.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{timeouts}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
+    - name: db.client.connections.use_time
+      description: The time between borrowing a connection and returning it to the
+        pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.wait_time
+      description: The time it took to obtain an open connection from the pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: pool.name
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.create_time-4f586679
-    - db.client.connection.idle.min-73bdafbc
-    - db.client.connection.max-c7917942
-    - db.client.connection.pending_requests-a0f41111
-    - db.client.connection.timeouts-d2dbfa58
-    - db.client.connection.use_time-a06760eb
-    - db.client.connection.wait_time-40a55682
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.create_time
+      description: The time it took to create a new connection.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.timeouts
+      description: The number of connection timeouts that have occurred trying to
+        obtain a connection from the pool.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{timeout}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.use_time
+      description: The time between borrowing a connection and returning it to the
+        pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.wait_time
+      description: The time it took to obtain an open connection from the pool.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: http-url-connection
   display_name: HttpURLConnection
   description: |
@@ -5804,18 +6662,132 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
+  - when: default
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5846,8 +6818,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.netflix.hystrix:hystrix-core:[1.4.0,)
-  configuration_refs:
-  - otel.instrumentation.hystrix.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.hystrix.experimental-span-attributes
+    declarative_name: java.hystrix.experimental_span_attributes/development
+    description: Enables capturing the experimental `hystrix.command`, `hystrix.circuit_open`
+      and `hystrix.group` span attributes.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -5874,14 +6851,87 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - iceberg.scan.data_files.count-7869922f
-    - iceberg.scan.data_files.size-25d28777
-    - iceberg.scan.data_manifests.count-91f2a926
-    - iceberg.scan.delete_files.count-2ce39a8f
-    - iceberg.scan.delete_files.size-c63edff8
-    - iceberg.scan.delete_manifests.count-304a613c
-    - iceberg.scan.planning.duration-6654a71a
+    metrics:
+    - name: iceberg.scan.data_files.count
+      description: The number of data files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.data_files.size
+      description: The total size of all scanned data files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.data_manifests.count
+      description: The number of data manifests.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.delete_files.count
+      description: The number of delete files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.delete_file.type
+        type: STRING
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.delete_files.size
+      description: The total size of all scanned delete files.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.delete_manifests.count
+      description: The number of delete manifests.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{file}'
+      attributes:
+      - name: iceberg.scan.state
+        type: STRING
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
+    - name: iceberg.scan.planning.duration
+      description: The total duration needed to plan the scan.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: iceberg.schema.id
+        type: LONG
+      - name: iceberg.table.name
+        type: STRING
 - name: influxdb-2.4
   display_name: InfluxDB Client
   description: This instrumentation enables database client spans and metrics for
@@ -5896,8 +6946,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.influxdb:influxdb-java:[2.4,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables or disables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -5916,8 +6970,23 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-d4212042
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5952,18 +7021,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 11+
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -5985,6 +7131,45 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
 - name: java-http-server
   display_name: Java HTTP Server
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -6001,16 +7186,67 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -6053,10 +7289,13 @@ libraries:
   scope:
     name: io.opentelemetry.java-util-logging
   has_javaagent: true
-  configuration_refs:
-  - otel.instrumentation.java-util-logging.experimental-log-attributes
-  - otel.instrumentation.java-util-logging.experimental.capture-arguments
-  - otel.instrumentation.java-util-logging.experimental.capture-template
+  configurations:
+  - name: otel.instrumentation.java-util-logging.experimental-log-attributes
+    declarative_name: java.java_util_logging.experimental_log_attributes/development
+    description: Enables capturing the experimental `thread.name` and `thread.id`
+      log attributes.
+    type: boolean
+    default: false
 - name: javalin-5.0
   display_name: Javalin
   description: This instrumentation enriches existing HTTP server spans with route
@@ -6100,8 +7339,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.ws.rs:jsr311-api:[0.5,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -6126,9 +7369,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.ws.rs:javax.ws.rs-api:[,]
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6153,9 +7404,17 @@ libraries:
   javaagent_target_versions:
   - org.apache.cxf:cxf-rt-frontend-jaxrs:[3.2,4)
   - org.apache.tomee:openejb-cxf-rs:(8,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6190,9 +7449,17 @@ libraries:
   javaagent_target_versions:
   - org.glassfish.jersey.containers:jersey-container-servlet:[2.0,3.0.0)
   - org.glassfish.jersey.core:jersey-server:[2.0,3.0.0)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6227,9 +7494,17 @@ libraries:
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-jaxrs:[3.0.0.Final,3.1.0.Final)
   - org.jboss.resteasy:resteasy-jaxrs:[3.5.0.Final,4)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6264,9 +7539,17 @@ libraries:
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-core:[4.0.0.Final,6)
   - org.jboss.resteasy:resteasy-jaxrs:[3.1.0.Final,3.5.0.Final)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6301,9 +7584,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.ws.rs:jakarta.ws.rs-api:[3.0.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6328,9 +7619,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish.jersey.core:jersey-server:[3.0.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -6365,9 +7664,17 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jboss.resteasy:resteasy-core:[6.0.0.Final,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.jaxrs.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jaxrs.experimental-span-attributes
+    declarative_name: java.jaxrs.experimental_span_attributes/development
+    description: Enables the experimental `jaxrs.canceled` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -6400,8 +7707,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.xml.ws:jaxws-api:[2.0,]
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -6425,8 +7736,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.axis2:axis2-jaxws:[1.6.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -6446,8 +7761,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.cxf:cxf-rt-frontend-jaxws:[3.0.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
 - name: jaxws-2.0-metro-2.2
   display_name: Metro JAX-WS
   description: |
@@ -6462,17 +7781,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.sun.xml.ws:jaxws-rt:[2.2,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-- name: jaxws-cxf-3.0
-  source_path: instrumentation/jaxws/jaxws-cxf-3.0
-  scope:
-    name: io.opentelemetry.jaxws-cxf-3.0
-  telemetry:
-  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    spans:
-    - span_kind: INTERNAL
-      attributes: []
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
 - name: jaxws-jws-api-1.1
   display_name: JWS API
   description: |
@@ -6487,8 +7801,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.jws:javax.jws-api:[1.1,]
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -6498,15 +7816,6 @@ libraries:
         type: STRING
       - name: code.namespace
         type: STRING
-- name: jaxws-metro-2.2
-  source_path: instrumentation/jaxws/jaxws-metro-2.2
-  scope:
-    name: io.opentelemetry.jaxws-metro-2.2
-  telemetry:
-  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    spans:
-    - span_kind: INTERNAL
-      attributes: []
 - name: jboss-logmanager-appender-1.1
   display_name: JBoss Log Manager
   description: |
@@ -6520,11 +7829,22 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jboss.logmanager:jboss-logmanager:[1.1.0.GA,)
-  configuration_refs:
-  - otel.instrumentation.jboss-logmanager.experimental-log-attributes
-  - otel.instrumentation.jboss-logmanager.experimental.capture-arguments
-  - otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
-  - otel.instrumentation.jboss-logmanager.experimental.capture-template
+  configurations:
+  - name: otel.instrumentation.jboss-logmanager.experimental-log-attributes
+    declarative_name: java.jboss_logmanager.experimental_log_attributes/development
+    description: |
+      Enables the capture of experimental log attributes, including thread name and thread ID.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
+    declarative_name: java.jboss_logmanager.capture_mdc_attributes/development
+    description: |
+      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+    type: list
+    default: ''
+    examples:
+    - custom-mdc-key
+    - key1,key2,key3
 - name: jboss-logmanager-mdc-1.1
   display_name: JBoss Log Manager
   description: |
@@ -6551,14 +7871,144 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
-  - otel.instrumentation.jdbc-datasource.enabled
-  - otel.instrumentation.jdbc.experimental.capture-query-parameters
-  - otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
-  - otel.instrumentation.jdbc.experimental.transaction.enabled
-  - otel.instrumentation.jdbc.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.jdbc.query-sanitization.enabled
+    declarative_name: java.jdbc.query_sanitization.enabled
+    description: Enables query sanitization for database queries. Takes precedence
+      over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.jdbc.experimental.transaction.enabled
+    declarative_name: java.jdbc.transaction/development.enabled
+    description: Enables experimental instrumentation to create spans for COMMIT and
+      ROLLBACK operations.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jdbc.experimental.sqlcommenter.enabled
+    declarative_name: java.jdbc.sqlcommenter/development.enabled
+    description: |
+      Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance. Consult with database experts before enabling.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.jdbc.experimental.capture-query-parameters
+    declarative_name: java.jdbc.capture_query_parameters/development
+    description: |
+      Sets whether the query parameters should be captured as span attributes named <code>db.query.parameter.&lt;key&gt;</code>. Enabling this option disables the statement sanitization.<p>WARNING: captured query parameters may contain sensitive information such as passwords, personally identifiable information or protected health info.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jdbc-datasource.enabled
+    declarative_name: java.jdbc_datasource.enabled
+    description: Enables instrumentation of JDBC datasource connections.
+    type: boolean
+    default: false
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.connection_string
+        type: STRING
+      - name: db.name
+        type: STRING
+      - name: db.operation
+        type: STRING
+      - name: db.sql.table
+        type: STRING
+      - name: db.statement
+        type: STRING
+      - name: db.system
+        type: STRING
+      - name: db.user
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+    - span_kind: INTERNAL
+      attributes:
+      - name: code.function
+        type: STRING
+      - name: code.namespace
+        type: STRING
+      - name: db.connection_string
+        type: STRING
+      - name: db.name
+        type: STRING
+      - name: db.system
+        type: STRING
+      - name: db.user
+        type: STRING
+  - when: otel.semconv-stability.opt-in=database,service.peer
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.query.text
+        type: STRING
+      - name: db.stored_procedure.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: service.peer.name
+        type: STRING
+    - span_kind: INTERNAL
+      attributes:
+      - name: code.function
+        type: STRING
+      - name: code.namespace
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.system.name
+        type: STRING
 - name: jedis-1.4
   display_name: Jedis
   description: This instrumentation enables database client spans and database client
@@ -6573,9 +8023,31 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[1.4.0,2.0.0)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -6594,8 +8066,21 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-32559b79
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6625,9 +8110,68 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[2.0.0,3.0.0)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: structured_list
+    default: ''
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation
+        type: STRING
+      - name: db.statement
+        type: STRING
+      - name: db.system
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=database,service.peer
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.text
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
 - name: jedis-3.0
   display_name: Jedis
   description: This instrumentation enables database client spans and database client
@@ -6642,9 +8186,31 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[3.0.0,4)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -6669,11 +8235,30 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-bfd9d23c
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -6704,8 +8289,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - redis.clients:jedis:[4.0.0-beta1,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -6723,12 +8312,39 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-7714cbf7
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -6738,6 +8354,10 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
         type: LONG
 - name: jetty-8.0
   display_name: Eclipse Jetty
@@ -6756,15 +8376,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[8.0.0.v20110901,11)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -6812,15 +8463,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[11, 12)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -6868,15 +8550,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-server:[12,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -6924,18 +8637,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-client:[9.2,10)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6958,8 +8748,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -6998,18 +8803,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.eclipse.jetty:jetty-client:[12,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7032,8 +8914,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7069,8 +8966,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.jfinal:jfinal:[3.2,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7095,9 +8996,19 @@ libraries:
   - jakarta.jms:jakarta.jms-api:(,3)
   - javax.jms:javax.jms-api:(,)
   - javax.jms:jms-api:(,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -7139,9 +9050,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.jms:jakarta.jms-api:[3.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -7182,18 +9103,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.jodd:jodd-http:[4.1.1,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7215,6 +9213,45 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
 - name: jsf-mojarra-1.2
   display_name: Eclipse Mojarra
   description: |
@@ -7232,8 +9269,12 @@ libraries:
   - javax.faces:jsf-impl:[1.2,2)
   - org.glassfish:jakarta.faces:[2.3.9,3)
   - org.glassfish:javax.faces:[2.0.7,3)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7253,8 +9294,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.glassfish:jakarta.faces:[3,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7273,8 +9318,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.myfaces.core:myfaces-impl:[1.2,3)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7294,8 +9343,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.myfaces.core:myfaces-impl:[3,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -7314,9 +9367,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat:tomcat-jasper:[7.0.19,10)
-  configuration_refs:
-  - otel.instrumentation.common.experimental.view-telemetry.enabled
-  - otel.instrumentation.jsp.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
+    declarative_name: java.common.view_telemetry/development.enabled
+    description: Enables the creation of experimental view spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.jsp.experimental-span-attributes
+    declarative_name: java.jsp.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `jsp.forwardOrigin`, `jsp.requestURL`, `jsp.compiler`, and `jsp.classFQCN`.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -7347,11 +9409,164 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.kafka:kafka-clients:[0.11.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
-  - otel.instrumentation.kafka.producer-propagation.enabled
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.kafka.producer-propagation.enabled
+    declarative_name: java.kafka.producer_propagation.enabled
+    description: Enable context propagation for Kafka message producers.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
+    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
+      and `messaging.kafka.bootstrap.servers`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CONSUMER
+      attributes:
+      - name: messaging.batch.message_count
+        type: LONG
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.consumer.group
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.offset
+        type: LONG
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.message.body.size
+        type: LONG
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+    - span_kind: PRODUCER
+      attributes:
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.offset
+        type: LONG
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+  - when: otel.instrumentation.kafka.experimental-span-attributes=true
+    spans:
+    - span_kind: CONSUMER
+      attributes:
+      - name: kafka.record.queue_time_ms
+        type: LONG
+      - name: messaging.batch.message_count
+        type: LONG
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.consumer.group
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.offset
+        type: LONG
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.message.body.size
+        type: LONG
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+    - span_kind: PRODUCER
+      attributes:
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.bootstrap.servers
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.offset
+        type: LONG
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+  - when: otel.semconv-stability.opt-in=messaging
+    spans:
+    - span_kind: CONSUMER
+      attributes:
+      - name: messaging.batch.message_count
+        type: LONG
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.kafka.offset
+        type: LONG
+      - name: messaging.message.body.size
+        type: LONG
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+    - span_kind: PRODUCER
+      attributes:
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.tombstone
+        type: BOOLEAN
+      - name: messaging.kafka.offset
+        type: LONG
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
 - name: kafka-clients-2.6
   display_name: Apache Kafka Client
   description: This standalone instrumentation enables messaging spans for Kafka producers
@@ -7448,10 +9663,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.kafka:kafka-streams:[0.11.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
+    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
+      and `messaging.kafka.bootstrap.servers`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -7542,8 +9771,23 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -7616,22 +9860,127 @@ libraries:
   javaagent_target_versions:
   - io.ktor:ktor-client-core:[2.0.0,3.0.0)
   - io.ktor:ktor-server-core:[2.0.0,3.0.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7724,22 +10073,127 @@ libraries:
   javaagent_target_versions:
   - io.ktor:ktor-client-core:[3.0.0,)
   - io.ktor:ktor-server-core:[3.0.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7792,11 +10246,65 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.instrumentation.http.server.emit-experimental-telemetry=true
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.active_requests-2c1402e2
-    - http.server.request.duration-1f6f63ed
-    - http.server.response.body.size-9ece7062
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.active_requests
+      description: Number of active HTTP server requests.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    - name: http.server.response.body.size
+      description: Size of HTTP server response bodies.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: By
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7863,19 +10371,99 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.kubernetes:client-java-api:[7.0.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - otel.instrumentation.kubernetes-client.experimental-span-attributes
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.kubernetes-client.experimental-span-attributes
+    declarative_name: java.kubernetes_client.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `kubernetes-client.namespace` and `kubernetes-client.name` for Kubernetes API requests.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7894,8 +10482,21 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.instrumentation.kubernetes-client.experimental-span-attributes=true
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -7917,6 +10518,39 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
 - name: lettuce-4.0
   display_name: Lettuce
   description: |
@@ -7931,10 +10565,36 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - biz.paluch.redis:lettuce:[4.0.Final,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - otel.instrumentation.lettuce.connection-telemetry.enabled
-  - otel.instrumentation.lettuce.experimental-span-attributes-48d10623
+  configurations:
+  - name: otel.instrumentation.lettuce.connection-telemetry.enabled
+    declarative_name: java.lettuce.connection_telemetry.enabled
+    description: Enables connection telemetry spans for Redis connections.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.lettuce.experimental-span-attributes
+    declarative_name: java.lettuce.experimental_span_attributes/development
+    description: Enables experimental span attribute `lettuce.command.cancelled`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -7967,11 +10627,22 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.system.name
@@ -7998,11 +10669,42 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.lettuce:lettuce-core:[5.0.0.RELEASE,5.1.0.RELEASE)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
-  - otel.instrumentation.lettuce.connection-telemetry.enabled
-  - otel.instrumentation.lettuce.experimental-span-attributes-f6bf8fef
+  configurations:
+  - name: otel.instrumentation.lettuce.connection-telemetry.enabled
+    declarative_name: java.lettuce.connection_telemetry.enabled
+    description: Enables connection telemetry spans for Redis connections.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.lettuce.experimental-span-attributes
+    declarative_name: java.lettuce.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `lettuce.command.cancelled` and `lettuce.command.results.count`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -8013,6 +10715,37 @@ libraries:
       - name: db.statement
         type: STRING
       - name: db.system
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+  - when: otel.instrumentation.common.v3-preview=true
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.text
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: error.type
         type: STRING
       - name: peer.service
         type: STRING
@@ -8041,11 +10774,22 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -8075,9 +10819,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.lettuce:lettuce-core:[5.1.0.RELEASE,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
+  configurations:
+  - name: otel.instrumentation.lettuce.experimental.command-encoding-events.enabled
+    declarative_name: java.lettuce.command_encoding_events/development.enabled
+    description: Enables capturing `redis.encode.start` and `redis.encode.end` span
+      events.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -8101,6 +10854,45 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
+  - when: otel.semconv-stability.opt-in=database
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.text
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
 - name: liberty-20.0
   display_name: Liberty
   description: |
@@ -8113,13 +10905,39 @@ libraries:
   scope:
     name: io.opentelemetry.liberty-20.0
   has_javaagent: true
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
 - name: liberty-dispatcher-20.0
   display_name: Liberty
   description: |
@@ -8132,11 +10950,29 @@ libraries:
   scope:
     name: io.opentelemetry.liberty-dispatcher-20.0
   has_javaagent: true
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
 - name: log4j-appender-1.2
   display_name: Log4j
   description: |
@@ -8150,10 +10986,28 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - log4j:log4j:[1.2,)
-  configuration_refs:
-  - otel.instrumentation.log4j-appender.experimental-log-attributes
-  - otel.instrumentation.log4j-appender.experimental.capture-code-attributes
-  - otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-436113d6
+  configurations:
+  - name: otel.instrumentation.log4j-appender.experimental-log-attributes
+    declarative_name: java.log4j_appender.experimental_log_attributes/development
+    description: |
+      Enables the capture of experimental log attributes, including thread name and thread ID.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
+    declarative_name: java.log4j_appender.capture_mdc_attributes/development
+    description: |
+      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+    type: list
+    default: ''
+    examples:
+    - custom-mdc-key
+    - key1,key2,key3
+  - name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
+    declarative_name: java.log4j_appender.capture_code_attributes/development
+    description: |
+      Enables the capture of code location attributes, including file path, class name, method name, and line number.
+    type: boolean
+    default: false
 - name: log4j-appender-2.17
   display_name: Log4j
   description: |
@@ -8168,14 +11022,40 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.0,)
-  configuration_refs:
-  - otel.instrumentation.log4j-appender.experimental-log-attributes
-  - otel.instrumentation.log4j-appender.experimental.capture-arguments
-  - otel.instrumentation.log4j-appender.experimental.capture-code-attributes
-  - otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
-  - otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
-  - otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes-e8e19d91
-  - otel.instrumentation.log4j-appender.experimental.capture-template
+  configurations:
+  - name: otel.instrumentation.log4j-appender.experimental-log-attributes
+    declarative_name: java.log4j_appender.experimental_log_attributes/development
+    description: |
+      Enables the capture of experimental log attributes, including thread name and thread ID.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.log4j-appender.experimental.capture-code-attributes
+    declarative_name: java.log4j_appender.capture_code_attributes/development
+    description: |
+      Enables the capture of code location attributes, including file path, class name, method name, and line number.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
+    declarative_name: java.log4j_appender.capture_map_message_attributes/development
+    description: |
+      Enables the capture of attributes from Log4j MapMessage instances.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
+    declarative_name: java.log4j_appender.capture_marker_attribute/development
+    description: |
+      Enables the capture of the Log4j marker attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
+    declarative_name: java.log4j_appender.capture_mdc_attributes/development
+    description: |
+      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+    type: list
+    default: ''
+    examples:
+    - '*'
+    - key1,key2
 - name: log4j-context-data-2.7
   display_name: Log4j
   description: |
@@ -8187,12 +11067,37 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.7,2.17.0)
-  configuration_refs:
-  - otel.instrumentation.common.logging.span-id-key
-  - otel.instrumentation.common.logging.trace-flags-key
-  - otel.instrumentation.common.logging.trace-id-key
-  - otel.instrumentation.common.mdc.resource-attributes
-  - otel.instrumentation.log4j-context-data.add-baggage
+  configurations:
+  - name: otel.instrumentation.log4j-context-data.add-baggage
+    declarative_name: java.log4j_context_data.add_baggage
+    description: |
+      Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.logging.trace-id-key
+    declarative_name: java.common.logging.trace_id_key
+    description: |
+      Specifies the key name used to store the trace ID in the logging context.
+    type: string
+    default: trace_id
+  - name: otel.instrumentation.common.logging.span-id-key
+    declarative_name: java.common.logging.span_id_key
+    description: |
+      Specifies the key name used to store the span ID in the logging context.
+    type: string
+    default: span_id
+  - name: otel.instrumentation.common.logging.trace-flags-key
+    declarative_name: java.common.logging.trace_flags_key
+    description: |
+      Specifies the key name used to store the trace flags in the logging context.
+    type: string
+    default: trace_flags
+  - name: otel.instrumentation.common.mdc.resource-attributes
+    declarative_name: java.common.mdc.resource_attributes
+    description: |
+      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
+    type: list
+    default: ''
 - name: log4j-context-data-2.17
   display_name: Log4j
   description: |
@@ -8204,12 +11109,37 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.logging.log4j:log4j-core:[2.17.0,)
-  configuration_refs:
-  - otel.instrumentation.common.logging.span-id-key
-  - otel.instrumentation.common.logging.trace-flags-key
-  - otel.instrumentation.common.logging.trace-id-key
-  - otel.instrumentation.common.mdc.resource-attributes
-  - otel.instrumentation.log4j-context-data.add-baggage
+  configurations:
+  - name: otel.instrumentation.log4j-context-data.add-baggage
+    declarative_name: java.log4j_context_data.add_baggage
+    description: |
+      Enables adding baggage entries to the Log4j ThreadContext, prefixed with "baggage.".
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.logging.trace-id-key
+    declarative_name: java.common.logging.trace_id_key
+    description: |
+      Specifies the key name used to store the trace ID in the logging context.
+    type: string
+    default: trace_id
+  - name: otel.instrumentation.common.logging.span-id-key
+    declarative_name: java.common.logging.span_id_key
+    description: |
+      Specifies the key name used to store the span ID in the logging context.
+    type: string
+    default: span_id
+  - name: otel.instrumentation.common.logging.trace-flags-key
+    declarative_name: java.common.logging.trace_flags_key
+    description: |
+      Specifies the key name used to store the trace flags in the logging context.
+    type: string
+    default: trace_flags
+  - name: otel.instrumentation.common.mdc.resource-attributes
+    declarative_name: java.common.mdc.resource_attributes
+    description: |
+      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
+    type: list
+    default: ''
 - name: log4j-mdc-1.2
   display_name: Log4j
   description: |
@@ -8221,11 +11151,31 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - log4j:log4j:[1.2,)
-  configuration_refs:
-  - otel.instrumentation.common.logging.span-id-key
-  - otel.instrumentation.common.logging.trace-flags-key
-  - otel.instrumentation.common.logging.trace-id-key
-  - otel.instrumentation.common.mdc.resource-attributes
+  configurations:
+  - name: otel.instrumentation.common.logging.trace-id-key
+    declarative_name: java.common.logging.trace_id_key
+    description: |
+      Specifies the key name used to store the trace ID in the logging context.
+    type: string
+    default: trace_id
+  - name: otel.instrumentation.common.logging.span-id-key
+    declarative_name: java.common.logging.span_id_key
+    description: |
+      Specifies the key name used to store the span ID in the logging context.
+    type: string
+    default: span_id
+  - name: otel.instrumentation.common.logging.trace-flags-key
+    declarative_name: java.common.logging.trace_flags_key
+    description: |
+      Specifies the key name used to store the trace flags in the logging context.
+    type: string
+    default: trace_flags
+  - name: otel.instrumentation.common.mdc.resource-attributes
+    declarative_name: java.common.mdc.resource_attributes
+    description: |
+      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
+    type: list
+    default: ''
 - name: logback-appender-1.0
   display_name: Logback
   description: |
@@ -8240,17 +11190,70 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - ch.qos.logback:logback-classic:[0.9.16,)
-  configuration_refs:
-  - otel.instrumentation.logback-appender.experimental-log-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-arguments
-  - otel.instrumentation.logback-appender.experimental.capture-code-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
-  - otel.instrumentation.logback-appender.experimental.capture-marker-attribute
-  - otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
-  - otel.instrumentation.logback-appender.experimental.capture-template
+  configurations:
+  - name: otel.instrumentation.logback-appender.experimental-log-attributes
+    declarative_name: java.logback_appender.experimental_log_attributes/development
+    description: |
+      Enables the capture of experimental log attributes, including thread name and thread ID.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-code-attributes
+    declarative_name: java.logback_appender.capture_code_attributes/development
+    description: |
+      Enables the capture of code location attributes, including file path, class name, method name, and line number.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
+    declarative_name: java.logback_appender.capture_marker_attribute/development
+    description: |
+      Enables the capture of the Logback marker attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
+    declarative_name: java.logback_appender.capture_key_value_pair_attributes/development
+    description: |
+      Enables the capture of attributes from Logback key-value pairs.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
+    declarative_name: java.logback_appender.capture_logger_context_attributes/development
+    description: |
+      Enables the capture of attributes from the Logback logger context.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-template
+    declarative_name: java.logback_appender.capture_template/development
+    description: |
+      Enables the capture of the log message template before parameter substitution.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-arguments
+    declarative_name: java.logback_appender.capture_arguments/development
+    description: |
+      Enables the capture of log message arguments as separate attributes.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-logstash-marker-attributes
+    declarative_name: java.logback_appender.capture_logstash_marker_attributes/development
+    description: |
+      Enables the capture of attributes from Logstash markers.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-logstash-structured-arguments
+    declarative_name: java.logback_appender.capture_logstash_structured_arguments/development
+    description: |
+      Enables the capture of attributes from Logstash structured arguments.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
+    declarative_name: java.logback_appender.capture_mdc_attributes/development
+    description: |
+      Controls which MDC attributes to capture. Use "*" to capture all MDC attributes or provide a comma-separated list of specific keys.
+    type: list
+    default: ''
+    examples:
+    - custom-mdc-key
+    - key1,key2,key3
 - name: logback-mdc-1.0
   display_name: Logback
   description: |
@@ -8263,12 +11266,37 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - ch.qos.logback:logback-classic:[1.0.0,1.2.3]
-  configuration_refs:
-  - otel.instrumentation.common.logging.span-id-key
-  - otel.instrumentation.common.logging.trace-flags-key
-  - otel.instrumentation.common.logging.trace-id-key
-  - otel.instrumentation.common.mdc.resource-attributes
-  - otel.instrumentation.logback-mdc.add-baggage
+  configurations:
+  - name: otel.instrumentation.logback-mdc.add-baggage
+    declarative_name: java.logback_mdc.add_baggage
+    description: |
+      Enables adding baggage entries to the Logback MDC, prefixed with "baggage.".
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.logging.trace-id-key
+    declarative_name: java.common.logging.trace_id_key
+    description: |
+      Specifies the key name used to store the trace ID in the logging context.
+    type: string
+    default: trace_id
+  - name: otel.instrumentation.common.logging.span-id-key
+    declarative_name: java.common.logging.span_id_key
+    description: |
+      Specifies the key name used to store the span ID in the logging context.
+    type: string
+    default: span_id
+  - name: otel.instrumentation.common.logging.trace-flags-key
+    declarative_name: java.common.logging.trace_flags_key
+    description: |
+      Specifies the key name used to store the trace flags in the logging context.
+    type: string
+    default: trace_flags
+  - name: otel.instrumentation.common.mdc.resource-attributes
+    declarative_name: java.common.mdc.resource_attributes
+    description: |
+      Specifies which resource attributes to add to the logging context as a comma-separated list of attribute keys.
+    type: list
+    default: ''
 - name: micrometer-1.5
   display_name: Micrometer
   description: |
@@ -8282,10 +11310,28 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.micrometer:micrometer-core:[1.5.0,)
-  configuration_refs:
-  - otel.instrumentation.micrometer.base-time-unit
-  - otel.instrumentation.micrometer.histogram-gauges.enabled
-  - otel.instrumentation.micrometer.prometheus-mode.enabled
+  configurations:
+  - name: otel.instrumentation.micrometer.prometheus-mode.enabled
+    declarative_name: java.micrometer.prometheus_mode.enabled
+    description: |
+      Simulates the behavior of Micrometer's PrometheusMeterRegistry. The instruments will be renamed to match Micrometer instrument naming, and the base time unit will be set to seconds.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.micrometer.base-time-unit
+    declarative_name: java.micrometer.base_time_unit
+    description: |
+      Sets the base time unit for the OpenTelemetry MeterRegistry. Supported values: ns, us, ms, s, min, h, d.
+    type: string
+    default: s
+    examples:
+    - ns
+    - milliseconds
+  - name: otel.instrumentation.micrometer.histogram-gauges.enabled
+    declarative_name: java.micrometer.histogram_gauges.enabled
+    description: |
+      Enables gauge-based Micrometer histograms for DistributionSummary and Timer instruments.
+    type: boolean
+    default: false
 - name: mongo-3.1
   display_name: MongoDB Driver
   description: |
@@ -8301,9 +11347,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongo-java-driver:[3.1,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.mongo.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.mongo.query-sanitization.enabled
+    declarative_name: java.mongo.query_sanitization.enabled
+    description: |
+      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -8326,8 +11381,25 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-e36c6087
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8360,9 +11432,18 @@ libraries:
   javaagent_target_versions:
   - org.mongodb:mongo-java-driver:[3.7, 4.0)
   - org.mongodb:mongodb-driver-core:[3.7, 4.0)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.mongo.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.mongo.query-sanitization.enabled
+    declarative_name: java.mongo.query_sanitization.enabled
+    description: |
+      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -8385,8 +11466,25 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-e36c6087
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8418,9 +11516,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongodb-driver-core:[4.0,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.mongo.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.mongo.query-sanitization.enabled
+    declarative_name: java.mongo.query_sanitization.enabled
+    description: |
+      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -8443,8 +11550,25 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-e36c6087
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8476,9 +11600,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.mongodb:mongodb-driver-async:[3.3,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - otel.instrumentation.mongo.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.mongo.query-sanitization.enabled
+    declarative_name: java.mongo.query_sanitization.enabled
+    description: |
+      Enables query sanitization for MongoDB queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -8501,8 +11634,25 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-e36c6087
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.collection.name
+        type: STRING
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8554,8 +11704,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.nats:jnats:[2.17.2,)
-  configuration_refs:
-  - messaging.capture-headers
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
   telemetry:
   - when: default
     spans:
@@ -8604,22 +11759,125 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.netty:netty:[3.8.0.Final,4)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8675,73 +11933,38 @@ libraries:
         type: STRING
       - name: user_agent.original
         type: STRING
-- name: netty-4.0
-  display_name: Netty HTTP codec
-  description: |
-    This instrumentation enables HTTP client spans, HTTP client metrics, HTTP server spans, and HTTP server metrics for the Netty framework.
-  semantic_conventions:
-  - HTTP_CLIENT_SPANS
-  - HTTP_CLIENT_METRICS
-  - HTTP_SERVER_SPANS
-  - HTTP_SERVER_METRICS
-  library_link: https://netty.io/
-  source_path: instrumentation/netty/netty-4.0
-  scope:
-    name: io.opentelemetry.netty-4.0
-  has_javaagent: true
-  javaagent_target_versions:
-  - io.netty:netty-all:[4.0.0.Final,4.1.0.Final)
-  - io.netty:netty-codec-http:[4.0.0.Final,4.1.0.Final)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - otel.instrumentation.netty.connection-telemetry.enabled
-  - otel.instrumentation.netty.ssl-telemetry.enabled
-  - sanitization.url.sensitive-query-parameters
-- name: netty-4.1
-  display_name: Netty HTTP codec
-  description: |
-    This instrumentation enables HTTP client spans, HTTP client metrics, HTTP server spans, and HTTP server metrics for the Netty framework. Does not currently support capturing HTTP/2 traffic.
-  semantic_conventions:
-  - HTTP_CLIENT_SPANS
-  - HTTP_CLIENT_METRICS
-  - HTTP_SERVER_SPANS
-  - HTTP_SERVER_METRICS
-  library_link: https://netty.io/
-  source_path: instrumentation/netty/netty-4.1
-  scope:
-    name: io.opentelemetry.netty-4.1
-    schema_url: https://opentelemetry.io/schemas/1.41.0
-  has_standalone_library: true
-  has_javaagent: true
-  javaagent_target_versions:
-  - io.netty:netty-all:[4.1.0.Final,5.0.0)
-  - io.netty:netty-codec-http:[4.1.0.Final,5.0.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - otel.instrumentation.netty.connection-telemetry.enabled
-  - otel.instrumentation.netty.ssl-telemetry.enabled
-  - sanitization.url.sensitive-query-parameters
-  telemetry:
-  - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-639e2d0b
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8763,6 +11986,587 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
+    - span_kind: SERVER
+      attributes:
+      - name: client.address
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.path
+        type: STRING
+      - name: url.query
+        type: STRING
+      - name: url.scheme
+        type: STRING
+      - name: user_agent.original
+        type: STRING
+- name: netty-4.0
+  display_name: Netty HTTP codec
+  description: |
+    This instrumentation enables HTTP client spans, HTTP client metrics, HTTP server spans, and HTTP server metrics for the Netty framework.
+  semantic_conventions:
+  - HTTP_CLIENT_SPANS
+  - HTTP_CLIENT_METRICS
+  - HTTP_SERVER_SPANS
+  - HTTP_SERVER_METRICS
+  library_link: https://netty.io/
+  source_path: instrumentation/netty/netty-4.0
+  scope:
+    name: io.opentelemetry.netty-4.0
+    schema_url: https://opentelemetry.io/schemas/1.41.0
+  has_javaagent: true
+  javaagent_target_versions:
+  - io.netty:netty-all:[4.0.0.Final,4.1.0.Final)
+  - io.netty:netty-codec-http:[4.0.0.Final,4.1.0.Final)
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.netty.connection-telemetry.enabled
+    declarative_name: java.netty.connection_telemetry.enabled
+    description: Enable the creation of Connect and DNS spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.netty.ssl-telemetry.enabled
+    declarative_name: java.netty.ssl_telemetry.enabled
+    description: Enable SSL telemetry.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  telemetry:
+  - when: default
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+    - span_kind: SERVER
+      attributes:
+      - name: client.address
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.path
+        type: STRING
+      - name: url.query
+        type: STRING
+      - name: url.scheme
+        type: STRING
+      - name: user_agent.original
+        type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
+    - span_kind: SERVER
+      attributes:
+      - name: client.address
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.path
+        type: STRING
+      - name: url.query
+        type: STRING
+      - name: url.scheme
+        type: STRING
+      - name: user_agent.original
+        type: STRING
+- name: netty-4.1
+  display_name: Netty HTTP codec
+  description: |
+    This instrumentation enables HTTP client spans, HTTP client metrics, HTTP server spans, and HTTP server metrics for the Netty framework. Does not currently support capturing HTTP/2 traffic.
+  semantic_conventions:
+  - HTTP_CLIENT_SPANS
+  - HTTP_CLIENT_METRICS
+  - HTTP_SERVER_SPANS
+  - HTTP_SERVER_METRICS
+  library_link: https://netty.io/
+  source_path: instrumentation/netty/netty-4.1
+  scope:
+    name: io.opentelemetry.netty-4.1
+    schema_url: https://opentelemetry.io/schemas/1.41.0
+  has_standalone_library: true
+  has_javaagent: true
+  javaagent_target_versions:
+  - io.netty:netty-all:[4.1.0.Final,5.0.0)
+  - io.netty:netty-codec-http:[4.1.0.Final,5.0.0)
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.netty.connection-telemetry.enabled
+    declarative_name: java.netty.connection_telemetry.enabled
+    description: Enable the creation of Connect and DNS spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.netty.ssl-telemetry.enabled
+    declarative_name: java.netty.ssl_telemetry.enabled
+    description: Enable SSL telemetry.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+  telemetry:
+  - when: default
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: peer.service
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.full
+        type: STRING
+    - span_kind: SERVER
+      attributes:
+      - name: client.address
+        type: STRING
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: url.path
+        type: STRING
+      - name: url.query
+        type: STRING
+      - name: url.scheme
+        type: STRING
+      - name: user_agent.original
+        type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
       - name: url.full
         type: STRING
     - span_kind: SERVER
@@ -8809,18 +12613,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.squareup.okhttp:okhttp:[2.2,3)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8843,8 +12724,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8882,18 +12778,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.squareup.okhttp3:okhttp:[3.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8922,8 +12895,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -8966,13 +12954,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.openai:openai-java:[1.1.0,3)
-  configuration_refs:
-  - otel.instrumentation.genai.capture-message-content-274e53a8
+  configurations:
+  - name: otel.instrumentation.genai.capture-message-content
+    declarative_name: java.common.gen_ai.capture_message_content
+    description: |
+      Enables including the full content of user and assistant messages in emitted log events. Note that full content can have data privacy and size concerns, and care should be taken when enabling this.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - gen_ai.client.operation.duration-32ef946d
-    - gen_ai.client.token.usage-c5ff244f
+    metrics:
+    - name: gen_ai.client.operation.duration
+      description: GenAI operation duration.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.response.model
+        type: STRING
+    - name: gen_ai.client.token.usage
+      description: Measures number of input and output tokens used.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: '{token}'
+      attributes:
+      - name: gen_ai.operation.name
+        type: STRING
+      - name: gen_ai.provider.name
+        type: STRING
+      - name: gen_ai.request.model
+        type: STRING
+      - name: gen_ai.response.model
+        type: STRING
+      - name: gen_ai.token.type
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9035,8 +13056,45 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.opensearch.client:opensearch-java:[3.0,)
-  configuration_refs:
-  - otel.instrumentation.opensearch.capture-search-query
+  configurations:
+  - name: otel.instrumentation.opensearch.capture-search-query
+    declarative_name: java.opensearch.capture_search_query
+    description: |
+      Enable the capture of sanitized search query bodies. Search queries may contain personal or sensitive information.
+    type: boolean
+    default: true
+  telemetry:
+  - when: default
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation
+        type: STRING
+      - name: db.statement
+        type: STRING
+      - name: db.system
+        type: STRING
+  - when: otel.semconv-stability.opt-in=database
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.query.text
+        type: STRING
+      - name: db.system.name
+        type: STRING
 - name: opensearch-rest-1.0
   display_name: OpenSearch REST Client
   description: |
@@ -9064,8 +13122,17 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9102,8 +13169,17 @@ libraries:
       - name: db.system
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9113,14 +13189,6 @@ libraries:
         type: STRING
       - name: db.system.name
         type: STRING
-- name: opentelemetry-api-1.52
-  source_path: instrumentation/opentelemetry-api/opentelemetry-api-1.52
-  scope:
-    name: io.opentelemetry.opentelemetry-api-1.52
-- name: opentelemetry-instrumentation-api
-  source_path: instrumentation/opentelemetry-instrumentation-api
-  scope:
-    name: io.opentelemetry.opentelemetry-instrumentation-api
 - name: oracle-ucp-11.2
   display_name: Oracle UCP
   description: |
@@ -9137,15 +13205,64 @@ libraries:
   - com.oracle.database.jdbc:ucp:[,)
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.pending_requests-a0698f55
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.max-c7917942
-    - db.client.connection.pending_requests-a0f41111
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: oshi-5.0
   display_name: OSHI
   description: |
@@ -9160,33 +13277,166 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.github.oshi:oshi-core:[5.0.0,)
-  configuration_refs:
-  - otel.instrumentation.oshi.experimental-metrics.enabled
+  configurations:
+  - name: otel.instrumentation.oshi.experimental-metrics.enabled
+    declarative_name: java.oshi.experimental_metrics/development.enabled
+    description: Enable the experimental `runtime.java.memory` and `runtime.java.cpu_time`
+      metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - system.disk.io-58ee1ced
-    - system.disk.operations-cf678806
-    - system.memory.usage-11625112
-    - system.memory.utilization-677660f3
-    - system.network.errors-0d1e8b98
-    - system.network.io-518133c1
-    - system.network.packets-6d263c01
+    metrics:
+    - name: system.disk.io
+      description: System disk IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.disk.operations
+      description: System disk operations
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{operations}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.memory.usage
+      description: System memory usage
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: state
+        type: STRING
+    - name: system.memory.utilization
+      description: System memory utilization
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes:
+      - name: state
+        type: STRING
+    - name: system.network.errors
+      description: System network errors
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{errors}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.network.io
+      description: System network IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.network.packets
+      description: System network packets
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{packets}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
   - when: otel.instrumentation.oshi.experimental-metrics.enabled=true
-    metric_refs:
-    - runtime.java.cpu_time-ac10c23f
-    - runtime.java.memory-2a143889
-    - system.disk.io-58ee1ced
-    - system.disk.operations-cf678806
-    - system.memory.usage-11625112
-    - system.memory.utilization-677660f3
-    - system.network.errors-0d1e8b98
-    - system.network.io-518133c1
-    - system.network.packets-6d263c01
-- name: payara
-  source_path: instrumentation/payara
-  scope:
-    name: io.opentelemetry.payara
+    metrics:
+    - name: runtime.java.cpu_time
+      description: Runtime Java CPU time
+      instrument: gauge
+      data_type: LONG_GAUGE
+      unit: ms
+      attributes:
+      - name: type
+        type: STRING
+    - name: runtime.java.memory
+      description: Runtime Java memory
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: type
+        type: STRING
+    - name: system.disk.io
+      description: System disk IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.disk.operations
+      description: System disk operations
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{operations}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.memory.usage
+      description: System memory usage
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: state
+        type: STRING
+    - name: system.memory.utilization
+      description: System memory utilization
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes:
+      - name: state
+        type: STRING
+    - name: system.network.errors
+      description: System network errors
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{errors}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.network.io
+      description: System network IO
+      instrument: counter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
+    - name: system.network.packets
+      description: System network packets
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{packets}'
+      attributes:
+      - name: device
+        type: STRING
+      - name: direction
+        type: STRING
 - name: payara-5.2020
   display_name: Payara
   description: |
@@ -9236,22 +13486,127 @@ libraries:
   - org.apache.pekko:pekko-http_2.12:[1.0,)
   - org.apache.pekko:pekko-http_2.13:[1.0,)
   - org.apache.pekko:pekko-http_3:[1.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9311,8 +13666,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.typesafe.play:play_2.11:[2.4.0,2.6)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9335,8 +13694,12 @@ libraries:
   - com.typesafe.play:play_2.12:[2.6.0,)
   - com.typesafe.play:play_2.13:[2.6.0,)
   - org.playframework:play_3:[2.6.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -9358,18 +13721,93 @@ libraries:
   javaagent_target_versions:
   - com.typesafe.play:play-ahc-ws-standalone_2.11:[1.0.0,2.0.0)
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[1.0.0,2.0.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9410,18 +13848,93 @@ libraries:
   - com.typesafe.play:play-ahc-ws-standalone_2.11:[2.0.0,]
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[2.0.0,2.1.0)
   - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.0.6,2.1.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9462,18 +13975,93 @@ libraries:
   - com.typesafe.play:play-ahc-ws-standalone_2.12:[2.1.0,]
   - com.typesafe.play:play-ahc-ws-standalone_2.13:[2.1.0,]
   - org.playframework:play-ahc-ws-standalone_3:[3.0.0,]
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9507,8 +14095,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - tech.powerjob:powerjob-worker:[4.0.0,)
-  configuration_refs:
-  - otel.instrumentation.powerjob.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.powerjob.experimental-span-attributes
+    declarative_name: java.powerjob.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `job.system`, `scheduling.powerjob.job.id`, `scheduling.powerjob.job.param`, `scheduling.powerjob.job.instance.param`, and `scheduling.powerjob.job.type`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -9534,6 +14127,12 @@ libraries:
         type: STRING
       - name: scheduling.powerjob.job.type
         type: STRING
+  - when: otel.semconv-stability.opt-in=code
+    spans:
+    - span_kind: INTERNAL
+      attributes:
+      - name: code.function.name
+        type: STRING
 - name: pulsar-2.8
   display_name: Apache Pulsar Client
   description: |
@@ -9547,16 +14146,76 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.pulsar:pulsar-client:[2.8.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
-  - otel.instrumentation.pulsar.experimental-span-attributes-5ac8c0d9
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
+  - name: otel.instrumentation.pulsar.experimental-span-attributes
+    declarative_name: java.pulsar.experimental_span_attributes/development
+    description: |
+      Enables the experimental span attribute `messaging.pulsar.message.type` for producer spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
-    metric_refs:
-    - messaging.publish.duration-05731f17
-    - messaging.receive.duration-4b4a91de
-    - messaging.receive.messages-2499c5ac
+    metrics:
+    - name: messaging.publish.duration
+      description: Measures the duration of publish operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: messaging.receive.duration
+      description: Measures the duration of receive operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: messaging.receive.messages
+      description: Measures the number of received messages.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{message}'
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -9597,10 +14256,55 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.instrumentation.pulsar.experimental-span-attributes=true
-    metric_refs:
-    - messaging.publish.duration-05731f17
-    - messaging.receive.duration-4b4a91de
-    - messaging.receive.messages-2499c5ac
+    metrics:
+    - name: messaging.publish.duration
+      description: Measures the duration of publish operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: messaging.receive.duration
+      description: Measures the duration of receive operation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: messaging.receive.messages
+      description: Measures the number of received messages.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{message}'
+      attributes:
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CONSUMER
       attributes:
@@ -9642,10 +14346,6 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
-- name: quarkus-resteasy-reactive
-  source_path: instrumentation/quarkus-resteasy-reactive
-  scope:
-    name: io.opentelemetry.quarkus-resteasy-reactive
 - name: quarkus-resteasy-reactive-1.11
   display_name: Quarkus RESTEasy Reactive
   description: |
@@ -9671,8 +14371,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.quartz-scheduler:quartz:[2.0.0,)
-  configuration_refs:
-  - otel.instrumentation.quartz.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.quartz.experimental-span-attributes
+    declarative_name: java.quartz.experimental_span_attributes/development
+    description: Enables the experimental `job.system` span attribute.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -9707,11 +14411,43 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.r2dbc:r2dbc-spi:[0.9.0.RELEASE,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
-  - otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
-  - otel.instrumentation.r2dbc.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.r2dbc.query-sanitization.enabled
+    declarative_name: java.r2dbc.query_sanitization.enabled
+    description: |
+      Enables query sanitization for database queries. Takes precedence over otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
+    declarative_name: java.r2dbc.sqlcommenter/development.enabled
+    description: |
+      Enables augmenting queries with a comment containing the tracing information. See [sqlcommenter](https://google.github.io/sqlcommenter/) for more info. WARNING: augmenting queries with tracing context will make query texts unique, which may have adverse impact on database performance.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -9738,18 +14474,37 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-d4212042
-    spans:
-    - span_kind: CLIENT
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
       attributes:
       - name: db.namespace
         type: STRING
       - name: db.query.summary
         type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.query.summary
+        type: STRING
       - name: db.query.text
         type: STRING
       - name: db.system.name
+        type: STRING
+      - name: error.type
         type: STRING
       - name: server.address
         type: STRING
@@ -9770,10 +14525,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.rabbitmq:amqp-client:[2.7.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-59c44ca8
-  - otel.instrumentation.rabbitmq.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.rabbitmq.experimental-span-attributes
+    declarative_name: java.rabbitmq.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `rabbitmq.command`, `rabbitmq.delivery_mode`, `rabbitmq.queue`, and `rabbitmq.record.queue_time_ms`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables the creation of consumer spans on messaging receive operations. These spans will measure the time between receiving a message and the consumer processing that message.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: List of messaging headers to capture.
+    type: list
+    default: ''
   telemetry:
   - when: default
     spans:
@@ -9897,10 +14666,14 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.ratpack:ratpack-core:[1.4.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
-  - when: otel.semconv-stability.opt-in=service.peer
+  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
     - span_kind: INTERNAL
       attributes: []
@@ -9925,23 +14698,130 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.ratpack:ratpack-core:[1.7.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -9990,8 +14870,21 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10013,6 +14906,43 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
+      - name: url.full
+        type: STRING
 - name: reactor-3.1
   display_name: Reactor
   description: |
@@ -10027,8 +14957,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.projectreactor:reactor-core:[3.1.0.RELEASE,)
-  configuration_refs:
-  - otel.instrumentation.reactor.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.reactor.experimental-span-attributes
+    declarative_name: java.reactor.experimental_span_attributes/development
+    description: |
+      Enables the capture of the experimental `reactor.canceled` attribute on spans when reactive streams are cancelled.
+    type: boolean
+    default: false
 - name: reactor-3.4
   display_name: Reactor
   description: |
@@ -10055,10 +14990,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.projectreactor.kafka:reactor-kafka:[1.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.kafka.experimental-span-attributes-956cabd8
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
+  - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
+    description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.kafka.experimental-span-attributes=true
     spans:
@@ -10131,19 +15080,100 @@ libraries:
   javaagent_target_versions:
   - io.projectreactor.netty:reactor-netty-http:[1.0.0,)
   - io.projectreactor.netty:reactor-netty:[1.0.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - otel.instrumentation.reactor-netty.connection-telemetry.enabled
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.reactor-netty.connection-telemetry.enabled
+    declarative_name: java.reactor_netty.connection_telemetry.enabled
+    description: Enables the creation of Connect and DNS spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -10169,6 +15199,51 @@ libraries:
         type: STRING
       - name: server.port
         type: LONG
+      - name: url.full
+        type: STRING
+  - when: otel.semconv-stability.opt-in=service.peer
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: http.request.method
+        type: STRING
+      - name: http.request.method_original
+        type: STRING
+      - name: http.request.resend_count
+        type: LONG
+      - name: http.response.status_code
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+      - name: service.peer.name
+        type: STRING
       - name: url.full
         type: STRING
 - name: rediscala-1.8
@@ -10200,16 +15275,39 @@ libraries:
         type: STRING
       - name: db.system
         type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-55295033
-    spans:
-    - span_kind: CLIENT
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
       attributes:
       - name: db.operation.name
         type: STRING
       - name: db.system.name
         type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: db.operation.batch.size
+        type: LONG
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
 - name: redisson-3.0
   display_name: Redisson
   description: This instrumentation enables database client spans and database client
@@ -10241,12 +15339,35 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-7714cbf7
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -10256,6 +15377,10 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
         type: LONG
 - name: redisson-3.17
   display_name: Redisson
@@ -10288,12 +15413,35 @@ libraries:
         type: LONG
       - name: network.type
         type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-7714cbf7
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -10303,6 +15451,10 @@ libraries:
       - name: network.peer.address
         type: STRING
       - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
         type: LONG
 - name: resources
   display_name: Resource Detectors
@@ -10314,8 +15466,12 @@ libraries:
   scope:
     name: io.opentelemetry.resources
   has_standalone_library: true
-  configuration_refs:
-  - otel.instrumentation.resources.experimental.process-command-attributes.enabled
+  configurations:
+  - name: otel.instrumentation.resources.experimental.process-command-attributes.enabled
+    description: |
+      Enables capture of process command-line resource attributes when v3 preview suppresses them by default.
+    type: boolean
+    default: false
 - name: restlet-1.1
   display_name: Restlet
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -10334,15 +15490,48 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.restlet:org.restlet:[1.1.0, 1.2-M1)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -10394,15 +15583,48 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.restlet.jse:org.restlet:[2.0.0,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -10483,9 +15705,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.rocketmq:rocketmq-client:[4.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.rocketmq-client.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
+  - name: otel.instrumentation.rocketmq-client.experimental-span-attributes
+    declarative_name: java.rocketmq_client.experimental_span_attributes/development
+    description: |
+      Enables capturing experimental span attributes `messaging.rocketmq.message.tag`, `messaging.rocketmq.broker_address`, `messaging.rocketmq.send_result`, `messaging.rocketmq.queue_id`, and `messaging.rocketmq.queue_offset`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -10562,9 +15794,19 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.rocketmq:rocketmq-client-java:[5.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: |
+      Enables capturing messaging headers as span attributes. Provide a comma-separated list of header names to capture.
+    type: list
+    default: ''
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -10626,20 +15868,447 @@ libraries:
     name: io.opentelemetry.runtime-telemetry
   has_standalone_library: true
   has_javaagent: true
-  configuration_refs:
-  - otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
-  - otel.instrumentation.runtime-telemetry.emit-experimental-metrics
-  - otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
-  - otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
-  - otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
-- name: runtime-telemetry-java17
-  source_path: instrumentation/runtime-telemetry/runtime-telemetry-java17
-  scope:
-    name: io.opentelemetry.runtime-telemetry-java17
-- name: runtime-telemetry-java8
-  source_path: instrumentation/runtime-telemetry/runtime-telemetry-java8
-  scope:
-    name: io.opentelemetry.runtime-telemetry-java8
+  configurations:
+  - name: otel.instrumentation.runtime-telemetry.emit-experimental-metrics
+    declarative_name: java.runtime_telemetry.emit_experimental_metrics/development
+    description: Enables the capture of experimental JMX-based JVM runtime metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.runtime-telemetry.emit-experimental-jfr-metrics
+    declarative_name: java.runtime_telemetry.emit_experimental_jfr_metrics/development
+    description: |
+      Enables the capture of experimental JFR-based JVM runtime metrics on Java 17+.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.runtime-telemetry.experimental.prefer-jfr
+    declarative_name: java.runtime_telemetry.prefer_jfr/development
+    description: |
+      Prefer JFR over JMX for metrics available from both sources, on Java 17+. When enabled, overlapping metrics are collected via JFR and the corresponding JMX metrics are suppressed.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled
+    declarative_name: java.runtime_telemetry.package_emitter/development.enabled
+    description: Enables creating events for JAR libraries used by the application.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second
+    declarative_name: java.runtime_telemetry.package_emitter/development.jars_per_second
+    description: The number of JAR files processed per second by the package emitter.
+    type: int
+    default: 10
+  telemetry:
+  - when: Java17
+    metrics:
+    - name: jvm.buffer.count
+      description: Number of buffers in the pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{buffer}'
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.buffer.memory.limit
+      description: Measure of total memory capacity of buffers.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.buffer.memory.used
+      description: Measure of memory used by buffers.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.class.count
+      description: Number of classes currently loaded.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.loaded
+      description: Number of classes loaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.unloaded
+      description: Number of classes unloaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.cpu.count
+      description: Number of processors available to the Java virtual machine.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{cpu}'
+      attributes: []
+    - name: jvm.cpu.longlock
+      description: Long lock times
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes: []
+    - name: jvm.cpu.recent_utilization
+      description: Recent CPU utilization for the process as reported by the JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes: []
+    - name: jvm.cpu.time
+      description: CPU time used by the process as reported by the JVM.
+      instrument: counter
+      data_type: DOUBLE_SUM
+      unit: s
+      attributes: []
+    - name: jvm.gc.duration
+      description: Duration of JVM garbage collection actions.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: jvm.gc.action
+        type: STRING
+      - name: jvm.gc.name
+        type: STRING
+    - name: jvm.memory.committed
+      description: Measure of memory committed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.init
+      description: Measure of initial memory requested.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.limit
+      description: Measure of max obtainable memory.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used
+      description: Measure of memory used.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used_after_last_gc
+      description: Measure of memory used, as measured after the most recent garbage
+        collection event on this pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.system.cpu.utilization
+      description: Recent CPU utilization for the whole system as reported by the
+        JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes: []
+    - name: jvm.thread.count
+      description: Number of executing platform threads.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{thread}'
+      attributes:
+      - name: jvm.thread.daemon
+        type: BOOLEAN
+      - name: jvm.thread.state
+        type: STRING
+  - when: Java21
+    metrics:
+    - name: jvm.class.count
+      description: Number of classes currently loaded.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.loaded
+      description: Number of classes loaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.unloaded
+      description: Number of classes unloaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.cpu.count
+      description: Number of processors available to the Java virtual machine.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{cpu}'
+      attributes: []
+    - name: jvm.cpu.recent_utilization
+      description: Recent CPU utilization for the process as reported by the JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes: []
+    - name: jvm.cpu.time
+      description: CPU time used by the process as reported by the JVM.
+      instrument: counter
+      data_type: DOUBLE_SUM
+      unit: s
+      attributes: []
+    - name: jvm.gc.duration
+      description: Duration of JVM garbage collection actions.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: jvm.gc.action
+        type: STRING
+      - name: jvm.gc.name
+        type: STRING
+    - name: jvm.memory.committed
+      description: Measure of memory committed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.limit
+      description: Measure of max obtainable memory.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used
+      description: Measure of memory used.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used_after_last_gc
+      description: Measure of memory used, as measured after the most recent garbage
+        collection event on this pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.thread.count
+      description: Number of executing platform threads.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{thread}'
+      attributes:
+      - name: jvm.thread.daemon
+        type: BOOLEAN
+      - name: jvm.thread.state
+        type: STRING
+    - name: jvm.thread.virtual.pinned
+      description: Duration of virtual thread pinning.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes: []
+  - when: default
+    metrics:
+    - name: jvm.buffer.count
+      description: Number of buffers in the pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{buffer}'
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.buffer.memory.limit
+      description: Measure of total memory capacity of buffers.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.buffer.memory.used
+      description: Measure of memory used by buffers.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.buffer.pool.name
+        type: STRING
+    - name: jvm.class.count
+      description: Number of classes currently loaded.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.loaded
+      description: Number of classes loaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.class.unloaded
+      description: Number of classes unloaded since JVM start.
+      instrument: counter
+      data_type: LONG_SUM
+      unit: '{class}'
+      attributes: []
+    - name: jvm.cpu.count
+      description: Number of processors available to the Java virtual machine.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{cpu}'
+      attributes: []
+    - name: jvm.cpu.recent_utilization
+      description: Recent CPU utilization for the process as reported by the JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes: []
+    - name: jvm.cpu.time
+      description: CPU time used by the process as reported by the JVM.
+      instrument: counter
+      data_type: DOUBLE_SUM
+      unit: s
+      attributes: []
+    - name: jvm.file_descriptor.count
+      description: Number of open file descriptors as reported by the JVM.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{file_descriptor}'
+      attributes: []
+    - name: jvm.file_descriptor.limit
+      description: Measure of max open file descriptors as reported by the JVM.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{file_descriptor}'
+      attributes: []
+    - name: jvm.gc.duration
+      description: Duration of JVM garbage collection actions.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: jvm.gc.action
+        type: STRING
+      - name: jvm.gc.cause
+        type: STRING
+      - name: jvm.gc.name
+        type: STRING
+    - name: jvm.memory.committed
+      description: Measure of memory committed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.init
+      description: Measure of initial memory requested.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.limit
+      description: Measure of max obtainable memory.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used
+      description: Measure of memory used.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.memory.used_after_last_gc
+      description: Measure of memory used, as measured after the most recent garbage
+        collection event on this pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: By
+      attributes:
+      - name: jvm.memory.pool.name
+        type: STRING
+      - name: jvm.memory.type
+        type: STRING
+    - name: jvm.system.cpu.load_1m
+      description: Average CPU load of the whole system for the last minute as reported
+        by the JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '{run_queue_item}'
+      attributes: []
+    - name: jvm.system.cpu.utilization
+      description: Recent CPU utilization for the whole system as reported by the
+        JVM.
+      instrument: gauge
+      data_type: DOUBLE_GAUGE
+      unit: '1'
+      attributes: []
+    - name: jvm.thread.count
+      description: Number of executing platform threads.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{thread}'
+      attributes:
+      - name: jvm.thread.daemon
+        type: BOOLEAN
+      - name: jvm.thread.state
+        type: STRING
 - name: rxjava-2.0
   display_name: RxJava
   description: |
@@ -10654,8 +16323,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava2:rxjava:[2.0.6,)
-  configuration_refs:
-  - otel.instrumentation.rxjava.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.rxjava.experimental-span-attributes
+    declarative_name: java.rxjava.experimental_span_attributes/development
+    description: |
+      Enables the experimental span attribute `rxjava.canceled`.
+    type: boolean
+    default: false
 - name: rxjava-3.0
   display_name: RxJava
   description: |
@@ -10670,8 +16344,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava3:rxjava:[3.0.0,3.1.0]
-  configuration_refs:
-  - otel.instrumentation.rxjava.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.rxjava.experimental-span-attributes
+    declarative_name: java.rxjava.experimental_span_attributes/development
+    description: |
+      Enables the experimental span attribute `rxjava.canceled`.
+    type: boolean
+    default: false
 - name: rxjava-3.1.1
   display_name: RxJava
   description: |
@@ -10686,12 +16365,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.reactivex.rxjava3:rxjava:[3.1.1,)
-  configuration_refs:
-  - otel.instrumentation.rxjava.experimental-span-attributes
-- name: scala-fork-join-2.8
-  source_path: instrumentation/scala-fork-join-2.8
-  scope:
-    name: io.opentelemetry.scala-fork-join-2.8
+  configurations:
+  - name: otel.instrumentation.rxjava.experimental-span-attributes
+    declarative_name: java.rxjava.experimental_span_attributes/development
+    description: |
+      Enables the experimental span attribute `rxjava.canceled`.
+    type: boolean
+    default: false
 - name: scala-forkjoin-2.8
   display_name: Scala ForkJoinPool
   description: |
@@ -10720,15 +16400,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.servlet:servlet-api:[2.2, 3.0)
-  configuration_refs:
-  - otel.experimental.javascript-snippet-ad834761
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
-  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+  configurations:
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
+    description: Enables adding the trace ID and span ID as request attributes for
+      downstream servlet access.
+    type: boolean
+    default: true
+  - name: otel.experimental.javascript-snippet
+    declarative_name: java.servlet.javascript_snippet/development
+    description: Experimental setting to inject a JavaScript snippet into HTML responses
+      after the opening `<head>` tag.
+    type: string
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -10782,15 +16493,50 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - javax.servlet:javax.servlet-api:[3.0,)
-  configuration_refs:
-  - otel.experimental.javascript-snippet-cfa9f908
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
-  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+  configurations:
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
+    description: Enables adding the trace ID and span ID as request attributes for
+      downstream servlet access.
+    type: boolean
+    default: true
+  - name: otel.experimental.javascript-snippet
+    declarative_name: java.servlet.javascript_snippet/development
+    description: Experimental setting to inject a JavaScript snippet into HTML responses
+      after the opening `<head>` tag.
+    type: string
+    default: ''
+    examples:
+    - <script type="text/javascript">console.log('test')</script>
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -10848,15 +16594,48 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - jakarta.servlet:jakarta.servlet-api:[5.0.0,)
-  configuration_refs:
-  - otel.experimental.javascript-snippet-ad834761
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
-  - otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+  configurations:
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.servlet.experimental.trace-id-request-attribute.enabled
+    declarative_name: java.servlet.trace_id_request_attribute/development.enabled
+    description: Enables adding the trace ID and span ID as request attributes for
+      downstream servlet access.
+    type: boolean
+    default: true
+  - name: otel.experimental.javascript-snippet
+    declarative_name: java.servlet.javascript_snippet/development
+    description: Experimental setting to inject a JavaScript snippet into HTML responses
+      after the opening `<head>` tag.
+    type: string
+    default: ''
   telemetry:
   - when: otel.instrumentation.servlet.experimental.capture-request-parameters=test-parameter
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -10913,8 +16692,80 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.alipay.sofa:sofa-rpc-all:[5.4.0,)
-  configuration_refs:
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  telemetry:
+  - when: default
+    metrics:
+    - name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: peer.service
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - span_kind: SERVER
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
 - name: spark-2.3
   display_name: Spark Web Framework
   description: |
@@ -10940,10 +16791,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.batch:spring-batch-core:[3.0.0.RELEASE,5)
-  configuration_refs:
-  - otel.instrumentation.spring-batch.experimental-span-attributes
-  - otel.instrumentation.spring-batch.experimental.chunk.new-trace
-  - otel.instrumentation.spring-batch.item.enabled
+  configurations:
+  - name: otel.instrumentation.spring-batch.experimental-span-attributes
+    declarative_name: java.spring_batch.experimental_span_attributes/development
+    description: Adds the experimental attribute `job.system` to spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.spring-batch.experimental.chunk.new-trace
+    declarative_name: java.spring_batch.chunk/development.new_trace
+    description: When enabled, a new root span will be created for each chunk processing.
+      Please note that this may lead to a high number of spans being created.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.spring-batch.item.enabled
+    declarative_name: java.spring_batch.item.enabled
+    description: When enabled, spans will be created for each item processed. Please
+      note that this may lead to a high number of spans being created.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -11013,8 +16878,13 @@ libraries:
   javaagent_target_versions:
   - org.springframework.cloud:spring-cloud-starter-gateway-server-webflux:[4.3.0,)
   - org.springframework.cloud:spring-cloud-starter-gateway:[2.0.0.RELEASE,)
-  configuration_refs:
-  - otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+    declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
+    description: |
+      Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
+    type: boolean
+    default: false
 - name: spring-cloud-gateway-webmvc-4.3
   display_name: Spring Cloud Gateway Server WebMVC
   description: |
@@ -11027,8 +16897,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.cloud:spring-cloud-starter-gateway-server-webmvc:[4.3.0,)
-  configuration_refs:
-  - otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+    declarative_name: java.spring_cloud_gateway.experimental_span_attributes/development
+    description: |
+      Enables experimental `spring-cloud-gateway.route` attributes (e.g., `spring-cloud-gateway.route.id`, `spring-cloud-gateway.route.uri`, etc.) on spans.
+    type: boolean
+    default: false
 - name: spring-core-2.0
   display_name: Spring Core
   description: |
@@ -11055,7 +16930,7 @@ libraries:
   - org.springframework.data:spring-data-commons:[1.8.0.RELEASE,)
   - org.springframework:spring-aop:[1.2,)
   telemetry:
-  - when: otel.semconv-stability.opt-in=database
+  - when: default
     spans:
     - span_kind: INTERNAL
       attributes:
@@ -11075,10 +16950,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.integration:spring-integration-core:[4.1.0.RELEASE,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.spring-integration.global-channel-interceptor-patterns
-  - otel.instrumentation.spring-integration.producer.enabled
+  configurations:
+  - name: otel.instrumentation.spring-integration.producer.enabled
+    declarative_name: java.spring_integration.producer.enabled
+    description: |
+      Create producer spans when messages are sent to an output channel. Enable when you're using a messaging library that doesn't have its own instrumentation for generating producer spans. Note that the detection of output channels only works for Spring Cloud Stream `DirectWithAttributesChannel`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.spring-integration.global-channel-interceptor-patterns
+    declarative_name: java.spring_integration.global_channel_interceptor_patterns
+    description: A list of Spring channel name patterns that will be intercepted.
+    type: list
+    default: '*'
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
     spans:
@@ -11109,9 +16997,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-jms:[2.0,6)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -11139,9 +17036,18 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-jms:[6.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -11169,15 +17075,55 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.kafka:spring-kafka:[2.7.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.kafka.experimental-span-attributes-6596b308
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
+    description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`
+      and `messaging.kafka.bootstrap.servers`.
+    type: boolean
+    default: false
   telemetry:
-  - when: default
+  - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
     - span_kind: CONSUMER
       attributes:
+      - name: messaging.batch.message_count
+        type: LONG
+      - name: messaging.client_id
+        type: STRING
+      - name: messaging.destination.name
+        type: STRING
+      - name: messaging.destination.partition.id
+        type: STRING
+      - name: messaging.kafka.consumer.group
+        type: STRING
+      - name: messaging.kafka.message.key
+        type: STRING
+      - name: messaging.kafka.message.offset
+        type: LONG
+      - name: messaging.message.body.size
+        type: LONG
+      - name: messaging.operation
+        type: STRING
+      - name: messaging.system
+        type: STRING
+  - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true
+    spans:
+    - span_kind: CONSUMER
+      attributes:
+      - name: kafka.record.queue_time_ms
+        type: LONG
       - name: messaging.batch.message_count
         type: LONG
       - name: messaging.client_id
@@ -11212,10 +17158,24 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.pulsar:spring-pulsar:[1.0.0,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
-  - otel.instrumentation.pulsar.experimental-span-attributes-1d77bf4d
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.pulsar.experimental-span-attributes
+    declarative_name: java.pulsar.experimental_span_attributes/development
+    description: |
+      Enables capturing experimental span attribute `messaging.pulsar.message.type` on PRODUCER spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -11244,8 +17204,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.amqp:spring-rabbit:(,)
-  configuration_refs:
-  - messaging.capture-headers
+  configurations:
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
     spans:
@@ -11302,8 +17266,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-context:[3.1.0.RELEASE,]
-  configuration_refs:
-  - otel.instrumentation.spring-scheduling.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spring-scheduling.experimental-span-attributes
+    declarative_name: java.spring_scheduling.experimental_span_attributes/development
+    description: Adds the experimental span attribute `job.system` with the value
+      `spring_scheduling`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -11337,15 +17306,60 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.security:spring-security-config:[6.0.0,]
-  configuration_refs:
-  - otel.instrumentation.common.enduser.id.enabled
-  - otel.instrumentation.common.enduser.role.enabled
-  - otel.instrumentation.common.enduser.scope.enabled
-  - otel.instrumentation.common.user.name.enabled
-  - otel.instrumentation.common.user.roles.enabled
-  - otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
-  - otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
-  - otel.instrumentation.spring-security.user.roles.granted-authority-prefix
+  configurations:
+  - name: otel.instrumentation.common.enduser.id.enabled
+    declarative_name: java.common.enduser.id.enabled
+    description: Enables capturing the enduser.id attribute. This property and the
+      associated attribute are not supported when v3 preview is enabled.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.enduser.role.enabled
+    declarative_name: java.common.enduser.role.enabled
+    description: Enables capturing the enduser.role attribute. This property and the
+      associated attribute are not supported when v3 preview is enabled.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.enduser.scope.enabled
+    declarative_name: java.common.enduser.scope.enabled
+    description: Enables capturing the enduser.scope attribute when v3 preview is
+      not enabled. This property is not honored when v3 preview is enabled.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.user.name.enabled
+    declarative_name: java.common.user.name.enabled
+    description: Enables capturing the user.name attribute when v3 preview is enabled.
+      This property and the associated attribute are not supported when v3 preview
+      is disabled.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.user.roles.enabled
+    declarative_name: java.common.user.roles.enabled
+    description: Enables capturing the user.roles attribute when v3 preview is enabled.
+      This property and the associated attribute are not supported when v3 preview
+      is disabled.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
+    declarative_name: java.spring_security.enduser.role.granted_authority_prefix
+    description: Prefix of granted authorities identifying roles to capture in the
+      `enduser.role` semantic attribute. This property is not honored when v3 preview
+      is enabled; use the `user.roles` variant instead.
+    type: string
+    default: ROLE_
+  - name: otel.instrumentation.spring-security.user.roles.granted-authority-prefix
+    declarative_name: java.spring_security.user.roles.granted_authority_prefix
+    description: Prefix of granted authorities identifying roles to capture in the
+      `user.roles` semantic attribute when v3 preview is enabled. This property is
+      not honored when v3 preview is disabled; use the `enduser.role` variant instead.
+    type: string
+    default: ROLE_
+  - name: otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
+    declarative_name: java.spring_security.enduser.scope.granted_authority_prefix
+    description: Prefix of granted authorities identifying scopes to capture in the
+      `enduser.scope` semantic attribute. This property and the associated attribute
+      are not supported when v3 preview is enabled.
+    type: string
+    default: SCOPE_
 - name: spring-web-3.1
   display_name: Spring Web
   description: |
@@ -11361,8 +17375,21 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11379,8 +17406,21 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11410,9 +17450,35 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-web:[6.0.0,)
-  configuration_refs:
-  - http.client.emit-experimental-telemetry
-  - java.common.http.client.url_template_rules
+  configurations:
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enables the capture of experimental HTTP client telemetry, including URL template as the span name.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
 - name: spring-webflux-5.0
   display_name: Spring WebFlux
   description: |
@@ -11430,12 +17496,29 @@ libraries:
   - io.projectreactor.ipc:reactor-netty:[0.7.0.RELEASE,)
   - io.projectreactor.netty:reactor-netty:[0.8.0.RELEASE,)
   - org.springframework:spring-webflux:[5.0.0.RELEASE,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
-  - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11453,8 +17536,6 @@ libraries:
         type: LONG
       - name: url.full
         type: STRING
-  - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
-    spans:
     - span_kind: INTERNAL
       attributes:
       - name: code.function
@@ -11462,16 +17543,21 @@ libraries:
       - name: code.namespace
         type: STRING
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.semconv-stability.opt-in=service.peer
-    spans:
-    - span_kind: INTERNAL
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
       attributes:
-      - name: code.function
+      - name: http.request.method
         type: STRING
-      - name: code.namespace
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
         type: STRING
-  - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11488,6 +17574,12 @@ libraries:
       - name: service.peer.name
         type: STRING
       - name: url.full
+        type: STRING
+    - span_kind: INTERNAL
+      attributes:
+      - name: code.function
+        type: STRING
+      - name: code.namespace
         type: STRING
 - name: spring-webflux-5.3
   display_name: Spring WebFlux
@@ -11506,9 +17598,35 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
-    - http.server.request.duration-2311bdb1
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11553,9 +17671,35 @@ libraries:
       - name: user_agent.original
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
-    - http.server.request.duration-2311bdb1
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11614,10 +17758,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-webmvc:[3.1.0.RELEASE,6)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.common.experimental.view-telemetry.enabled
-  - otel.instrumentation.spring-webmvc.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
+    declarative_name: java.spring_webmvc.experimental_span_attributes/development
+    description: |
+      Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
+    declarative_name: java.common.view_telemetry/development.enabled
+    description: Enables the creation of experimental view spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -11654,8 +17811,23 @@ libraries:
   has_standalone_library: true
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -11706,10 +17878,23 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework:spring-webmvc:[6.0.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
-  - otel.instrumentation.common.experimental.view-telemetry.enabled
-  - otel.instrumentation.spring-webmvc.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spring-webmvc.experimental-span-attributes
+    declarative_name: java.spring_webmvc.experimental_span_attributes/development
+    description: |
+      Enables the capture of experimental span attributes `spring-webmvc.view.name` and `spring-webmvc.view.type`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.common.experimental.view-telemetry.enabled
+    declarative_name: java.common.view_telemetry/development.enabled
+    description: Enables the creation of experimental view spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true,otel.instrumentation.common.experimental.view-telemetry.enabled=true
     spans:
@@ -11743,8 +17928,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.springframework.ws:spring-ws-core:[2.0.0.RELEASE,]
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -11768,8 +17957,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - net.spy:spymemcached:[2.12.0,)
-  configuration_refs:
-  - otel.instrumentation.spymemcached.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.spymemcached.experimental-span-attributes
+    declarative_name: java.spymemcached.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `spymemcached.result` and `spymemcached.command.cancelled`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -11800,8 +17994,21 @@ libraries:
       - name: spymemcached.result
         type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.operation.duration-32559b79
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -11829,8 +18036,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.struts:struts2-core:[2.1.0,7)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -11855,8 +18066,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.struts:struts2-core:[7.0.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -11880,8 +18095,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tapestry:tapestry-core:[5.4.0,)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.common.experimental.controller-telemetry.enabled=true
     spans:
@@ -11904,6 +18123,157 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.thrift:libthrift:[0.13.0,)
+  telemetry:
+  - when: default
+    metrics:
+    - name: rpc.client.duration
+      description: The duration of an outbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.duration
+      description: The duration of an inbound RPC invocation.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: ms
+      attributes:
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - span_kind: SERVER
+      attributes:
+      - name: network.local.address
+        type: STRING
+      - name: network.local.port
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.service
+        type: STRING
+      - name: rpc.system
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+  - when: otel.semconv-stability.opt-in=rpc
+    metrics:
+    - name: rpc.client.call.duration
+      description: Measures the duration of outbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - name: rpc.server.call.duration
+      description: Measures the duration of inbound remote procedure calls (RPC).
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    spans:
+    - span_kind: CLIENT
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
+    - span_kind: SERVER
+      attributes:
+      - name: error.type
+        type: STRING
+      - name: network.local.address
+        type: STRING
+      - name: network.local.port
+        type: LONG
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: network.type
+        type: STRING
+      - name: rpc.method
+        type: STRING
+      - name: rpc.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
 - name: tomcat-7.0
   display_name: Apache Tomcat
   description: This instrumentation enables HTTP server spans and HTTP server metrics
@@ -11921,17 +18291,58 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat.embed:tomcat-embed-core:[7.0.4, 10)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -11982,17 +18393,58 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat.embed:tomcat-embed-core:[10,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
-  - otel.instrumentation.servlet.experimental-span-attributes
-  - otel.instrumentation.servlet.experimental.capture-request-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental-span-attributes
+    declarative_name: java.servlet.experimental_span_attributes/development
+    description: Enables capturing the experimental `servlet.timeout` span attribute.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.servlet.experimental.capture-request-parameters
+    declarative_name: java.servlet.capture_request_parameters/development
+    description: List of request parameter names to capture as span attributes.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-1f6f63ed
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: http.route
+        type: STRING
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -12039,23 +18491,105 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - org.apache.tomcat:tomcat-jdbc:[8.5.0,)
-  configuration_refs:
-  - otel.semconv-stability.opt-in
+  configurations:
+  - name: otel.semconv-stability.opt-in
+    declarative_name: general.semconv_stability.opt_in
+    description: |
+      Opt-in to emit stable semantic conventions instead of the old experimental semantic conventions. Accepts a comma-separated list of semantic convention groups (e.g., `database`, `http`, `messaging`). Use `<group>/dup` to emit both old and new conventions simultaneously. Stable semantic conventions will become the default in version 3.0 of the agent.
+    type: list
+    default: ''
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.idle.max-f9946dd5
-    - db.client.connections.idle.min-f04d4083
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.pending_requests-a0698f55
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.pending_requests
+      description: The number of pending requests for an open connection, cumulative
+        for the entire pool.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{requests}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.idle.max-b95e4f5c
-    - db.client.connection.idle.min-73bdafbc
-    - db.client.connection.max-c7917942
-    - db.client.connection.pending_requests-a0f41111
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.idle.max
+      description: The maximum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.idle.min
+      description: The minimum number of idle open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+    - name: db.client.connection.pending_requests
+      description: The number of current pending requests for an open connection.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{request}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: twilio-6.6
   display_name: Twilio
   description: |
@@ -12067,8 +18601,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.twilio.sdk:twilio:(,8.0.0)
-  configuration_refs:
-  - otel.instrumentation.twilio.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.twilio.experimental-span-attributes
+    declarative_name: java.twilio.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `twilio.type`, `twilio.account`, `twilio.sid`, `twilio.parentSid`, and `twilio.status`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -12101,15 +18640,46 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.undertow:undertow-core:[1.4.0.Final,)
-  configuration_refs:
-  - http.known-methods
-  - http.server.capture-request-headers
-  - http.server.capture-response-headers
-  - http.server.emit-experimental-telemetry
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP server telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics.
+    type: boolean
+    default: false
   telemetry:
   - when: default
-    metric_refs:
-    - http.server.request.duration-639e2d0b
+    metrics:
+    - name: http.server.request.duration
+      description: Duration of HTTP server requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: url.scheme
+        type: STRING
     spans:
     - span_kind: SERVER
       attributes:
@@ -12156,8 +18726,12 @@ libraries:
   javaagent_target_versions:
   - com.vaadin:flow-server:[2.2.0,3)
   - com.vaadin:flow-server:[3.1.0,25.0.0)
-  configuration_refs:
-  - common.controller-telemetry.enabled
+  configurations:
+  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: Enables the creation of experimental controller spans.
+    type: boolean
+    default: false
 - name: vertx-http-client-3.0
   display_name: Vert.x HTTP Client
   description: |
@@ -12173,18 +18747,93 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[3.0.0,4.0.0)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12203,8 +18852,21 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-98bb5f3b
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12237,18 +18899,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[4.0.0,5)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12275,8 +19014,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12318,18 +19072,95 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-core:[5.0.0,)
-  configuration_refs:
-  - common.peer-service-mapping
-  - http.client.capture-request-headers
-  - http.client.capture-response-headers
-  - http.client.emit-experimental-telemetry
-  - http.known-methods
-  - java.common.http.client.url_template_rules
-  - sanitization.url.sensitive-query-parameters
+  configurations:
+  - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: |
+      Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`.
+    type: list
+    default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: List of HTTP request headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: List of HTTP response headers to capture in HTTP client telemetry.
+    type: list
+    default: ''
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: |
+      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics.
+    type: boolean
+    default: false
+  - declarative_name: java.common.http.client.url_template_rules
+    description: |
+      Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only applied when experimental HTTP client telemetry is enabled.
+    type: list
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - pattern
+      - template
+      properties:
+        pattern:
+          type: string
+          description: Regular expression matched against the request URL.
+        template:
+          type: string
+          description: Template used to derive the low-cardinality route.
+        override:
+          type: boolean
+          description: Whether this rule overrides an already-applied template.
+          default: false
+  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: List of URL query parameter names whose values are redacted in URL
+      attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
+    type: list
+    default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
   telemetry:
   - when: default
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12356,8 +19187,23 @@ libraries:
       - name: url.full
         type: STRING
   - when: otel.semconv-stability.opt-in=service.peer
-    metric_refs:
-    - http.client.request.duration-a64b5297
+    metrics:
+    - name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: http.request.method
+        type: STRING
+      - name: http.response.status_code
+        type: LONG
+      - name: network.protocol.version
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
@@ -12397,11 +19243,29 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-kafka-client:[3.5.1,)
-  configuration_refs:
-  - messaging.capture-headers
-  - otel.instrumentation.kafka.experimental-span-attributes-5d2fc7d4
-  - otel.instrumentation.kafka.producer-propagation.enabled
-  - otel.instrumentation.messaging.experimental.receive-telemetry.enabled-469576a6
+  configurations:
+  - name: otel.instrumentation.kafka.producer-propagation.enabled
+    declarative_name: java.kafka.producer_propagation.enabled
+    description: Enable context propagation for Kafka message producers.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.kafka.experimental-span-attributes
+    declarative_name: java.kafka.experimental_span_attributes/development
+    description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms`
+      and `messaging.kafka.bootstrap.servers`.
+    type: boolean
+    default: false
+  - name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: A comma-separated list of header names to capture as span attributes.
+    type: list
+    default: ''
+  - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    declarative_name: java.common.messaging.receive_telemetry/development.enabled
+    description: |
+      Enables experimental receive telemetry, which will cause consumers to start a new trace, with only a span link connecting it to the producer trace.
+    type: boolean
+    default: false
   telemetry:
   - when: otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true
     spans:
@@ -12463,9 +19327,31 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-redis-client:[4.0.0,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
-  - common.peer-service-mapping
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
+  - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: Used to specify a mapping from host names or IP addresses to peer
+      services.
+    type: map
+    default: ''
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+      - peer
+      - service_name
+      properties:
+        peer:
+          type: string
+          description: Host name or IP address to match against.
+        service_name:
+          type: string
+          description: Peer service name to record for matching peers.
   telemetry:
   - when: default
     spans:
@@ -12490,13 +19376,34 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-8ae2b8ce
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.operation.name
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: network.peer.address
+        type: STRING
+      - name: network.peer.port
+        type: LONG
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.operation.name
         type: STRING
       - name: db.query.text
@@ -12540,8 +19447,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-sql-client:[4.0.0,5)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -12564,13 +19475,30 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-d4212042
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.query.summary
         type: STRING
       - name: db.query.text
@@ -12600,8 +19528,12 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - io.vertx:vertx-sql-client:[5.0.0,)
-  configuration_refs:
-  - common.db.query-sanitization.enabled
+  configurations:
+  - name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: Enables query sanitization for database queries.
+    type: boolean
+    default: true
   telemetry:
   - when: default
     spans:
@@ -12624,13 +19556,30 @@ libraries:
       - name: server.port
         type: LONG
   - when: otel.semconv-stability.opt-in=database,service.peer
-    metric_refs:
-    - db.client.operation.duration-d4212042
+    metrics:
+    - name: db.client.operation.duration
+      description: Duration of database client operations.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes:
+      - name: db.namespace
+        type: STRING
+      - name: db.query.summary
+        type: STRING
+      - name: db.system.name
+        type: STRING
+      - name: server.address
+        type: STRING
+      - name: server.port
+        type: LONG
     spans:
     - span_kind: CLIENT
       attributes:
       - name: db.namespace
         type: STRING
+      - name: db.operation.batch.size
+        type: LONG
       - name: db.query.summary
         type: STRING
       - name: db.query.text
@@ -12674,13 +19623,47 @@ libraries:
   - org.vibur:vibur-dbcp:[11.0,)
   telemetry:
   - when: default
-    metric_refs:
-    - db.client.connections.max-ddde65fe
-    - db.client.connections.usage-5ef1d5ef
+    metrics:
+    - name: db.client.connections.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+    - name: db.client.connections.usage
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connections}'
+      attributes:
+      - name: pool.name
+        type: STRING
+      - name: state
+        type: STRING
   - when: otel.semconv-stability.opt-in=database
-    metric_refs:
-    - db.client.connection.count-2e6ba9b7
-    - db.client.connection.max-c7917942
+    metrics:
+    - name: db.client.connection.count
+      description: The number of connections that are currently in state described
+        by the state attribute.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
+      - name: db.client.connection.state
+        type: STRING
+    - name: db.client.connection.max
+      description: The maximum number of open connections allowed.
+      instrument: updowncounter
+      data_type: LONG_SUM
+      unit: '{connection}'
+      attributes:
+      - name: db.client.connection.pool.name
+        type: STRING
 - name: wicket-8.0
   display_name: Apache Wicket
   description: |
@@ -12704,8 +19687,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[1.9.2, 2.1.2)
-  configuration_refs:
-  - otel.instrumentation.xxl-job.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.xxl-job.experimental-span-attributes
+    declarative_name: java.xxl_job.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -12739,8 +19727,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[2.1.2,2.3.0)
-  configuration_refs:
-  - otel.instrumentation.xxl-job.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.xxl-job.experimental-span-attributes
+    declarative_name: java.xxl_job.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -12774,8 +19767,13 @@ libraries:
   has_javaagent: true
   javaagent_target_versions:
   - com.xuxueli:xxl-job-core:[2.3.0,)
-  configuration_refs:
-  - otel.instrumentation.xxl-job.experimental-span-attributes
+  configurations:
+  - name: otel.instrumentation.xxl-job.experimental-span-attributes
+    declarative_name: java.xxl_job.experimental_span_attributes/development
+    description: |
+      Enables experimental span attributes `job.system`, `scheduling.xxl-job.glue.type`, and `scheduling.xxl-job.job.id`.
+    type: boolean
+    default: false
   telemetry:
   - when: default
     spans:
@@ -12841,9 +19839,24 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - otel.instrumentation.external-annotations.exclude-methods
-  - otel.instrumentation.external-annotations.include
+  configurations:
+  - name: otel.instrumentation.external-annotations.include
+    declarative_name: java.external_annotations.include
+    description: Semicolon-separated list of annotation class names to instrument.
+    type: list
+    default: ''
+    examples:
+    - com.example.Trace
+    - com.example.Trace;com.example.OtherTrace
+  - name: otel.instrumentation.external-annotations.exclude-methods
+    declarative_name: java.external_annotations.exclude_methods
+    description: All methods to be excluded from auto-instrumentation by annotation-based
+      advices.
+    type: string
+    default: ''
+    examples:
+    - com.example.MyClass[method1,method2]
+    - com.example.MyClass[method1];com.example.OtherClass[method2]
 - name: jmx-metrics
   display_name: JMX Metrics
   description: |
@@ -12853,11 +19866,27 @@ custom:
     name: io.opentelemetry.jmx-metrics
   has_standalone_library: true
   has_javaagent: true
-  configuration_refs:
-  - otel.jmx.config
-  - otel.jmx.discovery.delay
-  - otel.jmx.enabled
-  - otel.jmx.target.system
+  configurations:
+  - name: otel.jmx.enabled
+    declarative_name: java.jmx.enabled
+    description: Enables collection of JMX metrics.
+    type: boolean
+    default: true
+  - name: otel.jmx.config
+    declarative_name: java.jmx.config
+    description: List of paths to JMX metric definition YAML files.
+    type: list
+    default: ''
+  - name: otel.jmx.discovery.delay
+    declarative_name: java.jmx.discovery.delay
+    description: Time in milliseconds between JMX MBean detection attempts.
+    type: int
+    default: 60000
+  - name: otel.jmx.target.system
+    declarative_name: java.jmx.target.system
+    description: List of predefined JMX target systems to collect metrics for.
+    type: list
+    default: ''
 - name: methods
   display_name: Methods
   description: |
@@ -12868,8 +19897,16 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - Java 8+
-  configuration_refs:
-  - otel.instrumentation.methods.include
+  configurations:
+  - name: otel.instrumentation.methods.include
+    declarative_name: java.methods.include
+    description: Semicolon-separated list of fully qualified class and method patterns
+      to instrument.
+    type: list
+    default: ''
+    examples:
+    - com.example.MyClass[method1]
+    - com.example.MyClass[method1,method2];com.example.OtherClass[call]
 - name: opentelemetry-extension-annotations-1.0
   display_name: OpenTelemetry Extension Annotations
   description: |
@@ -12880,8 +19917,16 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - io.opentelemetry:opentelemetry-extension-annotations:[0.16.0,)
-  configuration_refs:
-  - otel.instrumentation.opentelemetry-annotations.exclude-methods
+  configurations:
+  - name: otel.instrumentation.opentelemetry-annotations.exclude-methods
+    declarative_name: java.opentelemetry_extension_annotations.exclude_methods
+    description: All methods to be excluded from auto-instrumentation by annotation-based
+      advices.
+    type: string
+    default: ''
+    examples:
+    - com.example.MyClass[method1,method2]
+    - com.example.MyClass[method1];com.example.OtherClass[method2]
 - name: opentelemetry-instrumentation-annotations-1.16
   display_name: OpenTelemetry Instrumentation Annotations
   description: |
@@ -12892,5 +19937,13 @@ custom:
   has_javaagent: true
   javaagent_target_versions:
   - io.opentelemetry:opentelemetry-instrumentation-annotations:(,)
-  configuration_refs:
-  - otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
+  configurations:
+  - name: otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
+    declarative_name: java.opentelemetry_instrumentation_annotations.exclude_methods
+    description: All methods to be excluded from auto-instrumentation by annotation-based
+      advices.
+    type: string
+    default: ''
+    examples:
+    - com.example.MyClass[method1,method2]
+    - com.example.MyClass[method1];com.example.OtherClass[method2]

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -218,7 +218,9 @@ libraries:
 ```
 
 Configuration ids are the curated ids from the shared registry (see below) for shared options, or the
-config `name` for module-specific options. Metric ids are `<metric name>-<short content hash>`; the
+config `name` for module-specific options. If two module-specific options share the same `name` but
+have different content, their ids are disambiguated as `<config name>-<short content hash>`. Metric
+ids are `<metric name>-<short content hash>`; the
 hash disambiguates metrics that share a name but have different attribute sets. Any consumer of
 `instrumentation-list.yaml` must resolve `configuration_refs` / `metric_refs` against `definitions`
 before reading the underlying config/metric content.

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -167,17 +167,55 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
     conforms to. (See [telemetry schema docs](https://opentelemetry.io/docs/specs/otel/schemas/#schema-url))
   - attributes: The instrumentation scope’s optional attributes provide additional information
     about the scope.
-- configuration settings
-  - List of settings that are available for the instrumentation module
-  - Each setting has a name (flat property format), optional declarative_name (YAML path format), description, type, default value, and optional examples
-  - `name` is optional for declarative-only settings that have no flat property (they must provide a `declarative_name`)
-  - Structured-list settings additionally carry `declarative_type: structured_list` and a `declarative_schema` describing the per-item object shape
-- metrics
-  - List of metrics that the instrumentation module collects, including the metric name, description, type, and attributes.
-  - Separate lists for the metrics emitted by default vs via configuration options.
+- configuration_refs
+  - List of configuration definition ids the instrumentation module exposes.
+  - Each id resolves to an entry in the top-level `definitions.configurations` catalog (see below).
+- metrics (referenced via `metric_refs`)
+  - Each telemetry `when` block lists `metric_refs`: the ids of metric definitions the module emits.
+  - Each id resolves to an entry in the top-level `definitions.metrics` catalog.
+  - Separate `when` blocks distinguish metrics emitted by default vs via configuration options.
 - spans
-  - List of spans kinds the instrumentation module generates, including the attributes and their types.
-  - Separate lists for the spans emitted by default vs via configuration options.
+  - List of span kinds the instrumentation module generates, including the attributes and their types.
+  - Emitted inline under each telemetry `when` block (spans are not yet part of the definitions catalog).
+  - Separate `when` blocks distinguish spans emitted by default vs via configuration options.
+
+### Definitions catalog
+
+To avoid inlining the same metric or configuration block into every instrumentation entry, common
+definitions are collected once into a top-level `definitions` section and referenced by id:
+
+```yaml
+definitions:
+  configurations:
+    http.known-methods:          # id, reused as the configuration_refs value
+      name: otel.instrumentation.http.known-methods
+      declarative_name: java.common.http.known_methods
+      description: ...
+      type: list
+      default: CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE
+  metrics:
+    http.client.request.duration-1a2b3c4d:   # <metric name>-<short content hash>
+      name: http.client.request.duration
+      description: Duration of HTTP client requests.
+      instrument: histogram
+      data_type: HISTOGRAM
+      unit: s
+      attributes: [...]
+libraries:
+- name: java-http-client
+  configuration_refs:
+  - http.known-methods
+  telemetry:
+  - when: default
+    metric_refs:
+    - http.client.request.duration-1a2b3c4d
+```
+
+Configuration ids are the curated ids from the shared registry (see below) for shared options, or the
+config `name` for module-specific options. Metric ids are `<metric name>-<short content hash>`; the
+hash disambiguates metrics that share a name but have different attribute sets. Any consumer of
+`instrumentation-list.yaml` must resolve `configuration_refs` / `metric_refs` against `definitions`
+before reading the underlying config/metric content.
 
 ## Methodology
 
@@ -201,9 +239,14 @@ disabled_by_default: true                         # Defaults to `false`
 classification: internal                          # instrumentation classification: library | internal | custom
 library_link: https://...                         # URL to the library or framework's main website or documentation
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled    # Optional: YAML config path
-    description: Enables query sanitization for database queries.
+  # Reference a shared definition instead of hand-copying a common config block. The id must exist
+  # in instrumentation-docs/src/main/resources/shared-config-definitions.yaml (an unknown ref fails
+  # the build). See "Shared configuration definitions" below.
+  - ref: common.db.query-sanitization.enabled
+  # Module-specific configs are still defined inline:
+  - name: otel.instrumentation.my-module.enabled
+    declarative_name: java.my_module.enabled    # Optional: YAML config path
+    description: Enables the my-module feature.
     type: boolean               # boolean | string | list | map (the flat form)
     default: true
     examples:                   # Optional: Example values for this configuration
@@ -247,6 +290,28 @@ additional_telemetry:                             # Manually document telemetry 
           - name: "span.attribute"
             type: "STRING"
 ```
+
+### Shared configuration definitions
+
+Many instrumentations expose the same configuration options (for example `http.known-methods` or
+`common.peer-service-mapping`). Instead of hand-copying an identical block into every `metadata.yaml`,
+these are defined once in
+[`src/main/resources/shared-config-definitions.yaml`](src/main/resources/shared-config-definitions.yaml)
+under a stable id, and each module references them:
+
+```yaml
+configurations:
+  - ref: http.known-methods
+  - ref: common.peer-service-mapping
+```
+
+At metadata-parse time (`SharedConfigurationRegistry`) each `ref` is expanded into the full
+configuration option; an unknown id fails the build. The same ids are reused as the keys in the
+generated `definitions.configurations` catalog, so editing a description in the registry once updates
+every module that references it.
+
+To add a new shared option, add an entry to `shared-config-definitions.yaml` and reference it by id.
+To change an option for a single module only, define it inline instead of using a `ref`.
 
 ### Gradle File Derived Information
 

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -17,7 +17,7 @@ will enable metric and span collection:
 ```kotlin
 tasks {
   test {
-    systemProperty("collectMetadata", findProperty("collectMetadata"))
+    systemProperty("collectMetadata", otelProps.collectMetadata)
     ...
   }
 }
@@ -32,18 +32,16 @@ For example, to collect and write metadata for the `otel.semconv-stability.opt-i
 set for an instrumentation:
 
 ```kotlin
-val collectMetadata = findProperty("collectMetadata")?.toString() ?: "false"
-
 tasks {
+  withType<Test>().configureEach {
+    systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
   val testStableSemconv by registering(Test::class) {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
 
-    systemProperty("collectMetadata", collectMetadata)
+    systemProperty("collectMetadata", otelProps.collectMetadata)
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
-  }
-
-  test {
-    systemProperty("collectMetadata", collectMetadata)
   }
 
   check {
@@ -170,10 +168,18 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
 - configuration_refs
   - List of configuration definition ids the instrumentation module exposes.
   - Each id resolves to an entry in the top-level `definitions.configurations` catalog (see below).
+  - This is the _generated_ representation. In a module's `metadata.yaml` you still author each
+    configuration either inline or as a shared `ref` (see "metadata.yaml file" and "Shared
+    configuration definitions" below); the generator collects both forms into the catalog and emits
+    the ids here.
 - metrics (referenced via `metric_refs`)
   - Each telemetry `when` block lists `metric_refs`: the ids of metric definitions the module emits.
   - Each id resolves to an entry in the top-level `definitions.metrics` catalog.
   - Separate `when` blocks distinguish metrics emitted by default vs via configuration options.
+  - This is the _generated_ representation, produced automatically from collected telemetry (and any
+    inline `additional_telemetry`). Metrics are always authored inline (or auto-collected from
+    tests) — there is no author-time shared metric catalog; the generator does the de-duplication
+    into `definitions.metrics` for you.
 - spans
   - List of span kinds the instrumentation module generates, including the attributes and their types.
   - Emitted inline under each telemetry `when` block (spans are not yet part of the definitions catalog).

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -44,8 +44,12 @@ public class DocGeneratorApplication {
       writer.write("# This file is generated and should not be manually edited.\n");
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(
+          "# Common metrics and configurations are collected in the top-level `definitions` catalog;\n");
+      writer.write(
+          "# each module references them by id via `metric_refs` and `configuration_refs`.\n");
+      writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      writer.write("file_format: 0.5\n\n");
+      writer.write("file_format: 0.6\n\n");
       YamlHelper.generateInstrumentationYaml(modules, writer);
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.docs.internal;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -25,7 +26,11 @@ public record ConfigurationOption(
     @JsonProperty("declarative_type") @Nullable ConfigurationType declarativeType,
     @JsonProperty("declarative_schema") @Nullable DeclarativeSchema declarativeSchema,
     @Nullable String ref,
-    @Nullable String id) {
+    // The definition id is assigned internally via withId() during registry resolution; it must
+    // never be supplied from metadata.yaml, otherwise an inline option could claim a registry id
+    // and
+    // overwrite the shared definition in buildDefinitionCatalog.
+    @JsonIgnore @Nullable String id) {
 
   public ConfigurationOption {
     // A reference entry (`- ref: <id>`) in a metadata.yaml carries only the ref id; it is resolved

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -23,40 +23,67 @@ public record ConfigurationOption(
     ConfigurationType type,
     @Nullable List<String> examples,
     @JsonProperty("declarative_type") @Nullable ConfigurationType declarativeType,
-    @JsonProperty("declarative_schema") @Nullable DeclarativeSchema declarativeSchema) {
+    @JsonProperty("declarative_schema") @Nullable DeclarativeSchema declarativeSchema,
+    @Nullable String ref,
+    @Nullable String id) {
 
   public ConfigurationOption {
-    requireNonNull(description, "description");
-    requireNonNull(defaultValue, "defaultValue");
-    requireNonNull(type, "type");
-
-    // Most configs are backed by a flat system property (name). Declarative-only configs (such as
-    // the url_template_rules structured list) have no flat property and rely on declarative_name.
-    if (name == null && declarativeName == null) {
-      throw new IllegalArgumentException(
-          "ConfigurationOption must have a name or a declarative_name");
-    }
-    if ((name != null && name.isBlank()) || description.isBlank()) {
-      throw new IllegalArgumentException("ConfigurationOption name/description cannot be blank");
-    }
-
-    if (declarativeType == ConfigurationType.STRUCTURED_LIST) {
-      if (declarativeSchema == null
-          || declarativeSchema.properties() == null
-          || declarativeSchema.properties().isEmpty()) {
+    // A reference entry (`- ref: <id>`) in a metadata.yaml carries only the ref id; it is resolved
+    // against the shared configuration registry before use, so it skips the field validation that
+    // applies to fully-specified options.
+    if (ref != null) {
+      if (name != null || declarativeName != null || description != null) {
         throw new IllegalArgumentException(
-            "structured_list configuration must define a declarative_schema with properties");
+            "A ref ConfigurationOption must not also specify name/declarative_name/description");
       }
-      if (declarativeSchema.required() != null
-          && !declarativeSchema.properties().keySet().containsAll(declarativeSchema.required())) {
+    } else {
+      requireNonNull(description, "description");
+      requireNonNull(defaultValue, "defaultValue");
+      requireNonNull(type, "type");
+
+      // Most configs are backed by a flat system property (name). Declarative-only configs (such as
+      // the url_template_rules structured list) have no flat property and rely on declarative_name.
+      if (name == null && declarativeName == null) {
         throw new IllegalArgumentException(
-            "declarative_schema required keys must be a subset of its properties");
+            "ConfigurationOption must have a name or a declarative_name");
+      }
+      if ((name != null && name.isBlank()) || description.isBlank()) {
+        throw new IllegalArgumentException("ConfigurationOption name/description cannot be blank");
+      }
+
+      if (declarativeType == ConfigurationType.STRUCTURED_LIST) {
+        if (declarativeSchema == null
+            || declarativeSchema.properties() == null
+            || declarativeSchema.properties().isEmpty()) {
+          throw new IllegalArgumentException(
+              "structured_list configuration must define a declarative_schema with properties");
+        }
+        if (declarativeSchema.required() != null
+            && !declarativeSchema.properties().keySet().containsAll(declarativeSchema.required())) {
+          throw new IllegalArgumentException(
+              "declarative_schema required keys must be a subset of its properties");
+        }
       }
     }
   }
 
   public ConfigurationOption(
       String name, String description, String defaultValue, ConfigurationType type) {
-    this(name, null, description, defaultValue, type, null, null, null);
+    this(name, null, description, defaultValue, type, null, null, null, null, null);
+  }
+
+  /** Returns a copy of this option with the given definition id assigned. */
+  public ConfigurationOption withId(String id) {
+    return new ConfigurationOption(
+        name,
+        declarativeName,
+        description,
+        defaultValue,
+        type,
+        examples,
+        declarativeType,
+        declarativeSchema,
+        ref,
+        id);
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/ConfigurationOption.java
@@ -30,11 +30,26 @@ public record ConfigurationOption(
   public ConfigurationOption {
     // A reference entry (`- ref: <id>`) in a metadata.yaml carries only the ref id; it is resolved
     // against the shared configuration registry before use, so it skips the field validation that
-    // applies to fully-specified options.
+    // applies to fully-specified options. Because resolve() replaces the entire entry with the
+    // shared definition, any other field set alongside the ref would be silently discarded. Reject
+    // such entries (and a blank ref) so authors cannot publish settings that appear effective but
+    // are ignored.
     if (ref != null) {
-      if (name != null || declarativeName != null || description != null) {
+      if (ref.isBlank()) {
+        throw new IllegalArgumentException("A ref ConfigurationOption must not have a blank ref");
+      }
+      if (name != null
+          || declarativeName != null
+          || description != null
+          || defaultValue != null
+          || type != null
+          || examples != null
+          || declarativeType != null
+          || declarativeSchema != null
+          || id != null) {
         throw new IllegalArgumentException(
-            "A ref ConfigurationOption must not also specify name/declarative_name/description");
+            "A ref ConfigurationOption must not specify any other fields; it carries only the ref"
+                + " id");
       }
     } else {
       requireNonNull(description, "description");

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/SharedConfigurationRegistry.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/SharedConfigurationRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads the shared configuration definitions ("globals") from {@code
+ * shared-config-definitions.yaml} on the classpath and resolves {@code ref} entries in a module's
+ * configuration list into full {@link ConfigurationOption}s.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class SharedConfigurationRegistry {
+
+  private static final String RESOURCE = "/shared-config-definitions.yaml";
+
+  private static final SharedConfigurationRegistry INSTANCE =
+      new SharedConfigurationRegistry(load());
+
+  // id -> fully-specified option (with its id assigned)
+  private final Map<String, ConfigurationOption> definitions;
+
+  SharedConfigurationRegistry(Map<String, ConfigurationOption> definitions) {
+    this.definitions = definitions;
+  }
+
+  public static SharedConfigurationRegistry getInstance() {
+    return INSTANCE;
+  }
+
+  /** Returns the shared definitions keyed by id. */
+  public Map<String, ConfigurationOption> definitions() {
+    return definitions;
+  }
+
+  /**
+   * Expands each {@code ref} entry into its shared definition (tagged with the definition id) and
+   * passes non-ref entries through unchanged. Throws {@link IllegalArgumentException} on an unknown
+   * ref id so a mistyped ref fails the build rather than silently dropping a config.
+   */
+  public List<ConfigurationOption> resolve(List<ConfigurationOption> configurations) {
+    List<ConfigurationOption> resolved = new ArrayList<>(configurations.size());
+    for (ConfigurationOption configuration : configurations) {
+      if (configuration.ref() != null) {
+        ConfigurationOption definition = definitions.get(configuration.ref());
+        if (definition == null) {
+          throw new IllegalArgumentException(
+              "Unknown shared configuration ref: '"
+                  + configuration.ref()
+                  + "'. Known ids: "
+                  + definitions.keySet());
+        }
+        resolved.add(definition);
+      } else {
+        resolved.add(configuration);
+      }
+    }
+    return resolved;
+  }
+
+  private static Map<String, ConfigurationOption> load() {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    try (InputStream stream = SharedConfigurationRegistry.class.getResourceAsStream(RESOURCE)) {
+      if (stream == null) {
+        throw new IllegalStateException("Missing shared config definitions resource: " + RESOURCE);
+      }
+      RegistryFile file = mapper.readValue(stream, RegistryFile.class);
+      Map<String, ConfigurationOption> byId = new LinkedHashMap<>();
+      Map<String, ConfigurationOption> configurations = file.configurations();
+      if (configurations != null) {
+        configurations.forEach((id, option) -> byId.put(id, option.withId(id)));
+      }
+      return byId;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read " + RESOURCE, e);
+    }
+  }
+
+  private record RegistryFile(Map<String, ConfigurationOption> configurations) {}
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/SharedConfigurationRegistry.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/SharedConfigurationRegistry.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 /**
  * Loads the shared configuration definitions ("globals") from {@code
- * shared-config-definitions.yaml} on the classpath and resolves {@code ref} entries in a module's
- * configuration list into full {@link ConfigurationOption}s.
+ * shared-config-definitions.yaml} and resolves {@code ref} entries in a module's configuration list
+ * into full {@link ConfigurationOption}s.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -30,7 +30,6 @@ public final class SharedConfigurationRegistry {
   private static final SharedConfigurationRegistry INSTANCE =
       new SharedConfigurationRegistry(load());
 
-  // id -> fully-specified option (with its id assigned)
   private final Map<String, ConfigurationOption> definitions;
 
   SharedConfigurationRegistry(Map<String, ConfigurationOption> definitions) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.instrumentation.docs.utils;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,13 +22,18 @@ import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
+import io.opentelemetry.instrumentation.docs.internal.SharedConfigurationRegistry;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
 import java.io.BufferedWriter;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -49,19 +56,31 @@ public class YamlHelper {
 
     Yaml yaml = new Yaml(options);
 
-    Map<String, Object> libraries = getLibraryInstrumentations(list);
+    // Common metrics and configurations are collected once into a shared catalog; each module then
+    // references them by id instead of inlining full copies (see DefinitionCatalog).
+    DefinitionCatalog catalog = buildDefinitionCatalog(list);
+
+    Map<String, Object> definitions = catalog.toDefinitionsMap();
+    if (!definitions.isEmpty()) {
+      Map<String, Object> definitionsRoot = new LinkedHashMap<>();
+      definitionsRoot.put("definitions", definitions);
+      yaml.dump(definitionsRoot, writer);
+    }
+
+    Map<String, Object> libraries = getLibraryInstrumentations(list, catalog);
     if (!libraries.isEmpty()) {
       yaml.dump(libraries, writer);
     }
 
     // add custom instrumentation modules
-    Map<String, Object> custom = getCustomInstrumentations(list);
+    Map<String, Object> custom = getCustomInstrumentations(list, catalog);
     if (!custom.isEmpty()) {
       yaml.dump(custom, writer);
     }
   }
 
-  private static Map<String, Object> getLibraryInstrumentations(List<InstrumentationModule> list) {
+  private static Map<String, Object> getLibraryInstrumentations(
+      List<InstrumentationModule> list, DefinitionCatalog catalog) {
     List<InstrumentationModule> libraryInstrumentations =
         list.stream()
             .filter(
@@ -79,7 +98,7 @@ public class YamlHelper {
 
     List<Map<String, Object>> instrumentations = new ArrayList<>();
     for (InstrumentationModule module : libraryInstrumentations) {
-      instrumentations.add(baseProperties(module));
+      instrumentations.add(baseProperties(module, catalog));
     }
 
     Map<String, Object> output = new TreeMap<>();
@@ -87,7 +106,8 @@ public class YamlHelper {
     return output;
   }
 
-  private static Map<String, Object> getCustomInstrumentations(List<InstrumentationModule> list) {
+  private static Map<String, Object> getCustomInstrumentations(
+      List<InstrumentationModule> list, DefinitionCatalog catalog) {
     List<InstrumentationModule> filtered =
         list.stream()
             .filter(
@@ -101,7 +121,7 @@ public class YamlHelper {
 
     List<Map<String, Object>> instrumentations = new ArrayList<>();
     for (InstrumentationModule module : filtered) {
-      instrumentations.add(baseProperties(module));
+      instrumentations.add(baseProperties(module, catalog));
     }
 
     Map<String, Object> newOutput = new TreeMap<>();
@@ -113,7 +133,8 @@ public class YamlHelper {
   }
 
   /** Assembles map of properties that all modules could have */
-  private static Map<String, Object> baseProperties(InstrumentationModule module) {
+  private static Map<String, Object> baseProperties(
+      InstrumentationModule module, DefinitionCatalog catalog) {
     Map<String, Object> moduleMap = new LinkedHashMap<>();
     moduleMap.put("name", module.getInstrumentationName());
 
@@ -140,7 +161,7 @@ public class YamlHelper {
       moduleMap.put("javaagent_target_versions", agentTargetVersions);
     }
 
-    addConfigurations(module, moduleMap);
+    addConfigurations(module, moduleMap, catalog);
 
     // Get telemetry grouping lists
     Set<String> telemetryGroups = new TreeSet<>(module.getMetrics().keySet());
@@ -151,18 +172,15 @@ public class YamlHelper {
       for (String group : telemetryGroups) {
         Map<String, Object> telemetryEntry = new LinkedHashMap<>();
         telemetryEntry.put("when", group);
-        List<EmittedMetrics.Metric> metrics =
-            new ArrayList<>(module.getMetrics().getOrDefault(group, emptyList()));
-        List<Map<String, Object>> metricsList = new ArrayList<>();
 
-        // sort by name for determinism in the order
-        metrics.sort(Comparator.comparing(EmittedMetrics.Metric::getName));
-
-        for (EmittedMetrics.Metric metric : metrics) {
-          metricsList.add(getMetricsMap(metric));
+        // Metrics are emitted as references into the shared definitions catalog. TreeSet gives
+        // deterministic (sorted, de-duplicated) ref ordering.
+        Set<String> metricRefs = new TreeSet<>();
+        for (EmittedMetrics.Metric metric : module.getMetrics().getOrDefault(group, emptyList())) {
+          metricRefs.add(catalog.metricId(metric));
         }
-        if (!metricsList.isEmpty()) {
-          telemetryEntry.put("metrics", metricsList);
+        if (!metricRefs.isEmpty()) {
+          telemetryEntry.put("metric_refs", new ArrayList<>(metricRefs));
         }
 
         List<EmittedSpans.Span> spans =
@@ -179,7 +197,7 @@ public class YamlHelper {
           telemetryEntry.put("spans", spanList);
         }
 
-        if (!spanList.isEmpty() || !metricsList.isEmpty()) {
+        if (!spanList.isEmpty() || !metricRefs.isEmpty()) {
           telemetryList.add(telemetryEntry);
         }
       }
@@ -241,13 +259,15 @@ public class YamlHelper {
   }
 
   private static void addConfigurations(
-      InstrumentationModule module, Map<String, Object> moduleMap) {
+      InstrumentationModule module, Map<String, Object> moduleMap, DefinitionCatalog catalog) {
     if (module.getMetadata() != null && !module.getMetadata().getConfigurations().isEmpty()) {
-      List<Map<String, Object>> configurations = new ArrayList<>();
+      // Configurations are emitted as references into the shared definitions catalog. TreeSet gives
+      // deterministic (sorted, de-duplicated) ref ordering.
+      Set<String> configRefs = new TreeSet<>();
       for (ConfigurationOption configuration : module.getMetadata().getConfigurations()) {
-        configurations.add(configurationToMap(configuration));
+        configRefs.add(catalog.configId(configuration));
       }
-      moduleMap.put("configurations", configurations);
+      moduleMap.put("configuration_refs", new ArrayList<>(configRefs));
     }
   }
 
@@ -340,7 +360,12 @@ public class YamlHelper {
 
   public static InstrumentationMetadata metaDataParser(String input)
       throws JsonProcessingException {
-    return mapper.readValue(input, InstrumentationMetadata.class);
+    InstrumentationMetadata metadata = mapper.readValue(input, InstrumentationMetadata.class);
+    // Expand any `- ref: <id>` configuration entries into their shared definitions so all consumers
+    // (the doc generator and the declarative-config validation test) see fully-resolved options.
+    metadata.setConfigurations(
+        SharedConfigurationRegistry.getInstance().resolve(metadata.getConfigurations()));
+    return metadata;
   }
 
   public static EmittedScope emittedScopeParser(String input) {
@@ -353,6 +378,178 @@ public class YamlHelper {
 
   public static EmittedSpans emittedSpansParser(String input) throws JsonProcessingException {
     return mapper.readValue(input, EmittedSpans.class);
+  }
+
+  /**
+   * Builds the shared definitions catalog from every module that will be emitted (library + custom;
+   * internal modules are excluded from the output so their definitions would be orphans). Each
+   * unique metric/configuration block is assigned a deterministic id and stored once; modules then
+   * reference these ids.
+   */
+  private static DefinitionCatalog buildDefinitionCatalog(List<InstrumentationModule> list) {
+    DefinitionCatalog catalog = new DefinitionCatalog();
+
+    List<InstrumentationModule> emitted =
+        list.stream()
+            .filter(
+                module -> {
+                  InstrumentationClassification classification =
+                      module.getMetadata().getClassification();
+                  return classification.equals(InstrumentationClassification.LIBRARY)
+                      || classification.equals(InstrumentationClassification.CUSTOM);
+                })
+            .toList();
+
+    // Metrics: id = <metric name>-<short content hash>. The hash disambiguates the multiple
+    // attribute-set variants that share a metric name.
+    for (InstrumentationModule module : emitted) {
+      for (List<EmittedMetrics.Metric> metrics : module.getMetrics().values()) {
+        for (EmittedMetrics.Metric metric : metrics) {
+          Map<String, Object> def = getMetricsMap(metric);
+          String canonical = canonicalize(def);
+          if (!catalog.metricCanonicalToId.containsKey(canonical)) {
+            String id = metric.getName() + "-" + shortHash(canonical);
+            catalog.metricCanonicalToId.put(canonical, id);
+            catalog.metricDefs.put(id, def);
+          }
+        }
+      }
+    }
+
+    // Configurations: registry-backed configs (resolved from a `ref`) use their curated registry
+    // id. Module-specific configs are keyed by their config name, unless two distinct contents
+    // share
+    // a name, in which case a short content hash disambiguates them.
+    Map<String, Set<String>> nonRegistryNameToCanonicals = new HashMap<>();
+    Map<String, Map<String, Object>> canonicalToDef = new LinkedHashMap<>();
+    for (InstrumentationModule module : emitted) {
+      if (module.getMetadata() == null) {
+        continue;
+      }
+      for (ConfigurationOption configuration : module.getMetadata().getConfigurations()) {
+        Map<String, Object> def = configurationToMap(configuration);
+        String canonical = canonicalize(def);
+        canonicalToDef.put(canonical, def);
+        if (configuration.id() != null) {
+          catalog.configDefs.put(configuration.id(), def);
+          catalog.configCanonicalToId.put(canonical, configuration.id());
+        } else {
+          nonRegistryNameToCanonicals
+              .computeIfAbsent(configNameKey(configuration), k -> new TreeSet<>())
+              .add(canonical);
+        }
+      }
+    }
+    nonRegistryNameToCanonicals.forEach(
+        (name, canonicals) -> {
+          boolean unique = canonicals.size() == 1;
+          for (String canonical : canonicals) {
+            // Skip content already cataloged via a registry ref (an inline copy of a shared
+            // config).
+            if (catalog.configCanonicalToId.containsKey(canonical)) {
+              continue;
+            }
+            String id = unique ? name : name + "-" + shortHash(canonical);
+            catalog.configDefs.put(id, canonicalToDef.get(canonical));
+            catalog.configCanonicalToId.put(canonical, id);
+          }
+        });
+
+    return catalog;
+  }
+
+  private static String configNameKey(ConfigurationOption configuration) {
+    String key =
+        configuration.name() != null ? configuration.name() : configuration.declarativeName();
+    return requireNonNull(
+        key, "configuration must have a name or declarative_name to derive a definition id");
+  }
+
+  /**
+   * Produces a stable, order-independent string representation of a definition map (map keys sorted
+   * recursively) used both as the de-duplication key and as the input to the id hash.
+   */
+  private static String canonicalize(Object value) {
+    StringBuilder sb = new StringBuilder();
+    canonicalize(value, sb);
+    return sb.toString();
+  }
+
+  private static void canonicalize(Object value, StringBuilder sb) {
+    if (value instanceof Map<?, ?> map) {
+      TreeMap<String, Object> sorted = new TreeMap<>();
+      map.forEach((k, v) -> sorted.put(String.valueOf(k), v));
+      sb.append('{');
+      sorted.forEach(
+          (k, v) -> {
+            sb.append(k).append('=');
+            canonicalize(v, sb);
+            sb.append(';');
+          });
+      sb.append('}');
+    } else if (value instanceof List<?> list) {
+      sb.append('[');
+      for (Object item : list) {
+        canonicalize(item, sb);
+        sb.append(',');
+      }
+      sb.append(']');
+    } else {
+      sb.append(value);
+    }
+  }
+
+  /** First 8 hex chars of the SHA-256 of the input; deterministic across runs and JVMs. */
+  private static String shortHash(String input) {
+    try {
+      byte[] hash = MessageDigest.getInstance("SHA-256").digest(input.getBytes(UTF_8));
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < 4; i++) {
+        sb.append(String.format(Locale.ROOT, "%02x", hash[i]));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new AssertionError("SHA-256 not available", e);
+    }
+  }
+
+  /**
+   * Holds the shared metric and configuration definitions and the lookups needed to resolve a
+   * module's metric/config back to its catalog id. This class is internal and is hence not for
+   * public use.
+   */
+  private static final class DefinitionCatalog {
+    final Map<String, Map<String, Object>> metricDefs = new TreeMap<>();
+    final Map<String, Map<String, Object>> configDefs = new TreeMap<>();
+    final Map<String, String> metricCanonicalToId = new HashMap<>();
+    final Map<String, String> configCanonicalToId = new HashMap<>();
+
+    String metricId(EmittedMetrics.Metric metric) {
+      return requireNonNull(
+          metricCanonicalToId.get(canonicalize(getMetricsMap(metric))),
+          "metric not present in definitions catalog");
+    }
+
+    String configId(ConfigurationOption configuration) {
+      String id = configuration.id();
+      if (id != null) {
+        return id;
+      }
+      return requireNonNull(
+          configCanonicalToId.get(canonicalize(configurationToMap(configuration))),
+          "configuration not present in definitions catalog");
+    }
+
+    Map<String, Object> toDefinitionsMap() {
+      Map<String, Object> definitions = new LinkedHashMap<>();
+      if (!configDefs.isEmpty()) {
+        definitions.put("configurations", configDefs);
+      }
+      if (!metricDefs.isEmpty()) {
+        definitions.put("metrics", metricDefs);
+      }
+      return definitions;
+    }
   }
 
   private YamlHelper() {}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -173,8 +173,6 @@ public class YamlHelper {
         Map<String, Object> telemetryEntry = new LinkedHashMap<>();
         telemetryEntry.put("when", group);
 
-        // Metrics are emitted as references into the shared definitions catalog. TreeSet gives
-        // deterministic (sorted, de-duplicated) ref ordering.
         Set<String> metricRefs = new TreeSet<>();
         for (EmittedMetrics.Metric metric : module.getMetrics().getOrDefault(group, emptyList())) {
           metricRefs.add(catalog.metricId(metric));
@@ -261,8 +259,6 @@ public class YamlHelper {
   private static void addConfigurations(
       InstrumentationModule module, Map<String, Object> moduleMap, DefinitionCatalog catalog) {
     if (module.getMetadata() != null && !module.getMetadata().getConfigurations().isEmpty()) {
-      // Configurations are emitted as references into the shared definitions catalog. TreeSet gives
-      // deterministic (sorted, de-duplicated) ref ordering.
       Set<String> configRefs = new TreeSet<>();
       for (ConfigurationOption configuration : module.getMetadata().getConfigurations()) {
         configRefs.add(catalog.configId(configuration));
@@ -381,9 +377,8 @@ public class YamlHelper {
   }
 
   /**
-   * Builds the shared definitions catalog from every module that will be emitted (library + custom;
-   * internal modules are excluded from the output so their definitions would be orphans). Each
-   * unique metric/configuration block is assigned a deterministic id and stored once; modules then
+   * Builds the shared definitions catalog from every module that will be emitted. Each unique
+   * metric/configuration block is assigned a deterministic id and stored once; modules then
    * reference these ids.
    */
   private static DefinitionCatalog buildDefinitionCatalog(List<InstrumentationModule> list) {
@@ -400,8 +395,6 @@ public class YamlHelper {
                 })
             .toList();
 
-    // Metrics: id = <metric name>-<short content hash>. The hash disambiguates the multiple
-    // attribute-set variants that share a metric name.
     for (InstrumentationModule module : emitted) {
       for (List<EmittedMetrics.Metric> metrics : module.getMetrics().values()) {
         for (EmittedMetrics.Metric metric : metrics) {
@@ -418,8 +411,7 @@ public class YamlHelper {
 
     // Configurations: registry-backed configs (resolved from a `ref`) use their curated registry
     // id. Module-specific configs are keyed by their config name, unless two distinct contents
-    // share
-    // a name, in which case a short content hash disambiguates them.
+    // share a name, in which case a short content hash disambiguates them.
     Map<String, Set<String>> nonRegistryNameToCanonicals = new HashMap<>();
     Map<String, Map<String, Object>> canonicalToDef = new LinkedHashMap<>();
     for (InstrumentationModule module : emitted) {
@@ -444,8 +436,7 @@ public class YamlHelper {
         (name, canonicals) -> {
           boolean unique = canonicals.size() == 1;
           for (String canonical : canonicals) {
-            // Skip content already cataloged via a registry ref (an inline copy of a shared
-            // config).
+            // Skip content already cataloged via a registry ref
             if (catalog.configCanonicalToId.containsKey(canonical)) {
               continue;
             }
@@ -499,7 +490,7 @@ public class YamlHelper {
     }
   }
 
-  /** First 8 hex chars of the SHA-256 of the input; deterministic across runs and JVMs. */
+  /** First 8 hex chars of the SHA-256 of the input. */
   private static String shortHash(String input) {
     try {
       byte[] hash = MessageDigest.getInstance("SHA-256").digest(input.getBytes(UTF_8));

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -57,7 +57,7 @@ configurations:
   http.client.emit-experimental-telemetry:
     name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: "Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics."
+    description: "Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.body.size` and `http.client.response.body.size` metrics."
     type: boolean
     default: false
 
@@ -78,7 +78,7 @@ configurations:
   http.server.emit-experimental-telemetry:
     name: otel.instrumentation.http.server.emit-experimental-telemetry
     declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: "Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics."
+    description: "Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics."
     type: boolean
     default: false
 

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -1,0 +1,111 @@
+# Shared configuration definitions ("globals") for instrumentation metadata.
+#
+# These are configuration options that many instrumentations expose identically. Instead of
+# hand-copying the full block into every instrumentation's metadata.yaml, a module references a
+# definition by id:
+#
+#   configurations:
+#     - ref: http.known-methods
+#     - name: otel.instrumentation.my-module.specific   # module-specific configs stay inline
+#       ...
+#
+# The doc generator resolves each `ref` against this file (see SharedConfigurationRegistry) and
+# fails the build on an unknown id. The id is also used as the definition key in the generated
+# docs/instrumentation-list.yaml `definitions.configurations` catalog, so keep ids stable.
+configurations:
+  http.known-methods:
+    name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
+    description: "Configures the instrumentation to recognize an alternative set of HTTP request methods. All other methods will be treated as `_OTHER`."
+    type: list
+    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+
+  common.peer-service-mapping:
+    name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.service_peer_mapping
+    description: "Used to specify a mapping from host names or IP addresses to peer services."
+    type: map
+    default: ""
+    declarative_type: structured_list
+    declarative_schema:
+      type: object
+      required:
+        - peer
+        - service_name
+      properties:
+        peer:
+          type: string
+          description: "Host name or IP address to match against."
+        service_name:
+          type: string
+          description: "Peer service name to record for matching peers."
+
+  http.client.capture-request-headers:
+    name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
+    description: "List of HTTP request headers to capture in HTTP client telemetry."
+    type: list
+    default: ""
+
+  http.client.capture-response-headers:
+    name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
+    description: "List of HTTP response headers to capture in HTTP client telemetry."
+    type: list
+    default: ""
+
+  http.client.emit-experimental-telemetry:
+    name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: "Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.size` and `http.client.response.size` metrics."
+    type: boolean
+    default: false
+
+  http.server.capture-request-headers:
+    name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
+    description: "List of HTTP request headers to capture in HTTP server telemetry."
+    type: list
+    default: ""
+
+  http.server.capture-response-headers:
+    name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
+    description: "List of HTTP response headers to capture in HTTP server telemetry."
+    type: list
+    default: ""
+
+  http.server.emit-experimental-telemetry:
+    name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
+    description: "Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.size` and `http.server.response.size` metrics."
+    type: boolean
+    default: false
+
+  common.controller-telemetry.enabled:
+    name: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    declarative_name: java.common.controller_telemetry/development.enabled
+    description: "Enables the creation of experimental controller spans."
+    type: boolean
+    default: false
+
+  sanitization.url.sensitive-query-parameters:
+    name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
+    description: "List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans."
+    type: list
+    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+
+  common.db.query-sanitization.enabled:
+    name: otel.instrumentation.common.db.query-sanitization.enabled
+    declarative_name: java.common.db.query_sanitization.enabled
+    description: "Enables query sanitization for database queries."
+    type: boolean
+    default: true
+
+  messaging.capture-headers:
+    name: otel.instrumentation.messaging.experimental.capture-headers
+    declarative_name: java.common.messaging.capture_headers/development
+    description: "A comma-separated list of header names to capture as span attributes."
+    type: list
+    default: ""

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.docs.internal.SemanticConvention.
 import static io.opentelemetry.instrumentation.docs.internal.SemanticConvention.DATABASE_CLIENT_SPANS;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.api.common.Attributes;
@@ -174,6 +175,13 @@ class YamlHelperTest {
     String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
+            definitions:
+              configurations:
+                otel.instrumentation.spring-web-6.0.enabled:
+                  name: otel.instrumentation.spring-web-6.0.enabled
+                  description: Enables or disables Spring Web 6.0 instrumentation.
+                  type: boolean
+                  default: true
             libraries:
             - name: spring-web-6.0
               description: Spring Web 6.0 instrumentation
@@ -189,11 +197,8 @@ class YamlHelperTest {
                 name: io.opentelemetry.spring-web-6.0
               javaagent_target_versions:
               - org.springframework:spring-web:[6.0.0,)
-              configurations:
-              - name: otel.instrumentation.spring-web-6.0.enabled
-                description: Enables or disables Spring Web 6.0 instrumentation.
-                type: boolean
-                default: true
+              configuration_refs:
+              - otel.instrumentation.spring-web-6.0.enabled
             custom:
             - name: opentelemetry-external-annotations
               source_path: instrumentation/opentelemetry-external-annotations-1.0
@@ -397,17 +402,10 @@ class YamlHelperTest {
     String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
-        libraries:
-        - name: mylib-2.3
-          source_path: instrumentation/mylib/mylib-core-2.3
-          scope:
-            name: io.opentelemetry.mylib-2.3
-          javaagent_target_versions:
-          - org.apache.mylib:mylib-core:2.3.0
-          telemetry:
-          - when: default
-            metrics:
-            - name: db.client.operation.duration
+        definitions:
+          metrics:
+            db.client.operation.duration-fce1854c:
+              name: db.client.operation.duration
               description: Duration of database client operations.
               instrument: histogram
               data_type: HISTOGRAM
@@ -423,6 +421,17 @@ class YamlHelperTest {
                 type: STRING
               - name: server.port
                 type: LONG
+        libraries:
+        - name: mylib-2.3
+          source_path: instrumentation/mylib/mylib-core-2.3
+          scope:
+            name: io.opentelemetry.mylib-2.3
+          javaagent_target_versions:
+          - org.apache.mylib:mylib-core:2.3.0
+          telemetry:
+          - when: default
+            metric_refs:
+            - db.client.operation.duration-fce1854c
         """;
 
     assertThat(result).isEqualTo(expectedYaml);
@@ -452,6 +461,36 @@ class YamlHelperTest {
     String result = generateInstrumentationYaml(modules);
     String expectedYaml =
         """
+        definitions:
+          metrics:
+            test.counter-0cc8d1c0:
+              name: test.counter
+              description: desc
+              instrument: counter
+              data_type: LONG_SUM
+              unit: '1'
+              attributes: []
+            test.gauge-3c51c34b:
+              name: test.gauge
+              description: desc
+              instrument: gauge
+              data_type: DOUBLE_GAUGE
+              unit: '{test}'
+              attributes: []
+            test.histogram-f3e00ac6:
+              name: test.histogram
+              description: desc
+              instrument: histogram
+              data_type: HISTOGRAM
+              unit: s
+              attributes: []
+            test.updowncounter-368958ee:
+              name: test.updowncounter
+              description: desc
+              instrument: updowncounter
+              data_type: LONG_SUM
+              unit: '1'
+              attributes: []
         libraries:
         - name: test-1.0
           source_path: instrumentation/test/test-1.0
@@ -459,31 +498,11 @@ class YamlHelperTest {
             name: io.opentelemetry.test-1.0
           telemetry:
           - when: default
-            metrics:
-            - name: test.counter
-              description: desc
-              instrument: counter
-              data_type: LONG_SUM
-              unit: '1'
-              attributes: []
-            - name: test.gauge
-              description: desc
-              instrument: gauge
-              data_type: DOUBLE_GAUGE
-              unit: '{test}'
-              attributes: []
-            - name: test.histogram
-              description: desc
-              instrument: histogram
-              data_type: HISTOGRAM
-              unit: s
-              attributes: []
-            - name: test.updowncounter
-              description: desc
-              instrument: updowncounter
-              data_type: LONG_SUM
-              unit: '1'
-              attributes: []
+            metric_refs:
+            - test.counter-0cc8d1c0
+            - test.gauge-3c51c34b
+            - test.histogram-f3e00ac6
+            - test.updowncounter-368958ee
         """;
 
     assertThat(result).isEqualTo(expectedYaml);
@@ -773,6 +792,71 @@ class YamlHelperTest {
             """;
 
     assertThat(result).isEqualTo(expectedYaml);
+  }
+
+  @Test
+  void testConfigurationRefIsResolvedFromSharedRegistry() throws JsonProcessingException {
+    String input =
+        """
+        configurations:
+          - ref: http.known-methods
+        """;
+
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
+
+    assertThat(metadata.getConfigurations()).hasSize(1);
+    ConfigurationOption resolved = metadata.getConfigurations().get(0);
+    assertThat(resolved.id()).isEqualTo("http.known-methods");
+    assertThat(resolved.name()).isEqualTo("otel.instrumentation.http.known-methods");
+    assertThat(resolved.type()).isEqualTo(ConfigurationType.LIST);
+  }
+
+  @Test
+  void testUnknownConfigurationRefFails() {
+    String input =
+        """
+        configurations:
+          - ref: does.not.exist
+        """;
+
+    assertThatThrownBy(() -> YamlHelper.metaDataParser(input))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does.not.exist");
+  }
+
+  @Test
+  void testSharedMetricDefinitionIsDeduplicatedAcrossModules() throws Exception {
+    // Two modules emit an identical metric; it should be cataloged once and referenced by both.
+    EmittedMetrics.Metric metric =
+        new EmittedMetrics.Metric(
+            "http.client.request.duration",
+            "Duration of HTTP client requests.",
+            "HISTOGRAM",
+            "s",
+            emptyList());
+
+    List<InstrumentationModule> modules = new ArrayList<>();
+    for (String name : List.of("alpha-1.0", "beta-1.0")) {
+      modules.add(
+          new InstrumentationModule.Builder(name)
+              .srcPath("instrumentation/" + name)
+              .metrics(Map.of("default", List.of(metric)))
+              .build());
+    }
+
+    String result = generateInstrumentationYaml(modules);
+
+    long definitionCount =
+        result
+            .lines()
+            .filter(
+                l -> l.trim().startsWith("http.client.request.duration-") && l.trim().endsWith(":"))
+            .count();
+    long refCount =
+        result.lines().filter(l -> l.trim().startsWith("- http.client.request.duration-")).count();
+
+    assertThat(definitionCount).isEqualTo(1);
+    assertThat(refCount).isEqualTo(2);
   }
 
   private static String generateInstrumentationYaml(List<InstrumentationModule> modules)

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -812,6 +812,26 @@ class YamlHelperTest {
   }
 
   @Test
+  void testInlineConfigurationCannotSupplyId() throws JsonProcessingException {
+    // The definition id is assigned internally; an inline option must not be able to claim one from
+    // metadata.yaml, otherwise it could overwrite a registry-backed definition in the catalog.
+    String input =
+        """
+        configurations:
+          - name: otel.instrumentation.my-module.example
+            description: Example option.
+            type: boolean
+            default: false
+            id: http.known-methods
+        """;
+
+    InstrumentationMetadata metadata = YamlHelper.metaDataParser(input);
+
+    assertThat(metadata.getConfigurations()).hasSize(1);
+    assertThat(metadata.getConfigurations().get(0).id()).isNull();
+  }
+
+  @Test
   void testUnknownConfigurationRefFails() {
     String input =
         """

--- a/instrumentation/activej-http-6.0/metadata.yaml
+++ b/instrumentation/activej-http-6.0/metadata.yaml
@@ -5,28 +5,7 @@ semantic_conventions:
   - HTTP_SERVER_SPANS
   - HTTP_SERVER_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -12,49 +12,11 @@ features:
   - HTTP_ROUTE
   - CONTEXT_PROPAGATION
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -78,26 +40,7 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/apache-dubbo-2.7/metadata.yaml
+++ b/instrumentation/apache-dubbo-2.7/metadata.yaml
@@ -9,21 +9,4 @@ semantic_conventions:
   - RPC_SERVER_METRICS
 library_link: https://github.com/apache/dubbo/
 configurations:
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.peer-service-mapping

--- a/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
+++ b/instrumentation/apache-httpasyncclient-4.1/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/armeria/armeria-1.3/metadata.yaml
+++ b/instrumentation/armeria/armeria-1.3/metadata.yaml
@@ -11,49 +11,11 @@ semantic_conventions:
 features:
   - HTTP_ROUTE
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -77,26 +39,7 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.8/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -73,8 +35,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-1.9/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -73,8 +35,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
+++ b/instrumentation/async-http-client/async-http-client-2.0/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -73,8 +35,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/metadata.yaml
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/metadata.yaml
@@ -12,10 +12,4 @@ configurations:
     type: int
     default: 10000
     description: Flush timeout in milliseconds.
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.known-methods

--- a/instrumentation/aws-sdk/aws-sdk-1.11/metadata.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/metadata.yaml
@@ -26,8 +26,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: Allows configuring headers to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/aws-sdk/aws-sdk-2.2/metadata.yaml
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/metadata.yaml
@@ -19,11 +19,7 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: Allows configuring headers to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.aws-sdk.experimental-span-attributes
     declarative_name: java.aws_sdk.experimental_span_attributes/development
     description: >

--- a/instrumentation/cassandra/cassandra-3.0/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-3.0/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/cassandra/cassandra-4.0/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-4.0/metadata.yaml
@@ -7,8 +7,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/apache/cassandra-java-driver
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/cassandra/cassandra-4.4/metadata.yaml
+++ b/instrumentation/cassandra/cassandra-4.4/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/metadata.yaml
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/metadata.yaml
@@ -7,8 +7,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/ClickHouse/clickhouse-java
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/metadata.yaml
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/metadata.yaml
@@ -7,8 +7,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/ClickHouse/clickhouse-java
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/couchbase/couchbase-2.0/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.0/metadata.yaml
@@ -16,8 +16,4 @@ configurations:
       attributes.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/couchbase/couchbase-2.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-2.6/metadata.yaml
@@ -15,8 +15,4 @@ configurations:
       Different operation types receive different experimental attributes.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/metadata.yaml
@@ -12,10 +12,4 @@ configurations:
       may contain personal or sensitive information.
     type: boolean
     default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.known-methods

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/metadata.yaml
@@ -12,10 +12,4 @@ configurations:
       may contain personal or sensitive information.
     type: boolean
     default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.known-methods

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/metadata.yaml
@@ -12,10 +12,4 @@ configurations:
       may contain personal or sensitive information.
     type: boolean
     default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.known-methods

--- a/instrumentation/finatra-2.9/metadata.yaml
+++ b/instrumentation/finatra-2.9/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -5,8 +5,4 @@ semantic_conventions:
   - DATABASE_CLIENT_SPANS
   - DATABASE_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/google-http-client-1.19/metadata.yaml
+++ b/instrumentation/google-http-client-1.19/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://github.com/googleapis/google-http-java-client
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/grails-3.0/metadata.yaml
+++ b/instrumentation/grails-3.0/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://grails.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/grizzly-2.3/metadata.yaml
+++ b/instrumentation/grizzly-2.3/metadata.yaml
@@ -5,28 +5,7 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://javaee.github.io/grizzly/httpserverframework.html
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and
-      `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
-      and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/helidon-4.3/metadata.yaml
+++ b/instrumentation/helidon-4.3/metadata.yaml
@@ -7,28 +7,7 @@ semantic_conventions:
 features:
   - HTTP_ROUTE
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/http-url-connection/metadata.yaml
+++ b/instrumentation/http-url-connection/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/HttpURLConnection.html
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -73,8 +35,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/influxdb-2.4/metadata.yaml
+++ b/instrumentation/influxdb-2.4/metadata.yaml
@@ -5,8 +5,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/influxdata/influxdb-java
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables or disables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/java-http-client/metadata.yaml
+++ b/instrumentation/java-http-client/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/package-summary.html
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/java-http-server/metadata.yaml
+++ b/instrumentation/java-http-server/metadata.yaml
@@ -5,46 +5,8 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://docs.oracle.com/en/java/javase/21/docs/api/jdk.httpserver/module-summary.html
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and
-      `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
-      and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-1.0/metadata.yaml
@@ -8,8 +8,4 @@ features:
 disabled_by_default: true
 library_link: https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/package-summary.html
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/metadata.yaml
@@ -8,11 +8,7 @@ features:
   - CONTROLLER_SPANS
 disabled_by_default: true
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-cxf-3.2/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/metadata.yaml
@@ -8,11 +8,7 @@ features:
   - CONTROLLER_SPANS
 disabled_by_default: true
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-jersey-3.0/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0/metadata.yaml
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-resteasy-6.0/metadata.yaml
@@ -7,11 +7,7 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.jaxrs.experimental-span-attributes
     declarative_name: java.jaxrs.experimental_span_attributes/development
     type: boolean

--- a/instrumentation/jaxws/jaxws-2.0-axis2-1.6/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-2.0-axis2-1.6/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-2.0-cxf-3.0/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-2.0-cxf-3.0/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    type: boolean
-    description: Enables the creation of experimental controller spans.
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-2.0-metro-2.2/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-2.0-metro-2.2/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-2.0/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-2.0/metadata.yaml
@@ -6,8 +6,4 @@ library_link: https://github.com/jakartaee/jax-ws-api
 features:
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jaxws/jaxws-jws-api-1.1/metadata.yaml
+++ b/instrumentation/jaxws/jaxws-jws-api-1.1/metadata.yaml
@@ -7,8 +7,4 @@ library_link: https://github.com/jakartaee/jws-api
 features:
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jdbc/metadata.yaml
+++ b/instrumentation/jdbc/metadata.yaml
@@ -16,11 +16,7 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled
   - name: otel.instrumentation.jdbc.experimental.transaction.enabled
     declarative_name: java.jdbc.transaction/development.enabled
     description: Enables experimental instrumentation to create spans for COMMIT and ROLLBACK operations.
@@ -35,24 +31,7 @@ configurations:
       database performance. Consult with database experts before enabling.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.peer-service-mapping
   - name: otel.instrumentation.jdbc.experimental.capture-query-parameters
     declarative_name: java.jdbc.capture_query_parameters/development
     description: >

--- a/instrumentation/jedis/jedis-1.4/metadata.yaml
+++ b/instrumentation/jedis/jedis-1.4/metadata.yaml
@@ -5,26 +5,5 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/redis/jedis
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.db.query-sanitization.enabled
+  - ref: common.peer-service-mapping

--- a/instrumentation/jedis/jedis-2.0/metadata.yaml
+++ b/instrumentation/jedis/jedis-2.0/metadata.yaml
@@ -5,13 +5,5 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/redis/jedis
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: structured_list
-    default: ""
+  - ref: common.db.query-sanitization.enabled
+  - ref: common.peer-service-mapping

--- a/instrumentation/jedis/jedis-3.0/metadata.yaml
+++ b/instrumentation/jedis/jedis-3.0/metadata.yaml
@@ -5,26 +5,5 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/redis/jedis
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.db.query-sanitization.enabled
+  - ref: common.peer-service-mapping

--- a/instrumentation/jedis/jedis-4.0/metadata.yaml
+++ b/instrumentation/jedis/jedis-4.0/metadata.yaml
@@ -5,8 +5,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/redis/jedis
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://eclipse.dev/jetty/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://eclipse.dev/jetty/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/jetty/jetty-11.0/metadata.yaml
+++ b/instrumentation/jetty/jetty-11.0/metadata.yaml
@@ -5,28 +5,7 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://eclipse.dev/jetty/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/jetty/jetty-12.0/metadata.yaml
+++ b/instrumentation/jetty/jetty-12.0/metadata.yaml
@@ -5,28 +5,7 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://eclipse.dev/jetty/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/jetty/jetty-8.0/metadata.yaml
+++ b/instrumentation/jetty/jetty-8.0/metadata.yaml
@@ -7,28 +7,7 @@ features:
   - CONTEXT_PROPAGATION
 library_link: https://eclipse.dev/jetty/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/jfinal-3.2/metadata.yaml
+++ b/instrumentation/jfinal-3.2/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://github.com/jfinal/jfinal
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jms/jms-1.1/metadata.yaml
+++ b/instrumentation/jms/jms-1.1/metadata.yaml
@@ -13,10 +13,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/jms/jms-3.0/metadata.yaml
+++ b/instrumentation/jms/jms-3.0/metadata.yaml
@@ -13,10 +13,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/jodd-http-4.2/metadata.yaml
+++ b/instrumentation/jodd-http-4.2/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://http.jodd.org/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/jsf/jsf-mojarra-1.2/metadata.yaml
+++ b/instrumentation/jsf/jsf-mojarra-1.2/metadata.yaml
@@ -6,8 +6,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://github.com/eclipse-ee4j/mojarra
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jsf/jsf-mojarra-3.0/metadata.yaml
+++ b/instrumentation/jsf/jsf-mojarra-3.0/metadata.yaml
@@ -6,8 +6,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://github.com/eclipse-ee4j/mojarra
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jsf/jsf-myfaces-1.2/metadata.yaml
+++ b/instrumentation/jsf/jsf-myfaces-1.2/metadata.yaml
@@ -6,8 +6,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://myfaces.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/jsf/jsf-myfaces-3.0/metadata.yaml
+++ b/instrumentation/jsf/jsf-myfaces-3.0/metadata.yaml
@@ -6,8 +6,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://myfaces.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/metadata.yaml
@@ -14,11 +14,7 @@ configurations:
     description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms` and `messaging.kafka.bootstrap.servers`.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     declarative_name: java.common.messaging.receive_telemetry/development.enabled
     description: >

--- a/instrumentation/kafka/kafka-streams-0.11/metadata.yaml
+++ b/instrumentation/kafka/kafka-streams-0.11/metadata.yaml
@@ -9,11 +9,7 @@ configurations:
     description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms` and `messaging.kafka.bootstrap.servers`.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     declarative_name: java.common.messaging.receive_telemetry/development.enabled
     description: >

--- a/instrumentation/ktor/ktor-2.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-2.0/metadata.yaml
@@ -11,67 +11,14 @@ features:
   - HTTP_ROUTE
 library_link: https://ktor.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -95,8 +42,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/ktor/ktor-3.0/metadata.yaml
+++ b/instrumentation/ktor/ktor-3.0/metadata.yaml
@@ -11,67 +11,14 @@ features:
   - HTTP_ROUTE
 library_link: https://ktor.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -95,8 +42,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/kubernetes-client-7.0/metadata.yaml
+++ b/instrumentation/kubernetes-client-7.0/metadata.yaml
@@ -12,49 +12,11 @@ configurations:
       `kubernetes-client.name` for Kubernetes API requests.
     type: boolean
     default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -78,8 +40,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/lettuce/lettuce-4.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-4.0/metadata.yaml
@@ -17,21 +17,4 @@ configurations:
     description: Enables experimental span attribute `lettuce.command.cancelled`.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.peer-service-mapping

--- a/instrumentation/lettuce/lettuce-5.0/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-5.0/metadata.yaml
@@ -19,26 +19,5 @@ configurations:
       `lettuce.command.results.count`.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.db.query-sanitization.enabled
+  - ref: common.peer-service-mapping

--- a/instrumentation/lettuce/lettuce-5.1/metadata.yaml
+++ b/instrumentation/lettuce/lettuce-5.1/metadata.yaml
@@ -12,8 +12,4 @@ configurations:
     description: Enables capturing `redis.encode.start` and `redis.encode.end` span events.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/liberty/liberty-20.0/metadata.yaml
+++ b/instrumentation/liberty/liberty-20.0/metadata.yaml
@@ -7,31 +7,10 @@ semantic_conventions:
   - HTTP_SERVER_SPANS
   - HTTP_SERVER_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
   - name: otel.instrumentation.servlet.experimental-span-attributes
     declarative_name: java.servlet.experimental_span_attributes/development
     description: Enables capturing the experimental `servlet.timeout` span attribute.

--- a/instrumentation/liberty/liberty-dispatcher-20.0/metadata.yaml
+++ b/instrumentation/liberty/liberty-dispatcher-20.0/metadata.yaml
@@ -7,28 +7,7 @@ semantic_conventions:
   - HTTP_SERVER_SPANS
   - HTTP_SERVER_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/mongo/mongo-3.1/metadata.yaml
+++ b/instrumentation/mongo/mongo-3.1/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/mongo/mongo-3.7/metadata.yaml
+++ b/instrumentation/mongo/mongo-3.7/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/mongo/mongo-4.0/metadata.yaml
+++ b/instrumentation/mongo/mongo-4.0/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/mongo/mongo-async-3.3/metadata.yaml
+++ b/instrumentation/mongo/mongo-async-3.3/metadata.yaml
@@ -14,8 +14,4 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/nats/nats-2.17/metadata.yaml
+++ b/instrumentation/nats/nats-2.17/metadata.yaml
@@ -4,10 +4,4 @@ semantic_conventions:
   - MESSAGING_SPANS
 library_link: https://nats.io/
 configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/netty/netty-3.8/metadata.yaml
+++ b/instrumentation/netty/netty-3.8/metadata.yaml
@@ -9,49 +9,11 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://netty.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -75,26 +37,7 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/netty/netty-4.0/metadata.yaml
+++ b/instrumentation/netty/netty-4.0/metadata.yaml
@@ -9,49 +9,11 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://netty.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -75,24 +37,9 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
   - name: otel.instrumentation.netty.connection-telemetry.enabled
     declarative_name: java.netty.connection_telemetry.enabled
     description: Enable the creation of Connect and DNS spans.
@@ -103,8 +50,4 @@ configurations:
     description: Enable SSL telemetry.
     type: boolean
     default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/netty/netty-4.1/metadata.yaml
+++ b/instrumentation/netty/netty-4.1/metadata.yaml
@@ -9,49 +9,11 @@ semantic_conventions:
   - HTTP_SERVER_METRICS
 library_link: https://netty.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -75,24 +37,9 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
   - name: otel.instrumentation.netty.connection-telemetry.enabled
     declarative_name: java.netty.connection_telemetry.enabled
     description: Enable the creation of Connect and DNS spans.
@@ -103,8 +50,4 @@ configurations:
     description: Enable SSL telemetry.
     type: boolean
     default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/okhttp/okhttp-2.2/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-2.2/metadata.yaml
@@ -4,49 +4,11 @@ semantic_conventions:
   - HTTP_CLIENT_SPANS
   - HTTP_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -70,8 +32,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/okhttp/okhttp-3.0/metadata.yaml
+++ b/instrumentation/okhttp/okhttp-3.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://square.github.io/okhttp/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/pekko/pekko-http-1.0/metadata.yaml
+++ b/instrumentation/pekko/pekko-http-1.0/metadata.yaml
@@ -12,49 +12,11 @@ features:
   - HTTP_ROUTE
   - CONTEXT_PROPAGATION
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -78,26 +40,7 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/play/play-mvc/play-mvc-2.4/metadata.yaml
+++ b/instrumentation/play/play-mvc/play-mvc-2.4/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://www.playframework.com/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/play/play-mvc/play-mvc-2.6/metadata.yaml
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://www.playframework.com/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-1.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://www.playframework.com/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://www.playframework.com/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
+++ b/instrumentation/play/play-ws/play-ws-2.1/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://www.playframework.com/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/pulsar/pulsar-2.8/metadata.yaml
+++ b/instrumentation/pulsar/pulsar-2.8/metadata.yaml
@@ -12,13 +12,7 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.pulsar.experimental-span-attributes
     declarative_name: java.pulsar.experimental_span_attributes/development
     description: >

--- a/instrumentation/r2dbc-1.0/metadata.yaml
+++ b/instrumentation/r2dbc-1.0/metadata.yaml
@@ -14,11 +14,7 @@ configurations:
       otel.instrumentation.common.db.query-sanitization.enabled.
     type: boolean
     default: true
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled
   - name: otel.instrumentation.r2dbc.experimental.sqlcommenter.enabled
     declarative_name: java.r2dbc.sqlcommenter/development.enabled
     description: >
@@ -28,21 +24,4 @@ configurations:
       database performance.
     type: boolean
     default: false
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.peer-service-mapping

--- a/instrumentation/rabbitmq-2.7/metadata.yaml
+++ b/instrumentation/rabbitmq-2.7/metadata.yaml
@@ -18,8 +18,4 @@ configurations:
       measure the time between receiving a message and the consumer processing that message.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: List of messaging headers to capture.
-    type: list
-    default: ""
+  - ref: messaging.capture-headers

--- a/instrumentation/ratpack/ratpack-1.4/metadata.yaml
+++ b/instrumentation/ratpack/ratpack-1.4/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://ratpack.io/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/ratpack/ratpack-1.7/metadata.yaml
+++ b/instrumentation/ratpack/ratpack-1.7/metadata.yaml
@@ -13,72 +13,15 @@ features:
   - CONTROLLER_SPANS
 library_link: https://ratpack.io/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -102,8 +45,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/reactor/reactor-kafka-1.0/metadata.yaml
+++ b/instrumentation/reactor/reactor-kafka-1.0/metadata.yaml
@@ -12,13 +12,7 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.kafka.experimental-span-attributes
     declarative_name: java.kafka.experimental_span_attributes/development
     description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms`.

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://projectreactor.io/docs/netty/release/reference/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -78,8 +40,4 @@ configurations:
     description: Enables the creation of Connect and DNS spans.
     type: boolean
     default: false
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/restlet/restlet-1.1/metadata.yaml
+++ b/instrumentation/restlet/restlet-1.1/metadata.yaml
@@ -7,28 +7,7 @@ features:
   - HTTP_ROUTE
 library_link: https://restlet.github.io/
 configurations:
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: http.known-methods

--- a/instrumentation/restlet/restlet-2.0/metadata.yaml
+++ b/instrumentation/restlet/restlet-2.0/metadata.yaml
@@ -7,28 +7,7 @@ features:
   - HTTP_ROUTE
 library_link: https://restlet.github.io/
 configurations:
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
-      `http.server.response.size` metrics.
-    type: boolean
-    default: false
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
+  - ref: http.known-methods

--- a/instrumentation/rocketmq/rocketmq-client-4.8/metadata.yaml
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/metadata.yaml
@@ -6,13 +6,7 @@ semantic_conventions:
   - MESSAGING_SPANS
 library_link: https://rocketmq.apache.org/
 configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.rocketmq-client.experimental-span-attributes
     declarative_name: java.rocketmq_client.experimental_span_attributes/development
     description: >

--- a/instrumentation/rocketmq/rocketmq-client-5.0/metadata.yaml
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/metadata.yaml
@@ -13,10 +13,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: >
-      Enables capturing messaging headers as span attributes. Provide a comma-separated list of
-      header names to capture.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/sofa-rpc-5.4/metadata.yaml
+++ b/instrumentation/sofa-rpc-5.4/metadata.yaml
@@ -9,21 +9,4 @@ semantic_conventions:
   - RPC_SERVER_METRICS
 library_link: https://github.com/sofastack/sofa-rpc/
 configurations:
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ''
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.peer-service-mapping

--- a/instrumentation/spring/spring-integration-4.1/metadata.yaml
+++ b/instrumentation/spring/spring-integration-4.1/metadata.yaml
@@ -15,8 +15,4 @@ configurations:
     type: list
     description: A list of Spring channel name patterns that will be intercepted.
     default: "*"
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    type: list
-    description: A comma-separated list of header names to capture as span attributes.
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/metadata.yaml
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/metadata.yaml
@@ -11,8 +11,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/metadata.yaml
@@ -11,8 +11,4 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/spring/spring-kafka-2.7/metadata.yaml
+++ b/instrumentation/spring/spring-kafka-2.7/metadata.yaml
@@ -11,11 +11,7 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.kafka.experimental-span-attributes
     declarative_name: java.kafka.experimental_span_attributes/development
     description: Enables the capture of the experimental consumer attribute `kafka.record.queue_time_ms` and `messaging.kafka.bootstrap.servers`.

--- a/instrumentation/spring/spring-pulsar-1.0/metadata.yaml
+++ b/instrumentation/spring/spring-pulsar-1.0/metadata.yaml
@@ -11,11 +11,7 @@ configurations:
       only a span link connecting it to the producer trace.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.pulsar.experimental-span-attributes
     declarative_name: java.pulsar.experimental_span_attributes/development
     description: >

--- a/instrumentation/spring/spring-rabbit-1.0/metadata.yaml
+++ b/instrumentation/spring/spring-rabbit-1.0/metadata.yaml
@@ -4,8 +4,4 @@ library_link: https://spring.io/projects/spring-amqp
 semantic_conventions:
   - MESSAGING_SPANS
 configurations:
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers

--- a/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
@@ -6,7 +6,13 @@ features:
   - HTTP_ROUTE
 library_link: https://github.com/spring-projects/spring-framework
 configurations:
-  - ref: http.client.emit-experimental-telemetry
+  - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
+    description: >
+      Enables the capture of experimental HTTP client telemetry, including URL template
+      as the span name.
+    type: boolean
+    default: false
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only

--- a/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
@@ -6,13 +6,7 @@ features:
   - HTTP_ROUTE
 library_link: https://github.com/spring-projects/spring-framework
 configurations:
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enables the capture of experimental HTTP client telemetry, including URL template
-      as the span name.
-    type: boolean
-    default: false
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/metadata.yaml
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/metadata.yaml
@@ -8,8 +8,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/package-summary.html
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/metadata.yaml
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/metadata.yaml
@@ -16,11 +16,7 @@ configurations:
     description: >
       Enables the capture of experimental span attributes `spring-webmvc.view.name` and
       `spring-webmvc.view.type`.
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
     declarative_name: java.common.view_telemetry/development.enabled
     description: Enables the creation of experimental view spans.

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/metadata.yaml
@@ -16,11 +16,7 @@ configurations:
     description: >
       Enables the capture of experimental span attributes `spring-webmvc.view.name` and
       `spring-webmvc.view.type`.
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled
   - name: otel.instrumentation.common.experimental.view-telemetry.enabled
     declarative_name: java.common.view_telemetry/development.enabled
     description: Enables the creation of experimental view spans.

--- a/instrumentation/spring/spring-ws-2.0/metadata.yaml
+++ b/instrumentation/spring/spring-ws-2.0/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://spring.io/projects/spring-ws
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/struts/struts-2.3/metadata.yaml
+++ b/instrumentation/struts/struts-2.3/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://struts.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/struts/struts-7.0/metadata.yaml
+++ b/instrumentation/struts/struts-7.0/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://struts.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/tapestry-5.4/metadata.yaml
+++ b/instrumentation/tapestry-5.4/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - CONTROLLER_SPANS
 library_link: https://tapestry.apache.org/
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/tomcat/tomcat-10.0/metadata.yaml
+++ b/instrumentation/tomcat/tomcat-10.0/metadata.yaml
@@ -7,31 +7,10 @@ semantic_conventions:
 features:
   - HTTP_ROUTE
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
-      and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
   - name: otel.instrumentation.servlet.experimental-span-attributes
     declarative_name: java.servlet.experimental_span_attributes/development
     description: Enables capturing the experimental `servlet.timeout` span attribute.

--- a/instrumentation/tomcat/tomcat-7.0/metadata.yaml
+++ b/instrumentation/tomcat/tomcat-7.0/metadata.yaml
@@ -7,31 +7,10 @@ semantic_conventions:
 features:
   - HTTP_ROUTE
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
-      and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry
   - name: otel.instrumentation.servlet.experimental-span-attributes
     declarative_name: java.servlet.experimental_span_attributes/development
     description: Enables capturing the experimental `servlet.timeout` span attribute.

--- a/instrumentation/undertow-1.4/metadata.yaml
+++ b/instrumentation/undertow-1.4/metadata.yaml
@@ -5,28 +5,7 @@ semantic_conventions:
   - HTTP_SERVER_SPANS
   - HTTP_SERVER_METRICS
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.server.capture-request-headers
-    declarative_name: general.http.server.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.capture-response-headers
-    declarative_name: general.http.server.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP server telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.server.emit-experimental-telemetry
-    declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.server.request.body.size`
-      and `http.server.response.body.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.server.capture-request-headers
+  - ref: http.server.capture-response-headers
+  - ref: http.server.emit-experimental-telemetry

--- a/instrumentation/vaadin-14.2/metadata.yaml
+++ b/instrumentation/vaadin-14.2/metadata.yaml
@@ -7,8 +7,4 @@ features:
   - HTTP_ROUTE
   - CONTROLLER_SPANS
 configurations:
-  - name: otel.instrumentation.common.experimental.controller-telemetry.enabled
-    declarative_name: java.common.controller_telemetry/development.enabled
-    description: Enables the creation of experimental controller spans.
-    type: boolean
-    default: false
+  - ref: common.controller-telemetry.enabled

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-3.0/metadata.yaml
@@ -7,49 +7,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://vertx.io/docs/vertx-core/java/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -73,8 +35,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-4.0/metadata.yaml
@@ -5,49 +5,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://vertx.io/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -71,8 +33,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-http-client/vertx-http-client-5.0/metadata.yaml
@@ -6,49 +6,11 @@ semantic_conventions:
   - HTTP_CLIENT_METRICS
 library_link: https://vertx.io/docs/vertx-core/java/
 configurations:
-  - name: otel.instrumentation.http.known-methods
-    declarative_name: java.common.http.known_methods
-    description: >
-      Configures the instrumentation to recognize an alternative set of HTTP request methods. All
-      other methods will be treated as `_OTHER`.
-    type: list
-    default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
-  - name: otel.instrumentation.http.client.capture-request-headers
-    declarative_name: general.http.client.request_captured_headers
-    description: List of HTTP request headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.http.client.capture-response-headers
-    declarative_name: general.http.client.response_captured_headers
-    description: List of HTTP response headers to capture in HTTP client telemetry.
-    type: list
-    default: ""
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
-      and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
-      `http.client.response.size` metrics.
-    type: boolean
-    default: false
+  - ref: http.known-methods
+  - ref: http.client.capture-request-headers
+  - ref: http.client.capture-response-headers
+  - ref: common.peer-service-mapping
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only
@@ -72,8 +34,4 @@ configurations:
           type: boolean
           default: false
           description: Whether this rule overrides an already-applied template.
-  - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
-    declarative_name: general.sanitization.url.sensitive_query_parameters/development
-    description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
-    type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+  - ref: sanitization.url.sensitive-query-parameters

--- a/instrumentation/vertx/vertx-kafka-client-3.6/metadata.yaml
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/metadata.yaml
@@ -18,11 +18,7 @@ configurations:
     description: Enables the capture of the experimental consumer attributes `kafka.record.queue_time_ms` and `messaging.kafka.bootstrap.servers`.
     type: boolean
     default: false
-  - name: otel.instrumentation.messaging.experimental.capture-headers
-    declarative_name: java.common.messaging.capture_headers/development
-    description: A comma-separated list of header names to capture as span attributes.
-    type: list
-    default: ''
+  - ref: messaging.capture-headers
   - name: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
     declarative_name: java.common.messaging.receive_telemetry/development.enabled
     description: >

--- a/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-redis-client-4.0/metadata.yaml
@@ -7,26 +7,5 @@ semantic_conventions:
   - DATABASE_CLIENT_SPANS
   - DATABASE_CLIENT_METRICS
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
-  - name: otel.instrumentation.common.peer-service-mapping
-    declarative_name: java.common.service_peer_mapping
-    description: Used to specify a mapping from host names or IP addresses to peer services.
-    type: map
-    default: ""
-    declarative_type: structured_list
-    declarative_schema:
-      type: object
-      required:
-        - peer
-        - service_name
-      properties:
-        peer:
-          type: string
-          description: Host name or IP address to match against.
-        service_name:
-          type: string
-          description: Peer service name to record for matching peers.
+  - ref: common.db.query-sanitization.enabled
+  - ref: common.peer-service-mapping

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/metadata.yaml
@@ -7,8 +7,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/eclipse-vertx/vertx-sql-client
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/metadata.yaml
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/metadata.yaml
@@ -7,8 +7,4 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/eclipse-vertx/vertx-sql-client
 configurations:
-  - name: otel.instrumentation.common.db.query-sanitization.enabled
-    declarative_name: java.common.db.query_sanitization.enabled
-    description: Enables query sanitization for database queries.
-    type: boolean
-    default: true
+  - ref: common.db.query-sanitization.enabled


### PR DESCRIPTION
Adds a catalog of definitions for common configs and metrics that are re-used, so we can just reference them. Eventually we can take this further for spans, but I think there's more we can do around the span metadata in general so I held off for now.

If it would make it easier to review, I can split this between the core code change and the metadata file updates, just let me know.

I've run a test on my fork (resulting updated file [here](https://github.com/jaydeluca/opentelemetry-java-instrumentation/blob/4ab3952d3ddb15f169baf8fb3e6025b44db939fa/docs/instrumentation-list.yaml)), as well as already drafted what's needed on the ecosystem explorer side to ingest this new format.

Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19077#discussion_r3546419908