### PR TITLE
Add shared messaging process topology

### DIFF
--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database,code,service.peer,rpc")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
     inputs.dir(jflexOutputDir)
   }
 
@@ -99,6 +100,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,code/dup,service.peer/dup,rpc/dup")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     inputs.dir(jflexOutputDir)
   }
 
@@ -117,6 +119,11 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testBothSemconv, testExceptionSignalLogs, testExceptionSignalLogsDup)
+    dependsOn(
+      testStableSemconv,
+      testBothSemconv,
+      testExceptionSignalLogs,
+      testExceptionSignalLogsDup,
+    )
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -5,24 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-import java.util.Locale;
-
-/**
- * Represents type of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">operations</a>
- * that may be used in a messaging system.
- */
+/** Represents an operation that may be used in a messaging system. */
 public enum MessageOperation {
-  PUBLISH,
-  RECEIVE,
-  PROCESS;
+  PUBLISH(MessagingOperationType.SEND),
+  RECEIVE(MessagingOperationType.RECEIVE),
+  PROCESS(MessagingOperationType.PROCESS);
 
-  /**
-   * Returns the operation name as defined in <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">the
-   * specification</a>.
-   */
-  String operationName() {
-    return name().toLowerCase(Locale.ROOT);
+  private final MessagingOperationType operationType;
+
+  MessageOperation(MessagingOperationType operationType) {
+    this.operationType = operationType;
+  }
+
+  MessagingOperationType type() {
+    return operationType;
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -17,7 +21,7 @@ import javax.annotation.Nullable;
 
 /**
  * Extractor of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md">messaging
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md">messaging
  * attributes</a>.
  *
  * <p>This class delegates to a type-specific {@link MessagingAttributesGetter} for individual
@@ -29,8 +33,10 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
-  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
       AttributeKey.stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+      AttributeKey.stringKey("messaging.client.id");
   private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
       AttributeKey.booleanKey("messaging.destination.anonymous");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
@@ -51,49 +57,80 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       AttributeKey.stringKey("messaging.message.id");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final AttributeKey<String> MESSAGING_SYSTEM =
       AttributeKey.stringKey("messaging.system");
 
   static final String TEMP_DESTINATION_NAME = "(temporary)";
 
-  /**
-   * Creates the messaging attributes extractor for the given {@link MessageOperation operation}
-   * with default configuration.
-   */
+  /** Creates the messaging attributes extractor for the given operation type. */
+  // will be renamed in 3.0 to create()
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> createForOperationType(
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessagingOperationType operationType) {
+    return builderForOperationType(getter, operationType).build();
+  }
+
+  /** Creates the messaging attributes extractor for the given operation. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
   }
 
   /**
-   * Returns a new {@link MessagingAttributesExtractorBuilder} for the given {@link MessageOperation
-   * operation} that can be used to configure the messaging attributes extractor.
+   * Returns a new {@link MessagingAttributesExtractorBuilder} configured for the given operation
+   * type.
    */
+  // will be renamed in 3.0 to builder()
+  public static <REQUEST, RESPONSE>
+      MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builderForOperationType(
+          MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+          @Nullable MessagingOperationType operationType) {
+    return new MessagingAttributesExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a new messaging attributes extractor builder for the given operation. */
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
-    return new MessagingAttributesExtractorBuilder<>(getter, operation);
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
+    return new MessagingAttributesExtractorBuilder<>(
+        getter, operation == null ? null : operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  private final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private final String operationName;
+  private final boolean supportsStableSemconv;
   private final List<String> capturedHeaders;
 
   MessagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter,
-      MessageOperation operation,
+      @Nullable MessagingOperationType operationType,
+      @Nullable String operationName,
+      boolean supportsStableSemconv,
       List<String> capturedHeaders) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
   }
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    boolean emitOldSemconv = !supportsStableSemconv || emitOldMessagingSemconv();
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
     attributes.put(MESSAGING_SYSTEM, getter.getSystem(request));
     boolean isTemporaryDestination = getter.isTemporaryDestination(request);
     if (isTemporaryDestination) {
       attributes.put(MESSAGING_DESTINATION_TEMPORARY, true);
-      attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      if (emitStableSemconv) {
+        attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
+        attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
+      } else {
+        attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      }
     } else {
       attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
       attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
@@ -106,9 +143,20 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     attributes.put(MESSAGING_MESSAGE_CONVERSATION_ID, getter.getConversationId(request));
     attributes.put(MESSAGING_MESSAGE_BODY_SIZE, getter.getMessageBodySize(request));
     attributes.put(MESSAGING_MESSAGE_ENVELOPE_SIZE, getter.getMessageEnvelopeSize(request));
-    attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
-    if (operation != null) {
-      attributes.put(MESSAGING_OPERATION, operation.operationName());
+    if (emitOldSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID_OLD, getter.getClientId(request));
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
+    }
+    if (emitOldSemconv && operationType != null) {
+      attributes.put(MESSAGING_OPERATION, operationType.defaultOperationName());
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_OPERATION_NAME, operationName);
+      if (operationType != null) {
+        attributes.put(MESSAGING_OPERATION_TYPE, operationType.value());
+      }
     }
   }
 
@@ -121,6 +169,13 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
     attributes.put(MESSAGING_MESSAGE_ID, getter.getMessageId(request, response));
     attributes.put(MESSAGING_BATCH_MESSAGE_COUNT, getter.getBatchMessageCount(request, response));
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String errorType = getter.getErrorType(request, response, error);
+      if (errorType == null && error != null) {
+        errorType = error.getClass().getName();
+      }
+      attributes.put(ERROR_TYPE, errorType);
+    }
 
     for (String name : capturedHeaders) {
       List<String> values = getter.getMessageHeader(request, name);
@@ -137,17 +192,21 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   @Override
   @Nullable
   public SpanKey internalGetSpanKey() {
-    if (operation == null) {
+    if (operationType == null) {
       return null;
     }
 
-    switch (operation) {
-      case PUBLISH:
+    switch (operationType) {
+      case CREATE:
+        return SpanKey.PRODUCER_CREATE;
+      case SEND:
         return SpanKey.PRODUCER;
       case RECEIVE:
         return SpanKey.CONSUMER_RECEIVE;
       case PROCESS:
         return SpanKey.CONSUMER_PROCESS;
+      case SETTLE:
+        return SpanKey.CONSUMER_SETTLE;
     }
     throw new IllegalStateException("Can't possibly happen");
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -38,6 +38,9 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @CanIgnoreReturnValue
   public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
       String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -6,24 +6,40 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /** A builder of {@link MessagingAttributesExtractor}. */
 public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private String operationName;
+  private final boolean supportsStableSemconv;
   List<String> capturedHeaders = emptyList();
 
   MessagingAttributesExtractorBuilder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+      @Nullable MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationType == null ? null : operationType.defaultOperationName();
+    this.supportsStableSemconv = supportsStableSemconv;
+  }
+
+  /** Configures the system-specific operation name emitted as {@code messaging.operation.name}. */
+  @CanIgnoreReturnValue
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
+      String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
   }
 
   /**
@@ -47,6 +63,10 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * MessagingAttributesExtractorBuilder}.
    */
   public AttributesExtractor<REQUEST, RESPONSE> build() {
-    return new MessagingAttributesExtractor<>(getter, operation, capturedHeaders);
+    if (supportsStableSemconv) {
+      requireNonNull(operationName, "operationName");
+    }
+    return new MessagingAttributesExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv, capturedHeaders);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
@@ -56,6 +56,21 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
   }
 
   /**
+   * Returns a description of a class of error the operation ended with.
+   *
+   * <p>If this method returns {@code null}, the exception class name (if any) will be used as error
+   * type.
+   *
+   * <p>The cardinality of the error type should be low. The instrumentations implementing this
+   * method are recommended to document the custom values they support.
+   */
+  @Nullable
+  default String getErrorType(
+      REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error) {
+    return null;
+  }
+
+  /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
    * were none.
    *

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
@@ -23,10 +26,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#consumer-metrics">Consumer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#consumer-metrics">consumer
  * metrics</a>.
  */
 public final class MessagingConsumerMetrics implements OperationListener {
@@ -35,39 +39,86 @@ public final class MessagingConsumerMetrics implements OperationListener {
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingConsumerMetrics.State> MESSAGING_CONSUMER_METRICS_STATE =
       ContextKey.named("messaging-consumer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingConsumerMetrics.class.getName());
 
-  private final DoubleHistogram receiveDurationHistogram;
-  private final LongCounter receiveMessageCount;
+  private final boolean supportsStableSemconv;
+  private final boolean consumedMessagesOnly;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram receiveDurationHistogram;
+  @Nullable private final LongCounter receiveMessageCount;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter consumedMessagesCounter;
 
-  private MessagingConsumerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.receive.duration")
-            .setDescription("Measures the duration of receive operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyReceiveDurationAdvice(durationBuilder);
-    receiveDurationHistogram = durationBuilder.build();
-
-    LongCounterBuilder longCounterBuilder =
-        meter
-            .counterBuilder("messaging.receive.messages")
-            .setDescription("Measures the number of received messages.")
-            .setUnit("{message}");
-    MessagingMetricsAdvice.applyReceiveMessagesAdvice(longCounterBuilder);
-    receiveMessageCount = longCounterBuilder.build();
+  private MessagingConsumerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    consumedMessagesOnly = variant == Variant.CONSUMED_MESSAGES_ONLY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    receiveDurationHistogram =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveDuration(meter) : null;
+    receiveMessageCount =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveMessages(meter) : null;
+    clientOperationDurationHistogram =
+        !consumedMessagesOnly && emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    consumedMessagesCounter = emitStableSemconv ? buildConsumedMessages(meter) : null;
+    enabled =
+        receiveDurationHistogram != null
+            || receiveMessageCount != null
+            || clientOperationDurationHistogram != null
+            || consumedMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging consumer", MessagingConsumerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.receive.duration} and {@code messaging.receive.messages}
+   * instruments.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE_AND_OLD));
+  }
+
+  /** Returns only the stable consumed-messages metric for a delivered message. */
+  public static OperationMetrics getConsumedMessages() {
+    return OperationMetricsUtil.create(
+        "messaging consumed messages",
+        meter -> new MessagingConsumerMetrics(meter, Variant.CONSUMED_MESSAGES_ONLY));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_CONSUMER_METRICS_STATE,
         new AutoValue_MessagingConsumerMetrics_State(startAttributes, startNanos));
@@ -75,6 +126,9 @@ public final class MessagingConsumerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingConsumerMetrics.State state = context.get(MESSAGING_CONSUMER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -85,21 +139,104 @@ public final class MessagingConsumerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
-    receiveDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
+    String operationType = attributes.get(MESSAGING_OPERATION_TYPE);
+    boolean recordsLegacyReceive =
+        !supportsStableSemconv
+            || "receive".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.RECEIVE.value().equals(operationType);
+    if (receiveDurationHistogram != null && recordsLegacyReceive) {
+      receiveDurationHistogram.record(duration, attributes, context);
+    }
+    // Metric view attribute advice can only select keys statically. The concrete destination name
+    // must be omitted when a template is available or the destination is temporary or anonymous,
+    // so this conditional requirement must be enforced before recording.
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || consumedMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null
+        && !MessagingOperationType.PROCESS.value().equals(operationType)) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
 
-    long receiveMessagesCount = getReceiveMessagesCount(state.startAttributes(), endAttributes);
-    receiveMessageCount.add(receiveMessagesCount, attributes, context);
+    Long batchMessageCount = getBatchMessageCount(state.startAttributes(), endAttributes);
+    if (receiveMessageCount != null && recordsLegacyReceive) {
+      long receiveMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (!supportsStableSemconv || receiveMessagesCount > 0) {
+        receiveMessageCount.add(receiveMessagesCount, attributes, context);
+      }
+    }
+    if (consumedMessagesCounter != null
+        && (consumedMessagesOnly || MessagingOperationType.RECEIVE.value().equals(operationType))) {
+      long consumedMessagesCount =
+          getConsumedMessagesCount(attributes, batchMessageCount, consumedMessagesOnly);
+      if (consumedMessagesCount > 0) {
+        consumedMessagesCounter.add(consumedMessagesCount, filteredAttributes, context);
+      }
+    }
   }
 
-  private static long getReceiveMessagesCount(Attributes... attributesList) {
+  @Nullable
+  private static Long getBatchMessageCount(Attributes... attributesList) {
     for (Attributes attributes : attributesList) {
       Long value = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
       if (value != null) {
         return value;
       }
     }
-    return 1;
+    return null;
+  }
+
+  private static long getConsumedMessagesCount(
+      Attributes attributes, @Nullable Long batchMessageCount, boolean consumedMessagesOnly) {
+    if (batchMessageCount != null) {
+      return batchMessageCount;
+    }
+    return consumedMessagesOnly || attributes.get(ERROR_TYPE) == null ? 1 : 0;
+  }
+
+  private static DoubleHistogram buildReceiveDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.receive.duration")
+            .setDescription("Measures the duration of receive operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildReceiveMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.receive.messages")
+            .setDescription("Measures the number of received messages.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyOldMessagesAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildConsumedMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.consumed.messages")
+            .setDescription("Number of messages that were delivered to the application.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyConsumedMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -108,5 +245,19 @@ public final class MessagingConsumerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD,
+    /** Only the stable consumed-messages counter, for a delivered message. */
+    CONSUMED_MESSAGES_ONLY
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
@@ -12,10 +12,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
 final class MessagingMetricsAdvice {
@@ -28,14 +30,26 @@ final class MessagingMetricsAdvice {
       AttributeKey.stringKey("messaging.system");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
       AttributeKey.stringKey("messaging.destination.name");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
+      AttributeKey.booleanKey("messaging.destination.anonymous");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
+      AttributeKey.booleanKey("messaging.destination.temporary");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      AttributeKey.stringKey("messaging.destination.subscription.name");
   private static final AttributeKey<String> MESSAGING_DESTINATION_PARTITION_ID =
       AttributeKey.stringKey("messaging.destination.partition.id");
   private static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
       AttributeKey.stringKey("messaging.destination.template");
 
-  private static final List<AttributeKey<?>> MESSAGING_ATTRIBUTES =
+  private static final List<AttributeKey<?>> OLD_ATTRIBUTES =
       asList(
           MESSAGING_SYSTEM,
           MESSAGING_DESTINATION_NAME,
@@ -46,25 +60,90 @@ final class MessagingMetricsAdvice {
           SERVER_PORT,
           SERVER_ADDRESS);
 
-  static void applyPublishDurationAdvice(DoubleHistogramBuilder builder) {
+  private static final List<AttributeKey<?>> CLIENT_OPERATION_DURATION_ATTRIBUTES =
+      buildAttributes(true, true, true);
+  private static final List<AttributeKey<?>> SENT_MESSAGES_ATTRIBUTES =
+      buildAttributes(false, false, true);
+  private static final List<AttributeKey<?>> CONSUMED_MESSAGES_ATTRIBUTES =
+      buildAttributes(true, false, true);
+  private static final List<AttributeKey<?>> PROCESS_DURATION_ATTRIBUTES =
+      buildAttributes(true, false, true);
+
+  private static List<AttributeKey<?>> buildAttributes(
+      boolean includeConsumerAttributes, boolean includeOperationType, boolean includeErrorType) {
+    List<AttributeKey<?>> attributes = new ArrayList<>();
+    attributes.add(MESSAGING_OPERATION_NAME);
+    attributes.add(MESSAGING_SYSTEM);
+    if (includeErrorType) {
+      attributes.add(ERROR_TYPE);
+    }
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_CONSUMER_GROUP_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_NAME);
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_DESTINATION_SUBSCRIPTION_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_TEMPLATE);
+    if (includeOperationType) {
+      attributes.add(MESSAGING_OPERATION_TYPE);
+    }
+    attributes.add(MESSAGING_DESTINATION_PARTITION_ID);
+    attributes.add(SERVER_ADDRESS);
+    attributes.add(SERVER_PORT);
+    return unmodifiableList(attributes);
+  }
+
+  static Attributes filterAttributes(Attributes attributes) {
+    if (attributes.get(MESSAGING_DESTINATION_TEMPLATE) == null
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_ANONYMOUS))
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_TEMPORARY))) {
+      return attributes;
+    }
+    return attributes.toBuilder().remove(MESSAGING_DESTINATION_NAME).build();
+  }
+
+  static void applyOldDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
   }
 
-  static void applyReceiveDurationAdvice(DoubleHistogramBuilder builder) {
+  static void applyClientOperationDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder)
+        .setAttributesAdvice(CLIENT_OPERATION_DURATION_ATTRIBUTES);
   }
 
-  static void applyReceiveMessagesAdvice(LongCounterBuilder builder) {
+  static void applyProcessDurationAdvice(DoubleHistogramBuilder builder) {
+    if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
+      return;
+    }
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(PROCESS_DURATION_ATTRIBUTES);
+  }
+
+  static void applyOldMessagesAdvice(LongCounterBuilder builder) {
     if (!(builder instanceof ExtendedLongCounterBuilder)) {
       return;
     }
-    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
+  }
+
+  static void applySentMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(SENT_MESSAGES_ATTRIBUTES);
+  }
+
+  static void applyConsumedMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(CONSUMED_MESSAGES_ATTRIBUTES);
   }
 
   private MessagingMetricsAdvice() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+/**
+ * Represents a <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#operation-types">messaging
+ * operation type</a>.
+ */
+public enum MessagingOperationType {
+  CREATE("create", "create"),
+  SEND("send", "publish"),
+  RECEIVE("receive", "receive"),
+  PROCESS("process", "process"),
+  SETTLE("settle", "settle");
+
+  private final String value;
+  private final String defaultOperationName;
+
+  MessagingOperationType(String value, String defaultOperationName) {
+    this.value = value;
+    this.defaultOperationName = defaultOperationName;
+  }
+
+  String value() {
+    return value;
+  }
+
+  String defaultOperationName() {
+    return defaultOperationName;
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.FINE;
+
+import com.google.auto.value.AutoValue;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
+import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * {@link OperationListener} which keeps track of <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#metric-messagingprocessduration">message
+ * processing metrics</a>.
+ */
+public final class MessagingProcessMetrics implements OperationListener {
+  private static final double NANOS_PER_S = SECONDS.toNanos(1);
+
+  private static final ContextKey<State> MESSAGING_PROCESS_METRICS_STATE =
+      ContextKey.named("messaging-process-metrics-state");
+  private static final Logger logger = Logger.getLogger(MessagingProcessMetrics.class.getName());
+
+  @Nullable private final DoubleHistogram processDurationHistogram;
+
+  private MessagingProcessMetrics(Meter meter) {
+    processDurationHistogram = emitStableMessagingSemconv() ? buildProcessDuration(meter) : null;
+  }
+
+  public static OperationMetrics get() {
+    return OperationMetricsUtil.create("messaging process", MessagingProcessMetrics::new);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (processDurationHistogram == null) {
+      return context;
+    }
+    return context.with(
+        MESSAGING_PROCESS_METRICS_STATE,
+        new AutoValue_MessagingProcessMetrics_State(startAttributes, startNanos));
+  }
+
+  @Override
+  public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (processDurationHistogram == null) {
+      return;
+    }
+    State state = context.get(MESSAGING_PROCESS_METRICS_STATE);
+    if (state == null) {
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record messaging process metrics.",
+          context);
+      return;
+    }
+
+    Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    processDurationHistogram.record(
+        (endNanos - state.startTimeNanos()) / NANOS_PER_S,
+        MessagingMetricsAdvice.filterAttributes(attributes),
+        context);
+  }
+
+  private static DoubleHistogram buildProcessDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.process.duration")
+            .setDescription("Duration of processing operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyProcessDurationAdvice(builder);
+    return builder.build();
+  }
+
+  @AutoValue
+  abstract static class State {
+    abstract Attributes startAttributes();
+
+    abstract long startTimeNanos();
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -20,39 +25,84 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#metric-messagingpublishduration">Producer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#producer-metrics">producer
  * metrics</a>.
  */
 public final class MessagingProducerMetrics implements OperationListener {
   private static final double NANOS_PER_S = SECONDS.toNanos(1);
 
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingProducerMetrics.State> MESSAGING_PRODUCER_METRICS_STATE =
       ContextKey.named("messaging-producer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingProducerMetrics.class.getName());
 
-  private final DoubleHistogram publishDurationHistogram;
+  private final boolean supportsStableSemconv;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram publishDurationHistogram;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter sentMessagesCounter;
 
-  private MessagingProducerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.publish.duration")
-            .setDescription("Measures the duration of publish operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyPublishDurationAdvice(durationBuilder);
-    publishDurationHistogram = durationBuilder.build();
+  private MessagingProducerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    publishDurationHistogram = emitOldSemconv ? buildPublishDuration(meter) : null;
+    clientOperationDurationHistogram =
+        emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    sentMessagesCounter = emitStableSemconv ? buildSentMessages(meter) : null;
+    enabled =
+        publishDurationHistogram != null
+            || clientOperationDurationHistogram != null
+            || sentMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging producer", MessagingProducerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.publish.duration} instrument.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE_AND_OLD));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_PRODUCER_METRICS_STATE,
         new AutoValue_MessagingProducerMetrics_State(startAttributes, startNanos));
@@ -60,6 +110,9 @@ public final class MessagingProducerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingProducerMetrics.State state = context.get(MESSAGING_PRODUCER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -70,9 +123,64 @@ public final class MessagingProducerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
 
-    publishDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    if (publishDurationHistogram != null
+        && (!supportsStableSemconv
+            || "publish".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.SEND
+                .value()
+                .equals(attributes.get(MESSAGING_OPERATION_TYPE)))) {
+      publishDurationHistogram.record(duration, attributes, context);
+    }
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || sentMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
+    if (sentMessagesCounter != null
+        && MessagingOperationType.SEND.value().equals(attributes.get(MESSAGING_OPERATION_TYPE))) {
+      Long batchMessageCount = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
+      long sentMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (sentMessagesCount > 0) {
+        sentMessagesCounter.add(sentMessagesCount, filteredAttributes, context);
+      }
+    }
+  }
+
+  private static DoubleHistogram buildPublishDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.publish.duration")
+            .setDescription("Measures the duration of publish operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildSentMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.sent.messages")
+            .setDescription("Number of messages producer attempted to send to the broker.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applySentMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -81,5 +189,17 @@ public final class MessagingProducerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+
+/** Selects messaging span kinds according to the configured semantic convention version. */
+public final class MessagingSpanKindExtractor {
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessagingOperationType operationType) {
+    return create(operationType, true);
+  }
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   *
+   * @param isSpanContextPropagated whether the context of a {@link MessagingOperationType#SEND}
+   *     span is propagated as the message creation context; ignored for other operation types
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(
+      MessagingOperationType operationType, boolean isSpanContextPropagated) {
+    SpanKind spanKind;
+    switch (operationType) {
+      case CREATE:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case SEND:
+        spanKind =
+            emitStableMessagingSemconv() && !isSpanContextPropagated
+                ? SpanKind.CLIENT
+                : SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+        spanKind = emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
+        break;
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      case SETTLE:
+        spanKind = SpanKind.CLIENT;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  /** Returns a span kind extractor for the given operation. */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
+    SpanKind spanKind;
+    switch (operation) {
+      case PUBLISH:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  private MessagingSpanKindExtractor() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -5,35 +5,75 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtractor<REQUEST> {
 
   /**
    * Returns a {@link SpanNameExtractor} that constructs the span name according to <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#span-name">
-   * messaging semantic conventions</a>: {@code <destination name> <operation name>}.
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-name">
+   * messaging semantic conventions</a>.
    *
    * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <destination
    *     name>}.
-   * @see MessageOperation used to extract {@code <operation name>}.
+   * @see MessagingOperationType used to extract {@code <operation name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return builder(getter, operationType).build();
+  }
+
+  /** Returns a messaging span name extractor for the given operation. */
+  public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
-    return new MessagingSpanNameExtractor<>(getter, operation);
+    return builder(getter, operation).build();
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractorBuilder} that can be used to configure the
+   * messaging span name extractor.
+   */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a messaging span name extractor builder for the given operation. */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, ?> getter;
-  private final MessageOperation operation;
+  private final MessagingOperationType operationType;
+  private final String operationName;
+  private final boolean supportsStableSemconv;
 
-  private MessagingSpanNameExtractor(
-      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+  MessagingSpanNameExtractor(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      String operationName,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
   }
 
   @Override
   public String extract(REQUEST request) {
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String destinationName = getter.getDestinationTemplate(request);
+      if (destinationName == null
+          && !getter.isTemporaryDestination(request)
+          && !getter.isAnonymousDestination(request)) {
+        destinationName = getter.getDestination(request);
+      }
+      return destinationName == null ? operationName : operationName + " " + destinationName;
+    }
+
     String destinationName =
         getter.isTemporaryDestination(request)
             ? MessagingAttributesExtractor.TEMP_DESTINATION_NAME
@@ -42,6 +82,6 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
       destinationName = "unknown";
     }
 
-    return destinationName + " " + operation.operationName();
+    return destinationName + " " + operationType.defaultOperationName();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -31,6 +31,9 @@ public final class MessagingSpanNameExtractorBuilder<REQUEST> {
   /** Configures the system-specific operation name used in the v1.43 messaging span name. */
   @CanIgnoreReturnValue
   public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+
+/** A builder of {@link MessagingSpanNameExtractor}. */
+public final class MessagingSpanNameExtractorBuilder<REQUEST> {
+
+  private final MessagingAttributesGetter<REQUEST, ?> getter;
+  private final MessagingOperationType operationType;
+  private final boolean supportsStableSemconv;
+  private String operationName;
+
+  MessagingSpanNameExtractorBuilder(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
+    this.getter = getter;
+    this.operationType = requireNonNull(operationType, "operationType");
+    this.supportsStableSemconv = supportsStableSemconv;
+    this.operationName = operationType.defaultOperationName();
+  }
+
+  /** Configures the system-specific operation name used in the v1.43 messaging span name. */
+  @CanIgnoreReturnValue
+  public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractor} with the settings of this {@link
+   * MessagingSpanNameExtractorBuilder}.
+   */
+  public SpanNameExtractor<REQUEST> build() {
+    return new MessagingSpanNameExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.function.BiFunction;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessContextCustomizer<REQUEST> implements ContextCustomizer<REQUEST> {
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
+    return create((parentContext, request) -> propagator.extract(parentContext, request, getter));
+  }
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    return new MessagingProcessContextCustomizer<>(producerContextExtractor);
+  }
+
+  private final BiFunction<Context, REQUEST, Context> producerContextExtractor;
+
+  private MessagingProcessContextCustomizer(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    this.producerContextExtractor = producerContextExtractor;
+  }
+
+  @Override
+  public Context onStart(Context parentContext, REQUEST request, Attributes startAttributes) {
+    Context extractedContext = producerContextExtractor.apply(parentContext, request);
+    Span parentSpan = Span.fromContext(parentContext);
+    if (!parentSpan.getSpanContext().isValid()) {
+      return extractedContext;
+    }
+    return extractedContext.with(parentSpan);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessInstrumenterFactory {
+
+  public static <REQUEST, RESPONSE> Instrumenter<REQUEST, RESPONSE> create(
+      InstrumenterBuilder<REQUEST, RESPONSE> builder,
+      TextMapPropagator propagator,
+      TextMapGetter<REQUEST> getter,
+      boolean receiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv()) {
+      builder.addSpanLinksExtractor(
+          (spanLinks, parentContext, request) -> {
+            SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+            SpanContext producerSpanContext =
+                Span.fromContext(propagator.extract(parentContext, request, getter))
+                    .getSpanContext();
+            if (parentSpanContext.isValid()
+                && producerSpanContext.isValid()
+                && (!producerSpanContext.getTraceId().equals(parentSpanContext.getTraceId())
+                    || !producerSpanContext.getSpanId().equals(parentSpanContext.getSpanId()))) {
+              spanLinks.addLink(producerSpanContext);
+            }
+          });
+      builder.addContextCustomizer(MessagingProcessContextCustomizer.create(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    if (receiveInstrumentationEnabled) {
+      builder.addSpanLinksExtractor(new PropagatorBasedSpanLinksExtractor<>(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    return builder.buildConsumerInstrumenter(getter);
+  }
+
+  private MessagingProcessInstrumenterFactory() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -6,7 +6,10 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -17,15 +20,21 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,8 +56,8 @@ class MessagingAttributesExtractorTest {
       boolean temporary,
       boolean anonymous,
       String destination,
-      MessageOperation operation,
-      String expectedDestination) {
+      MessagingOperationType operationType,
+      String operationName) {
     // given
     Map<String, String> request = new HashMap<>();
     request.put("system", "myQueue");
@@ -63,13 +72,16 @@ class MessagingAttributesExtractorTest {
     }
     request.put("url", "http://broker/topic");
     request.put("conversationId", "42");
+    request.put("messageId", "42");
     request.put("bodySize", "100");
     request.put("envelopeSize", "120");
     request.put("clientId", "43");
     request.put("batchMessageCount", "2");
 
     AttributesExtractor<Map<String, String>, String> underTest =
-        MessagingAttributesExtractor.create(TestGetter.INSTANCE, operation);
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName(operationName)
+            .build();
 
     Context context = Context.root();
 
@@ -78,16 +90,22 @@ class MessagingAttributesExtractorTest {
     underTest.onStart(startAttributes, context, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, context, request, "42", null);
+    underTest.onEnd(endAttributes, context, request, "42", new IllegalStateException());
 
     // then
     List<MapEntry<AttributeKey<?>, Object>> expectedEntries = new ArrayList<>();
     expectedEntries.add(entry(MESSAGING_SYSTEM, "myQueue"));
-    expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, expectedDestination));
     if (temporary) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPORARY, true));
+      if (emitStableMessagingSemconv()) {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+        expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
+      } else {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, "(temporary)"));
+      }
     } else {
-      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, expectedDestination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
     }
     if (anonymous) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_ANONYMOUS, true));
@@ -95,22 +113,143 @@ class MessagingAttributesExtractorTest {
     expectedEntries.add(entry(MESSAGING_MESSAGE_CONVERSATION_ID, "42"));
     expectedEntries.add(entry(MESSAGING_MESSAGE_BODY_SIZE, 100L));
     expectedEntries.add(entry(MESSAGING_MESSAGE_ENVELOPE_SIZE, 120L));
-    expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
-    expectedEntries.add(entry(MESSAGING_OPERATION, operation.operationName()));
+    if (emitOldMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION, operationType.defaultOperationName()));
+    }
+    if (emitStableMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client.id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION_NAME, operationName));
+      expectedEntries.add(entry(MESSAGING_OPERATION_TYPE, operationType.value()));
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     MapEntry<? extends AttributeKey<?>, ?>[] expectedEntriesArr =
         expectedEntries.toArray(new MapEntry[0]);
     assertThat(startAttributes.build()).containsOnly(expectedEntriesArr);
 
-    assertThat(endAttributes.build())
-        .containsOnly(entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    if (emitStableMessagingSemconv()) {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"),
+              entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L),
+              entry(ERROR_TYPE, IllegalStateException.class.getName()));
+    } else {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    }
   }
 
   static Stream<Arguments> destinations() {
     return Stream.of(
-        Arguments.of(false, false, "destination", MessageOperation.RECEIVE, "destination"),
-        Arguments.of(true, true, null, MessageOperation.PROCESS, "(temporary)"));
+        argumentSet(
+            "create operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.CREATE,
+            "create"),
+        argumentSet(
+            "regular destination",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.RECEIVE,
+            "poll"),
+        argumentSet(
+            "temporary anonymous destination",
+            true,
+            true,
+            "generated-destination",
+            MessagingOperationType.PROCESS,
+            "process"),
+        argumentSet(
+            "settle operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.SETTLE,
+            "settle"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("spanKeys")
+  void shouldReturnSpanKey(MessagingOperationType operationType, SpanKey spanKey) {
+    MessagingAttributesExtractor<Map<String, String>, String> underTest =
+        new MessagingAttributesExtractor<>(
+            TestGetter.INSTANCE,
+            operationType,
+            operationType.defaultOperationName(),
+            true,
+            new ArrayList<>());
+
+    assertThat(underTest.internalGetSpanKey()).isSameAs(spanKey);
+  }
+
+  static Stream<Arguments> spanKeys() {
+    return Stream.of(
+        argumentSet("create", MessagingOperationType.CREATE, SpanKey.PRODUCER_CREATE),
+        argumentSet("send", MessagingOperationType.SEND, SpanKey.PRODUCER),
+        argumentSet("receive", MessagingOperationType.RECEIVE, SpanKey.CONSUMER_RECEIVE),
+        argumentSet("process", MessagingOperationType.PROCESS, SpanKey.CONSUMER_PROCESS),
+        argumentSet("settle", MessagingOperationType.SETTLE, SpanKey.CONSUMER_SETTLE));
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldSupportDeprecatedMessageOperation() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.create(TestGetter.INSTANCE, MessageOperation.PUBLISH);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), singletonMap("anonymousDestination", "y"));
+
+    assertThat(attributes.build())
+        .containsOnly(
+            entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
+  }
+
+  @Test
+  void shouldExtractOperationNameWithoutOperationType() {
+    MessagingOperationType operationType = null;
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName("ack")
+            .build();
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), emptyMap());
+
+    Attributes expected =
+        emitStableMessagingSemconv()
+            ? Attributes.of(MESSAGING_OPERATION_NAME, "ack")
+            : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldRequireOperationNameForStableSemconv() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, null)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("operationName");
+  }
+
+  @Test
+  void shouldExtractErrorTypeFromResponse() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.createForOperationType(
+            TestGetter.INSTANCE, MessagingOperationType.RECEIVE);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onEnd(attributes, Context.root(), emptyMap(), "failure", null);
+
+    Attributes expected =
+        emitStableMessagingSemconv() ? Attributes.of(ERROR_TYPE, "failure") : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
   }
 
   @Test
@@ -118,20 +257,24 @@ class MessagingAttributesExtractorTest {
     // given
     AttributesExtractor<Map<String, String>, String> underTest =
         MessagingAttributesExtractor.create(TestGetter.INSTANCE, null);
+    AttributesExtractor<Map<String, String>, String> builtUnderTest =
+        MessagingAttributesExtractor.builder(TestGetter.INSTANCE, null).build();
 
     Context context = Context.root();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, context, emptyMap());
+    AttributesBuilder builtStartAttributes = Attributes.builder();
+    builtUnderTest.onStart(builtStartAttributes, context, emptyMap());
 
     AttributesBuilder endAttributes = Attributes.builder();
     underTest.onEnd(endAttributes, context, emptyMap(), null, null);
 
     // then
-    assertThat(startAttributes.build().isEmpty()).isTrue();
-
-    assertThat(endAttributes.build().isEmpty()).isTrue();
+    assertThat(startAttributes.build()).isEmpty();
+    assertThat(builtStartAttributes.build()).isEmpty();
+    assertThat(endAttributes.build()).isEmpty();
   }
 
   enum TestGetter implements MessagingAttributesGetter<Map<String, String>, String> {
@@ -184,7 +327,7 @@ class MessagingAttributesExtractorTest {
 
     @Override
     public String getMessageId(Map<String, String> request, String response) {
-      return response;
+      return request.get("messageId");
     }
 
     @Nullable
@@ -198,6 +341,11 @@ class MessagingAttributesExtractorTest {
     public Long getBatchMessageCount(Map<String, String> request, @Nullable String response) {
       String payloadSize = request.get("batchMessageCount");
       return payloadSize == null ? null : Long.valueOf(payloadSize);
+    }
+
+    @Override
+    public String getErrorType(Map<String, String> request, String response, Throwable error) {
+      return "failure".equals(response) ? response : null;
     }
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -210,6 +210,17 @@ class MessagingAttributesExtractorTest {
             entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldRejectOperationNameForDeprecatedMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builder(TestGetter.INSTANCE, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
+  }
+
   @Test
   void shouldExtractOperationNameWithoutOperationType() {
     MessagingOperationType operationType = null;

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingConsumerMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void collectsMetricsAndCountsBatchOnce() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_CONSUMER_GROUP_NAME, "group")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "subscription")
+            .build();
+    Attributes responseAttributes =
+        Attributes.builder()
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 3)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 2 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
+
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of receive operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Measures the number of received messages.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "receive")))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.consumed.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Number of messages that were delivered to the application.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription")))));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void failedReceiveWithoutBatchCountCountsNoConsumedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Attributes responseAttributes =
+        Attributes.of(ERROR_TYPE, IllegalStateException.class.getName());
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasLongSumSatisfying(
+                          sum -> sum.hasPointsSatisfying(point -> point.hasValue(1))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void consumedMessagesOnlyCountsFailedDelivery() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getConsumedMessages().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(
+        context, Attributes.of(ERROR_TYPE, IllegalStateException.class.getName()), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (!emitStableMessagingSemconv()) {
+      assertThat(metrics).isEmpty();
+      return;
+    }
+    assertThat(metrics)
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.client.consumed.messages")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonReceiveOperations")
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void selectsStableMetricsByOperationType(String operationType, boolean recordsClientDuration) {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() && recordsClientDuration ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.consumed.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.duration"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.messages"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountReceivedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static Stream<Arguments> nonReceiveOperations() {
+    return Stream.of(
+        argumentSet("process", "process", false), argumentSet("settle", "settle", true));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingConsumerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "receive"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .hasSize(2)
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+class MessagingMetricsAdviceTest {
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void filtersHighCardinalityDestinationNames() {
+    Attributes lowCardinality = Attributes.of(MESSAGING_DESTINATION_NAME, "orders");
+    assertThat(MessagingMetricsAdvice.filterAttributes(lowCardinality)).isSameAs(lowCardinality);
+
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "orders-42")
+                    .put(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}")
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}"));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "tmp-42")
+                    .put(MESSAGING_DESTINATION_TEMPORARY, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPORARY, true));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "generated-42")
+                    .put(MESSAGING_DESTINATION_ANONYMOUS, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_ANONYMOUS, true));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void emitsProcessDurationAccordingToConfiguration() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProcessMetrics.get().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+
+    Context root = Context.root();
+    Context context = listener.onStart(root, attributes, nanos(100));
+    Attributes endAttributes =
+        Attributes.builder()
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+    listener.onEnd(context, endAttributes, nanos(350));
+
+    if (!emitStableMessagingSemconv()) {
+      assertThat(context).isSameAs(root);
+      assertThat(metricReader.collectAllMetrics()).isEmpty();
+      return;
+    }
+
+    assertThat(metricReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.process.duration")
+                    .hasUnit("s")
+                    .hasDescription("Duration of processing operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSum(0.25)
+                                        .hasBucketBoundaries(DURATION_BUCKETS)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
@@ -5,26 +5,30 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.TraceFlags;
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 class MessagingProducerMetricsTest {
@@ -32,89 +36,234 @@ class MessagingProducerMetricsTest {
   private static final double[] DURATION_BUCKETS =
       MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
   void collectsMetrics() {
-    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider meterProvider =
         SdkMeterProvider.builder().registerMetricReader(metricReader).build();
-
-    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
     Attributes requestAttributes =
         Attributes.builder()
             .put(MESSAGING_SYSTEM, "pulsar")
-            .put(MESSAGING_DESTINATION_NAME, "persistent://public/default/topic")
-            .put(MESSAGING_OPERATION, "publish")
-            .put(SERVER_PORT, 6650)
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
             .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 6650)
             .build();
-
     Attributes responseAttributes =
         Attributes.builder()
-            .put(MESSAGING_MESSAGE_ID, "1:1:0:0")
             .put(MESSAGING_DESTINATION_PARTITION_ID, "1")
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 2)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
             .build();
 
-    Context parent =
-        Context.root()
-            .with(
-                Span.wrap(
-                    SpanContext.create(
-                        "ff01020304050600ff0a0b0c0d0e0f00",
-                        "090a0b0c0d0e0f00",
-                        TraceFlags.getSampled(),
-                        TraceState.getDefault())));
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(250));
 
-    Context context1 = listener.onStart(parent, requestAttributes, nanos(100));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 1 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.publish.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of publish operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_OPERATION, "publish"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null),
+                                              equalTo(SERVER_PORT, 6650),
+                                              equalTo(SERVER_ADDRESS, "localhost")))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "send"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.sent.messages")
+                      .hasUnit("{message}")
+                      .hasDescription(
+                          "Number of messages producer attempted to send to the broker.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(2)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))));
+    }
+  }
 
-    Context context2 = listener.onStart(Context.root(), requestAttributes, nanos(150));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void createDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "create" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
-    listener.onEnd(context1, responseAttributes, nanos(250));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.sent.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.publish.duration"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasUnit("s")
-                    .hasDescription("Measures the duration of publish operation.")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(0.15 /* seconds */)
-                                        .hasAttributesSatisfying(
-                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
-                                            equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
-                                            equalTo(
-                                                MESSAGING_DESTINATION_NAME,
-                                                "persistent://public/default/topic"),
-                                            equalTo(SERVER_PORT, 6650),
-                                            equalTo(SERVER_ADDRESS, "localhost"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00"))
-                                        .hasBucketBoundaries(DURATION_BUCKETS))));
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"));
+  }
 
-    listener.onEnd(context2, responseAttributes, nanos(300));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.publish.duration"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "publish"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point -> point.hasSum(0.3 /* seconds */))));
+        .satisfiesExactly(metric -> assertThat(metric).hasName("messaging.publish.duration"));
   }
 
   private static long nanos(int millis) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingSpanKindExtractorTest {
+
+  @ParameterizedTest
+  @MethodSource("spanKinds")
+  void extractsSpanKind(
+      MessagingOperationType operationType,
+      boolean isSpanContextPropagated,
+      SpanKind oldKind,
+      SpanKind kind) {
+    SpanKind actualKind =
+        MessagingSpanKindExtractor.create(operationType, isSpanContextPropagated)
+            .extract(new Object());
+
+    assertThat(actualKind).isEqualTo(emitStableMessagingSemconv() ? kind : oldKind);
+  }
+
+  @Test
+  void sendDefaultsToPropagatedSpanContext() {
+    SpanKind spanKind =
+        MessagingSpanKindExtractor.create(MessagingOperationType.SEND).extract(new Object());
+
+    assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
+  }
+
+  @Test
+  void messageOperationUsesLegacySpanKind() {
+    SpanKind receiveKind =
+        MessagingSpanKindExtractor.create(MessageOperation.RECEIVE).extract(new Object());
+
+    assertThat(receiveKind).isEqualTo(SpanKind.CONSUMER);
+  }
+
+  private static Stream<Arguments> spanKinds() {
+    return Stream.of(
+        argumentSet(
+            "create", MessagingOperationType.CREATE, true, SpanKind.PRODUCER, SpanKind.PRODUCER),
+        argumentSet(
+            "send with propagated context",
+            MessagingOperationType.SEND,
+            true,
+            SpanKind.PRODUCER,
+            SpanKind.PRODUCER),
+        argumentSet(
+            "send without propagated context",
+            MessagingOperationType.SEND,
+            false,
+            SpanKind.PRODUCER,
+            SpanKind.CLIENT),
+        argumentSet(
+            "receive", MessagingOperationType.RECEIVE, true, SpanKind.CONSUMER, SpanKind.CLIENT),
+        argumentSet(
+            "process", MessagingOperationType.PROCESS, true, SpanKind.CONSUMER, SpanKind.CONSUMER),
+        argumentSet(
+            "settle", MessagingOperationType.SETTLE, true, SpanKind.CLIENT, SpanKind.CLIENT));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,36 +27,118 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
+  @Test
+  void shouldKeepLegacyNameForMessageOperation() {
+    Message message = new Message();
+    when(getter.isTemporaryDestination(message)).thenReturn(false);
+    when(getter.getDestination(message)).thenReturn("destination");
+
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
+
+    assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
   @ParameterizedTest
   @MethodSource("spanNameParams")
   void shouldExtractSpanName(
       boolean isTemporaryQueue,
+      boolean isAnonymousQueue,
       String destinationName,
-      MessageOperation operation,
-      String expectedSpanName) {
+      String destinationTemplate,
+      MessagingOperationType operationType,
+      String operationName,
+      String oldSpanName,
+      String spanName) {
     // given
     Message message = new Message();
 
-    if (isTemporaryQueue) {
-      when(getter.isTemporaryDestination(message)).thenReturn(true);
+    if (emitStableMessagingSemconv()) {
+      when(getter.getDestinationTemplate(message)).thenReturn(destinationTemplate);
+      if (destinationTemplate == null) {
+        when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+        if (!isTemporaryQueue) {
+          when(getter.isAnonymousDestination(message)).thenReturn(isAnonymousQueue);
+          if (!isAnonymousQueue) {
+            when(getter.getDestination(message)).thenReturn(destinationName);
+          }
+        }
+      }
     } else {
-      when(getter.getDestination(message)).thenReturn(destinationName);
+      when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+      if (!isTemporaryQueue) {
+        when(getter.getDestination(message)).thenReturn(destinationName);
+      }
     }
 
-    SpanNameExtractor<Message> underTest = MessagingSpanNameExtractor.create(getter, operation);
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.builder(getter, operationType)
+            .setOperationName(operationName)
+            .build();
 
     // when
-    String spanName = underTest.extract(message);
+    String actualSpanName = underTest.extract(message);
 
     // then
-    assertThat(spanName).isEqualTo(expectedSpanName);
+    assertThat(actualSpanName).isEqualTo(emitStableMessagingSemconv() ? spanName : oldSpanName);
+    if (emitStableMessagingSemconv() && destinationTemplate != null) {
+      verify(getter, never()).isTemporaryDestination(message);
+      verify(getter, never()).isAnonymousDestination(message);
+    }
   }
 
   static Stream<Arguments> spanNameParams() {
     return Stream.of(
-        Arguments.of(false, "destination", MessageOperation.PUBLISH, "destination publish"),
-        Arguments.of(true, null, MessageOperation.PROCESS, "(temporary) process"),
-        Arguments.of(false, null, MessageOperation.RECEIVE, "unknown receive"));
+        argumentSet(
+            "operation name override",
+            false,
+            false,
+            "destination",
+            null,
+            MessagingOperationType.SEND,
+            "send",
+            "destination publish",
+            "send destination"),
+        argumentSet(
+            "temporary destination",
+            true,
+            false,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "(temporary) process",
+            "process generated-{id}"),
+        argumentSet(
+            "missing destination",
+            false,
+            false,
+            null,
+            null,
+            MessagingOperationType.RECEIVE,
+            "receive",
+            "unknown receive",
+            "receive"),
+        argumentSet(
+            "destination template",
+            false,
+            false,
+            "customer-42",
+            "customer-{id}",
+            MessagingOperationType.SEND,
+            "send",
+            "customer-42 publish",
+            "send customer-{id}"),
+        argumentSet(
+            "anonymous destination",
+            false,
+            true,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "generated process",
+            "process generated-{id}"));
   }
 
   static class Message {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -37,6 +38,16 @@ class MessagingSpanNameExtractorTest {
         MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
 
     assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
+  @Test
+  void shouldRejectOperationNameForMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingSpanNameExtractor.builder(getter, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
   }
 
   @ParameterizedTest

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessContextCustomizerTest {
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  private static final ContextCustomizer<Map<String, String>> underTest =
+      MessagingProcessContextCustomizer.create(W3CTraceContextPropagator.getInstance(), getter);
+
+  @Test
+  void preservesAmbientParent() {
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+    Span ambientSpan = Span.fromContext(ambient);
+
+    Context result = underTest.onStart(ambient, carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result)).isSameAs(ambientSpan);
+  }
+
+  @Test
+  void preservesPropagatedFieldsWithAmbientParent() {
+    ContextKey<String> propagatedKey = ContextKey.named("propagated");
+    ContextCustomizer<String> customizer =
+        MessagingProcessContextCustomizer.create(
+            (parent, request) -> parent.with(propagatedKey, request));
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+
+    Context result = customizer.onStart(ambient, "value", Attributes.empty());
+
+    assertThat(result.get(propagatedKey)).isEqualTo("value");
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(Span.fromContext(ambient).getSpanContext());
+  }
+
+  @Test
+  void usesProducerWhenAmbientParentIsMissing() {
+    Context result = underTest.onStart(Context.root(), carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(spanContext("22222222222222222222222222222222", "2222222222222222"));
+  }
+
+  private static Map<String, String> carrier() {
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    return Collections.unmodifiableMap(carrier);
+  }
+
+  private static Context context(String traceId, String spanId) {
+    return Context.root().with(Span.wrap(spanContext(traceId, spanId)));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingProcessInstrumenterFactoryTest {
+
+  private static final SpanContext ambientParent =
+      spanContext("11111111111111111111111111111111", "1111111111111111");
+  private static final SpanContext producer =
+      spanContext("22222222222222222222222222222222", "2222222222222222");
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void stableUsesProducerAsParentWithoutLink() {
+    assumeTrue(emitStableMessagingSemconv());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root(), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @Test
+  void stableDoesNotLinkAmbientParent() {
+    assumeTrue(emitStableMessagingSemconv());
+    SpanContext localProducer =
+        SpanContext.create(
+            producer.getTraceId(),
+            producer.getSpanId(),
+            producer.getTraceFlags(),
+            producer.getTraceState());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(localProducer)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("receiveInstrumentationSettings")
+  void usesExpectedParentAndLink(boolean receiveInstrumentationEnabled, boolean producerIsParent) {
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            receiveInstrumentationEnabled);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(ambientParent)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    SpanContext expectedParent = producerIsParent ? producer : ambientParent;
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      span.hasName("process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasTraceId(expectedParent.getTraceId())
+                          .hasParentSpanId(expectedParent.getSpanId());
+                      if (producerIsParent) {
+                        span.hasLinks();
+                      } else {
+                        span.hasLinks(LinkData.create(producer));
+                      }
+                    }));
+  }
+
+  private static Stream<Arguments> receiveInstrumentationSettings() {
+    boolean stable = emitStableMessagingSemconv();
+    String semconv = stable ? "stable" : "old";
+    return Stream.of(
+        argumentSet(semconv + " receive disabled", false, !stable),
+        argumentSet(semconv + " receive enabled", true, false));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -169,11 +169,14 @@ public final class SemconvStability {
     return mode.version() >= 1;
   }
 
-  public static boolean emitOldMessagingSemconv() {
+  public static boolean emitOldMessagingSemconv() { // to be removed in 3.0
     return emitOldMessagingSemconv;
   }
 
-  public static boolean emitStableMessagingSemconv() {
+  // Returns whether the selected v1 experimental messaging semantic conventions should be emitted.
+  // The method name follows the existing pattern; it does not indicate that the messaging
+  // conventions are stable.
+  public static boolean emitStableMessagingSemconv() { // to be removed in 3.0
     return emitStableMessagingSemconv;
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
@@ -43,12 +43,16 @@ public final class SpanKey {
   private static final ContextKey<Span> DB_CLIENT_KEY =
       ContextKey.named("opentelemetry-traces-span-key-db-client");
 
+  private static final ContextKey<Span> PRODUCER_CREATE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-producer-create");
   private static final ContextKey<Span> PRODUCER_KEY =
       ContextKey.named("opentelemetry-traces-span-key-producer");
   private static final ContextKey<Span> CONSUMER_RECEIVE_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-receive");
   private static final ContextKey<Span> CONSUMER_PROCESS_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-process");
+  private static final ContextKey<Span> CONSUMER_SETTLE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-consumer-settle");
 
   /* Span keys */
 
@@ -66,9 +70,11 @@ public final class SpanKey {
   public static final SpanKey RPC_CLIENT = new SpanKey(RPC_CLIENT_KEY);
   public static final SpanKey DB_CLIENT = new SpanKey(DB_CLIENT_KEY);
 
+  public static final SpanKey PRODUCER_CREATE = new SpanKey(PRODUCER_CREATE_KEY);
   public static final SpanKey PRODUCER = new SpanKey(PRODUCER_KEY);
   public static final SpanKey CONSUMER_RECEIVE = new SpanKey(CONSUMER_RECEIVE_KEY);
   public static final SpanKey CONSUMER_PROCESS = new SpanKey(CONSUMER_PROCESS_KEY);
+  public static final SpanKey CONSUMER_SETTLE = new SpanKey(CONSUMER_SETTLE_KEY);
 
   private final ContextKey<Span> key;
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -9,6 +9,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.common.ComponentLoader;
@@ -22,6 +23,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class SemconvStabilityTest {
@@ -377,6 +380,69 @@ class SemconvStabilityTest {
     assertThat(rpc).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(servicePeer).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(messaging).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
+  }
+
+  @ParameterizedTest
+  @MethodSource("messagingSelectionModes")
+  void messagingSelectionMatrix(
+      boolean v3Preview, Set<String> stableOptIn, Set<String> preview, SemconvMode expectedMode) {
+    SemconvMode messaging =
+        new SemconvSelectionResolver(general(), v3Preview, stableOptIn, preview).messaging();
+
+    assertThat(messaging).isEqualTo(expectedMode);
+  }
+
+  private static List<Arguments> messagingSelectionModes() {
+    return asList(
+        argumentSet("legacy default", false, noStableOptIn(), noPreview(), SemconvMode.V0_STABLE),
+        argumentSet(
+            "legacy opt-in property",
+            false,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "preview property",
+            false,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "legacy opt-in dual emit",
+            false,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "preview dual emit",
+            false,
+            noStableOptIn(),
+            preview("messaging/dup"),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "v3 activation remains staged",
+            true,
+            noStableOptIn(),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in property",
+            true,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in dual emit",
+            true,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 with explicit preview",
+            true,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL));
   }
 
   @SafeVarargs

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
@@ -51,6 +51,7 @@ public class SpanKeyBridging {
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.DB_CLIENT,
         SpanKey.DB_CLIENT);
 
+    putIfPresent(map, "PRODUCER_CREATE", SpanKey.PRODUCER_CREATE);
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.PRODUCER,
         SpanKey.PRODUCER);
@@ -60,7 +61,24 @@ public class SpanKeyBridging {
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.CONSUMER_PROCESS,
         SpanKey.CONSUMER_PROCESS);
+    putIfPresent(map, "CONSUMER_SETTLE", SpanKey.CONSUMER_SETTLE);
     return map;
+  }
+
+  private static void putIfPresent(
+      Map<application.io.opentelemetry.instrumentation.api.internal.SpanKey, SpanKey> map,
+      String fieldName,
+      SpanKey agentSpanKey) {
+    try {
+      application.io.opentelemetry.instrumentation.api.internal.SpanKey applicationSpanKey =
+          (application.io.opentelemetry.instrumentation.api.internal.SpanKey)
+              application.io.opentelemetry.instrumentation.api.internal.SpanKey.class
+                  .getField(fieldName)
+                  .get(null);
+      map.put(applicationSpanKey, agentSpanKey);
+    } catch (ReflectiveOperationException ignored) {
+      // The application may use an instrumentation-api version from before this key was added.
+    }
   }
 
   @Nullable

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
@@ -68,9 +68,11 @@ class ContextBridgeTest {
                   SpanKey.HTTP_CLIENT,
                   SpanKey.RPC_CLIENT,
                   SpanKey.DB_CLIENT,
+                  SpanKey.PRODUCER_CREATE,
                   SpanKey.PRODUCER,
                   SpanKey.CONSUMER_RECEIVE,
-                  SpanKey.CONSUMER_PROCESS);
+                  SpanKey.CONSUMER_PROCESS,
+                  SpanKey.CONSUMER_SETTLE);
 
           spanKeys.forEach(
               spanKey -> assertThat(spanKey.fromContextOrNull(Context.current())).isNotNull());

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -73,9 +73,11 @@ public class AgentSpanTestingInstrumenter {
       SpanKey.HTTP_CLIENT,
       SpanKey.RPC_CLIENT,
       SpanKey.DB_CLIENT,
+      SpanKey.PRODUCER_CREATE,
       SpanKey.PRODUCER,
       SpanKey.CONSUMER_RECEIVE,
       SpanKey.CONSUMER_PROCESS,
+      SpanKey.CONSUMER_SETTLE,
     };
   }
 


### PR DESCRIPTION
Depends on #19267.

Dependency baseline: `a9d865517b871722de14a0becaedffc5c028eb06`.
Review only: `a9d865517b871722de14a0becaedffc5c028eb06..e5625a8c979a21529850bc6407a2fc35e95cd6dd`.

Exactly one topology commit. Stable process spans avoid parent-equal links by IDs, preserve the original ambient Span object, and retain propagated non-span context.

Validated across default/stable/dual modes plus the full `instrumentation-api-incubator:check` lifecycle.