### PR TITLE
Undeprecate ConfigProperties API methods

### DIFF
--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
@@ -22,7 +22,6 @@ public interface IgnoredTypesConfigurer extends Ordered {
    * Configure the passed {@code builder} and define which classes should be ignored when
    * instrumenting.
    */
-  // TODO remove default implementation in next major release when deleting the deprecated method
   default void configure(IgnoredTypesBuilder builder) {}
 
   /**

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/ignore/IgnoredTypesConfigurer.java
@@ -28,10 +28,7 @@ public interface IgnoredTypesConfigurer extends Ordered {
   /**
    * Configure the passed {@code builder} and define which classes should be ignored when
    * instrumenting.
-   *
-   * @deprecated Use {@link #configure(IgnoredTypesBuilder)} instead. Will be removed in 3.0.
    */
-  @Deprecated // to be removed in 3.0
   default void configure(IgnoredTypesBuilder builder, ConfigProperties config) {
     configure(builder);
   }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/InstrumentationModule.java
@@ -93,10 +93,7 @@ public abstract class InstrumentationModule implements Ordered {
   /**
    * Allows instrumentation modules to disable themselves by default, or to additionally disable
    * themselves on some other condition.
-   *
-   * @deprecated Use {@link #defaultEnabled()} instead. Will be removed in 3.0.
    */
-  @Deprecated // to be removed in 3.0
   public boolean defaultEnabled(ConfigProperties config) {
     return defaultEnabled();
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentExtension.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentExtension.java
@@ -35,9 +35,7 @@ public interface AgentExtension extends Ordered {
    *
    * @return The customized agent. Note that this method MUST return a non-null {@link AgentBuilder}
    *     instance that contains all customizations defined in this extension.
-   * @deprecated Use {@link #extend(AgentBuilder)} instead. Will be removed in 3.0.
    */
-  @Deprecated // to be removed in 3.0
   default AgentBuilder extend(AgentBuilder agentBuilder, ConfigProperties config) {
     return extend(agentBuilder);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -105,8 +105,6 @@ public class AgentInstaller {
     }
   }
 
-  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
-  @SuppressWarnings("deprecation")
   private static void installBytebuddyAgent(
       Instrumentation inst,
       ClassLoader extensionClassLoader,
@@ -273,8 +271,6 @@ public class AgentInstaller {
     agentBuilder.installOn(instrumentation);
   }
 
-  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
-  @SuppressWarnings("deprecation")
   private static void setBootstrapPackages(
       ConfigProperties config, ClassLoader extensionClassLoader) {
     BootstrapPackagesBuilderImpl builder = new BootstrapPackagesBuilderImpl();
@@ -289,8 +285,6 @@ public class AgentInstaller {
     DefineClassHelper.internalSetHandler(DefineClassHandler.INSTANCE);
   }
 
-  // Need to call deprecated API for backward compatibility with extensions that haven't migrated.
-  @SuppressWarnings("deprecation")
   private static AgentBuilder configureIgnoredTypes(
       ConfigProperties config, ClassLoader extensionClassLoader, AgentBuilder agentBuilder) {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bootstrap/BootstrapPackagesConfigurer.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/bootstrap/BootstrapPackagesConfigurer.java
@@ -29,10 +29,7 @@ public interface BootstrapPackagesConfigurer {
   /**
    * Configure the passed {@code builder} and define which classes should always be loaded by the
    * bootstrap class loader.
-   *
-   * @deprecated Use {@link #configure(BootstrapPackagesBuilder)} instead. Will be removed in 3.0.
    */
-  @Deprecated // to be removed in 3.0
   default void configure(BootstrapPackagesBuilder builder, ConfigProperties config) {
     configure(builder);
   }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/InstrumentationModuleInstaller.java
@@ -75,8 +75,6 @@ public final class InstrumentationModuleInstaller {
                 ClassFileLocator.ForClassLoader.of(extensionsClassLoader)));
   }
 
-  // Need to call deprecated API for backward compatibility with modules that haven't migrated
-  @SuppressWarnings("deprecation")
   AgentBuilder install(
       InstrumentationModule instrumentationModule,
       AgentBuilder parentAgentBuilder,

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/bytebuddy/TestAgentListener.java
@@ -49,7 +49,6 @@ public class TestAgentListener implements AgentBuilder.Listener {
     return builder.buildIgnoredTypesTrie();
   }
 
-  @SuppressWarnings("deprecation") // supporting deprecated method for backward compatibility
   private static Trie<IgnoreAllow> buildOtherConfiguredIgnores() {
     IgnoredTypesBuilderImpl builder = new IgnoredTypesBuilderImpl();
     for (IgnoredTypesConfigurer configurer :


### PR DESCRIPTION
`ConfigProvider` and `DeclarativeConfigProperties` are still incubating APIs. `DeclarativeConfigProperties` is expected to move to a stable package eventually, at which point the incubator class will be removed.

Repository implementations (and distros) can use these incubating APIs internally and migrate atomically, but extension authors should probably not depend on them before they stabilize.
