### PR TITLE
Cover Kafka ecosystem messaging v1.43 telemetry

### DIFF
--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database,code,service.peer,rpc")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
     inputs.dir(jflexOutputDir)
   }
 
@@ -99,6 +100,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,code/dup,service.peer/dup,rpc/dup")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     inputs.dir(jflexOutputDir)
   }
 
@@ -117,6 +119,11 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testBothSemconv, testExceptionSignalLogs, testExceptionSignalLogsDup)
+    dependsOn(
+      testStableSemconv,
+      testBothSemconv,
+      testExceptionSignalLogs,
+      testExceptionSignalLogsDup,
+    )
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -5,24 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-import java.util.Locale;
-
-/**
- * Represents type of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">operations</a>
- * that may be used in a messaging system.
- */
+/** Represents an operation that may be used in a messaging system. */
 public enum MessageOperation {
-  PUBLISH,
-  RECEIVE,
-  PROCESS;
+  PUBLISH(MessagingOperationType.SEND),
+  RECEIVE(MessagingOperationType.RECEIVE),
+  PROCESS(MessagingOperationType.PROCESS);
 
-  /**
-   * Returns the operation name as defined in <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">the
-   * specification</a>.
-   */
-  String operationName() {
-    return name().toLowerCase(Locale.ROOT);
+  private final MessagingOperationType operationType;
+
+  MessageOperation(MessagingOperationType operationType) {
+    this.operationType = operationType;
+  }
+
+  MessagingOperationType type() {
+    return operationType;
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -17,7 +21,7 @@ import javax.annotation.Nullable;
 
 /**
  * Extractor of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md">messaging
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md">messaging
  * attributes</a>.
  *
  * <p>This class delegates to a type-specific {@link MessagingAttributesGetter} for individual
@@ -29,8 +33,10 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
-  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
       AttributeKey.stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+      AttributeKey.stringKey("messaging.client.id");
   private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
       AttributeKey.booleanKey("messaging.destination.anonymous");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
@@ -51,49 +57,80 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       AttributeKey.stringKey("messaging.message.id");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final AttributeKey<String> MESSAGING_SYSTEM =
       AttributeKey.stringKey("messaging.system");
 
   static final String TEMP_DESTINATION_NAME = "(temporary)";
 
-  /**
-   * Creates the messaging attributes extractor for the given {@link MessageOperation operation}
-   * with default configuration.
-   */
+  /** Creates the messaging attributes extractor for the given operation type. */
+  // will be renamed in 3.0 to create()
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> createForOperationType(
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessagingOperationType operationType) {
+    return builderForOperationType(getter, operationType).build();
+  }
+
+  /** Creates the messaging attributes extractor for the given operation. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
   }
 
   /**
-   * Returns a new {@link MessagingAttributesExtractorBuilder} for the given {@link MessageOperation
-   * operation} that can be used to configure the messaging attributes extractor.
+   * Returns a new {@link MessagingAttributesExtractorBuilder} configured for the given operation
+   * type.
    */
+  // will be renamed in 3.0 to builder()
+  public static <REQUEST, RESPONSE>
+      MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builderForOperationType(
+          MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+          @Nullable MessagingOperationType operationType) {
+    return new MessagingAttributesExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a new messaging attributes extractor builder for the given operation. */
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
-    return new MessagingAttributesExtractorBuilder<>(getter, operation);
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
+    return new MessagingAttributesExtractorBuilder<>(
+        getter, operation == null ? null : operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  private final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private final String operationName;
+  private final boolean supportsStableSemconv;
   private final List<String> capturedHeaders;
 
   MessagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter,
-      MessageOperation operation,
+      @Nullable MessagingOperationType operationType,
+      @Nullable String operationName,
+      boolean supportsStableSemconv,
       List<String> capturedHeaders) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
   }
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    boolean emitOldSemconv = !supportsStableSemconv || emitOldMessagingSemconv();
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
     attributes.put(MESSAGING_SYSTEM, getter.getSystem(request));
     boolean isTemporaryDestination = getter.isTemporaryDestination(request);
     if (isTemporaryDestination) {
       attributes.put(MESSAGING_DESTINATION_TEMPORARY, true);
-      attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      if (emitStableSemconv) {
+        attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
+        attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
+      } else {
+        attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      }
     } else {
       attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
       attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
@@ -106,9 +143,20 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     attributes.put(MESSAGING_MESSAGE_CONVERSATION_ID, getter.getConversationId(request));
     attributes.put(MESSAGING_MESSAGE_BODY_SIZE, getter.getMessageBodySize(request));
     attributes.put(MESSAGING_MESSAGE_ENVELOPE_SIZE, getter.getMessageEnvelopeSize(request));
-    attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
-    if (operation != null) {
-      attributes.put(MESSAGING_OPERATION, operation.operationName());
+    if (emitOldSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID_OLD, getter.getClientId(request));
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
+    }
+    if (emitOldSemconv && operationType != null) {
+      attributes.put(MESSAGING_OPERATION, operationType.defaultOperationName());
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_OPERATION_NAME, operationName);
+      if (operationType != null) {
+        attributes.put(MESSAGING_OPERATION_TYPE, operationType.value());
+      }
     }
   }
 
@@ -121,6 +169,13 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
     attributes.put(MESSAGING_MESSAGE_ID, getter.getMessageId(request, response));
     attributes.put(MESSAGING_BATCH_MESSAGE_COUNT, getter.getBatchMessageCount(request, response));
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String errorType = getter.getErrorType(request, response, error);
+      if (errorType == null && error != null) {
+        errorType = error.getClass().getName();
+      }
+      attributes.put(ERROR_TYPE, errorType);
+    }
 
     for (String name : capturedHeaders) {
       List<String> values = getter.getMessageHeader(request, name);
@@ -137,17 +192,21 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   @Override
   @Nullable
   public SpanKey internalGetSpanKey() {
-    if (operation == null) {
+    if (operationType == null) {
       return null;
     }
 
-    switch (operation) {
-      case PUBLISH:
+    switch (operationType) {
+      case CREATE:
+        return SpanKey.PRODUCER_CREATE;
+      case SEND:
         return SpanKey.PRODUCER;
       case RECEIVE:
         return SpanKey.CONSUMER_RECEIVE;
       case PROCESS:
         return SpanKey.CONSUMER_PROCESS;
+      case SETTLE:
+        return SpanKey.CONSUMER_SETTLE;
     }
     throw new IllegalStateException("Can't possibly happen");
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -38,6 +38,9 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @CanIgnoreReturnValue
   public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
       String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -6,24 +6,40 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /** A builder of {@link MessagingAttributesExtractor}. */
 public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private String operationName;
+  private final boolean supportsStableSemconv;
   List<String> capturedHeaders = emptyList();
 
   MessagingAttributesExtractorBuilder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+      @Nullable MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationType == null ? null : operationType.defaultOperationName();
+    this.supportsStableSemconv = supportsStableSemconv;
+  }
+
+  /** Configures the system-specific operation name emitted as {@code messaging.operation.name}. */
+  @CanIgnoreReturnValue
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
+      String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
   }
 
   /**
@@ -47,6 +63,10 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * MessagingAttributesExtractorBuilder}.
    */
   public AttributesExtractor<REQUEST, RESPONSE> build() {
-    return new MessagingAttributesExtractor<>(getter, operation, capturedHeaders);
+    if (supportsStableSemconv) {
+      requireNonNull(operationName, "operationName");
+    }
+    return new MessagingAttributesExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv, capturedHeaders);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
@@ -56,6 +56,21 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
   }
 
   /**
+   * Returns a description of a class of error the operation ended with.
+   *
+   * <p>If this method returns {@code null}, the exception class name (if any) will be used as error
+   * type.
+   *
+   * <p>The cardinality of the error type should be low. The instrumentations implementing this
+   * method are recommended to document the custom values they support.
+   */
+  @Nullable
+  default String getErrorType(
+      REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error) {
+    return null;
+  }
+
+  /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
    * were none.
    *

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
@@ -23,10 +26,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#consumer-metrics">Consumer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#consumer-metrics">consumer
  * metrics</a>.
  */
 public final class MessagingConsumerMetrics implements OperationListener {
@@ -35,39 +39,86 @@ public final class MessagingConsumerMetrics implements OperationListener {
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingConsumerMetrics.State> MESSAGING_CONSUMER_METRICS_STATE =
       ContextKey.named("messaging-consumer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingConsumerMetrics.class.getName());
 
-  private final DoubleHistogram receiveDurationHistogram;
-  private final LongCounter receiveMessageCount;
+  private final boolean supportsStableSemconv;
+  private final boolean consumedMessagesOnly;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram receiveDurationHistogram;
+  @Nullable private final LongCounter receiveMessageCount;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter consumedMessagesCounter;
 
-  private MessagingConsumerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.receive.duration")
-            .setDescription("Measures the duration of receive operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyReceiveDurationAdvice(durationBuilder);
-    receiveDurationHistogram = durationBuilder.build();
-
-    LongCounterBuilder longCounterBuilder =
-        meter
-            .counterBuilder("messaging.receive.messages")
-            .setDescription("Measures the number of received messages.")
-            .setUnit("{message}");
-    MessagingMetricsAdvice.applyReceiveMessagesAdvice(longCounterBuilder);
-    receiveMessageCount = longCounterBuilder.build();
+  private MessagingConsumerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    consumedMessagesOnly = variant == Variant.CONSUMED_MESSAGES_ONLY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    receiveDurationHistogram =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveDuration(meter) : null;
+    receiveMessageCount =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveMessages(meter) : null;
+    clientOperationDurationHistogram =
+        !consumedMessagesOnly && emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    consumedMessagesCounter = emitStableSemconv ? buildConsumedMessages(meter) : null;
+    enabled =
+        receiveDurationHistogram != null
+            || receiveMessageCount != null
+            || clientOperationDurationHistogram != null
+            || consumedMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging consumer", MessagingConsumerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.receive.duration} and {@code messaging.receive.messages}
+   * instruments.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE_AND_OLD));
+  }
+
+  /** Returns only the stable consumed-messages metric for a delivered message. */
+  public static OperationMetrics getConsumedMessages() {
+    return OperationMetricsUtil.create(
+        "messaging consumed messages",
+        meter -> new MessagingConsumerMetrics(meter, Variant.CONSUMED_MESSAGES_ONLY));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_CONSUMER_METRICS_STATE,
         new AutoValue_MessagingConsumerMetrics_State(startAttributes, startNanos));
@@ -75,6 +126,9 @@ public final class MessagingConsumerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingConsumerMetrics.State state = context.get(MESSAGING_CONSUMER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -85,21 +139,104 @@ public final class MessagingConsumerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
-    receiveDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
+    String operationType = attributes.get(MESSAGING_OPERATION_TYPE);
+    boolean recordsLegacyReceive =
+        !supportsStableSemconv
+            || "receive".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.RECEIVE.value().equals(operationType);
+    if (receiveDurationHistogram != null && recordsLegacyReceive) {
+      receiveDurationHistogram.record(duration, attributes, context);
+    }
+    // Metric view attribute advice can only select keys statically. The concrete destination name
+    // must be omitted when a template is available or the destination is temporary or anonymous,
+    // so this conditional requirement must be enforced before recording.
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || consumedMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null
+        && !MessagingOperationType.PROCESS.value().equals(operationType)) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
 
-    long receiveMessagesCount = getReceiveMessagesCount(state.startAttributes(), endAttributes);
-    receiveMessageCount.add(receiveMessagesCount, attributes, context);
+    Long batchMessageCount = getBatchMessageCount(state.startAttributes(), endAttributes);
+    if (receiveMessageCount != null && recordsLegacyReceive) {
+      long receiveMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (!supportsStableSemconv || receiveMessagesCount > 0) {
+        receiveMessageCount.add(receiveMessagesCount, attributes, context);
+      }
+    }
+    if (consumedMessagesCounter != null
+        && (consumedMessagesOnly || MessagingOperationType.RECEIVE.value().equals(operationType))) {
+      long consumedMessagesCount =
+          getConsumedMessagesCount(attributes, batchMessageCount, consumedMessagesOnly);
+      if (consumedMessagesCount > 0) {
+        consumedMessagesCounter.add(consumedMessagesCount, filteredAttributes, context);
+      }
+    }
   }
 
-  private static long getReceiveMessagesCount(Attributes... attributesList) {
+  @Nullable
+  private static Long getBatchMessageCount(Attributes... attributesList) {
     for (Attributes attributes : attributesList) {
       Long value = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
       if (value != null) {
         return value;
       }
     }
-    return 1;
+    return null;
+  }
+
+  private static long getConsumedMessagesCount(
+      Attributes attributes, @Nullable Long batchMessageCount, boolean consumedMessagesOnly) {
+    if (batchMessageCount != null) {
+      return batchMessageCount;
+    }
+    return consumedMessagesOnly || attributes.get(ERROR_TYPE) == null ? 1 : 0;
+  }
+
+  private static DoubleHistogram buildReceiveDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.receive.duration")
+            .setDescription("Measures the duration of receive operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildReceiveMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.receive.messages")
+            .setDescription("Measures the number of received messages.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyOldMessagesAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildConsumedMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.consumed.messages")
+            .setDescription("Number of messages that were delivered to the application.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyConsumedMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -108,5 +245,19 @@ public final class MessagingConsumerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD,
+    /** Only the stable consumed-messages counter, for a delivered message. */
+    CONSUMED_MESSAGES_ONLY
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
@@ -12,10 +12,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
 final class MessagingMetricsAdvice {
@@ -28,14 +30,26 @@ final class MessagingMetricsAdvice {
       AttributeKey.stringKey("messaging.system");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
       AttributeKey.stringKey("messaging.destination.name");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
+      AttributeKey.booleanKey("messaging.destination.anonymous");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
+      AttributeKey.booleanKey("messaging.destination.temporary");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      AttributeKey.stringKey("messaging.destination.subscription.name");
   private static final AttributeKey<String> MESSAGING_DESTINATION_PARTITION_ID =
       AttributeKey.stringKey("messaging.destination.partition.id");
   private static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
       AttributeKey.stringKey("messaging.destination.template");
 
-  private static final List<AttributeKey<?>> MESSAGING_ATTRIBUTES =
+  private static final List<AttributeKey<?>> OLD_ATTRIBUTES =
       asList(
           MESSAGING_SYSTEM,
           MESSAGING_DESTINATION_NAME,
@@ -46,25 +60,90 @@ final class MessagingMetricsAdvice {
           SERVER_PORT,
           SERVER_ADDRESS);
 
-  static void applyPublishDurationAdvice(DoubleHistogramBuilder builder) {
+  private static final List<AttributeKey<?>> CLIENT_OPERATION_DURATION_ATTRIBUTES =
+      buildAttributes(true, true, true);
+  private static final List<AttributeKey<?>> SENT_MESSAGES_ATTRIBUTES =
+      buildAttributes(false, false, true);
+  private static final List<AttributeKey<?>> CONSUMED_MESSAGES_ATTRIBUTES =
+      buildAttributes(true, false, true);
+  private static final List<AttributeKey<?>> PROCESS_DURATION_ATTRIBUTES =
+      buildAttributes(true, false, true);
+
+  private static List<AttributeKey<?>> buildAttributes(
+      boolean includeConsumerAttributes, boolean includeOperationType, boolean includeErrorType) {
+    List<AttributeKey<?>> attributes = new ArrayList<>();
+    attributes.add(MESSAGING_OPERATION_NAME);
+    attributes.add(MESSAGING_SYSTEM);
+    if (includeErrorType) {
+      attributes.add(ERROR_TYPE);
+    }
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_CONSUMER_GROUP_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_NAME);
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_DESTINATION_SUBSCRIPTION_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_TEMPLATE);
+    if (includeOperationType) {
+      attributes.add(MESSAGING_OPERATION_TYPE);
+    }
+    attributes.add(MESSAGING_DESTINATION_PARTITION_ID);
+    attributes.add(SERVER_ADDRESS);
+    attributes.add(SERVER_PORT);
+    return unmodifiableList(attributes);
+  }
+
+  static Attributes filterAttributes(Attributes attributes) {
+    if (attributes.get(MESSAGING_DESTINATION_TEMPLATE) == null
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_ANONYMOUS))
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_TEMPORARY))) {
+      return attributes;
+    }
+    return attributes.toBuilder().remove(MESSAGING_DESTINATION_NAME).build();
+  }
+
+  static void applyOldDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
   }
 
-  static void applyReceiveDurationAdvice(DoubleHistogramBuilder builder) {
+  static void applyClientOperationDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder)
+        .setAttributesAdvice(CLIENT_OPERATION_DURATION_ATTRIBUTES);
   }
 
-  static void applyReceiveMessagesAdvice(LongCounterBuilder builder) {
+  static void applyProcessDurationAdvice(DoubleHistogramBuilder builder) {
+    if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
+      return;
+    }
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(PROCESS_DURATION_ATTRIBUTES);
+  }
+
+  static void applyOldMessagesAdvice(LongCounterBuilder builder) {
     if (!(builder instanceof ExtendedLongCounterBuilder)) {
       return;
     }
-    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
+  }
+
+  static void applySentMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(SENT_MESSAGES_ATTRIBUTES);
+  }
+
+  static void applyConsumedMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(CONSUMED_MESSAGES_ATTRIBUTES);
   }
 
   private MessagingMetricsAdvice() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+/**
+ * Represents a <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#operation-types">messaging
+ * operation type</a>.
+ */
+public enum MessagingOperationType {
+  CREATE("create", "create"),
+  SEND("send", "publish"),
+  RECEIVE("receive", "receive"),
+  PROCESS("process", "process"),
+  SETTLE("settle", "settle");
+
+  private final String value;
+  private final String defaultOperationName;
+
+  MessagingOperationType(String value, String defaultOperationName) {
+    this.value = value;
+    this.defaultOperationName = defaultOperationName;
+  }
+
+  String value() {
+    return value;
+  }
+
+  String defaultOperationName() {
+    return defaultOperationName;
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.FINE;
+
+import com.google.auto.value.AutoValue;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
+import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * {@link OperationListener} which keeps track of <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#metric-messagingprocessduration">message
+ * processing metrics</a>.
+ */
+public final class MessagingProcessMetrics implements OperationListener {
+  private static final double NANOS_PER_S = SECONDS.toNanos(1);
+
+  private static final ContextKey<State> MESSAGING_PROCESS_METRICS_STATE =
+      ContextKey.named("messaging-process-metrics-state");
+  private static final Logger logger = Logger.getLogger(MessagingProcessMetrics.class.getName());
+
+  @Nullable private final DoubleHistogram processDurationHistogram;
+
+  private MessagingProcessMetrics(Meter meter) {
+    processDurationHistogram = emitStableMessagingSemconv() ? buildProcessDuration(meter) : null;
+  }
+
+  public static OperationMetrics get() {
+    return OperationMetricsUtil.create("messaging process", MessagingProcessMetrics::new);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (processDurationHistogram == null) {
+      return context;
+    }
+    return context.with(
+        MESSAGING_PROCESS_METRICS_STATE,
+        new AutoValue_MessagingProcessMetrics_State(startAttributes, startNanos));
+  }
+
+  @Override
+  public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (processDurationHistogram == null) {
+      return;
+    }
+    State state = context.get(MESSAGING_PROCESS_METRICS_STATE);
+    if (state == null) {
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record messaging process metrics.",
+          context);
+      return;
+    }
+
+    Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    processDurationHistogram.record(
+        (endNanos - state.startTimeNanos()) / NANOS_PER_S,
+        MessagingMetricsAdvice.filterAttributes(attributes),
+        context);
+  }
+
+  private static DoubleHistogram buildProcessDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.process.duration")
+            .setDescription("Duration of processing operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyProcessDurationAdvice(builder);
+    return builder.build();
+  }
+
+  @AutoValue
+  abstract static class State {
+    abstract Attributes startAttributes();
+
+    abstract long startTimeNanos();
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -20,39 +25,84 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#metric-messagingpublishduration">Producer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#producer-metrics">producer
  * metrics</a>.
  */
 public final class MessagingProducerMetrics implements OperationListener {
   private static final double NANOS_PER_S = SECONDS.toNanos(1);
 
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingProducerMetrics.State> MESSAGING_PRODUCER_METRICS_STATE =
       ContextKey.named("messaging-producer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingProducerMetrics.class.getName());
 
-  private final DoubleHistogram publishDurationHistogram;
+  private final boolean supportsStableSemconv;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram publishDurationHistogram;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter sentMessagesCounter;
 
-  private MessagingProducerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.publish.duration")
-            .setDescription("Measures the duration of publish operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyPublishDurationAdvice(durationBuilder);
-    publishDurationHistogram = durationBuilder.build();
+  private MessagingProducerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    publishDurationHistogram = emitOldSemconv ? buildPublishDuration(meter) : null;
+    clientOperationDurationHistogram =
+        emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    sentMessagesCounter = emitStableSemconv ? buildSentMessages(meter) : null;
+    enabled =
+        publishDurationHistogram != null
+            || clientOperationDurationHistogram != null
+            || sentMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging producer", MessagingProducerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.publish.duration} instrument.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE_AND_OLD));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_PRODUCER_METRICS_STATE,
         new AutoValue_MessagingProducerMetrics_State(startAttributes, startNanos));
@@ -60,6 +110,9 @@ public final class MessagingProducerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingProducerMetrics.State state = context.get(MESSAGING_PRODUCER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -70,9 +123,64 @@ public final class MessagingProducerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
 
-    publishDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    if (publishDurationHistogram != null
+        && (!supportsStableSemconv
+            || "publish".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.SEND
+                .value()
+                .equals(attributes.get(MESSAGING_OPERATION_TYPE)))) {
+      publishDurationHistogram.record(duration, attributes, context);
+    }
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || sentMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
+    if (sentMessagesCounter != null
+        && MessagingOperationType.SEND.value().equals(attributes.get(MESSAGING_OPERATION_TYPE))) {
+      Long batchMessageCount = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
+      long sentMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (sentMessagesCount > 0) {
+        sentMessagesCounter.add(sentMessagesCount, filteredAttributes, context);
+      }
+    }
+  }
+
+  private static DoubleHistogram buildPublishDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.publish.duration")
+            .setDescription("Measures the duration of publish operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildSentMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.sent.messages")
+            .setDescription("Number of messages producer attempted to send to the broker.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applySentMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -81,5 +189,17 @@ public final class MessagingProducerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+
+/** Selects messaging span kinds according to the configured semantic convention version. */
+public final class MessagingSpanKindExtractor {
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessagingOperationType operationType) {
+    return create(operationType, true);
+  }
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   *
+   * @param isSpanContextPropagated whether the context of a {@link MessagingOperationType#SEND}
+   *     span is propagated as the message creation context; ignored for other operation types
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(
+      MessagingOperationType operationType, boolean isSpanContextPropagated) {
+    SpanKind spanKind;
+    switch (operationType) {
+      case CREATE:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case SEND:
+        spanKind =
+            emitStableMessagingSemconv() && !isSpanContextPropagated
+                ? SpanKind.CLIENT
+                : SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+        spanKind = emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
+        break;
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      case SETTLE:
+        spanKind = SpanKind.CLIENT;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  /** Returns a span kind extractor for the given operation. */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
+    SpanKind spanKind;
+    switch (operation) {
+      case PUBLISH:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  private MessagingSpanKindExtractor() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -5,35 +5,75 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtractor<REQUEST> {
 
   /**
    * Returns a {@link SpanNameExtractor} that constructs the span name according to <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#span-name">
-   * messaging semantic conventions</a>: {@code <destination name> <operation name>}.
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-name">
+   * messaging semantic conventions</a>.
    *
    * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <destination
    *     name>}.
-   * @see MessageOperation used to extract {@code <operation name>}.
+   * @see MessagingOperationType used to extract {@code <operation name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return builder(getter, operationType).build();
+  }
+
+  /** Returns a messaging span name extractor for the given operation. */
+  public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
-    return new MessagingSpanNameExtractor<>(getter, operation);
+    return builder(getter, operation).build();
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractorBuilder} that can be used to configure the
+   * messaging span name extractor.
+   */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a messaging span name extractor builder for the given operation. */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, ?> getter;
-  private final MessageOperation operation;
+  private final MessagingOperationType operationType;
+  private final String operationName;
+  private final boolean supportsStableSemconv;
 
-  private MessagingSpanNameExtractor(
-      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+  MessagingSpanNameExtractor(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      String operationName,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
   }
 
   @Override
   public String extract(REQUEST request) {
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String destinationName = getter.getDestinationTemplate(request);
+      if (destinationName == null
+          && !getter.isTemporaryDestination(request)
+          && !getter.isAnonymousDestination(request)) {
+        destinationName = getter.getDestination(request);
+      }
+      return destinationName == null ? operationName : operationName + " " + destinationName;
+    }
+
     String destinationName =
         getter.isTemporaryDestination(request)
             ? MessagingAttributesExtractor.TEMP_DESTINATION_NAME
@@ -42,6 +82,6 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
       destinationName = "unknown";
     }
 
-    return destinationName + " " + operation.operationName();
+    return destinationName + " " + operationType.defaultOperationName();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -31,6 +31,9 @@ public final class MessagingSpanNameExtractorBuilder<REQUEST> {
   /** Configures the system-specific operation name used in the v1.43 messaging span name. */
   @CanIgnoreReturnValue
   public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+
+/** A builder of {@link MessagingSpanNameExtractor}. */
+public final class MessagingSpanNameExtractorBuilder<REQUEST> {
+
+  private final MessagingAttributesGetter<REQUEST, ?> getter;
+  private final MessagingOperationType operationType;
+  private final boolean supportsStableSemconv;
+  private String operationName;
+
+  MessagingSpanNameExtractorBuilder(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
+    this.getter = getter;
+    this.operationType = requireNonNull(operationType, "operationType");
+    this.supportsStableSemconv = supportsStableSemconv;
+    this.operationName = operationType.defaultOperationName();
+  }
+
+  /** Configures the system-specific operation name used in the v1.43 messaging span name. */
+  @CanIgnoreReturnValue
+  public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractor} with the settings of this {@link
+   * MessagingSpanNameExtractorBuilder}.
+   */
+  public SpanNameExtractor<REQUEST> build() {
+    return new MessagingSpanNameExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.function.BiFunction;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessContextCustomizer<REQUEST> implements ContextCustomizer<REQUEST> {
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
+    return create((parentContext, request) -> propagator.extract(parentContext, request, getter));
+  }
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    return new MessagingProcessContextCustomizer<>(producerContextExtractor);
+  }
+
+  private final BiFunction<Context, REQUEST, Context> producerContextExtractor;
+
+  private MessagingProcessContextCustomizer(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    this.producerContextExtractor = producerContextExtractor;
+  }
+
+  @Override
+  public Context onStart(Context parentContext, REQUEST request, Attributes startAttributes) {
+    Context extractedContext = producerContextExtractor.apply(parentContext, request);
+    Span parentSpan = Span.fromContext(parentContext);
+    if (!parentSpan.getSpanContext().isValid()) {
+      return extractedContext;
+    }
+    return extractedContext.with(parentSpan);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessInstrumenterFactory {
+
+  public static <REQUEST, RESPONSE> Instrumenter<REQUEST, RESPONSE> create(
+      InstrumenterBuilder<REQUEST, RESPONSE> builder,
+      TextMapPropagator propagator,
+      TextMapGetter<REQUEST> getter,
+      boolean receiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv()) {
+      builder.addSpanLinksExtractor(
+          (spanLinks, parentContext, request) -> {
+            SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+            SpanContext producerSpanContext =
+                Span.fromContext(propagator.extract(parentContext, request, getter))
+                    .getSpanContext();
+            if (parentSpanContext.isValid()
+                && producerSpanContext.isValid()
+                && (!producerSpanContext.getTraceId().equals(parentSpanContext.getTraceId())
+                    || !producerSpanContext.getSpanId().equals(parentSpanContext.getSpanId()))) {
+              spanLinks.addLink(producerSpanContext);
+            }
+          });
+      builder.addContextCustomizer(MessagingProcessContextCustomizer.create(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    if (receiveInstrumentationEnabled) {
+      builder.addSpanLinksExtractor(new PropagatorBasedSpanLinksExtractor<>(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    return builder.buildConsumerInstrumenter(getter);
+  }
+
+  private MessagingProcessInstrumenterFactory() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -6,7 +6,10 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -17,15 +20,21 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,8 +56,8 @@ class MessagingAttributesExtractorTest {
       boolean temporary,
       boolean anonymous,
       String destination,
-      MessageOperation operation,
-      String expectedDestination) {
+      MessagingOperationType operationType,
+      String operationName) {
     // given
     Map<String, String> request = new HashMap<>();
     request.put("system", "myQueue");
@@ -63,13 +72,16 @@ class MessagingAttributesExtractorTest {
     }
     request.put("url", "http://broker/topic");
     request.put("conversationId", "42");
+    request.put("messageId", "42");
     request.put("bodySize", "100");
     request.put("envelopeSize", "120");
     request.put("clientId", "43");
     request.put("batchMessageCount", "2");
 
     AttributesExtractor<Map<String, String>, String> underTest =
-        MessagingAttributesExtractor.create(TestGetter.INSTANCE, operation);
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName(operationName)
+            .build();
 
     Context context = Context.root();
 
@@ -78,16 +90,22 @@ class MessagingAttributesExtractorTest {
     underTest.onStart(startAttributes, context, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, context, request, "42", null);
+    underTest.onEnd(endAttributes, context, request, "42", new IllegalStateException());
 
     // then
     List<MapEntry<AttributeKey<?>, Object>> expectedEntries = new ArrayList<>();
     expectedEntries.add(entry(MESSAGING_SYSTEM, "myQueue"));
-    expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, expectedDestination));
     if (temporary) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPORARY, true));
+      if (emitStableMessagingSemconv()) {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+        expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
+      } else {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, "(temporary)"));
+      }
     } else {
-      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, expectedDestination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
     }
     if (anonymous) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_ANONYMOUS, true));
@@ -95,22 +113,143 @@ class MessagingAttributesExtractorTest {
     expectedEntries.add(entry(MESSAGING_MESSAGE_CONVERSATION_ID, "42"));
     expectedEntries.add(entry(MESSAGING_MESSAGE_BODY_SIZE, 100L));
     expectedEntries.add(entry(MESSAGING_MESSAGE_ENVELOPE_SIZE, 120L));
-    expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
-    expectedEntries.add(entry(MESSAGING_OPERATION, operation.operationName()));
+    if (emitOldMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION, operationType.defaultOperationName()));
+    }
+    if (emitStableMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client.id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION_NAME, operationName));
+      expectedEntries.add(entry(MESSAGING_OPERATION_TYPE, operationType.value()));
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     MapEntry<? extends AttributeKey<?>, ?>[] expectedEntriesArr =
         expectedEntries.toArray(new MapEntry[0]);
     assertThat(startAttributes.build()).containsOnly(expectedEntriesArr);
 
-    assertThat(endAttributes.build())
-        .containsOnly(entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    if (emitStableMessagingSemconv()) {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"),
+              entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L),
+              entry(ERROR_TYPE, IllegalStateException.class.getName()));
+    } else {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    }
   }
 
   static Stream<Arguments> destinations() {
     return Stream.of(
-        Arguments.of(false, false, "destination", MessageOperation.RECEIVE, "destination"),
-        Arguments.of(true, true, null, MessageOperation.PROCESS, "(temporary)"));
+        argumentSet(
+            "create operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.CREATE,
+            "create"),
+        argumentSet(
+            "regular destination",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.RECEIVE,
+            "poll"),
+        argumentSet(
+            "temporary anonymous destination",
+            true,
+            true,
+            "generated-destination",
+            MessagingOperationType.PROCESS,
+            "process"),
+        argumentSet(
+            "settle operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.SETTLE,
+            "settle"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("spanKeys")
+  void shouldReturnSpanKey(MessagingOperationType operationType, SpanKey spanKey) {
+    MessagingAttributesExtractor<Map<String, String>, String> underTest =
+        new MessagingAttributesExtractor<>(
+            TestGetter.INSTANCE,
+            operationType,
+            operationType.defaultOperationName(),
+            true,
+            new ArrayList<>());
+
+    assertThat(underTest.internalGetSpanKey()).isSameAs(spanKey);
+  }
+
+  static Stream<Arguments> spanKeys() {
+    return Stream.of(
+        argumentSet("create", MessagingOperationType.CREATE, SpanKey.PRODUCER_CREATE),
+        argumentSet("send", MessagingOperationType.SEND, SpanKey.PRODUCER),
+        argumentSet("receive", MessagingOperationType.RECEIVE, SpanKey.CONSUMER_RECEIVE),
+        argumentSet("process", MessagingOperationType.PROCESS, SpanKey.CONSUMER_PROCESS),
+        argumentSet("settle", MessagingOperationType.SETTLE, SpanKey.CONSUMER_SETTLE));
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldSupportDeprecatedMessageOperation() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.create(TestGetter.INSTANCE, MessageOperation.PUBLISH);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), singletonMap("anonymousDestination", "y"));
+
+    assertThat(attributes.build())
+        .containsOnly(
+            entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
+  }
+
+  @Test
+  void shouldExtractOperationNameWithoutOperationType() {
+    MessagingOperationType operationType = null;
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName("ack")
+            .build();
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), emptyMap());
+
+    Attributes expected =
+        emitStableMessagingSemconv()
+            ? Attributes.of(MESSAGING_OPERATION_NAME, "ack")
+            : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldRequireOperationNameForStableSemconv() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, null)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("operationName");
+  }
+
+  @Test
+  void shouldExtractErrorTypeFromResponse() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.createForOperationType(
+            TestGetter.INSTANCE, MessagingOperationType.RECEIVE);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onEnd(attributes, Context.root(), emptyMap(), "failure", null);
+
+    Attributes expected =
+        emitStableMessagingSemconv() ? Attributes.of(ERROR_TYPE, "failure") : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
   }
 
   @Test
@@ -118,20 +257,24 @@ class MessagingAttributesExtractorTest {
     // given
     AttributesExtractor<Map<String, String>, String> underTest =
         MessagingAttributesExtractor.create(TestGetter.INSTANCE, null);
+    AttributesExtractor<Map<String, String>, String> builtUnderTest =
+        MessagingAttributesExtractor.builder(TestGetter.INSTANCE, null).build();
 
     Context context = Context.root();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, context, emptyMap());
+    AttributesBuilder builtStartAttributes = Attributes.builder();
+    builtUnderTest.onStart(builtStartAttributes, context, emptyMap());
 
     AttributesBuilder endAttributes = Attributes.builder();
     underTest.onEnd(endAttributes, context, emptyMap(), null, null);
 
     // then
-    assertThat(startAttributes.build().isEmpty()).isTrue();
-
-    assertThat(endAttributes.build().isEmpty()).isTrue();
+    assertThat(startAttributes.build()).isEmpty();
+    assertThat(builtStartAttributes.build()).isEmpty();
+    assertThat(endAttributes.build()).isEmpty();
   }
 
   enum TestGetter implements MessagingAttributesGetter<Map<String, String>, String> {
@@ -184,7 +327,7 @@ class MessagingAttributesExtractorTest {
 
     @Override
     public String getMessageId(Map<String, String> request, String response) {
-      return response;
+      return request.get("messageId");
     }
 
     @Nullable
@@ -198,6 +341,11 @@ class MessagingAttributesExtractorTest {
     public Long getBatchMessageCount(Map<String, String> request, @Nullable String response) {
       String payloadSize = request.get("batchMessageCount");
       return payloadSize == null ? null : Long.valueOf(payloadSize);
+    }
+
+    @Override
+    public String getErrorType(Map<String, String> request, String response, Throwable error) {
+      return "failure".equals(response) ? response : null;
     }
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -210,6 +210,17 @@ class MessagingAttributesExtractorTest {
             entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldRejectOperationNameForDeprecatedMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builder(TestGetter.INSTANCE, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
+  }
+
   @Test
   void shouldExtractOperationNameWithoutOperationType() {
     MessagingOperationType operationType = null;

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingConsumerMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void collectsMetricsAndCountsBatchOnce() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_CONSUMER_GROUP_NAME, "group")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "subscription")
+            .build();
+    Attributes responseAttributes =
+        Attributes.builder()
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 3)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 2 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
+
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of receive operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Measures the number of received messages.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "receive")))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.consumed.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Number of messages that were delivered to the application.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription")))));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void failedReceiveWithoutBatchCountCountsNoConsumedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Attributes responseAttributes =
+        Attributes.of(ERROR_TYPE, IllegalStateException.class.getName());
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasLongSumSatisfying(
+                          sum -> sum.hasPointsSatisfying(point -> point.hasValue(1))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void consumedMessagesOnlyCountsFailedDelivery() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getConsumedMessages().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(
+        context, Attributes.of(ERROR_TYPE, IllegalStateException.class.getName()), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (!emitStableMessagingSemconv()) {
+      assertThat(metrics).isEmpty();
+      return;
+    }
+    assertThat(metrics)
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.client.consumed.messages")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonReceiveOperations")
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void selectsStableMetricsByOperationType(String operationType, boolean recordsClientDuration) {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() && recordsClientDuration ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.consumed.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.duration"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.messages"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountReceivedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static Stream<Arguments> nonReceiveOperations() {
+    return Stream.of(
+        argumentSet("process", "process", false), argumentSet("settle", "settle", true));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingConsumerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "receive"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .hasSize(2)
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+class MessagingMetricsAdviceTest {
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void filtersHighCardinalityDestinationNames() {
+    Attributes lowCardinality = Attributes.of(MESSAGING_DESTINATION_NAME, "orders");
+    assertThat(MessagingMetricsAdvice.filterAttributes(lowCardinality)).isSameAs(lowCardinality);
+
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "orders-42")
+                    .put(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}")
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}"));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "tmp-42")
+                    .put(MESSAGING_DESTINATION_TEMPORARY, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPORARY, true));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "generated-42")
+                    .put(MESSAGING_DESTINATION_ANONYMOUS, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_ANONYMOUS, true));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void emitsProcessDurationAccordingToConfiguration() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProcessMetrics.get().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+
+    Context root = Context.root();
+    Context context = listener.onStart(root, attributes, nanos(100));
+    Attributes endAttributes =
+        Attributes.builder()
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+    listener.onEnd(context, endAttributes, nanos(350));
+
+    if (!emitStableMessagingSemconv()) {
+      assertThat(context).isSameAs(root);
+      assertThat(metricReader.collectAllMetrics()).isEmpty();
+      return;
+    }
+
+    assertThat(metricReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.process.duration")
+                    .hasUnit("s")
+                    .hasDescription("Duration of processing operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSum(0.25)
+                                        .hasBucketBoundaries(DURATION_BUCKETS)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
@@ -5,26 +5,30 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.TraceFlags;
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 class MessagingProducerMetricsTest {
@@ -32,89 +36,234 @@ class MessagingProducerMetricsTest {
   private static final double[] DURATION_BUCKETS =
       MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
   void collectsMetrics() {
-    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider meterProvider =
         SdkMeterProvider.builder().registerMetricReader(metricReader).build();
-
-    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
     Attributes requestAttributes =
         Attributes.builder()
             .put(MESSAGING_SYSTEM, "pulsar")
-            .put(MESSAGING_DESTINATION_NAME, "persistent://public/default/topic")
-            .put(MESSAGING_OPERATION, "publish")
-            .put(SERVER_PORT, 6650)
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
             .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 6650)
             .build();
-
     Attributes responseAttributes =
         Attributes.builder()
-            .put(MESSAGING_MESSAGE_ID, "1:1:0:0")
             .put(MESSAGING_DESTINATION_PARTITION_ID, "1")
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 2)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
             .build();
 
-    Context parent =
-        Context.root()
-            .with(
-                Span.wrap(
-                    SpanContext.create(
-                        "ff01020304050600ff0a0b0c0d0e0f00",
-                        "090a0b0c0d0e0f00",
-                        TraceFlags.getSampled(),
-                        TraceState.getDefault())));
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(250));
 
-    Context context1 = listener.onStart(parent, requestAttributes, nanos(100));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 1 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.publish.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of publish operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_OPERATION, "publish"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null),
+                                              equalTo(SERVER_PORT, 6650),
+                                              equalTo(SERVER_ADDRESS, "localhost")))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "send"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.sent.messages")
+                      .hasUnit("{message}")
+                      .hasDescription(
+                          "Number of messages producer attempted to send to the broker.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(2)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))));
+    }
+  }
 
-    Context context2 = listener.onStart(Context.root(), requestAttributes, nanos(150));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void createDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "create" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
-    listener.onEnd(context1, responseAttributes, nanos(250));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.sent.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.publish.duration"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasUnit("s")
-                    .hasDescription("Measures the duration of publish operation.")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(0.15 /* seconds */)
-                                        .hasAttributesSatisfying(
-                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
-                                            equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
-                                            equalTo(
-                                                MESSAGING_DESTINATION_NAME,
-                                                "persistent://public/default/topic"),
-                                            equalTo(SERVER_PORT, 6650),
-                                            equalTo(SERVER_ADDRESS, "localhost"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00"))
-                                        .hasBucketBoundaries(DURATION_BUCKETS))));
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"));
+  }
 
-    listener.onEnd(context2, responseAttributes, nanos(300));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.publish.duration"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "publish"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point -> point.hasSum(0.3 /* seconds */))));
+        .satisfiesExactly(metric -> assertThat(metric).hasName("messaging.publish.duration"));
   }
 
   private static long nanos(int millis) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingSpanKindExtractorTest {
+
+  @ParameterizedTest
+  @MethodSource("spanKinds")
+  void extractsSpanKind(
+      MessagingOperationType operationType,
+      boolean isSpanContextPropagated,
+      SpanKind oldKind,
+      SpanKind kind) {
+    SpanKind actualKind =
+        MessagingSpanKindExtractor.create(operationType, isSpanContextPropagated)
+            .extract(new Object());
+
+    assertThat(actualKind).isEqualTo(emitStableMessagingSemconv() ? kind : oldKind);
+  }
+
+  @Test
+  void sendDefaultsToPropagatedSpanContext() {
+    SpanKind spanKind =
+        MessagingSpanKindExtractor.create(MessagingOperationType.SEND).extract(new Object());
+
+    assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
+  }
+
+  @Test
+  void messageOperationUsesLegacySpanKind() {
+    SpanKind receiveKind =
+        MessagingSpanKindExtractor.create(MessageOperation.RECEIVE).extract(new Object());
+
+    assertThat(receiveKind).isEqualTo(SpanKind.CONSUMER);
+  }
+
+  private static Stream<Arguments> spanKinds() {
+    return Stream.of(
+        argumentSet(
+            "create", MessagingOperationType.CREATE, true, SpanKind.PRODUCER, SpanKind.PRODUCER),
+        argumentSet(
+            "send with propagated context",
+            MessagingOperationType.SEND,
+            true,
+            SpanKind.PRODUCER,
+            SpanKind.PRODUCER),
+        argumentSet(
+            "send without propagated context",
+            MessagingOperationType.SEND,
+            false,
+            SpanKind.PRODUCER,
+            SpanKind.CLIENT),
+        argumentSet(
+            "receive", MessagingOperationType.RECEIVE, true, SpanKind.CONSUMER, SpanKind.CLIENT),
+        argumentSet(
+            "process", MessagingOperationType.PROCESS, true, SpanKind.CONSUMER, SpanKind.CONSUMER),
+        argumentSet(
+            "settle", MessagingOperationType.SETTLE, true, SpanKind.CLIENT, SpanKind.CLIENT));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,36 +27,118 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
+  @Test
+  void shouldKeepLegacyNameForMessageOperation() {
+    Message message = new Message();
+    when(getter.isTemporaryDestination(message)).thenReturn(false);
+    when(getter.getDestination(message)).thenReturn("destination");
+
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
+
+    assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
   @ParameterizedTest
   @MethodSource("spanNameParams")
   void shouldExtractSpanName(
       boolean isTemporaryQueue,
+      boolean isAnonymousQueue,
       String destinationName,
-      MessageOperation operation,
-      String expectedSpanName) {
+      String destinationTemplate,
+      MessagingOperationType operationType,
+      String operationName,
+      String oldSpanName,
+      String spanName) {
     // given
     Message message = new Message();
 
-    if (isTemporaryQueue) {
-      when(getter.isTemporaryDestination(message)).thenReturn(true);
+    if (emitStableMessagingSemconv()) {
+      when(getter.getDestinationTemplate(message)).thenReturn(destinationTemplate);
+      if (destinationTemplate == null) {
+        when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+        if (!isTemporaryQueue) {
+          when(getter.isAnonymousDestination(message)).thenReturn(isAnonymousQueue);
+          if (!isAnonymousQueue) {
+            when(getter.getDestination(message)).thenReturn(destinationName);
+          }
+        }
+      }
     } else {
-      when(getter.getDestination(message)).thenReturn(destinationName);
+      when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+      if (!isTemporaryQueue) {
+        when(getter.getDestination(message)).thenReturn(destinationName);
+      }
     }
 
-    SpanNameExtractor<Message> underTest = MessagingSpanNameExtractor.create(getter, operation);
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.builder(getter, operationType)
+            .setOperationName(operationName)
+            .build();
 
     // when
-    String spanName = underTest.extract(message);
+    String actualSpanName = underTest.extract(message);
 
     // then
-    assertThat(spanName).isEqualTo(expectedSpanName);
+    assertThat(actualSpanName).isEqualTo(emitStableMessagingSemconv() ? spanName : oldSpanName);
+    if (emitStableMessagingSemconv() && destinationTemplate != null) {
+      verify(getter, never()).isTemporaryDestination(message);
+      verify(getter, never()).isAnonymousDestination(message);
+    }
   }
 
   static Stream<Arguments> spanNameParams() {
     return Stream.of(
-        Arguments.of(false, "destination", MessageOperation.PUBLISH, "destination publish"),
-        Arguments.of(true, null, MessageOperation.PROCESS, "(temporary) process"),
-        Arguments.of(false, null, MessageOperation.RECEIVE, "unknown receive"));
+        argumentSet(
+            "operation name override",
+            false,
+            false,
+            "destination",
+            null,
+            MessagingOperationType.SEND,
+            "send",
+            "destination publish",
+            "send destination"),
+        argumentSet(
+            "temporary destination",
+            true,
+            false,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "(temporary) process",
+            "process generated-{id}"),
+        argumentSet(
+            "missing destination",
+            false,
+            false,
+            null,
+            null,
+            MessagingOperationType.RECEIVE,
+            "receive",
+            "unknown receive",
+            "receive"),
+        argumentSet(
+            "destination template",
+            false,
+            false,
+            "customer-42",
+            "customer-{id}",
+            MessagingOperationType.SEND,
+            "send",
+            "customer-42 publish",
+            "send customer-{id}"),
+        argumentSet(
+            "anonymous destination",
+            false,
+            true,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "generated process",
+            "process generated-{id}"));
   }
 
   static class Message {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -37,6 +38,16 @@ class MessagingSpanNameExtractorTest {
         MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
 
     assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
+  @Test
+  void shouldRejectOperationNameForMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingSpanNameExtractor.builder(getter, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
   }
 
   @ParameterizedTest

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessContextCustomizerTest {
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  private static final ContextCustomizer<Map<String, String>> underTest =
+      MessagingProcessContextCustomizer.create(W3CTraceContextPropagator.getInstance(), getter);
+
+  @Test
+  void preservesAmbientParent() {
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+    Span ambientSpan = Span.fromContext(ambient);
+
+    Context result = underTest.onStart(ambient, carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result)).isSameAs(ambientSpan);
+  }
+
+  @Test
+  void preservesPropagatedFieldsWithAmbientParent() {
+    ContextKey<String> propagatedKey = ContextKey.named("propagated");
+    ContextCustomizer<String> customizer =
+        MessagingProcessContextCustomizer.create(
+            (parent, request) -> parent.with(propagatedKey, request));
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+
+    Context result = customizer.onStart(ambient, "value", Attributes.empty());
+
+    assertThat(result.get(propagatedKey)).isEqualTo("value");
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(Span.fromContext(ambient).getSpanContext());
+  }
+
+  @Test
+  void usesProducerWhenAmbientParentIsMissing() {
+    Context result = underTest.onStart(Context.root(), carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(spanContext("22222222222222222222222222222222", "2222222222222222"));
+  }
+
+  private static Map<String, String> carrier() {
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    return Collections.unmodifiableMap(carrier);
+  }
+
+  private static Context context(String traceId, String spanId) {
+    return Context.root().with(Span.wrap(spanContext(traceId, spanId)));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingProcessInstrumenterFactoryTest {
+
+  private static final SpanContext ambientParent =
+      spanContext("11111111111111111111111111111111", "1111111111111111");
+  private static final SpanContext producer =
+      spanContext("22222222222222222222222222222222", "2222222222222222");
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void stableUsesProducerAsParentWithoutLink() {
+    assumeTrue(emitStableMessagingSemconv());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root(), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @Test
+  void stableDoesNotLinkAmbientParent() {
+    assumeTrue(emitStableMessagingSemconv());
+    SpanContext localProducer =
+        SpanContext.create(
+            producer.getTraceId(),
+            producer.getSpanId(),
+            producer.getTraceFlags(),
+            producer.getTraceState());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(localProducer)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("receiveInstrumentationSettings")
+  void usesExpectedParentAndLink(boolean receiveInstrumentationEnabled, boolean producerIsParent) {
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            receiveInstrumentationEnabled);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(ambientParent)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    SpanContext expectedParent = producerIsParent ? producer : ambientParent;
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      span.hasName("process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasTraceId(expectedParent.getTraceId())
+                          .hasParentSpanId(expectedParent.getSpanId());
+                      if (producerIsParent) {
+                        span.hasLinks();
+                      } else {
+                        span.hasLinks(LinkData.create(producer));
+                      }
+                    }));
+  }
+
+  private static Stream<Arguments> receiveInstrumentationSettings() {
+    boolean stable = emitStableMessagingSemconv();
+    String semconv = stable ? "stable" : "old";
+    return Stream.of(
+        argumentSet(semconv + " receive disabled", false, !stable),
+        argumentSet(semconv + " receive enabled", true, false));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -169,11 +169,14 @@ public final class SemconvStability {
     return mode.version() >= 1;
   }
 
-  public static boolean emitOldMessagingSemconv() {
+  public static boolean emitOldMessagingSemconv() { // to be removed in 3.0
     return emitOldMessagingSemconv;
   }
 
-  public static boolean emitStableMessagingSemconv() {
+  // Returns whether the selected v1 experimental messaging semantic conventions should be emitted.
+  // The method name follows the existing pattern; it does not indicate that the messaging
+  // conventions are stable.
+  public static boolean emitStableMessagingSemconv() { // to be removed in 3.0
     return emitStableMessagingSemconv;
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
@@ -43,12 +43,16 @@ public final class SpanKey {
   private static final ContextKey<Span> DB_CLIENT_KEY =
       ContextKey.named("opentelemetry-traces-span-key-db-client");
 
+  private static final ContextKey<Span> PRODUCER_CREATE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-producer-create");
   private static final ContextKey<Span> PRODUCER_KEY =
       ContextKey.named("opentelemetry-traces-span-key-producer");
   private static final ContextKey<Span> CONSUMER_RECEIVE_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-receive");
   private static final ContextKey<Span> CONSUMER_PROCESS_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-process");
+  private static final ContextKey<Span> CONSUMER_SETTLE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-consumer-settle");
 
   /* Span keys */
 
@@ -66,9 +70,11 @@ public final class SpanKey {
   public static final SpanKey RPC_CLIENT = new SpanKey(RPC_CLIENT_KEY);
   public static final SpanKey DB_CLIENT = new SpanKey(DB_CLIENT_KEY);
 
+  public static final SpanKey PRODUCER_CREATE = new SpanKey(PRODUCER_CREATE_KEY);
   public static final SpanKey PRODUCER = new SpanKey(PRODUCER_KEY);
   public static final SpanKey CONSUMER_RECEIVE = new SpanKey(CONSUMER_RECEIVE_KEY);
   public static final SpanKey CONSUMER_PROCESS = new SpanKey(CONSUMER_PROCESS_KEY);
+  public static final SpanKey CONSUMER_SETTLE = new SpanKey(CONSUMER_SETTLE_KEY);
 
   private final ContextKey<Span> key;
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -9,6 +9,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.common.ComponentLoader;
@@ -22,6 +23,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class SemconvStabilityTest {
@@ -377,6 +380,69 @@ class SemconvStabilityTest {
     assertThat(rpc).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(servicePeer).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(messaging).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
+  }
+
+  @ParameterizedTest
+  @MethodSource("messagingSelectionModes")
+  void messagingSelectionMatrix(
+      boolean v3Preview, Set<String> stableOptIn, Set<String> preview, SemconvMode expectedMode) {
+    SemconvMode messaging =
+        new SemconvSelectionResolver(general(), v3Preview, stableOptIn, preview).messaging();
+
+    assertThat(messaging).isEqualTo(expectedMode);
+  }
+
+  private static List<Arguments> messagingSelectionModes() {
+    return asList(
+        argumentSet("legacy default", false, noStableOptIn(), noPreview(), SemconvMode.V0_STABLE),
+        argumentSet(
+            "legacy opt-in property",
+            false,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "preview property",
+            false,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "legacy opt-in dual emit",
+            false,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "preview dual emit",
+            false,
+            noStableOptIn(),
+            preview("messaging/dup"),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "v3 activation remains staged",
+            true,
+            noStableOptIn(),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in property",
+            true,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in dual emit",
+            true,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 with explicit preview",
+            true,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL));
   }
 
   @SafeVarargs

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
@@ -53,6 +53,28 @@ tasks {
     include("**/KafkaClientSuppressReceiveSpansTest.*")
   }
 
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientDefaultTest.testKafkaProducerAndConsumerSpan")
+      includeTestsMatching("KafkaClientDefaultTest.testAbandonedIteratorDoesNotParentNextProcessSpan")
+      includeTestsMatching("KafkaClientDefaultTest.testReceiveDoesNotParentProcessSpan")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+  }
+
+  val testMessagingPreviewDup = register<Test>("testMessagingPreviewDup") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientDefaultTest.testReceiveDoesNotParentProcessSpan")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging/dup")
+  }
+
   val testExperimental = register<Test>("testExperimental") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -67,7 +89,34 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
-  val testStableSemconv = register<Test>("testStableSemconv") {
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaClientPropagationDisabledTest")
+      excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    // kafka metrics are disabled by default with v3-preview enabled
+    jvmArgs("-Dotel.instrumentation.kafka-clients-metrics.enabled=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    include("**/KafkaClientSuppressReceiveSpansTest.*")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
@@ -75,15 +124,15 @@ tasks {
       excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     // kafka metrics are disabled by default with v3-preview enabled
     jvmArgs("-Dotel.instrumentation.kafka-clients-metrics.enabled=true")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testV3Preview, testV3PreviewReceiveSpansDisabled, testBothSemconv)
   }
 
   test {
@@ -95,7 +144,13 @@ tasks {
   }
 
   check {
-    dependsOn(testPropagationDisabled, testReceiveSpansDisabled, testExperimental)
+    dependsOn(
+      testPropagationDisabled,
+      testReceiveSpansDisabled,
+      testMessagingPreview,
+      testMessagingPreviewDup,
+      testExperimental,
+    )
   }
 }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.consumerReceiveInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -67,15 +68,15 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      Context parentContext = currentContext();
+      Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(currentContext());
       KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
 
       // disable process tracing and store the receive span for each individual record too
       boolean previousValue = KafkaClientsConsumerProcessTracing.setWrappingEnabled(false);
       try {
-        Context context = null;
+        Context receiveContext = null;
         if (consumerReceiveInstrumenter().shouldStart(parentContext, request)) {
-          context =
+          receiveContext =
               InstrumenterUtil.startAndEnd(
                   consumerReceiveInstrumenter(),
                   parentContext,
@@ -86,16 +87,14 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
                   timer.now());
         }
 
-        // we're storing the context of the receive span so that process spans can use it as
-        // parent context even though the span has ended
-        // this is the suggested behavior according to the spec batch receive scenario:
-        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#batch-receiving
+        Context processParentContext =
+            emitStableMessagingSemconv() ? parentContext : receiveContext;
         // we're attaching the consumer to the records to be able to retrieve things like consumer
         // group or clientId later
-        KafkaConsumerContextUtil.set(records, context, consumer);
+        KafkaConsumerContextUtil.set(records, processParentContext, consumer);
 
         for (ConsumerRecord<?, ?> record : records) {
-          KafkaConsumerContextUtil.set(record, context, consumer);
+          KafkaConsumerContextUtil.set(record, processParentContext, consumer);
         }
       } finally {
         KafkaClientsConsumerProcessTracing.setWrappingEnabled(previousValue);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaProducerInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.PRODUCER_PROPAGATION_ENABLED;
+import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED;
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.producerInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -79,8 +80,8 @@ class KafkaProducerInstrumentation implements TypeInstrumentation {
       }
 
       public ProducerRecord<?, ?> propagateContext(
-          ApiVersions apiVersions, ProducerRecord<?, ?> record) {
-        if (PRODUCER_PROPAGATION_ENABLED && KafkaPropagation.shouldPropagate(apiVersions)) {
+          ProducerRecord<?, ?> record, boolean shouldPropagate) {
+        if (shouldPropagate) {
           return KafkaPropagation.propagateContext(context, record);
         }
         return record;
@@ -112,13 +113,20 @@ class KafkaProducerInstrumentation implements TypeInstrumentation {
       String bootstrapServers =
           KafkaUtil.extractBootstrapServers(
               producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+      boolean shouldPropagate =
+          PRODUCER_PROPAGATION_ENABLED && KafkaPropagation.shouldPropagate(apiVersions);
       KafkaProducerRequest request =
-          KafkaProducerRequest.create(record, clientId, bootstrapServers);
+          KafkaProducerRequest.create(
+              record,
+              clientId,
+              bootstrapServers,
+              PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED
+                  && KafkaPropagation.shouldPropagate(apiVersions));
       AdviceScope adviceScope = AdviceScope.start(request);
       if (adviceScope == null) {
         return new Object[] {null, record, callback};
       }
-      record = adviceScope.propagateContext(apiVersions, record);
+      record = adviceScope.propagateContext(record, shouldPropagate);
       callback = adviceScope.wrapCallback(callback);
       return new Object[] {adviceScope, record, callback};
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -6,11 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProducerRequest;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaPropagation;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -22,20 +24,30 @@ public class KafkaSingletons {
       DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
           .get("producer_propagation")
           .getBoolean("enabled", true);
+  public static final boolean PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED =
+      PRODUCER_PROPAGATION_ENABLED
+          && KafkaPropagation.propagatesSpanContext(
+              GlobalOpenTelemetry.getPropagators().getTextMapPropagator());
 
   private static final Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter;
   private static final Instrumenter<KafkaReceiveRequest, Void> consumerReceiveInstrumenter;
   private static final Instrumenter<KafkaProcessRequest, Void> consumerProcessInstrumenter;
 
   static {
+    DeclarativeConfigProperties commonConfig =
+        DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "common");
+    Boolean messagingReceiveInstrumentationEnabled =
+        commonConfig.get("messaging").get("receive_telemetry/development").getBoolean("enabled");
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setCaptureExperimentalSpanAttributes(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
-                    .getBoolean("experimental_span_attributes/development", false))
-            .setMessagingReceiveTelemetryEnabled(
-                ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
+                    .getBoolean("experimental_span_attributes/development", false));
+    if (messagingReceiveInstrumentationEnabled != null) {
+      instrumenterFactory.setMessagingReceiveTelemetryEnabled(
+          messagingReceiveInstrumentationEnabled);
+    }
     producerInstrumenter = instrumenterFactory.createProducerInstrumenter();
     consumerReceiveInstrumenter = instrumenterFactory.createConsumerReceiveInstrumenter();
     consumerProcessInstrumenter = instrumenterFactory.createConsumerProcessInstrumenter();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -5,12 +5,16 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientPropagationBaseTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -18,6 +22,7 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,13 +81,53 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           });
     }
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes("10", greeting, testHeaders));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes("10", greeting, testHeaders, false)),
+                  span -> span.hasName("processing").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, testHeaders)),
@@ -95,18 +140,97 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             processAttributes("10", greeting, testHeaders, false)),
                 span -> span.hasName("processing").hasParent(trace.getSpan(1))));
+  }
+
+  @Test
+  void testReceiveDoesNotParentProcessSpan() throws Exception {
+    assumeTrue(emitStableMessagingSemconv());
+    producer.send(new ProducerRecord<>(SHARED_TOPIC, 10, "Hello Kafka!")).get(5, SECONDS);
+
+    awaitUntilConsumerIsReady();
+    ConsumerRecords<?, ?> records = poll(Duration.ofSeconds(5));
+    assertThat(records.count()).isEqualTo(1);
+
+    for (ConsumerRecord<?, ?> ignored : records) {
+      testing.runWithSpan("processing", () -> {});
+    }
+
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> {
+                  span.hasName("send " + SHARED_TOPIC).hasKind(SpanKind.PRODUCER).hasNoParent();
+                  producerSpan.set(span.actual());
+                },
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0)),
+                span -> span.hasName("processing").hasParent(trace.getSpan(1))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + SHARED_TOPIC).hasKind(SpanKind.CLIENT).hasNoParent()));
+  }
+
+  @Test
+  void testAbandonedIteratorDoesNotParentNextProcessSpan() throws Exception {
+    assumeTrue(emitStableMessagingSemconv());
+    producer.send(new ProducerRecord<>(SHARED_TOPIC, "first")).get(5, SECONDS);
+    awaitUntilConsumerIsReady();
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          Iterator<? extends ConsumerRecord<?, ?>> firstIterator =
+              poll(Duration.ofSeconds(5)).iterator();
+          assertThat(firstIterator.hasNext()).isTrue();
+          firstIterator.next();
+
+          try (Scope ignored = Context.root().makeCurrent()) {
+            producer.send(new ProducerRecord<>(SHARED_TOPIC, "second")).get(5, SECONDS);
+          }
+          Iterator<? extends ConsumerRecord<?, ?>> secondIterator =
+              poll(Duration.ofSeconds(5)).iterator();
+          assertThat(secondIterator.hasNext()).isTrue();
+          secondIterator.next();
+          assertThat(secondIterator.hasNext()).isFalse();
+          assertThat(firstIterator.hasNext()).isFalse();
+        });
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("send " + SHARED_TOPIC).hasNoParent()),
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("parent").hasNoParent(),
+                span -> span.hasName("poll " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("process " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("poll " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("process " + SHARED_TOPIC).hasParent(trace.getSpan(0))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("send " + SHARED_TOPIC).hasNoParent()));
   }
 
   @DisplayName("test pass through tombstone")
@@ -124,12 +248,44 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     }
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(sendAttributes(null, null, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(null, null, false, false))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(sendAttributes(null, null, false)));
@@ -138,12 +294,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
@@ -183,12 +345,44 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     }
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(null, greeting, false, false))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false)));
@@ -197,12 +391,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
@@ -247,13 +447,51 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           });
     }
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes("10", greeting, false, false)),
+                  span -> span.hasName("processing").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false)),
@@ -266,12 +504,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,12 +68,12 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -104,12 +105,12 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(sendAttributes(null, null, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -139,15 +140,21 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             processAttributes(null, greeting, false, false))));
+  }
+
+  private static String spanName(String oldOperation, String operationName) {
+    return emitStableMessagingSemconv()
+        ? operationName + " " + SHARED_TOPIC
+        : SHARED_TOPIC + " " + oldOperation;
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testL
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
@@ -23,6 +24,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -74,7 +77,7 @@ public abstract class KafkaClientBaseTest {
   @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected static final String SHARED_TOPIC = "shared.topic";
-  protected static final AttributeKey<String> MESSAGING_CLIENT_ID =
+  protected static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
       AttributeKey.stringKey("messaging.client_id");
 
   private KafkaContainer kafka;
@@ -181,9 +184,11 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "producer");
     if (emitOldMessagingSemconv()) {
       assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
     }
@@ -215,12 +220,17 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
                 satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
+    addClientIdAssertions(assertions, "consumer");
     // consumer group is not available in version 0.11
     if (testLatestDeps()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(
+          equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null));
+      assertions.add(
+          equalTo(MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null));
     }
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
@@ -236,9 +246,11 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "consumer");
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
@@ -251,7 +263,10 @@ public abstract class KafkaClientBaseTest {
     }
     // consumer group is not available in version 0.11
     if (testLatestDeps()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(
+          equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null));
+      assertions.add(
+          equalTo(MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null));
     }
     if (messageKey != null) {
       assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
@@ -270,5 +285,16 @@ public abstract class KafkaClientBaseTest {
       assertions.add(equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2"));
     }
     return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
@@ -34,8 +34,16 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testExceptionSignalLogs)
+    dependsOn(testExceptionSignalLogs, testV3Preview)
   }
 }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -34,6 +34,7 @@ public final class KafkaTelemetryBuilder {
   private boolean captureExperimentalSpanAttributes = false;
   private boolean propagationEnabled = true;
   private boolean messagingReceiveInstrumentationEnabled = false;
+  private boolean messagingReceiveInstrumentationConfigured = false;
 
   KafkaTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = requireNonNull(openTelemetry);
@@ -106,6 +107,7 @@ public final class KafkaTelemetryBuilder {
   public KafkaTelemetryBuilder setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    this.messagingReceiveInstrumentationConfigured = true;
     return this;
   }
 
@@ -113,8 +115,11 @@ public final class KafkaTelemetryBuilder {
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
             .setCapturedHeaders(capturedHeaders)
-            .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
-            .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
+            .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes);
+    if (messagingReceiveInstrumentationConfigured) {
+      instrumenterFactory.setMessagingReceiveTelemetryEnabled(
+          messagingReceiveInstrumentationEnabled);
+    }
 
     return new KafkaTelemetry(
         openTelemetry,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyMap;
 
 import io.opentelemetry.context.Context;
@@ -12,6 +13,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaUtil;
@@ -75,11 +77,11 @@ public class KafkaConsumerTelemetry {
     if (records.isEmpty()) {
       return null;
     }
-    Context parentContext = Context.current();
+    Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumerGroup, clientId);
-    Context context = null;
+    Context receiveContext = null;
     if (consumerReceiveInstrumenter.shouldStart(parentContext, request)) {
-      context =
+      receiveContext =
           InstrumenterUtil.startAndEnd(
               consumerReceiveInstrumenter,
               parentContext,
@@ -90,16 +92,12 @@ public class KafkaConsumerTelemetry {
               timer.now());
     }
 
-    // we're returning the context of the receive span so that process spans can use it as
-    // parent context even though the span has ended
-    // this is the suggested behavior according to the spec batch receive scenario:
-    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#batch-receiving
-    return context;
+    return emitStableMessagingSemconv() ? parentContext : receiveContext;
   }
 
   public <K, V> void buildAndFinishErrorSpan(
       Consumer<K, V> consumer, Timer timer, Throwable error) {
-    Context parentContext = Context.current();
+    Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     ConsumerRecords<K, V> records = new ConsumerRecords<>(emptyMap());
     KafkaReceiveRequest request =
         KafkaReceiveRequest.create(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaProducerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaProducerTelemetry.java
@@ -29,6 +29,7 @@ public class KafkaProducerTelemetry {
   private final TextMapPropagator propagator;
   private final Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter;
   private final boolean producerPropagationEnabled;
+  private final boolean producerSpanContextPropagationEnabled;
 
   public KafkaProducerTelemetry(
       TextMapPropagator propagator,
@@ -37,6 +38,8 @@ public class KafkaProducerTelemetry {
     this.propagator = propagator;
     this.producerInstrumenter = producerInstrumenter;
     this.producerPropagationEnabled = producerPropagationEnabled;
+    this.producerSpanContextPropagationEnabled =
+        producerPropagationEnabled && KafkaPropagation.propagatesSpanContext(propagator);
   }
 
   /**
@@ -48,7 +51,9 @@ public class KafkaProducerTelemetry {
       ProducerRecord<K, V> record, @Nullable String clientId, @Nullable String bootstrapServers) {
     Context parentContext = Context.current();
 
-    KafkaProducerRequest request = KafkaProducerRequest.create(record, clientId, bootstrapServers);
+    KafkaProducerRequest request =
+        KafkaProducerRequest.create(
+            record, clientId, bootstrapServers, producerSpanContextPropagationEnabled);
     if (!producerInstrumenter.shouldStart(parentContext, request)) {
       return record;
     }
@@ -79,7 +84,9 @@ public class KafkaProducerTelemetry {
       String bootstrapServers) {
     Context parentContext = Context.current();
 
-    KafkaProducerRequest request = KafkaProducerRequest.create(record, producer, bootstrapServers);
+    KafkaProducerRequest request =
+        KafkaProducerRequest.create(
+            record, producer, bootstrapServers, producerSpanContextPropagationEnabled);
     if (!producerInstrumenter.shouldStart(parentContext, request)) {
       return sendFn.apply(record, callback);
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -32,6 +38,7 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -112,6 +119,53 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
 
   void assertTraces() {
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanName("parent", "poll " + SHARED_TOPIC, "producer callback"),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            publishAttributes(captureExperimentalSpanAttributes())),
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks()
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(captureExperimentalSpanAttributes())),
+                span ->
+                    span.hasName("process child")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(2)));
+            SpanContext spanContext = trace.getSpan(1).getSpanContext();
+            producerSpanContext.set(
+                SpanContext.createFromRemoteParent(
+                    spanContext.getTraceId(),
+                    spanContext.getSpanId(),
+                    spanContext.getTraceFlags(),
+                    spanContext.getTraceState()));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpanContext.get()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes())),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("producer callback").hasKind(SpanKind.INTERNAL).hasNoParent()));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName("parent", SHARED_TOPIC + " receive", "producer callback"),
         trace -> {
@@ -159,49 +213,86 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
   }
 
   private static List<AttributeAssertion> publishAttributes(boolean experimental) {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "publish"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-        satisfies(
-            stringKey("messaging.kafka.bootstrap.servers"),
-            val -> {
-              if (experimental) {
-                val.matches("^localhost:\\d+(,localhost:\\d+)*$");
-              }
-            }));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+                satisfies(
+                    stringKey("messaging.kafka.bootstrap.servers"),
+                    val -> {
+                      if (experimental) {
+                        val.matches("^localhost:\\d+(,localhost:\\d+)*$");
+                      }
+                    })));
+    addClientIdAssertions(assertions, "producer");
+    return assertions;
   }
 
   private static List<AttributeAssertion> receiveAttributes() {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "receive"),
-        equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-        equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    addClientIdAssertions(assertions, "consumer");
+    return assertions;
   }
 
   private static List<AttributeAssertion> processAttributes(boolean experimental) {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "process"),
-        equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-        satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-        satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-        equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-        satisfies(
-            longKey("kafka.record.queue_time_ms"),
-            val -> {
-              if (experimental) {
-                val.isNotNegative();
-              }
-            }));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                satisfies(
+                    longKey("kafka.record.queue_time_ms"),
+                    val -> {
+                      if (experimental) {
+                        val.isNotNegative();
+                      }
+                    })));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+      assertions.add(equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"));
+      assertions.add(equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2"));
+    }
+    addClientIdAssertions(assertions, "consumer");
+    return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -6,25 +6,38 @@
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
 
   private static final KafkaTelemetry kafkaTelemetry =
-      KafkaTelemetry.create(testing.getOpenTelemetry());
+      KafkaTelemetry.builder(testing.getOpenTelemetry())
+          .setMessagingReceiveTelemetryEnabled(false)
+          .build();
 
   @Override
   protected KafkaTelemetry kafkaTelemetry() {
@@ -36,7 +49,6 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
     return false;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Override
   void assertTraces() {
     testing.waitAndAssertTraces(
@@ -44,32 +56,21 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))),
+                        .hasAttributesSatisfyingExactly(sendAttributes()),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-                            equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"),
-                            equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2")),
+                        .hasAttributesSatisfyingExactly(processAttributes()),
                 span ->
                     span.hasName("process child")
                         .hasKind(SpanKind.INTERNAL)
@@ -80,5 +81,55 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("producer callback").hasKind(SpanKind.INTERNAL).hasNoParent()));
+  }
+
+  private static List<AttributeAssertion> sendAttributes() {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)));
+    addClientIdAssertion(assertions, "producer");
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> processAttributes() {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"),
+                equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2")));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    addClientIdAssertion(assertions, "consumer");
+    return assertions;
+  }
+
+  private static void addClientIdAssertion(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperPropagationDisabledTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperPropagationDisabledTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.List;
@@ -18,13 +20,56 @@ class WrapperPropagationDisabledTest extends AbstractWrapperTest {
 
   @Override
   void assertTraces(boolean testHeaders, boolean testExperimental) {
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      span.hasName("send " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              sendAttributes(testHeaders, testExperimental)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks()
+                          .hasAttributesSatisfyingExactly(
+                              WrapperTest.receiveAttributes(testHeaders))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasNoParent()
+                          .hasLinks()
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(greeting, testHeaders, testExperimental)),
+                  span ->
+                      span.hasName("process child")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
-                        .hasKind(SpanKind.PRODUCER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(testHeaders, testExperimental)),
@@ -35,7 +80,10 @@ class WrapperPropagationDisabledTest extends AbstractWrapperTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks()

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSendExceptionTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSendExceptionTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -46,7 +47,8 @@ class WrapperSendExceptionTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("test-topic publish")
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "send test-topic" : "test-topic publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -5,28 +5,11 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.AbstractLongAssert;
-import org.assertj.core.api.AbstractStringAssert;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
@@ -43,13 +26,19 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(testHeaders, testExperimental)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -65,47 +54,11 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
   }
 
   static List<AttributeAssertion> sendAttributes(boolean testHeaders, boolean testExperimental) {
-    List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
-    if (testHeaders) {
-      assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
-    }
-    if (testExperimental) {
-      assertions.add(
-          satisfies(
-              stringKey("messaging.kafka.bootstrap.servers"),
-              val -> val.matches("^localhost:\\d+(,localhost:\\d+)*$")));
-    }
-    return assertions;
+    return WrapperTest.sendAttributes(testHeaders, testExperimental);
   }
 
   static List<AttributeAssertion> processAttributes(
       String greeting, boolean testHeaders, boolean testExperimental) {
-    List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
-                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
-    if (testHeaders) {
-      assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
-    }
-    if (testExperimental) {
-      assertions.add(
-          satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
-    }
-    return assertions;
+    return WrapperTest.processAttributes(greeting, testHeaders, testExperimental);
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -9,16 +9,23 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -55,6 +62,52 @@ class WrapperTest extends AbstractWrapperTest {
   @Override
   void assertTraces(boolean testHeaders, boolean testExperimental) {
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(testHeaders, testExperimental)),
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks()
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(greeting, testHeaders, testExperimental)),
+                span ->
+                    span.hasName("process child")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(2)),
+                span ->
+                    span.hasName("producer callback")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0)));
+            SpanContext spanContext = trace.getSpan(1).getSpanContext();
+            producerSpanContext.set(
+                SpanContext.createFromRemoteParent(
+                    spanContext.getTraceId(),
+                    spanContext.getSpanId(),
+                    spanContext.getTraceFlags(),
+                    spanContext.getTraceState()));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpanContext.get()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace -> {
           trace.hasSpansSatisfyingExactly(
@@ -105,10 +158,12 @@ class WrapperTest extends AbstractWrapperTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "producer");
+    addOffsetAssertions(assertions);
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -123,19 +178,23 @@ class WrapperTest extends AbstractWrapperTest {
     return assertions;
   }
 
-  private static List<AttributeAssertion> processAttributes(
+  static List<AttributeAssertion> processAttributes(
       String greeting, boolean testHeaders, boolean testExperimental) {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null)));
+    addClientIdAssertions(assertions, "consumer");
+    addOffsetAssertions(assertions);
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -154,16 +213,40 @@ class WrapperTest extends AbstractWrapperTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
                 equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    addClientIdAssertions(assertions, "consumer");
     if (testHeaders) {
       assertions.add(
           equalTo(
               MessageHeaderUtil.headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
     return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+  }
+
+  private static void addOffsetAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
   }
 
   @Test
@@ -182,14 +265,26 @@ class WrapperTest extends AbstractWrapperTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("unknown receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(emitStableMessagingSemconv() ? "poll" : "unknown receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
                         .hasException(emitExceptionAsSpanEvents() ? error : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(
+                                MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "poll" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "receive" : null),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableMessagingSemconv()
+                                    ? IllegalStateException.class.getName()
+                                    : null),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 0))));
 
     if (emitExceptionAsLogs()) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class KafkaConsumerContextUtilTest {
+
+  @RegisterExtension static final OpenTelemetryExtension testing = OpenTelemetryExtension.create();
+
+  @Test
+  void restoresProcessParentWithoutSuppressionMarker() {
+    assumeTrue(emitStableMessagingSemconv());
+    Span parentSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("parent").startSpan();
+    Span processSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("process").startSpan();
+    try {
+      Context parentContext = Context.root().with(parentSpan);
+      Context processContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(
+              parentContext.with(processSpan), parentContext);
+
+      Context restored = KafkaConsumerContextUtil.withoutLeakedProcessSpan(processContext);
+
+      assertThat(Span.fromContext(restored)).isSameAs(parentSpan);
+      assertThat(Span.fromContext(restored).isRecording()).isTrue();
+    } finally {
+      processSpan.end();
+      parentSpan.end();
+    }
+  }
+
+  @Test
+  void leavesUnrelatedCurrentSpanUntouched() {
+    assumeTrue(emitStableMessagingSemconv());
+    Span parentSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("parent").startSpan();
+    Span processSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("process").startSpan();
+    Span unrelatedSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("unrelated").startSpan();
+    try {
+      Context parentContext = Context.root().with(parentSpan);
+      Context processContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(
+              parentContext.with(processSpan), parentContext);
+      Context unrelatedContext = processContext.with(unrelatedSpan);
+
+      assertThat(KafkaConsumerContextUtil.withoutLeakedProcessSpan(unrelatedContext))
+          .isSameAs(unrelatedContext);
+    } finally {
+      unrelatedSpan.end();
+      processSpan.end();
+      parentSpan.end();
+    }
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaPropagationTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaPropagationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaPropagation;
+import org.junit.jupiter.api.Test;
+
+class KafkaPropagationTest {
+
+  @Test
+  void detectsSpanContextPropagation() {
+    assertThat(KafkaPropagation.propagatesSpanContext(W3CTraceContextPropagator.getInstance()))
+        .isTrue();
+    assertThat(KafkaPropagation.propagatesSpanContext(TextMapPropagator.noop())).isFalse();
+    assertThat(KafkaPropagation.propagatesSpanContext(W3CBaggagePropagator.getInstance()))
+        .isFalse();
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesExtractor.java
@@ -24,6 +24,8 @@ final class KafkaConsumerAttributesExtractor
       AttributeKey.stringKey("messaging.destination.partition.id");
   private static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       AttributeKey.stringKey("messaging.kafka.consumer.group");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
   private static final AttributeKey<String> MESSAGING_KAFKA_MESSAGE_KEY =
       AttributeKey.stringKey("messaging.kafka.message.key");
   private static final AttributeKey<Long> MESSAGING_KAFKA_MESSAGE_OFFSET =
@@ -54,7 +56,12 @@ final class KafkaConsumerAttributesExtractor
       attributes.put(MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true);
     }
 
-    attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    }
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+    }
   }
 
   private static boolean canSerialize(Class<?> keyClass) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -5,7 +5,11 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -17,6 +21,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
  * any time.
  */
 public final class KafkaConsumerContextUtil {
+  private static final ContextKey<Span> processSpanKey =
+      ContextKey.named("opentelemetry-kafka-process-span");
+  private static final ContextKey<Span> processParentSpanKey =
+      ContextKey.named("opentelemetry-kafka-process-parent-span");
   // these fields can be used for multiple instrumentations because of that we don't use a helper
   // class as field type
   private static final VirtualField<ConsumerRecord<?, ?>, Context> recordContextField =
@@ -27,6 +35,26 @@ public final class KafkaConsumerContextUtil {
       VirtualField.find(ConsumerRecords.class, Context.class);
   private static final VirtualField<ConsumerRecords<?, ?>, String[]> recordsConsumerInfoField =
       VirtualField.find(ConsumerRecords.class, String[].class);
+
+  public static Context withoutLeakedProcessSpan(Context context) {
+    if (!emitStableMessagingSemconv()) {
+      return context;
+    }
+
+    Span currentSpan = Span.fromContext(context);
+    if (currentSpan != context.get(processSpanKey)) {
+      return context;
+    }
+
+    Span parentSpan = context.get(processParentSpanKey);
+    return context.with(parentSpan != null ? parentSpan : Span.getInvalid());
+  }
+
+  public static Context withProcessParentSpan(Context context, Context parentContext) {
+    return context
+        .with(processSpanKey, Span.fromContext(context))
+        .with(processParentSpanKey, Span.fromContext(parentContext));
+  }
 
   public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {
     Context receiveContext = recordContextField.get(records);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -8,20 +8,23 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,12 +36,16 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  */
 public final class KafkaInstrumenterFactory {
 
+  private static final String SEND_OPERATION_NAME = "send";
+  private static final String POLL_OPERATION_NAME = "poll";
+
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private List<String> capturedHeaders = emptyList();
   private boolean captureExperimentalSpanAttributes = false;
   private boolean messagingReceiveInstrumentationEnabled = false;
+  private boolean messagingReceiveInstrumentationConfigured = false;
 
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
@@ -68,6 +75,7 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    this.messagingReceiveInstrumentationConfigured = true;
     return this;
   }
 
@@ -79,15 +87,18 @@ public final class KafkaInstrumenterFactory {
       Iterable<AttributesExtractor<KafkaProducerRequest, RecordMetadata>> extractors) {
 
     KafkaProducerAttributesGetter getter = new KafkaProducerAttributesGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     InstrumenterBuilder<KafkaProducerRequest, RecordMetadata> builder =
         Instrumenter.<KafkaProducerRequest, RecordMetadata>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.builder(getter, operationType)
+                    .setOperationName(SEND_OPERATION_NAME)
+                    .build())
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(
+                    getter, operationType, SEND_OPERATION_NAME, capturedHeaders))
             .addAttributesExtractors(extractors)
             .addAttributesExtractor(new KafkaProducerAttributesExtractor())
             .setErrorCauseExtractor(errorCauseExtractor);
@@ -95,7 +106,11 @@ public final class KafkaInstrumenterFactory {
       builder.addAttributesExtractor(new KafkaProducerExperimentalAttributesExtractor());
     }
     setMessagingSendExceptionEventExtractor(builder);
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
+    return builder.buildInstrumenter(
+        request ->
+            emitStableMessagingSemconv() && !request.isSpanContextPropagated()
+                ? SpanKind.CLIENT
+                : SpanKind.PRODUCER);
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createConsumerReceiveInstrumenter() {
@@ -105,21 +120,30 @@ public final class KafkaInstrumenterFactory {
   public Instrumenter<KafkaReceiveRequest, Void> createConsumerReceiveInstrumenter(
       Iterable<AttributesExtractor<KafkaReceiveRequest, Void>> extractors) {
     KafkaReceiveAttributesGetter getter = new KafkaReceiveAttributesGetter();
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
+    boolean receiveInstrumentationEnabled = receiveInstrumentationEnabled();
 
     InstrumenterBuilder<KafkaReceiveRequest, Void> builder =
         Instrumenter.<KafkaReceiveRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.builder(getter, operationType)
+                    .setOperationName(POLL_OPERATION_NAME)
+                    .build())
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(
+                    getter, operationType, POLL_OPERATION_NAME, capturedHeaders))
             .addAttributesExtractor(new KafkaReceiveAttributesExtractor())
             .addAttributesExtractors(extractors)
             .setErrorCauseExtractor(errorCauseExtractor)
-            .setEnabled(messagingReceiveInstrumentationEnabled);
+            .setEnabled(receiveInstrumentationEnabled);
+    if (emitStableMessagingSemconv()) {
+      builder.addSpanLinksExtractor(
+          new KafkaBatchProcessSpanLinksExtractor(
+              openTelemetry.getPropagators().getTextMapPropagator()));
+    }
     setMessagingReceiveExceptionEventExtractor(builder);
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return builder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   public Instrumenter<KafkaProcessRequest, Void> createConsumerProcessInstrumenter() {
@@ -129,15 +153,15 @@ public final class KafkaInstrumenterFactory {
   public Instrumenter<KafkaProcessRequest, Void> createConsumerProcessInstrumenter(
       Iterable<AttributesExtractor<KafkaProcessRequest, Void>> extractors) {
     KafkaConsumerAttributesGetter getter = new KafkaConsumerAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<KafkaProcessRequest, Void> builder =
         Instrumenter.<KafkaProcessRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(getter, operationType, capturedHeaders))
             .addAttributesExtractor(new KafkaConsumerAttributesExtractor())
             .addAttributesExtractors(extractors)
             .setErrorCauseExtractor(errorCauseExtractor);
@@ -146,28 +170,30 @@ public final class KafkaInstrumenterFactory {
     }
     setMessagingProcessExceptionEventExtractor(builder);
 
-    if (messagingReceiveInstrumentationEnabled) {
-      builder.addSpanLinksExtractor(
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(),
-              new KafkaConsumerRecordGetter()));
-      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    } else {
-      return builder.buildConsumerInstrumenter(new KafkaConsumerRecordGetter());
-    }
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new KafkaConsumerRecordGetter(),
+        receiveInstrumentationEnabled());
+  }
+
+  private boolean receiveInstrumentationEnabled() {
+    return messagingReceiveInstrumentationConfigured
+        ? messagingReceiveInstrumentationEnabled
+        : emitStableMessagingSemconv();
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
     KafkaReceiveAttributesGetter getter = new KafkaReceiveAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<KafkaReceiveRequest, Void> builder =
         Instrumenter.<KafkaReceiveRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(getter, operationType, capturedHeaders))
             .addAttributesExtractor(new KafkaReceiveAttributesExtractor())
             .addSpanLinksExtractor(
                 new KafkaBatchProcessSpanLinksExtractor(
@@ -180,9 +206,21 @@ public final class KafkaInstrumenterFactory {
   private static <REQUEST, RESPONSE>
       AttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
           MessagingAttributesGetter<REQUEST, RESPONSE> getter,
-          MessageOperation operation,
+          MessagingOperationType operationType,
+          String operationName,
           List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
+        .setOperationName(operationName)
+        .setCapturedHeaders(capturedHeaders)
+        .build();
+  }
+
+  private static <REQUEST, RESPONSE>
+      AttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
+          MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+          MessagingOperationType operationType,
+          List<String> capturedHeaders) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerRequest.java
@@ -22,22 +22,43 @@ public final class KafkaProducerRequest {
   private final ProducerRecord<?, ?> record;
   @Nullable private final String clientId;
   @Nullable private final String bootstrapServers;
+  private final boolean spanContextPropagated;
 
   public static KafkaProducerRequest create(
       ProducerRecord<?, ?> record, Producer<?, ?> producer, @Nullable String bootstrapServers) {
-    return create(record, extractClientId(producer), bootstrapServers);
+    return create(record, extractClientId(producer), bootstrapServers, true);
+  }
+
+  public static KafkaProducerRequest create(
+      ProducerRecord<?, ?> record,
+      Producer<?, ?> producer,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
+    return create(record, extractClientId(producer), bootstrapServers, spanContextPropagated);
   }
 
   public static KafkaProducerRequest create(
       ProducerRecord<?, ?> record, @Nullable String clientId, @Nullable String bootstrapServers) {
-    return new KafkaProducerRequest(record, clientId, bootstrapServers);
+    return create(record, clientId, bootstrapServers, true);
+  }
+
+  public static KafkaProducerRequest create(
+      ProducerRecord<?, ?> record,
+      @Nullable String clientId,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
+    return new KafkaProducerRequest(record, clientId, bootstrapServers, spanContextPropagated);
   }
 
   private KafkaProducerRequest(
-      ProducerRecord<?, ?> record, @Nullable String clientId, @Nullable String bootstrapServers) {
+      ProducerRecord<?, ?> record,
+      @Nullable String clientId,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
     this.record = record;
     this.clientId = clientId;
     this.bootstrapServers = bootstrapServers;
+    this.spanContextPropagated = spanContextPropagated;
   }
 
   public ProducerRecord<?, ?> getRecord() {
@@ -52,6 +73,10 @@ public final class KafkaProducerRequest {
   @Nullable
   public String getBootstrapServers() {
     return bootstrapServers;
+  }
+
+  public boolean isSpanContextPropagated() {
+    return spanContextPropagated;
   }
 
   @Nullable

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaPropagation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaPropagation.java
@@ -6,9 +6,17 @@
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.RecordBatch;
@@ -32,6 +40,36 @@ public final class KafkaPropagation {
   public static boolean shouldPropagate(ApiVersions apiVersions) {
     return !HAS_MAX_USABLE_PRODUCE_MAGIC
         || maxUsableProduceMagic(apiVersions) >= RecordBatch.MAGIC_VALUE_V2;
+  }
+
+  public static boolean propagatesSpanContext(TextMapPropagator propagator) {
+    SpanContext expected =
+        SpanContext.create(
+            "00000000000000000000000000000001",
+            "0000000000000001",
+            TraceFlags.getSampled(),
+            TraceState.getDefault());
+    Map<String, String> carrier = new HashMap<>();
+    propagator.inject(Context.root().with(Span.wrap(expected)), carrier, Map::put);
+    Context extracted =
+        propagator.extract(
+            Context.root(),
+            carrier,
+            new TextMapGetter<Map<String, String>>() {
+              @Override
+              public Iterable<String> keys(Map<String, String> carrier) {
+                return carrier.keySet();
+              }
+
+              @Nullable
+              @Override
+              public String get(@Nullable Map<String, String> carrier, String key) {
+                return carrier == null ? null : carrier.get(key);
+              }
+            });
+    SpanContext actual = Span.fromContext(extracted).getSpanContext();
+    return expected.getTraceId().equals(actual.getTraceId())
+        && expected.getSpanId().equals(actual.getSpanId());
   }
 
   @NoMuzzle

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesExtractor.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -17,11 +20,18 @@ final class KafkaReceiveAttributesExtractor
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       AttributeKey.stringKey("messaging.kafka.consumer.group");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
 
   @Override
   public void onStart(
       AttributesBuilder attributes, Context parentContext, KafkaReceiveRequest request) {
-    attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    }
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+    }
   }
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/TracingIterator.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/TracingIterator.java
@@ -44,7 +44,9 @@ public class TracingIterator<K, V> implements Iterator<ConsumerRecord<K, V>> {
 
     Context receiveContext = consumerContext.getContext();
     // use the receive CONSUMER as parent if it's available
-    this.parentContext = receiveContext != null ? receiveContext : Context.current();
+    this.parentContext =
+        KafkaConsumerContextUtil.withoutLeakedProcessSpan(
+            receiveContext != null ? receiveContext : Context.current());
     this.consumerContext = consumerContext;
   }
 
@@ -80,6 +82,8 @@ public class TracingIterator<K, V> implements Iterator<ConsumerRecord<K, V>> {
     if (next != null && wrappingEnabled.getAsBoolean()) {
       currentRequest = KafkaProcessRequest.create(consumerContext, next);
       currentContext = instrumenter.start(parentContext, currentRequest);
+      currentContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(currentContext, parentContext);
       currentScope = currentContext.makeCurrent();
     }
     return next;

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
@@ -9,12 +9,12 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class KafkaConnectSingletons {
 
@@ -33,15 +33,17 @@ public class KafkaConnectSingletons {
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new KafkaConnectAttributesGetter(), MessageOperation.PROCESS))
+                    new KafkaConnectAttributesGetter(), MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new KafkaConnectAttributesGetter(), MessageOperation.PROCESS)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new KafkaConnectAttributesGetter(), MessagingOperationType.PROCESS)
                     .build())
             .addSpanLinksExtractor(spanLinksExtractor);
     setMessagingProcessExceptionEventExtractor(builder);
 
-    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    instrumenter =
+        builder.buildInstrumenter(
+            MessagingSpanKindExtractor.create(MessagingOperationType.PROCESS));
   }
 
   public static Instrumenter<KafkaConnectTask, Void> instrumenter() {

--- a/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
@@ -43,7 +43,15 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testV3Preview)
   }
 }

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
@@ -5,13 +5,30 @@
 
 package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.groupTraces;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
@@ -21,7 +38,11 @@ import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.testing.assertj.TracesAssert;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.smoketest.SmokeTestInstrumentationExtension;
 import io.opentelemetry.smoketest.TelemetryRetriever;
@@ -29,8 +50,10 @@ import io.opentelemetry.smoketest.TelemetryRetrieverProvider;
 import io.restassured.http.ContentType;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -128,6 +151,37 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
 
   protected String getKafkaBootstrapServers() {
     return kafka.getHost() + ":" + kafkaExposedPort;
+  }
+
+  protected static String messagingSpanName(
+      String destinationName, String oldOperationName, String stableOperationName) {
+    if (emitStableMessagingSemconv()) {
+      return destinationName == null
+          ? stableOperationName
+          : stableOperationName + " " + destinationName;
+    }
+    return (destinationName == null ? "unknown" : destinationName) + " " + oldOperationName;
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  protected final void waitAndAssertTracesIgnoringStableReceive(
+      Consumer<TraceAssert>... assertions) {
+    await()
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              List<List<SpanData>> traces = groupTraces(testing.spans());
+              if (emitStableMessagingSemconv()) {
+                traces.removeIf(
+                    trace ->
+                        trace.size() == 1
+                            && trace.get(0).getKind() == SpanKind.CLIENT
+                            && (trace.get(0).getName().equals("poll")
+                                || trace.get(0).getName().startsWith("poll ")));
+              }
+              TracesAssert.assertThat(traces).hasTracesSatisfyingExactly(asList(assertions));
+            });
   }
 
   @Override
@@ -263,9 +317,7 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             .withCopyFileToContainer(
                 MountableFile.forHostPath(agentPath), "/opentelemetry-javaagent.jar")
             // Configure the agent to export spans to backend (like smoke tests)
-            .withEnv(
-                "JAVA_TOOL_OPTIONS",
-                "-javaagent:/opentelemetry-javaagent.jar " + "-Dotel.javaagent.debug=true")
+            .withEnv("JAVA_TOOL_OPTIONS", javaToolOptions())
             // Disable test exporter and force OTLP exporter
             .withEnv("OTEL_TESTING_EXPORTER_ENABLED", "false")
             .withEnv("OTEL_TRACES_EXPORTER", "otlp")
@@ -278,7 +330,9 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "1000")
             .withEnv(
                 "OTEL_SEMCONV_STABILITY_OPT_IN",
-                System.getProperty("otel.semconv-stability.opt-in"))
+                emitStableMessagingSemconv()
+                    ? "messaging"
+                    : System.getProperty("otel.semconv-stability.opt-in"))
             .withEnv("CONNECT_BOOTSTRAP_SERVERS", getInternalKafkaBootstrapServers())
             .withEnv("CONNECT_REST_ADVERTISED_HOST_NAME", KAFKA_CONNECT_NETWORK_ALIAS)
             .withEnv("CONNECT_PLUGIN_PATH", PLUGIN_PATH_CONTAINER)
@@ -307,6 +361,62 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
                     + " && "
                     + "echo 'Starting Kafka Connect with logging to /var/log/kafka-connect/' && "
                     + "/etc/confluent/docker/run 2>&1 | tee /var/log/kafka-connect/kafka-connect.log");
+  }
+
+  private static String javaToolOptions() {
+    StringBuilder options =
+        new StringBuilder("-javaagent:/opentelemetry-javaagent.jar -Dotel.javaagent.debug=true");
+    appendSystemProperty(options, "otel.instrumentation.common.v3-preview");
+    appendSystemProperty(options, "otel.semconv-stability.preview");
+    return options.toString();
+  }
+
+  private static void appendSystemProperty(StringBuilder options, String propertyName) {
+    String value = System.getProperty(propertyName);
+    if (value != null) {
+      options.append(" -D").append(propertyName).append('=').append(value);
+    }
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected static AttributeAssertion[] processAttributes(String destination, long batchSize) {
+    return processAttributes(destination, batchSize, true);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected static AttributeAssertion[] processAttributes(long batchSize) {
+    return processAttributes("", batchSize, false);
+  }
+
+  private static AttributeAssertion[] processAttributes(
+      String destination, long batchSize, boolean hasDestination) {
+    boolean v3Preview = Boolean.getBoolean("otel.instrumentation.common.v3-preview");
+    return new AttributeAssertion[] {
+      equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize),
+      equalTo(MESSAGING_DESTINATION_NAME, hasDestination ? destination : null),
+      equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_SYSTEM, KAFKA),
+      satisfies(
+          THREAD_ID,
+          val -> {
+            if (v3Preview) {
+              val.isNull();
+            } else {
+              val.isNotZero();
+            }
+          }),
+      satisfies(
+          THREAD_NAME,
+          val -> {
+            if (v3Preview) {
+              val.isNull();
+            } else {
+              val.isNotBlank();
+            }
+          })
+    };
   }
 
   @BeforeEach

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
@@ -7,16 +7,7 @@ package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.awaitility.Awaitility.await;
@@ -123,40 +114,48 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
     await().atMost(Duration.ofSeconds(60)).until(() -> getRecordCountFromMongo() >= 1);
 
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(testTopicName + " publish").hasKind(SpanKind.PRODUCER).hasNoParent();
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + testTopicName
+                              : testTopicName + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasNoParent();
                   producerSpanContext.set(span.actual().getSpanContext());
                 }),
         trace ->
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))),
         trace ->
             // kafka connect consumer trace, linked to producer span via a span link
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(testTopicName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + testTopicName
+                                : testTopicName + " process")
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpanContext.get()))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
-                            equalTo(MESSAGING_DESTINATION_NAME, testTopicName),
-                            equalTo(MESSAGING_OPERATION, PROCESS),
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            satisfies(THREAD_ID, val -> val.isNotZero()),
-                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                        .hasAttributesSatisfyingExactly(processAttributes(testTopicName, 1)),
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
@@ -217,36 +216,51 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0)));
 
     AtomicReference<SpanContext> producerSpanContext1 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext2 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext3 = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span -> {
-                  span.hasName(topicName1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName1
+                              : topicName1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext1.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName2
+                              : topicName2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext2.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName3 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName3
+                              : topicName3 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext3.set(span.actual().getSpanContext());
@@ -258,19 +272,14 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect consumer trace, linked to producer span via a span link
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("unknown process")
+                    span.hasName(emitStableMessagingSemconv() ? "process" : "unknown process")
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasLinks(
                             LinkData.create(producerSpanContext1.get()),
                             LinkData.create(producerSpanContext2.get()),
                             LinkData.create(producerSpanContext3.get()))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3),
-                            equalTo(MESSAGING_OPERATION, PROCESS),
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            satisfies(THREAD_ID, val -> val.isNotZero()),
-                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                        .hasAttributesSatisfyingExactly(processAttributes(3)),
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
@@ -7,16 +7,7 @@ package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,23 +131,34 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
     await().atMost(Duration.ofSeconds(60)).until(() -> getRecordCountFromPostgres() >= 1);
 
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(testTopicName + " publish").hasKind(SpanKind.PRODUCER).hasNoParent();
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + testTopicName
+                              : testTopicName + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasNoParent();
                   producerSpanContext.set(span.actual().getSpanContext());
                 }),
         trace ->
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))),
         trace -> {
@@ -173,17 +175,14 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
 
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(testTopicName + " process")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + testTopicName
+                              : testTopicName + " process")
                       .hasKind(CONSUMER)
                       .hasNoParent()
                       .hasLinks(LinkData.create(producerSpanContext.get()))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
-                          equalTo(MESSAGING_DESTINATION_NAME, testTopicName),
-                          equalTo(MESSAGING_OPERATION, PROCESS),
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          satisfies(THREAD_ID, val -> val.isNotZero()),
-                          satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                      .hasAttributesSatisfyingExactly(processAttributes(testTopicName, 1)),
               selectAssertion,
               selectAssertion,
               selectAssertion,
@@ -256,36 +255,51 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0)));
 
     AtomicReference<SpanContext> producerSpanContext1 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext2 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext3 = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span -> {
-                  span.hasName(topicName1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName1
+                              : topicName1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext1.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName2
+                              : topicName2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext2.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName3 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName3
+                              : topicName3 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext3.set(span.actual().getSpanContext());
@@ -307,19 +321,14 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
 
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName("unknown process")
+                  span.hasName(emitStableMessagingSemconv() ? "process" : "unknown process")
                       .hasKind(CONSUMER)
                       .hasNoParent()
                       .hasLinks(
                           LinkData.create(producerSpanContext1.get()),
                           LinkData.create(producerSpanContext2.get()),
                           LinkData.create(producerSpanContext3.get()))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3),
-                          equalTo(MESSAGING_OPERATION, PROCESS),
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          satisfies(THREAD_ID, val -> val.isNotZero()),
-                          satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                      .hasAttributesSatisfyingExactly(processAttributes(3)),
               selectAssertion,
               selectAssertion,
               selectAssertion,

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
@@ -54,6 +54,30 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
@@ -64,6 +88,8 @@ tasks {
   check {
     dependsOn(testReceiveSpansDisabled)
     dependsOn(testExperimental)
+    dependsOn(testV3Preview)
+    dependsOn(testV3PreviewReceiveSpansDisabled)
   }
 }
 

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.kafkastreams.v0_11;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
 import static java.util.Arrays.asList;
@@ -47,9 +53,9 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @DisplayName("test kafka produce and consume with streams in-between")
   @Test
   void testKafkaProduceAndConsumeWithStreamsInBetween() throws Exception {
@@ -98,33 +104,141 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
     AtomicReference<SpanData> producerPendingRef = new AtomicReference<>();
     AtomicReference<SpanData> producerProcessedRef = new AtomicReference<>();
 
-    // Add your assertTraces logic here
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          TelemetryDataUtil.orderByRootSpanName(
+              "send " + STREAM_PENDING, "poll " + STREAM_PENDING, "poll " + STREAM_PROCESSED),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("send " + STREAM_PENDING)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PENDING, true)),
+                span -> {
+                  List<AttributeAssertion> assertions =
+                      new ArrayList<>(
+                          messagingAttributes(
+                              STREAM_PENDING, "process", "process", "process", "consumer", false));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(stringKey("asdf"), "testing"));
+                  addOffsetAssertions(assertions, 0);
+                  if (EXPERIMENTAL_ATTRIBUTES) {
+                    assertions.add(
+                        satisfies(
+                            longKey("kafka.record.queue_time_ms"),
+                            val -> val.isGreaterThanOrEqualTo(0)));
+                  }
+                  if (testLatestDeps()) {
+                    addGroupAssertions(assertions, "test-application");
+                  }
+                  span.hasName("process " + STREAM_PENDING)
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(0))
+                      .hasLinks()
+                      .hasAttributesSatisfyingExactly(assertions);
+                },
+                span ->
+                    span.hasName("send " + STREAM_PROCESSED)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(1))
+                        .hasTraceId(receivedContext.getTraceId())
+                        .hasSpanId(receivedContext.getSpanId())
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes(STREAM_PROCESSED, false)),
+                span -> {
+                  List<AttributeAssertion> assertions =
+                      new ArrayList<>(
+                          messagingAttributes(
+                              STREAM_PROCESSED, "process", "process", "process", "consumer", true));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(longKey("testing"), 123));
+                  addOffsetAssertions(assertions, 0);
+                  if (EXPERIMENTAL_ATTRIBUTES) {
+                    assertions.add(
+                        satisfies(
+                            longKey("kafka.record.queue_time_ms"),
+                            val -> val.isGreaterThanOrEqualTo(0)));
+                  }
+                  if (testLatestDeps()) {
+                    addGroupAssertions(assertions, "test");
+                  }
+                  span.hasName("process " + STREAM_PROCESSED)
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(2))
+                      .hasLinks()
+                      .hasAttributesSatisfyingExactly(assertions);
+                });
+            producerPendingRef.set(trace.getSpan(0));
+            producerProcessedRef.set(trace.getSpan(2));
+          },
+          trace -> {
+            List<AttributeAssertion> assertions =
+                new ArrayList<>(
+                    messagingAttributes(
+                        STREAM_PENDING, "receive", "poll", "receive", "consumer", false));
+            assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            if (testLatestDeps()) {
+              addGroupAssertions(assertions, "test-application");
+            }
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + STREAM_PENDING)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerPendingRef.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(assertions));
+          },
+          trace -> {
+            List<AttributeAssertion> assertions =
+                new ArrayList<>(
+                    messagingAttributes(
+                        STREAM_PROCESSED, "receive", "poll", "receive", "consumer", true));
+            assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            if (testLatestDeps()) {
+              addGroupAssertions(assertions, "test");
+            }
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + STREAM_PROCESSED)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerProcessedRef.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(assertions));
+          });
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
         TelemetryDataUtil.orderByRootSpanName(
-            STREAM_PENDING + " publish",
-            STREAM_PENDING + " receive",
-            STREAM_PROCESSED + " receive"),
+            emitStableMessagingSemconv() ? "send " + STREAM_PENDING : STREAM_PENDING + " publish",
+            emitStableMessagingSemconv() ? "poll " + STREAM_PENDING : STREAM_PENDING + " receive",
+            emitStableMessagingSemconv()
+                ? "poll " + STREAM_PROCESSED
+                : STREAM_PROCESSED + " receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               // kafka-clients PRODUCER
               span ->
-                  span.hasName(STREAM_PENDING + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + STREAM_PENDING
+                              : STREAM_PENDING + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID,
-                              val -> val.isInstanceOf(String.class)),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PENDING, true)));
           producerPendingRef.set(trace.getSpan(0));
         },
         trace -> {
@@ -133,18 +247,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               span -> {
                 List<AttributeAssertion> assertions =
                     new ArrayList<>(
-                        asList(
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            satisfies(
-                                stringKey("messaging.client_id"), val -> val.endsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                        messagingAttributes(
+                            STREAM_PENDING, "receive", "poll", "receive", "consumer", false));
+                assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
                 if (testLatestDeps()) {
-                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
+                  addGroupAssertions(assertions, "test-application");
                 }
-                span.hasName(STREAM_PENDING + " receive")
-                    .hasKind(SpanKind.CONSUMER)
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "poll " + STREAM_PENDING
+                            : STREAM_PENDING + " receive")
+                    .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                     .hasNoParent()
                     .hasAttributesSatisfyingExactly(assertions);
               },
@@ -152,20 +265,16 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               span -> {
                 List<AttributeAssertion> assertions =
                     new ArrayList<>(
-                        asList(
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                stringKey("messaging.client_id"), val -> val.endsWith("consumer")),
-                            satisfies(
-                                MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(stringKey("asdf"), "testing")));
+                        messagingAttributes(
+                            STREAM_PENDING, "process", "process", "process", "consumer", false));
+                assertions.add(
+                    satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                assertions.add(
+                    satisfies(
+                        MESSAGING_DESTINATION_PARTITION_ID, val -> val.isInstanceOf(String.class)));
+                assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                assertions.add(equalTo(stringKey("asdf"), "testing"));
+                addOffsetAssertions(assertions, 0);
 
                 if (EXPERIMENTAL_ATTRIBUTES) {
                   assertions.add(
@@ -175,9 +284,12 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 }
 
                 if (testLatestDeps()) {
-                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
+                  addGroupAssertions(assertions, "test-application");
                 }
-                span.hasName(STREAM_PENDING + " process")
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "process " + STREAM_PENDING
+                            : STREAM_PENDING + " process")
                     .hasKind(SpanKind.CONSUMER)
                     .hasParent(trace.getSpan(0))
                     .hasLinks(LinkData.create(producerPendingRef.get().getSpanContext()))
@@ -185,24 +297,15 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               },
               // kafka-clients PRODUCER
               span ->
-                  span.hasName(STREAM_PROCESSED + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(1))
                       .hasTraceId(receivedContext.getTraceId())
                       .hasSpanId(receivedContext.getSpanId())
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.endsWith("producer")),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID,
-                              val -> val.isInstanceOf(String.class)),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PROCESSED, false)));
 
           producerProcessedRef.set(trace.getSpan(2));
         },
@@ -212,19 +315,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 span -> {
                   List<AttributeAssertion> assertions =
                       new ArrayList<>(
-                          asList(
-                              equalTo(MESSAGING_SYSTEM, KAFKA),
-                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                              equalTo(MESSAGING_OPERATION, "receive"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("consumer")),
-                              equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                          messagingAttributes(
+                              STREAM_PROCESSED, "receive", "poll", "receive", "consumer", true));
+                  assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
                   if (testLatestDeps()) {
-                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    addGroupAssertions(assertions, "test");
                   }
-                  span.hasName(STREAM_PROCESSED + " receive")
-                      .hasKind(SpanKind.CONSUMER)
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "poll " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " receive")
+                      .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(assertions);
                 },
@@ -232,21 +333,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 span -> {
                   List<AttributeAssertion> assertions =
                       new ArrayList<>(
-                          asList(
-                              equalTo(MESSAGING_SYSTEM, KAFKA),
-                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                              equalTo(MESSAGING_OPERATION, "process"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("consumer")),
-                              satisfies(
-                                  MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  val -> val.isInstanceOf(String.class)),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                              equalTo(longKey("testing"), 123)));
+                          messagingAttributes(
+                              STREAM_PROCESSED, "process", "process", "process", "consumer", true));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(longKey("testing"), 123));
+                  addOffsetAssertions(assertions, 0);
                   if (EXPERIMENTAL_ATTRIBUTES) {
                     assertions.add(
                         satisfies(
@@ -255,13 +352,94 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                   }
 
                   if (testLatestDeps()) {
-                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    addGroupAssertions(assertions, "test");
                   }
-                  span.hasName(STREAM_PROCESSED + " process")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " process")
                       .hasKind(SpanKind.CONSUMER)
                       .hasParent(trace.getSpan(0))
                       .hasLinks(LinkData.create(producerProcessedRef.get().getSpanContext()))
                       .hasAttributesSatisfyingExactly(assertions);
                 }));
+  }
+
+  private static List<AttributeAssertion> producerAttributes(String topic, boolean includeKey) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            messagingAttributes(topic, "publish", "send", "send", "producer", includeKey));
+    assertions.add(
+        satisfies(MESSAGING_DESTINATION_PARTITION_ID, val -> val.isInstanceOf(String.class)));
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, includeKey ? "10" : null));
+    assertions.add(
+        equalTo(
+            stringKey("messaging.kafka.bootstrap.servers"),
+            EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null));
+    addOffsetAssertions(assertions, 0);
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdSuffix,
+      boolean startsWith) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, KAFKA),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(
+              stringKey("messaging.client_id"),
+              val -> {
+                if (startsWith) {
+                  val.startsWith(clientIdSuffix);
+                } else {
+                  val.endsWith(clientIdSuffix);
+                }
+              }));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(
+              stringKey("messaging.client.id"),
+              val -> {
+                if (startsWith) {
+                  val.startsWith(clientIdSuffix);
+                } else {
+                  val.endsWith(clientIdSuffix);
+                }
+              }));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertions(List<AttributeAssertion> assertions, long offset) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, offset));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_OFFSET, offset));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkastreams.v0_11;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -92,6 +93,31 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
     SpanContext receivedContext = Span.fromContext(getContext(receivedHeaders)).getSpanContext();
 
     AtomicReference<SpanData> streamSendSpanRef = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("send " + STREAM_PENDING)
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasNoParent(),
+                  span ->
+                      span.hasName("process " + STREAM_PENDING)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("send " + STREAM_PROCESSED)
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(1))
+                          .hasTraceId(receivedContext.getTraceId())
+                          .hasSpanId(receivedContext.getSpanId()),
+                  span ->
+                      span.hasName("process " + STREAM_PROCESSED)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(2))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
@@ -51,6 +51,7 @@ public class SpanKeyBridging {
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.DB_CLIENT,
         SpanKey.DB_CLIENT);
 
+    putIfPresent(map, "PRODUCER_CREATE", SpanKey.PRODUCER_CREATE);
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.PRODUCER,
         SpanKey.PRODUCER);
@@ -60,7 +61,24 @@ public class SpanKeyBridging {
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.CONSUMER_PROCESS,
         SpanKey.CONSUMER_PROCESS);
+    putIfPresent(map, "CONSUMER_SETTLE", SpanKey.CONSUMER_SETTLE);
     return map;
+  }
+
+  private static void putIfPresent(
+      Map<application.io.opentelemetry.instrumentation.api.internal.SpanKey, SpanKey> map,
+      String fieldName,
+      SpanKey agentSpanKey) {
+    try {
+      application.io.opentelemetry.instrumentation.api.internal.SpanKey applicationSpanKey =
+          (application.io.opentelemetry.instrumentation.api.internal.SpanKey)
+              application.io.opentelemetry.instrumentation.api.internal.SpanKey.class
+                  .getField(fieldName)
+                  .get(null);
+      map.put(applicationSpanKey, agentSpanKey);
+    } catch (ReflectiveOperationException ignored) {
+      // The application may use an instrumentation-api version from before this key was added.
+    }
   }
 
   @Nullable

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
@@ -68,9 +68,11 @@ class ContextBridgeTest {
                   SpanKey.HTTP_CLIENT,
                   SpanKey.RPC_CLIENT,
                   SpanKey.DB_CLIENT,
+                  SpanKey.PRODUCER_CREATE,
                   SpanKey.PRODUCER,
                   SpanKey.CONSUMER_RECEIVE,
-                  SpanKey.CONSUMER_PROCESS);
+                  SpanKey.CONSUMER_PROCESS,
+                  SpanKey.CONSUMER_SETTLE);
 
           spanKeys.forEach(
               spanKey -> assertThat(spanKey.fromContextOrNull(Context.current())).isNotNull());

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -73,9 +73,11 @@ public class AgentSpanTestingInstrumenter {
       SpanKey.HTTP_CLIENT,
       SpanKey.RPC_CLIENT,
       SpanKey.DB_CLIENT,
+      SpanKey.PRODUCER_CREATE,
       SpanKey.PRODUCER,
       SpanKey.CONSUMER_RECEIVE,
       SpanKey.CONSUMER_PROCESS,
+      SpanKey.CONSUMER_SETTLE,
     };
   }
 

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -99,6 +99,26 @@ tasks {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
@@ -109,6 +129,12 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental, testReceiveSpansDisabled)
+    dependsOn(
+      testing.suites,
+      testExperimental,
+      testReceiveSpansDisabled,
+      testV3Preview,
+      testV3PreviewReceiveSpansDisabled,
+    )
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.reactor.kafka.v1_0;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -61,6 +67,7 @@ import reactor.kafka.sender.KafkaSender;
 import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractReactorKafkaTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractReactorKafkaTest.class);
@@ -162,13 +169,44 @@ public abstract class AbstractReactorKafkaTest {
   private static void assertWithReceiveTelemetry(SenderRecord<String, String, Object> record) {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                span ->
+                    span.hasName(spanName("testTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(processAttributes(record)),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes("testTopic"))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testTopic publish")
+                  span.hasName(spanName("testTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -178,12 +216,12 @@ public abstract class AbstractReactorKafkaTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes("testTopic")),
                 span ->
-                    span.hasName("testTopic process")
+                    span.hasName(spanName("testTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -197,29 +235,23 @@ public abstract class AbstractReactorKafkaTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testTopic publish")
+                    span.hasName(spanName("testTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(sendAttributes(record)),
                 span ->
-                    span.hasName("testTopic process")
+                    span.hasName(spanName("testTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(processAttributes(record)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> sendAttributes(ProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           equalTo(stringKey("messaging.kafka.bootstrap.servers"), kafka.getBootstrapServers()));
@@ -231,35 +263,23 @@ public abstract class AbstractReactorKafkaTest {
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> receiveAttributes(String topic) {
-    ArrayList<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "receive", "poll", "receive", "consumer");
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     if (HAS_CONSUMER_GROUP) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> processAttributes(ProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (HAS_CONSUMER_GROUP) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
@@ -274,5 +294,59 @@ public abstract class AbstractReactorKafkaTest {
       assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, "test"));
+    }
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  private static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -83,6 +83,31 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SpringKafkaTest.shouldCreateSpansForSingleRecordProcess")
+      includeTestsMatching("SpringKafkaTest.shouldHandleFailureInKafkaListener")
+      includeTestsMatching("SpringKafkaTest.shouldCreateSpansForBatchReceiveAndProcess")
+      includeTestsMatching("SpringKafkaTest.shouldHandleFailureInKafkaBatchListener")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     systemProperty(
@@ -92,7 +117,7 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }
 

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -7,18 +7,25 @@ package io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -77,75 +84,67 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testSingleTopic", "10")),
+                span ->
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            singleProcessAttributes("testSingleTopic", "testSingleListener", "10")),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+            producer.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes("testSingleTopic", "testSingleListener", 1))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testSingleTopic publish")
+                  span.hasName(spanName("testSingleTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testSingleTopic", "10")));
 
           producer.set(trace.getSpan(1));
         },
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testSingleTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
+                            receiveAttributes("testSingleTopic", "testSingleListener", 1)),
                 span ->
-                    span.hasName("testSingleTopic process")
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producer.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            satisfies(
-                                longKey("kafka.record.queue_time_ms"),
-                                val -> {
-                                  if (EXPERIMENTAL_ATTRIBUTES) {
-                                    val.isNotNegative();
-                                  }
-                                })),
+                            singleProcessAttributes("testSingleTopic", "testSingleListener", "10")),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -163,64 +162,64 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     Consumer<SpanDataAssert> receiveSpanAssert =
         span ->
-            span.hasName("testSingleTopic receive")
-                .hasKind(SpanKind.CONSUMER)
+            span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                .hasKind(receiveKind())
                 .hasNoParent()
                 .hasAttributesSatisfyingExactly(
-                    equalTo(MESSAGING_SYSTEM, "kafka"),
-                    equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                    equalTo(MESSAGING_OPERATION, "receive"),
-                    equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                    satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                    equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+                    receiveAttributes("testSingleTopic", "testSingleListener", 1));
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            satisfies(
-                longKey("kafka.record.queue_time_ms"),
-                val -> {
-                  if (EXPERIMENTAL_ATTRIBUTES) {
-                    val.isNotNegative();
-                  }
-                }));
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+      assertions.add(
+          trace -> {
+            List<Consumer<SpanDataAssert>> spanAssertions = new ArrayList<>();
+            spanAssertions.add(span -> span.hasName("producer"));
+            spanAssertions.add(
+                span ->
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testSingleTopic", "10")));
+            addSingleProcessAssertions(spanAssertions, trace, 2, true, testLatestDeps());
+            addSingleProcessAssertions(
+                spanAssertions, trace, testLatestDeps() ? 5 : 4, true, testLatestDeps());
+            addSingleProcessAssertions(
+                spanAssertions, trace, testLatestDeps() ? 8 : 6, false, false);
+            trace.hasSpansSatisfyingExactly(spanAssertions);
+            producer.set(trace.getSpan(1));
+          });
+      int receiveCount = testLatestDeps() ? 1 : 3;
+      for (int i = 0; i < receiveCount; i++) {
+        assertions.add(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertStableReceiveSpan(
+                            span, producer.get(), "testSingleTopic", "testSingleListener")));
+      }
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), assertions);
+      return;
+    }
+
     // trace structure differs in latest dep tests because CommonErrorHandler is only set for latest
     // dep tests
     if (testLatestDeps()) {
       testing.waitAndAssertSortedTraces(
-          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+          orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testSingleTopic publish")
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("producer")),
-                            equalTo(
-                                stringKey("messaging.kafka.bootstrap.servers"),
-                                EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                            producerAttributes("testSingleTopic", "10")));
 
             producer.set(trace.getSpan(1));
           },
@@ -228,59 +227,45 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(1)),
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(4)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(4)),
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, false)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(7))));
 
     } else {
       testing.waitAndAssertSortedTraces(
-          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+          orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testSingleTopic publish")
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("producer")),
-                            equalTo(
-                                stringKey("messaging.kafka.bootstrap.servers"),
-                                EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                            producerAttributes("testSingleTopic", "10")));
 
             producer.set(trace.getSpan(1));
           },
@@ -288,35 +273,35 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, false)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
     }
   }
@@ -331,47 +316,67 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
     AtomicReference<SpanData> producer1 = new AtomicReference<>();
     AtomicReference<SpanData> producer2 = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testBatchTopic", "20")));
+            producer1.set(trace.getSpan(1));
+            producer2.set(trace.getSpan(2));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasNoParent()
+                          .hasLinks(
+                              LinkData.create(producer1.get().getSpanContext()),
+                              LinkData.create(producer2.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(
+                              LinkData.create(producer1.get().getSpanContext()),
+                              LinkData.create(producer2.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes("testBatchTopic", "testBatchListener", 2))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactlyInAnyOrder(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)),
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "20")));
 
           producer1.set(trace.getSpan(1));
           producer2.set(trace.getSpan(2));
@@ -379,34 +384,20 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testBatchTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            receiveAttributes("testBatchTopic", "testBatchListener", 2)),
                 span ->
-                    span.hasName("testBatchTopic process")
+                    span.hasName(spanName("testBatchTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(
                             LinkData.create(producer1.get().getSpanContext()),
                             LinkData.create(producer2.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -424,29 +415,47 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+      assertions.add(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testBatchTopic", "10")));
+            producer.set(trace.getSpan(1));
+          });
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), true));
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), true));
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), false));
+      int receiveCount = testLatestDeps() ? 1 : 3;
+      for (int i = 0; i < receiveCount; i++) {
+        assertions.add(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertStableReceiveSpan(
+                            span, producer.get(), "testBatchTopic", "testBatchListener")));
+      }
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT), assertions);
+      return;
+    }
+
     List<Consumer<TraceAssert>> assertions = new ArrayList<>();
     assertions.add(
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")));
 
           producer.set(trace.getSpan(1));
         });
@@ -484,37 +493,194 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
     }
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER), assertions);
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()), assertions);
   }
 
   private static void assertReceiveSpan(SpanDataAssert span) {
-    span.hasName("testBatchTopic receive")
-        .hasKind(SpanKind.CONSUMER)
+    span.hasName(spanName("testBatchTopic", "receive", "poll"))
+        .hasKind(receiveKind())
         .hasNoParent()
         .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "receive"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            receiveAttributes("testBatchTopic", "testBatchListener", 1));
+  }
+
+  private static void addSingleProcessAssertions(
+      List<Consumer<SpanDataAssert>> assertions,
+      TraceAssert trace,
+      int processIndex,
+      boolean failed,
+      boolean addExceptionHandler) {
+    List<AttributeAssertion> processAttributes =
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
+    assertions.add(
+        span -> {
+          span.hasName(spanName("testSingleTopic", "process", "process"))
+              .hasKind(SpanKind.CONSUMER)
+              .hasParent(trace.getSpan(1))
+              .hasAttributesSatisfyingExactly(withErrorType(processAttributes, failed));
+          if (failed) {
+            span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
+          }
+        });
+    assertions.add(span -> span.hasName("consumer").hasParent(trace.getSpan(processIndex)));
+    if (addExceptionHandler) {
+      assertions.add(
+          span -> span.hasName("handle exception").hasParent(trace.getSpan(processIndex)));
+    }
+  }
+
+  private static void assertStableBatchProcessTrace(
+      TraceAssert trace, SpanData producer, boolean failed) {
+    trace.hasSpansSatisfyingExactly(
+        span -> {
+          span.hasName(spanName("testBatchTopic", "process", "process"))
+              .hasKind(SpanKind.CONSUMER)
+              .hasNoParent()
+              .hasLinks(LinkData.create(producer.getSpanContext()))
+              .hasAttributesSatisfyingExactly(
+                  withErrorType(
+                      batchProcessAttributes("testBatchTopic", "testBatchListener", 1), failed));
+          if (failed) {
+            span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
+          }
+        },
+        span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
+  }
+
+  private static void assertStableReceiveSpan(
+      SpanDataAssert span, SpanData producer, String topic, String group) {
+    span.hasName(spanName(topic, "receive", "poll"))
+        .hasKind(SpanKind.CLIENT)
+        .hasNoParent()
+        .hasLinks(LinkData.create(producer.getSpanContext()))
+        .hasAttributesSatisfyingExactly(receiveAttributes(topic, group, 1));
   }
 
   private static void assertProcessSpan(
       SpanDataAssert span, TraceAssert trace, SpanData producer, boolean failed) {
-    span.hasName("testBatchTopic process")
+    span.hasName(spanName("testBatchTopic", "process", "process"))
         .hasKind(SpanKind.CONSUMER)
         .hasParent(trace.getSpan(0))
         .hasLinks(LinkData.create(producer.getSpanContext()))
         .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            withErrorType(
+                batchProcessAttributes("testBatchTopic", "testBatchListener", 1), failed));
     if (failed) {
       span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
     }
+  }
+
+  private static List<AttributeAssertion> producerAttributes(String topic, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    assertions.add(
+        equalTo(
+            stringKey("messaging.kafka.bootstrap.servers"),
+            EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> receiveAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "receive", "poll", "receive", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> singleProcessAttributes(
+      String topic, String group, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative));
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    addGroupAssertions(assertions, group);
+    assertions.add(
+        satisfies(
+            longKey("kafka.record.queue_time_ms"),
+            val -> {
+              if (EXPERIMENTAL_ATTRIBUTES) {
+                val.isNotNegative();
+              }
+            }));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> batchProcessAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
+  }
+
+  private static List<AttributeAssertion> withErrorType(
+      List<AttributeAssertion> assertions, boolean failed) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv() && failed) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  private static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -6,19 +6,26 @@
 package io.opentelemetry.testing;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 
@@ -61,44 +68,18 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                equalTo(MESSAGING_OPERATION, "publish"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("producer")),
-                                satisfies(
-                                    MESSAGING_DESTINATION_PARTITION_ID,
-                                    AbstractStringAssert::isNotEmpty),
-                                satisfies(
-                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                    AbstractLongAssert::isNotNegative),
-                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                                sendAttributes("testSingleTopic", "10")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                satisfies(
-                                    MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-                                satisfies(
-                                    MESSAGING_DESTINATION_PARTITION_ID,
-                                    AbstractStringAssert::isNotEmpty),
-                                satisfies(
-                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                    AbstractLongAssert::isNotNegative),
-                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("consumer"))),
+                                singleProcessAttributes(
+                                    "testSingleTopic", "testSingleListener", "10")),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
@@ -116,16 +97,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             });
 
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")));
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
 
     testing()
         .waitAndAssertTraces(
@@ -135,30 +107,19 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                       asList(
                           span -> span.hasName("producer"),
                           span ->
-                              span.hasName("testSingleTopic publish")
+                              span.hasName(spanName("testSingleTopic", "publish", "send"))
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
-                                      equalTo(MESSAGING_SYSTEM, "kafka"),
-                                      equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                      equalTo(MESSAGING_OPERATION, "publish"),
-                                      satisfies(
-                                          stringKey("messaging.client_id"),
-                                          val -> val.startsWith("producer")),
-                                      satisfies(
-                                          MESSAGING_DESTINATION_PARTITION_ID,
-                                          AbstractStringAssert::isNotEmpty),
-                                      satisfies(
-                                          MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                          AbstractLongAssert::isNotNegative),
-                                      equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                                      sendAttributes("testSingleTopic", "10")),
                           span ->
-                              span.hasName("testSingleTopic process")
+                              span.hasName(spanName("testSingleTopic", "process", "process"))
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(1))
                                   .hasStatus(StatusData.error())
                                   .hasException(new IllegalArgumentException("boom"))
-                                  .hasAttributesSatisfyingExactly(processAttributes),
+                                  .hasAttributesSatisfyingExactly(
+                                      withErrorType(processAttributes, true)),
                           span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
               if (testLatestDeps()) {
                 assertions.add(
@@ -167,12 +128,13 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               assertions.addAll(
                   asList(
                       span ->
-                          span.hasName("testSingleTopic process")
+                          span.hasName(spanName("testSingleTopic", "process", "process"))
                               .hasKind(SpanKind.CONSUMER)
                               .hasParent(trace.getSpan(1))
                               .hasStatus(StatusData.error())
                               .hasException(new IllegalArgumentException("boom"))
-                              .hasAttributesSatisfyingExactly(processAttributes),
+                              .hasAttributesSatisfyingExactly(
+                                  withErrorType(processAttributes, true)),
                       span ->
                           span.hasName("consumer")
                               .hasParent(trace.getSpan(testLatestDeps() ? 5 : 4))));
@@ -183,7 +145,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               assertions.addAll(
                   asList(
                       span ->
-                          span.hasName("testSingleTopic process")
+                          span.hasName(spanName("testSingleTopic", "process", "process"))
                               .hasKind(SpanKind.CONSUMER)
                               .hasParent(trace.getSpan(1))
                               .hasStatus(StatusData.unset())
@@ -213,41 +175,15 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               trace.hasSpansSatisfyingExactlyInAnyOrder(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20")));
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "20")));
 
               producer1.set(trace.getSpan(1));
               producer2.set(trace.getSpan(2));
@@ -255,7 +191,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(
@@ -263,14 +199,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                     producer1.get().getSpanContext(),
                                     producer2.get().getSpanContext()))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("consumer")),
-                                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                                batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
   }
 
@@ -290,51 +219,33 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+        batchProcessAttributes("testBatchTopic", "testBatchListener", 1);
 
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanName("producer", "testBatchTopic process", "consumer"),
+            orderByRootSpanName(
+                "producer", spanName("testBatchTopic", "process", "process"), "consumer"),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")));
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")));
 
               producer.set(trace.getSpan(1));
             },
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes),
+                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
             trace -> {
               if (isLibraryInstrumentationTest() && testLatestDeps()) {
@@ -344,13 +255,13 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               } else {
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes),
+                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
               }
             },
@@ -360,7 +271,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               } else {
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
@@ -369,5 +280,94 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
               }
             });
+  }
+
+  private static List<AttributeAssertion> sendAttributes(String topic, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> singleProcessAttributes(
+      String topic, String group, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative));
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    addGroupAssertions(assertions, group);
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> batchProcessAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
+  }
+
+  private static List<AttributeAssertion> withErrorType(
+      List<AttributeAssertion> assertions, boolean failed) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv() && failed) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
@@ -64,12 +64,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
 
                   // first record
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record1)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(1))
                           .hasAttributesSatisfyingExactly(processAttributes(record1)),
@@ -77,12 +77,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
 
                   // second record
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record2)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(4))
                           .hasAttributesSatisfyingExactly(processAttributes(record2)),
@@ -95,7 +95,7 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinks(
@@ -127,12 +127,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(1))
                           .hasAttributesSatisfyingExactly(processAttributes(record)),
@@ -143,14 +143,14 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
                             .hasAttributesSatisfyingExactly(
-                                batchProcessAttributes("testBatchTopic")),
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,22 +52,27 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
         KafkaProducerRecord.create("testBatchTopic", "20", "testSpan2");
     sendBatchMessages(record1, record2);
 
+    if (emitStableMessagingSemconv()) {
+      assertStableBatchSuccess(record1, record2);
+      return;
+    }
+
     AtomicReference<SpanData> producer1 = new AtomicReference<>();
     AtomicReference<SpanData> producer2 = new AtomicReference<>();
 
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactlyInAnyOrder(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record1)),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record2)));
@@ -77,14 +83,14 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactlyInAnyOrder(
                     span ->
-                        span.hasName("testBatchTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic")),
 
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(
@@ -96,7 +102,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
 
                     // single consumer 1
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer1.get().getSpanContext()))
@@ -105,7 +111,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
 
                     // single consumer 2
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer2.get().getSpanContext()))
@@ -124,17 +130,22 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
     // make sure that the consumer eats up any leftover records
     kafkaConsumer.resume();
 
+    if (emitStableMessagingSemconv()) {
+      assertStableBatchFailure(record);
+      return;
+    }
+
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
     // the regular handler is not being called if the batch one fails
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -144,29 +155,135 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic")),
 
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
                             .hasAttributesSatisfyingExactly(
-                                batchProcessAttributes("testBatchTopic")),
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(1)),
 
                     // single consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(processAttributes(record)),
                     span -> span.hasName("process error").hasParent(trace.getSpan(3))));
+  }
+
+  private void assertStableBatchSuccess(
+      KafkaProducerRecord<String, String> record1, KafkaProducerRecord<String, String> record2) {
+    AtomicReference<SpanData> producer1 = new AtomicReference<>();
+    AtomicReference<SpanData> producer2 = new AtomicReference<>();
+
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+            trace -> {
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("producer"),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record1)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(processAttributes(record1)),
+                  span -> span.hasName("process testSpan1").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record2)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(4))
+                          .hasAttributesSatisfyingExactly(processAttributes(record2)),
+                  span -> span.hasName("process testSpan2").hasParent(trace.getSpan(5)));
+
+              producer1.set(trace.getSpan(1));
+              producer2.set(trace.getSpan(4));
+            },
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasNoParent()
+                            .hasLinks(
+                                LinkData.create(producer1.get().getSpanContext()),
+                                LinkData.create(producer2.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(
+                                batchProcessAttributes("testBatchTopic")),
+                    span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinks(
+                                LinkData.create(producer1.get().getSpanContext()),
+                                LinkData.create(producer2.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic"))));
+  }
+
+  private void assertStableBatchFailure(KafkaProducerRecord<String, String> record) {
+    AtomicReference<SpanData> producer = new AtomicReference<>();
+
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+            trace -> {
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("producer"),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(processAttributes(record)),
+                  span -> span.hasName("process error").hasParent(trace.getSpan(2)));
+
+              producer.set(trace.getSpan(1));
+            },
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasNoParent()
+                            .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                            .hasStatus(StatusData.error())
+                            .hasException(new IllegalArgumentException("boom"))
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
+                    span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic"))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
@@ -50,12 +50,12 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(sendAttributes(record)),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(processAttributes(record)),
@@ -78,17 +78,18 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(sendAttributes(record)),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,14 +50,47 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+              trace -> {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("producer"),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(1))
+                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                    span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+                producer.set(trace.getSpan(1));
+              },
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                              .hasKind(SpanKind.CLIENT)
+                              .hasNoParent()
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  receiveAttributes("testSingleTopic"))));
+      return;
+    }
+
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testSingleTopic publish")
+                      span.hasName(spanName("testSingleTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -66,12 +100,12 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testSingleTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testSingleTopic")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
@@ -91,14 +125,50 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+              trace -> {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("producer"),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(1))
+                            .hasStatus(StatusData.error())
+                            .hasException(new IllegalArgumentException("boom"))
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
+                    span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+                producer.set(trace.getSpan(1));
+              },
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                              .hasKind(SpanKind.CLIENT)
+                              .hasNoParent()
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  receiveAttributes("testSingleTopic"))));
+      return;
+    }
+
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testSingleTopic publish")
+                      span.hasName(spanName("testSingleTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -108,18 +178,19 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testSingleTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testSingleTopic")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
@@ -7,16 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -24,6 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -53,6 +61,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractVertxKafkaTest {
 
@@ -163,18 +172,12 @@ public abstract class AbstractVertxKafkaTest {
   protected abstract void sendRecord(
       KafkaProducerRecord<String, String> record, Handler<AsyncResult<RecordMetadata>> handler);
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   protected static List<AttributeAssertion> sendAttributes(
       KafkaProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(
@@ -196,40 +199,33 @@ public abstract class AbstractVertxKafkaTest {
     return batchConsumerAttributes(topic, "process");
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private List<AttributeAssertion> batchConsumerAttributes(String topic, String operation) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, operation),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
+        messagingAttributes(
+            topic,
+            operation,
+            operation.equals("receive") ? "poll" : operation,
+            operation.equals("receive") ? "receive" : "process",
+            "consumer");
+    assertions.add(satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive));
     if (hasConsumerGroup()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   protected List<AttributeAssertion> processAttributes(KafkaProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
     }
     // consumer group is not available in version 0.11
     if (hasConsumerGroup()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     String messageKey = record.key();
     if (messageKey != null) {
@@ -240,5 +236,67 @@ public abstract class AbstractVertxKafkaTest {
       assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, KAFKA),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, "test"));
+    }
+  }
+
+  protected static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  protected static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
+  }
+
+  protected static List<AttributeAssertion> withErrorType(List<AttributeAssertion> assertions) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv()) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -57,7 +57,25 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -57,7 +57,24 @@ tasks {
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -57,7 +57,24 @@ tasks {
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }


### PR DESCRIPTION
Depends on #19270.

Dependency baseline: `fafcc4cbf6709e82bf3ed30fdc4bd27ba7ff20fe`.
Review only: `fafcc4cbf6709e82bf3ed30fdc4bd27ba7ff20fe..d7d989b375abb9c64c00547bc084e57518422d7d`.

Exactly one Kafka ecosystem commit. Stable topology assertions cover producer/process chains plus separate linked poll traces, including receive-telemetry opt-out and receive-enabled retry/failure paths.

Validated locally with the full `check` lifecycle for Kafka Streams, Reactor Kafka, Vert.x Kafka 3.6/4/5 testing, Spring Kafka, and `testing-common`, plus repository-wide `spotlessCheck`. Spring Kafka stable receive-enabled coverage includes single/batch success and retry/failure topology with exact `error.type`, parent, and link assertions.