### PR TITLE
Move MethodsConfigurationParser to internal package

### DIFF
--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentation.java
@@ -27,7 +27,7 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.opentelemetry.javaagent.tooling.config.MethodsConfigurationParser;
+import io.opentelemetry.javaagent.tooling.config.internal.MethodsConfigurationParser;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodConfiguration.java
+++ b/instrumentation/methods/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/methods/MethodConfiguration.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
-import io.opentelemetry.javaagent.tooling.config.MethodsConfigurationParser;
+import io.opentelemetry.javaagent.tooling.config.internal.MethodsConfigurationParser;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;

--- a/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/v1_0/WithSpanInstrumentation.java
+++ b/instrumentation/opentelemetry-extension-annotations-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/extensionannotations/v1_0/WithSpanInstrumentation.java
@@ -26,7 +26,7 @@ import io.opentelemetry.instrumentation.api.annotation.support.async.AsyncOperat
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.opentelemetry.javaagent.tooling.config.MethodsConfigurationParser;
+import io.opentelemetry.javaagent.tooling.config.internal.MethodsConfigurationParser;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AnnotationExcludedMethods.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationannotations/v1_16/AnnotationExcludedMethods.java
@@ -12,7 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.none;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
-import io.opentelemetry.javaagent.tooling.config.MethodsConfigurationParser;
+import io.opentelemetry.javaagent.tooling.config.internal.MethodsConfigurationParser;
 import java.util.Map;
 import java.util.Set;
 import net.bytebuddy.description.ByteCodeElement;

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/internal/MethodsConfigurationParser.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/internal/MethodsConfigurationParser.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.tooling.config;
+package io.opentelemetry.javaagent.tooling.config.internal;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -19,6 +19,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public final class MethodsConfigurationParser {
 
   private static final Logger logger = Logger.getLogger(MethodsConfigurationParser.class.getName());

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/internal/MethodsConfigurationParserTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/config/internal/MethodsConfigurationParserTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.tooling.config;
+package io.opentelemetry.javaagent.tooling.config.internal;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;


### PR DESCRIPTION
Moves `MethodsConfigurationParser` into the `io.opentelemetry.javaagent.tooling.config.internal` package so it is not presented as supported tooling API.