### PR TITLE
Activate messaging v1.43 in common v3 preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🚫 Deprecations
+
+- Deprecate `MessageOperation` in favor of `MessagingOperationType`.
+  ([#19276](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19276))
+
 ## Version 2.30.0 (2026-07-22)
 
 This release targets the OpenTelemetry SDK 1.64.0.

--- a/instrumentation-api-incubator/build.gradle.kts
+++ b/instrumentation-api-incubator/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database,code,service.peer,rpc")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
     inputs.dir(jflexOutputDir)
   }
 
@@ -99,6 +100,7 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,code/dup,service.peer/dup,rpc/dup")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     inputs.dir(jflexOutputDir)
   }
 
@@ -117,6 +119,11 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testBothSemconv, testExceptionSignalLogs, testExceptionSignalLogsDup)
+    dependsOn(
+      testStableSemconv,
+      testBothSemconv,
+      testExceptionSignalLogs,
+      testExceptionSignalLogsDup,
+    )
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-/** Represents an operation that may be used in a messaging system. */
+/**
+ * Represents an operation that may be used in a messaging system.
+ *
+ * @deprecated Use {@link MessagingOperationType}. Will be removed in 3.0.
+ */
+@Deprecated // to be removed in 3.0
 public enum MessageOperation {
   PUBLISH(MessagingOperationType.SEND),
   RECEIVE(MessagingOperationType.RECEIVE),

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -5,24 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-import java.util.Locale;
-
-/**
- * Represents type of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">operations</a>
- * that may be used in a messaging system.
- */
+/** Represents an operation that may be used in a messaging system. */
 public enum MessageOperation {
-  PUBLISH,
-  RECEIVE,
-  PROCESS;
+  PUBLISH(MessagingOperationType.SEND),
+  RECEIVE(MessagingOperationType.RECEIVE),
+  PROCESS(MessagingOperationType.PROCESS);
 
-  /**
-   * Returns the operation name as defined in <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#operation-names">the
-   * specification</a>.
-   */
-  String operationName() {
-    return name().toLowerCase(Locale.ROOT);
+  private final MessagingOperationType operationType;
+
+  MessageOperation(MessagingOperationType operationType) {
+    this.operationType = operationType;
+  }
+
+  MessagingOperationType type() {
+    return operationType;
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -73,7 +73,11 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     return builderForOperationType(getter, operationType).build();
   }
 
-  /** Creates the messaging attributes extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #createForOperationType(MessagingAttributesGetter,
+   *     MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
@@ -91,7 +95,11 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     return new MessagingAttributesExtractorBuilder<>(getter, operationType, true);
   }
 
-  /** Returns a new messaging attributes extractor builder for the given operation. */
+  /**
+   * @deprecated Use {@link #builderForOperationType(MessagingAttributesGetter,
+   *     MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return new MessagingAttributesExtractorBuilder<>(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -17,7 +21,7 @@ import javax.annotation.Nullable;
 
 /**
  * Extractor of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md">messaging
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md">messaging
  * attributes</a>.
  *
  * <p>This class delegates to a type-specific {@link MessagingAttributesGetter} for individual
@@ -29,8 +33,10 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
-  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
       AttributeKey.stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID =
+      AttributeKey.stringKey("messaging.client.id");
   private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
       AttributeKey.booleanKey("messaging.destination.anonymous");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
@@ -51,49 +57,80 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       AttributeKey.stringKey("messaging.message.id");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final AttributeKey<String> MESSAGING_SYSTEM =
       AttributeKey.stringKey("messaging.system");
 
   static final String TEMP_DESTINATION_NAME = "(temporary)";
 
-  /**
-   * Creates the messaging attributes extractor for the given {@link MessageOperation operation}
-   * with default configuration.
-   */
+  /** Creates the messaging attributes extractor for the given operation type. */
+  // will be renamed in 3.0 to create()
+  public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> createForOperationType(
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessagingOperationType operationType) {
+    return builderForOperationType(getter, operationType).build();
+  }
+
+  /** Creates the messaging attributes extractor for the given operation. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
   }
 
   /**
-   * Returns a new {@link MessagingAttributesExtractorBuilder} for the given {@link MessageOperation
-   * operation} that can be used to configure the messaging attributes extractor.
+   * Returns a new {@link MessagingAttributesExtractorBuilder} configured for the given operation
+   * type.
    */
+  // will be renamed in 3.0 to builder()
+  public static <REQUEST, RESPONSE>
+      MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builderForOperationType(
+          MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+          @Nullable MessagingOperationType operationType) {
+    return new MessagingAttributesExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a new messaging attributes extractor builder for the given operation. */
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
-    return new MessagingAttributesExtractorBuilder<>(getter, operation);
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
+    return new MessagingAttributesExtractorBuilder<>(
+        getter, operation == null ? null : operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  private final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private final String operationName;
+  private final boolean supportsStableSemconv;
   private final List<String> capturedHeaders;
 
   MessagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter,
-      MessageOperation operation,
+      @Nullable MessagingOperationType operationType,
+      @Nullable String operationName,
+      boolean supportsStableSemconv,
       List<String> capturedHeaders) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
   }
 
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
+    boolean emitOldSemconv = !supportsStableSemconv || emitOldMessagingSemconv();
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
     attributes.put(MESSAGING_SYSTEM, getter.getSystem(request));
     boolean isTemporaryDestination = getter.isTemporaryDestination(request);
     if (isTemporaryDestination) {
       attributes.put(MESSAGING_DESTINATION_TEMPORARY, true);
-      attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      if (emitStableSemconv) {
+        attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
+        attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
+      } else {
+        attributes.put(MESSAGING_DESTINATION_NAME, TEMP_DESTINATION_NAME);
+      }
     } else {
       attributes.put(MESSAGING_DESTINATION_NAME, getter.getDestination(request));
       attributes.put(MESSAGING_DESTINATION_TEMPLATE, getter.getDestinationTemplate(request));
@@ -106,9 +143,20 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     attributes.put(MESSAGING_MESSAGE_CONVERSATION_ID, getter.getConversationId(request));
     attributes.put(MESSAGING_MESSAGE_BODY_SIZE, getter.getMessageBodySize(request));
     attributes.put(MESSAGING_MESSAGE_ENVELOPE_SIZE, getter.getMessageEnvelopeSize(request));
-    attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
-    if (operation != null) {
-      attributes.put(MESSAGING_OPERATION, operation.operationName());
+    if (emitOldSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID_OLD, getter.getClientId(request));
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_CLIENT_ID, getter.getClientId(request));
+    }
+    if (emitOldSemconv && operationType != null) {
+      attributes.put(MESSAGING_OPERATION, operationType.defaultOperationName());
+    }
+    if (emitStableSemconv) {
+      attributes.put(MESSAGING_OPERATION_NAME, operationName);
+      if (operationType != null) {
+        attributes.put(MESSAGING_OPERATION_TYPE, operationType.value());
+      }
     }
   }
 
@@ -121,6 +169,13 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
       @Nullable Throwable error) {
     attributes.put(MESSAGING_MESSAGE_ID, getter.getMessageId(request, response));
     attributes.put(MESSAGING_BATCH_MESSAGE_COUNT, getter.getBatchMessageCount(request, response));
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String errorType = getter.getErrorType(request, response, error);
+      if (errorType == null && error != null) {
+        errorType = error.getClass().getName();
+      }
+      attributes.put(ERROR_TYPE, errorType);
+    }
 
     for (String name : capturedHeaders) {
       List<String> values = getter.getMessageHeader(request, name);
@@ -137,17 +192,21 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   @Override
   @Nullable
   public SpanKey internalGetSpanKey() {
-    if (operation == null) {
+    if (operationType == null) {
       return null;
     }
 
-    switch (operation) {
-      case PUBLISH:
+    switch (operationType) {
+      case CREATE:
+        return SpanKey.PRODUCER_CREATE;
+      case SEND:
         return SpanKey.PRODUCER;
       case RECEIVE:
         return SpanKey.CONSUMER_RECEIVE;
       case PROCESS:
         return SpanKey.CONSUMER_PROCESS;
+      case SETTLE:
+        return SpanKey.CONSUMER_SETTLE;
     }
     throw new IllegalStateException("Can't possibly happen");
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -38,6 +38,9 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @CanIgnoreReturnValue
   public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
       String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -6,24 +6,40 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /** A builder of {@link MessagingAttributesExtractor}. */
 public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
 
   final MessagingAttributesGetter<REQUEST, RESPONSE> getter;
-  final MessageOperation operation;
+  @Nullable private final MessagingOperationType operationType;
+  @Nullable private String operationName;
+  private final boolean supportsStableSemconv;
   List<String> capturedHeaders = emptyList();
 
   MessagingAttributesExtractorBuilder(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+      @Nullable MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationType == null ? null : operationType.defaultOperationName();
+    this.supportsStableSemconv = supportsStableSemconv;
+  }
+
+  /** Configures the system-specific operation name emitted as {@code messaging.operation.name}. */
+  @CanIgnoreReturnValue
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setOperationName(
+      String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
   }
 
   /**
@@ -47,6 +63,10 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * MessagingAttributesExtractorBuilder}.
    */
   public AttributesExtractor<REQUEST, RESPONSE> build() {
-    return new MessagingAttributesExtractor<>(getter, operation, capturedHeaders);
+    if (supportsStableSemconv) {
+      requireNonNull(operationName, "operationName");
+    }
+    return new MessagingAttributesExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv, capturedHeaders);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
@@ -56,6 +56,21 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
   }
 
   /**
+   * Returns a description of a class of error the operation ended with.
+   *
+   * <p>If this method returns {@code null}, the exception class name (if any) will be used as error
+   * type.
+   *
+   * <p>The cardinality of the error type should be low. The instrumentations implementing this
+   * method are recommended to document the custom values they support.
+   */
+  @Nullable
+  default String getErrorType(
+      REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error) {
+    return null;
+  }
+
+  /**
    * Extracts all values of header named {@code name} from the request, or an empty list if there
    * were none.
    *

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -76,7 +76,12 @@ public final class MessagingConsumerMetrics implements OperationListener {
             || consumedMessagesCounter != null;
   }
 
-  /** Returns metrics for extractors configured with {@link MessageOperation}. */
+  /**
+   * Returns metrics for extractors configured with {@link MessageOperation}.
+   *
+   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
@@ -23,10 +26,11 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#consumer-metrics">Consumer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#consumer-metrics">consumer
  * metrics</a>.
  */
 public final class MessagingConsumerMetrics implements OperationListener {
@@ -35,39 +39,86 @@ public final class MessagingConsumerMetrics implements OperationListener {
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingConsumerMetrics.State> MESSAGING_CONSUMER_METRICS_STATE =
       ContextKey.named("messaging-consumer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingConsumerMetrics.class.getName());
 
-  private final DoubleHistogram receiveDurationHistogram;
-  private final LongCounter receiveMessageCount;
+  private final boolean supportsStableSemconv;
+  private final boolean consumedMessagesOnly;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram receiveDurationHistogram;
+  @Nullable private final LongCounter receiveMessageCount;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter consumedMessagesCounter;
 
-  private MessagingConsumerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.receive.duration")
-            .setDescription("Measures the duration of receive operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyReceiveDurationAdvice(durationBuilder);
-    receiveDurationHistogram = durationBuilder.build();
-
-    LongCounterBuilder longCounterBuilder =
-        meter
-            .counterBuilder("messaging.receive.messages")
-            .setDescription("Measures the number of received messages.")
-            .setUnit("{message}");
-    MessagingMetricsAdvice.applyReceiveMessagesAdvice(longCounterBuilder);
-    receiveMessageCount = longCounterBuilder.build();
+  private MessagingConsumerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    consumedMessagesOnly = variant == Variant.CONSUMED_MESSAGES_ONLY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    receiveDurationHistogram =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveDuration(meter) : null;
+    receiveMessageCount =
+        !consumedMessagesOnly && emitOldSemconv ? buildReceiveMessages(meter) : null;
+    clientOperationDurationHistogram =
+        !consumedMessagesOnly && emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    consumedMessagesCounter = emitStableSemconv ? buildConsumedMessages(meter) : null;
+    enabled =
+        receiveDurationHistogram != null
+            || receiveMessageCount != null
+            || clientOperationDurationHistogram != null
+            || consumedMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging consumer", MessagingConsumerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.receive.duration} and {@code messaging.receive.messages}
+   * instruments.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.STABLE_AND_OLD));
+  }
+
+  /** Returns only the stable consumed-messages metric for a delivered message. */
+  public static OperationMetrics getConsumedMessages() {
+    return OperationMetricsUtil.create(
+        "messaging consumed messages",
+        meter -> new MessagingConsumerMetrics(meter, Variant.CONSUMED_MESSAGES_ONLY));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_CONSUMER_METRICS_STATE,
         new AutoValue_MessagingConsumerMetrics_State(startAttributes, startNanos));
@@ -75,6 +126,9 @@ public final class MessagingConsumerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingConsumerMetrics.State state = context.get(MESSAGING_CONSUMER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -85,21 +139,104 @@ public final class MessagingConsumerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
-    receiveDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
+    String operationType = attributes.get(MESSAGING_OPERATION_TYPE);
+    boolean recordsLegacyReceive =
+        !supportsStableSemconv
+            || "receive".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.RECEIVE.value().equals(operationType);
+    if (receiveDurationHistogram != null && recordsLegacyReceive) {
+      receiveDurationHistogram.record(duration, attributes, context);
+    }
+    // Metric view attribute advice can only select keys statically. The concrete destination name
+    // must be omitted when a template is available or the destination is temporary or anonymous,
+    // so this conditional requirement must be enforced before recording.
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || consumedMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null
+        && !MessagingOperationType.PROCESS.value().equals(operationType)) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
 
-    long receiveMessagesCount = getReceiveMessagesCount(state.startAttributes(), endAttributes);
-    receiveMessageCount.add(receiveMessagesCount, attributes, context);
+    Long batchMessageCount = getBatchMessageCount(state.startAttributes(), endAttributes);
+    if (receiveMessageCount != null && recordsLegacyReceive) {
+      long receiveMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (!supportsStableSemconv || receiveMessagesCount > 0) {
+        receiveMessageCount.add(receiveMessagesCount, attributes, context);
+      }
+    }
+    if (consumedMessagesCounter != null
+        && (consumedMessagesOnly || MessagingOperationType.RECEIVE.value().equals(operationType))) {
+      long consumedMessagesCount =
+          getConsumedMessagesCount(attributes, batchMessageCount, consumedMessagesOnly);
+      if (consumedMessagesCount > 0) {
+        consumedMessagesCounter.add(consumedMessagesCount, filteredAttributes, context);
+      }
+    }
   }
 
-  private static long getReceiveMessagesCount(Attributes... attributesList) {
+  @Nullable
+  private static Long getBatchMessageCount(Attributes... attributesList) {
     for (Attributes attributes : attributesList) {
       Long value = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
       if (value != null) {
         return value;
       }
     }
-    return 1;
+    return null;
+  }
+
+  private static long getConsumedMessagesCount(
+      Attributes attributes, @Nullable Long batchMessageCount, boolean consumedMessagesOnly) {
+    if (batchMessageCount != null) {
+      return batchMessageCount;
+    }
+    return consumedMessagesOnly || attributes.get(ERROR_TYPE) == null ? 1 : 0;
+  }
+
+  private static DoubleHistogram buildReceiveDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.receive.duration")
+            .setDescription("Measures the duration of receive operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildReceiveMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.receive.messages")
+            .setDescription("Measures the number of received messages.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyOldMessagesAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildConsumedMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.consumed.messages")
+            .setDescription("Number of messages that were delivered to the application.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applyConsumedMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -108,5 +245,19 @@ public final class MessagingConsumerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD,
+    /** Only the stable consumed-messages counter, for a delivered message. */
+    CONSUMED_MESSAGES_ONLY
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdvice.java
@@ -12,10 +12,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogramBuilder;
 import io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
 final class MessagingMetricsAdvice {
@@ -28,14 +30,26 @@ final class MessagingMetricsAdvice {
       AttributeKey.stringKey("messaging.system");
   private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
       AttributeKey.stringKey("messaging.destination.name");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_ANONYMOUS =
+      AttributeKey.booleanKey("messaging.destination.anonymous");
+  private static final AttributeKey<Boolean> MESSAGING_DESTINATION_TEMPORARY =
+      AttributeKey.booleanKey("messaging.destination.temporary");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      AttributeKey.stringKey("messaging.destination.subscription.name");
   private static final AttributeKey<String> MESSAGING_DESTINATION_PARTITION_ID =
       AttributeKey.stringKey("messaging.destination.partition.id");
   private static final AttributeKey<String> MESSAGING_DESTINATION_TEMPLATE =
       AttributeKey.stringKey("messaging.destination.template");
 
-  private static final List<AttributeKey<?>> MESSAGING_ATTRIBUTES =
+  private static final List<AttributeKey<?>> OLD_ATTRIBUTES =
       asList(
           MESSAGING_SYSTEM,
           MESSAGING_DESTINATION_NAME,
@@ -46,25 +60,90 @@ final class MessagingMetricsAdvice {
           SERVER_PORT,
           SERVER_ADDRESS);
 
-  static void applyPublishDurationAdvice(DoubleHistogramBuilder builder) {
+  private static final List<AttributeKey<?>> CLIENT_OPERATION_DURATION_ATTRIBUTES =
+      buildAttributes(true, true, true);
+  private static final List<AttributeKey<?>> SENT_MESSAGES_ATTRIBUTES =
+      buildAttributes(false, false, true);
+  private static final List<AttributeKey<?>> CONSUMED_MESSAGES_ATTRIBUTES =
+      buildAttributes(true, false, true);
+  private static final List<AttributeKey<?>> PROCESS_DURATION_ATTRIBUTES =
+      buildAttributes(true, false, true);
+
+  private static List<AttributeKey<?>> buildAttributes(
+      boolean includeConsumerAttributes, boolean includeOperationType, boolean includeErrorType) {
+    List<AttributeKey<?>> attributes = new ArrayList<>();
+    attributes.add(MESSAGING_OPERATION_NAME);
+    attributes.add(MESSAGING_SYSTEM);
+    if (includeErrorType) {
+      attributes.add(ERROR_TYPE);
+    }
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_CONSUMER_GROUP_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_NAME);
+    if (includeConsumerAttributes) {
+      attributes.add(MESSAGING_DESTINATION_SUBSCRIPTION_NAME);
+    }
+    attributes.add(MESSAGING_DESTINATION_TEMPLATE);
+    if (includeOperationType) {
+      attributes.add(MESSAGING_OPERATION_TYPE);
+    }
+    attributes.add(MESSAGING_DESTINATION_PARTITION_ID);
+    attributes.add(SERVER_ADDRESS);
+    attributes.add(SERVER_PORT);
+    return unmodifiableList(attributes);
+  }
+
+  static Attributes filterAttributes(Attributes attributes) {
+    if (attributes.get(MESSAGING_DESTINATION_TEMPLATE) == null
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_ANONYMOUS))
+        && !Boolean.TRUE.equals(attributes.get(MESSAGING_DESTINATION_TEMPORARY))) {
+      return attributes;
+    }
+    return attributes.toBuilder().remove(MESSAGING_DESTINATION_NAME).build();
+  }
+
+  static void applyOldDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
   }
 
-  static void applyReceiveDurationAdvice(DoubleHistogramBuilder builder) {
+  static void applyClientOperationDurationAdvice(DoubleHistogramBuilder builder) {
     if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
       return;
     }
-    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedDoubleHistogramBuilder) builder)
+        .setAttributesAdvice(CLIENT_OPERATION_DURATION_ATTRIBUTES);
   }
 
-  static void applyReceiveMessagesAdvice(LongCounterBuilder builder) {
+  static void applyProcessDurationAdvice(DoubleHistogramBuilder builder) {
+    if (!(builder instanceof ExtendedDoubleHistogramBuilder)) {
+      return;
+    }
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(PROCESS_DURATION_ATTRIBUTES);
+  }
+
+  static void applyOldMessagesAdvice(LongCounterBuilder builder) {
     if (!(builder instanceof ExtendedLongCounterBuilder)) {
       return;
     }
-    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(MESSAGING_ATTRIBUTES);
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(OLD_ATTRIBUTES);
+  }
+
+  static void applySentMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(SENT_MESSAGES_ATTRIBUTES);
+  }
+
+  static void applyConsumedMessagesAdvice(LongCounterBuilder builder) {
+    if (!(builder instanceof ExtendedLongCounterBuilder)) {
+      return;
+    }
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(CONSUMED_MESSAGES_ATTRIBUTES);
   }
 
   private MessagingMetricsAdvice() {}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingOperationType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+/**
+ * Represents a <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#operation-types">messaging
+ * operation type</a>.
+ */
+public enum MessagingOperationType {
+  CREATE("create", "create"),
+  SEND("send", "publish"),
+  RECEIVE("receive", "receive"),
+  PROCESS("process", "process"),
+  SETTLE("settle", "settle");
+
+  private final String value;
+  private final String defaultOperationName;
+
+  MessagingOperationType(String value, String defaultOperationName) {
+    this.value = value;
+    this.defaultOperationName = defaultOperationName;
+  }
+
+  String value() {
+    return value;
+  }
+
+  String defaultOperationName() {
+    return defaultOperationName;
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetrics.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.FINE;
+
+import com.google.auto.value.AutoValue;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
+import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * {@link OperationListener} which keeps track of <a
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#metric-messagingprocessduration">message
+ * processing metrics</a>.
+ */
+public final class MessagingProcessMetrics implements OperationListener {
+  private static final double NANOS_PER_S = SECONDS.toNanos(1);
+
+  private static final ContextKey<State> MESSAGING_PROCESS_METRICS_STATE =
+      ContextKey.named("messaging-process-metrics-state");
+  private static final Logger logger = Logger.getLogger(MessagingProcessMetrics.class.getName());
+
+  @Nullable private final DoubleHistogram processDurationHistogram;
+
+  private MessagingProcessMetrics(Meter meter) {
+    processDurationHistogram = emitStableMessagingSemconv() ? buildProcessDuration(meter) : null;
+  }
+
+  public static OperationMetrics get() {
+    return OperationMetricsUtil.create("messaging process", MessagingProcessMetrics::new);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (processDurationHistogram == null) {
+      return context;
+    }
+    return context.with(
+        MESSAGING_PROCESS_METRICS_STATE,
+        new AutoValue_MessagingProcessMetrics_State(startAttributes, startNanos));
+  }
+
+  @Override
+  public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (processDurationHistogram == null) {
+      return;
+    }
+    State state = context.get(MESSAGING_PROCESS_METRICS_STATE);
+    if (state == null) {
+      logger.log(
+          FINE,
+          "No state present when ending context {0}. Cannot record messaging process metrics.",
+          context);
+      return;
+    }
+
+    Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    processDurationHistogram.record(
+        (endNanos - state.startTimeNanos()) / NANOS_PER_S,
+        MessagingMetricsAdvice.filterAttributes(attributes),
+        context);
+  }
+
+  private static DoubleHistogram buildProcessDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.process.duration")
+            .setDescription("Duration of processing operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyProcessDurationAdvice(builder);
+    return builder.build();
+  }
+
+  @AutoValue
+  abstract static class State {
+    abstract Attributes startAttributes();
+
+    abstract long startTimeNanos();
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -68,7 +68,12 @@ public final class MessagingProducerMetrics implements OperationListener {
             || sentMessagesCounter != null;
   }
 
-  /** Returns metrics for extractors configured with {@link MessageOperation}. */
+  /**
+   * Returns metrics for extractors configured with {@link MessageOperation}.
+   *
+   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 
 import com.google.auto.value.AutoValue;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
@@ -20,39 +25,84 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.OperationMetricsUtil;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * {@link OperationListener} which keeps track of <a
- * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.26.0/docs/messaging/messaging-metrics.md#metric-messagingpublishduration">Producer
+ * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-metrics.md#producer-metrics">producer
  * metrics</a>.
  */
 public final class MessagingProducerMetrics implements OperationListener {
   private static final double NANOS_PER_S = SECONDS.toNanos(1);
 
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
+  private static final AttributeKey<String> MESSAGING_OPERATION =
+      AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final ContextKey<MessagingProducerMetrics.State> MESSAGING_PRODUCER_METRICS_STATE =
       ContextKey.named("messaging-producer-metrics-state");
   private static final Logger logger = Logger.getLogger(MessagingProducerMetrics.class.getName());
 
-  private final DoubleHistogram publishDurationHistogram;
+  private final boolean supportsStableSemconv;
+  private final boolean enabled;
+  @Nullable private final DoubleHistogram publishDurationHistogram;
+  @Nullable private final DoubleHistogram clientOperationDurationHistogram;
+  @Nullable private final LongCounter sentMessagesCounter;
 
-  private MessagingProducerMetrics(Meter meter) {
-    DoubleHistogramBuilder durationBuilder =
-        meter
-            .histogramBuilder("messaging.publish.duration")
-            .setDescription("Measures the duration of publish operation.")
-            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
-            .setUnit("s");
-    MessagingMetricsAdvice.applyPublishDurationAdvice(durationBuilder);
-    publishDurationHistogram = durationBuilder.build();
+  private MessagingProducerMetrics(Meter meter, Variant variant) {
+    supportsStableSemconv = variant != Variant.LEGACY;
+    boolean emitOldSemconv =
+        variant == Variant.LEGACY
+            || (variant == Variant.STABLE_AND_OLD && emitOldMessagingSemconv());
+    boolean emitStableSemconv = supportsStableSemconv && emitStableMessagingSemconv();
+    publishDurationHistogram = emitOldSemconv ? buildPublishDuration(meter) : null;
+    clientOperationDurationHistogram =
+        emitStableSemconv ? buildClientOperationDuration(meter) : null;
+    sentMessagesCounter = emitStableSemconv ? buildSentMessages(meter) : null;
+    enabled =
+        publishDurationHistogram != null
+            || clientOperationDurationHistogram != null
+            || sentMessagesCounter != null;
   }
 
+  /** Returns metrics for extractors configured with {@link MessageOperation}. */
   public static OperationMetrics get() {
-    return OperationMetricsUtil.create("messaging producer", MessagingProducerMetrics::new);
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType}, emitting only
+   * the stable {@code messaging.client.*} instruments.
+   */
+  // will be renamed in 3.0 to get()
+  public static OperationMetrics getForOperationType() {
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE));
+  }
+
+  /**
+   * Returns metrics for extractors configured with {@link MessagingOperationType} that additionally
+   * emit the deprecated {@code messaging.publish.duration} instrument.
+   *
+   * <p>Intended only for instrumentations that already emitted the pre-1.43 metrics before
+   * migrating to {@link MessagingOperationType}, so that they keep emitting them until 3.0. New
+   * instrumentations should use {@link #getForOperationType()} instead.
+   */
+  public static OperationMetrics getForOperationTypeWithOldMetrics() { // to be removed in 3.0
+    return OperationMetricsUtil.create(
+        "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.STABLE_AND_OLD));
   }
 
   @Override
   @CanIgnoreReturnValue
   public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+    if (!enabled) {
+      return context;
+    }
     return context.with(
         MESSAGING_PRODUCER_METRICS_STATE,
         new AutoValue_MessagingProducerMetrics_State(startAttributes, startNanos));
@@ -60,6 +110,9 @@ public final class MessagingProducerMetrics implements OperationListener {
 
   @Override
   public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+    if (!enabled) {
+      return;
+    }
     MessagingProducerMetrics.State state = context.get(MESSAGING_PRODUCER_METRICS_STATE);
     if (state == null) {
       logger.log(
@@ -70,9 +123,64 @@ public final class MessagingProducerMetrics implements OperationListener {
     }
 
     Attributes attributes = state.startAttributes().toBuilder().putAll(endAttributes).build();
+    double duration = (endNanos - state.startTimeNanos()) / NANOS_PER_S;
 
-    publishDurationHistogram.record(
-        (endNanos - state.startTimeNanos()) / NANOS_PER_S, attributes, context);
+    if (publishDurationHistogram != null
+        && (!supportsStableSemconv
+            || "publish".equals(attributes.get(MESSAGING_OPERATION))
+            || MessagingOperationType.SEND
+                .value()
+                .equals(attributes.get(MESSAGING_OPERATION_TYPE)))) {
+      publishDurationHistogram.record(duration, attributes, context);
+    }
+    Attributes filteredAttributes =
+        clientOperationDurationHistogram != null || sentMessagesCounter != null
+            ? MessagingMetricsAdvice.filterAttributes(attributes)
+            : attributes;
+    if (clientOperationDurationHistogram != null) {
+      clientOperationDurationHistogram.record(duration, filteredAttributes, context);
+    }
+    if (sentMessagesCounter != null
+        && MessagingOperationType.SEND.value().equals(attributes.get(MESSAGING_OPERATION_TYPE))) {
+      Long batchMessageCount = attributes.get(MESSAGING_BATCH_MESSAGE_COUNT);
+      long sentMessagesCount = batchMessageCount == null ? 1 : batchMessageCount;
+      if (sentMessagesCount > 0) {
+        sentMessagesCounter.add(sentMessagesCount, filteredAttributes, context);
+      }
+    }
+  }
+
+  private static DoubleHistogram buildPublishDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.publish.duration")
+            .setDescription("Measures the duration of publish operation.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyOldDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static DoubleHistogram buildClientOperationDuration(Meter meter) {
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("messaging.client.operation.duration")
+            .setDescription(
+                "Duration of messaging operation initiated by a producer or consumer client.")
+            .setExplicitBucketBoundariesAdvice(MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS)
+            .setUnit("s");
+    MessagingMetricsAdvice.applyClientOperationDurationAdvice(builder);
+    return builder.build();
+  }
+
+  private static LongCounter buildSentMessages(Meter meter) {
+    LongCounterBuilder builder =
+        meter
+            .counterBuilder("messaging.client.sent.messages")
+            .setDescription("Number of messages producer attempted to send to the broker.")
+            .setUnit("{message}");
+    MessagingMetricsAdvice.applySentMessagesAdvice(builder);
+    return builder.build();
   }
 
   @AutoValue
@@ -81,5 +189,17 @@ public final class MessagingProducerMetrics implements OperationListener {
     abstract Attributes startAttributes();
 
     abstract long startTimeNanos();
+  }
+
+  private enum Variant {
+    /** Extractors configured with {@link MessageOperation}; old instruments only. */
+    LEGACY,
+    /** Extractors configured with {@link MessagingOperationType}; stable instruments only. */
+    STABLE,
+    /**
+     * Extractors configured with {@link MessagingOperationType} that also keep emitting the
+     * deprecated instruments.
+     */
+    STABLE_AND_OLD
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+
+/** Selects messaging span kinds according to the configured semantic convention version. */
+public final class MessagingSpanKindExtractor {
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessagingOperationType operationType) {
+    return create(operationType, true);
+  }
+
+  /**
+   * Returns a span kind extractor following the <a
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-kind">v1.43
+   * messaging span kind conventions</a>.
+   *
+   * @param isSpanContextPropagated whether the context of a {@link MessagingOperationType#SEND}
+   *     span is propagated as the message creation context; ignored for other operation types
+   */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(
+      MessagingOperationType operationType, boolean isSpanContextPropagated) {
+    SpanKind spanKind;
+    switch (operationType) {
+      case CREATE:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case SEND:
+        spanKind =
+            emitStableMessagingSemconv() && !isSpanContextPropagated
+                ? SpanKind.CLIENT
+                : SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+        spanKind = emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
+        break;
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      case SETTLE:
+        spanKind = SpanKind.CLIENT;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  /** Returns a span kind extractor for the given operation. */
+  public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
+    SpanKind spanKind;
+    switch (operation) {
+      case PUBLISH:
+        spanKind = SpanKind.PRODUCER;
+        break;
+      case RECEIVE:
+      case PROCESS:
+        spanKind = SpanKind.CONSUMER;
+        break;
+      default:
+        throw new IllegalStateException("Can't possibly happen");
+    }
+    return request -> spanKind;
+  }
+
+  private MessagingSpanKindExtractor() {}
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -58,7 +58,10 @@ public final class MessagingSpanKindExtractor {
     return request -> spanKind;
   }
 
-  /** Returns a span kind extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #create(MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
     SpanKind spanKind;
     switch (operation) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -5,35 +5,75 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtractor<REQUEST> {
 
   /**
    * Returns a {@link SpanNameExtractor} that constructs the span name according to <a
-   * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#span-name">
-   * messaging semantic conventions</a>: {@code <destination name> <operation name>}.
+   * href="https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/messaging/messaging-spans.md#span-name">
+   * messaging semantic conventions</a>.
    *
    * @see MessagingAttributesGetter#getDestination(Object) used to extract {@code <destination
    *     name>}.
-   * @see MessageOperation used to extract {@code <operation name>}.
+   * @see MessagingOperationType used to extract {@code <operation name>}.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return builder(getter, operationType).build();
+  }
+
+  /** Returns a messaging span name extractor for the given operation. */
+  public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
-    return new MessagingSpanNameExtractor<>(getter, operation);
+    return builder(getter, operation).build();
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractorBuilder} that can be used to configure the
+   * messaging span name extractor.
+   */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessagingOperationType operationType) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operationType, true);
+  }
+
+  /** Returns a messaging span name extractor builder for the given operation. */
+  public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
+      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+    return new MessagingSpanNameExtractorBuilder<>(getter, operation.type(), false);
   }
 
   private final MessagingAttributesGetter<REQUEST, ?> getter;
-  private final MessageOperation operation;
+  private final MessagingOperationType operationType;
+  private final String operationName;
+  private final boolean supportsStableSemconv;
 
-  private MessagingSpanNameExtractor(
-      MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
+  MessagingSpanNameExtractor(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      String operationName,
+      boolean supportsStableSemconv) {
     this.getter = getter;
-    this.operation = operation;
+    this.operationType = operationType;
+    this.operationName = operationName;
+    this.supportsStableSemconv = supportsStableSemconv;
   }
 
   @Override
   public String extract(REQUEST request) {
+    if (supportsStableSemconv && emitStableMessagingSemconv()) {
+      String destinationName = getter.getDestinationTemplate(request);
+      if (destinationName == null
+          && !getter.isTemporaryDestination(request)
+          && !getter.isAnonymousDestination(request)) {
+        destinationName = getter.getDestination(request);
+      }
+      return destinationName == null ? operationName : operationName + " " + destinationName;
+    }
+
     String destinationName =
         getter.isTemporaryDestination(request)
             ? MessagingAttributesExtractor.TEMP_DESTINATION_NAME
@@ -42,6 +82,6 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
       destinationName = "unknown";
     }
 
-    return destinationName + " " + operation.operationName();
+    return destinationName + " " + operationType.defaultOperationName();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -25,7 +25,11 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
     return builder(getter, operationType).build();
   }
 
-  /** Returns a messaging span name extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType)}. Will be
+   *     removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
     return builder(getter, operation).build();
@@ -40,7 +44,11 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
     return new MessagingSpanNameExtractorBuilder<>(getter, operationType, true);
   }
 
-  /** Returns a messaging span name extractor builder for the given operation. */
+  /**
+   * @deprecated Use {@link #builder(MessagingAttributesGetter, MessagingOperationType)}. Will be
+   *     removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST> MessagingSpanNameExtractorBuilder<REQUEST> builder(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
     return new MessagingSpanNameExtractorBuilder<>(getter, operation.type(), false);

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -31,6 +31,9 @@ public final class MessagingSpanNameExtractorBuilder<REQUEST> {
   /** Configures the system-specific operation name used in the v1.43 messaging span name. */
   @CanIgnoreReturnValue
   public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    if (!supportsStableSemconv) {
+      throw new IllegalStateException("Operation name is not configurable for legacy builders");
+    }
     this.operationName = requireNonNull(operationName, "operationName");
     return this;
   }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+
+/** A builder of {@link MessagingSpanNameExtractor}. */
+public final class MessagingSpanNameExtractorBuilder<REQUEST> {
+
+  private final MessagingAttributesGetter<REQUEST, ?> getter;
+  private final MessagingOperationType operationType;
+  private final boolean supportsStableSemconv;
+  private String operationName;
+
+  MessagingSpanNameExtractorBuilder(
+      MessagingAttributesGetter<REQUEST, ?> getter,
+      MessagingOperationType operationType,
+      boolean supportsStableSemconv) {
+    this.getter = getter;
+    this.operationType = requireNonNull(operationType, "operationType");
+    this.supportsStableSemconv = supportsStableSemconv;
+    this.operationName = operationType.defaultOperationName();
+  }
+
+  /** Configures the system-specific operation name used in the v1.43 messaging span name. */
+  @CanIgnoreReturnValue
+  public MessagingSpanNameExtractorBuilder<REQUEST> setOperationName(String operationName) {
+    this.operationName = requireNonNull(operationName, "operationName");
+    return this;
+  }
+
+  /**
+   * Returns a new {@link MessagingSpanNameExtractor} with the settings of this {@link
+   * MessagingSpanNameExtractorBuilder}.
+   */
+  public SpanNameExtractor<REQUEST> build() {
+    return new MessagingSpanNameExtractor<>(
+        getter, operationType, operationName, supportsStableSemconv);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.function.BiFunction;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessContextCustomizer<REQUEST> implements ContextCustomizer<REQUEST> {
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      TextMapPropagator propagator, TextMapGetter<REQUEST> getter) {
+    return create((parentContext, request) -> propagator.extract(parentContext, request, getter));
+  }
+
+  public static <REQUEST> ContextCustomizer<REQUEST> create(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    return new MessagingProcessContextCustomizer<>(producerContextExtractor);
+  }
+
+  private final BiFunction<Context, REQUEST, Context> producerContextExtractor;
+
+  private MessagingProcessContextCustomizer(
+      BiFunction<Context, REQUEST, Context> producerContextExtractor) {
+    this.producerContextExtractor = producerContextExtractor;
+  }
+
+  @Override
+  public Context onStart(Context parentContext, REQUEST request, Attributes startAttributes) {
+    Context extractedContext = producerContextExtractor.apply(parentContext, request);
+    Span parentSpan = Span.fromContext(parentContext);
+    if (!parentSpan.getSpanContext().isValid()) {
+      return extractedContext;
+    }
+    return extractedContext.with(parentSpan);
+  }
+}

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class MessagingProcessInstrumenterFactory {
+
+  public static <REQUEST, RESPONSE> Instrumenter<REQUEST, RESPONSE> create(
+      InstrumenterBuilder<REQUEST, RESPONSE> builder,
+      TextMapPropagator propagator,
+      TextMapGetter<REQUEST> getter,
+      boolean receiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv()) {
+      builder.addSpanLinksExtractor(
+          (spanLinks, parentContext, request) -> {
+            SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+            SpanContext producerSpanContext =
+                Span.fromContext(propagator.extract(parentContext, request, getter))
+                    .getSpanContext();
+            if (parentSpanContext.isValid()
+                && producerSpanContext.isValid()
+                && (!producerSpanContext.getTraceId().equals(parentSpanContext.getTraceId())
+                    || !producerSpanContext.getSpanId().equals(parentSpanContext.getSpanId()))) {
+              spanLinks.addLink(producerSpanContext);
+            }
+          });
+      builder.addContextCustomizer(MessagingProcessContextCustomizer.create(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    if (receiveInstrumentationEnabled) {
+      builder.addSpanLinksExtractor(new PropagatorBasedSpanLinksExtractor<>(propagator, getter));
+      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    }
+    return builder.buildConsumerInstrumenter(getter);
+  }
+
+  private MessagingProcessInstrumenterFactory() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -6,7 +6,10 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -17,15 +20,21 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ENVELOPE_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,8 +56,8 @@ class MessagingAttributesExtractorTest {
       boolean temporary,
       boolean anonymous,
       String destination,
-      MessageOperation operation,
-      String expectedDestination) {
+      MessagingOperationType operationType,
+      String operationName) {
     // given
     Map<String, String> request = new HashMap<>();
     request.put("system", "myQueue");
@@ -63,13 +72,16 @@ class MessagingAttributesExtractorTest {
     }
     request.put("url", "http://broker/topic");
     request.put("conversationId", "42");
+    request.put("messageId", "42");
     request.put("bodySize", "100");
     request.put("envelopeSize", "120");
     request.put("clientId", "43");
     request.put("batchMessageCount", "2");
 
     AttributesExtractor<Map<String, String>, String> underTest =
-        MessagingAttributesExtractor.create(TestGetter.INSTANCE, operation);
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName(operationName)
+            .build();
 
     Context context = Context.root();
 
@@ -78,16 +90,22 @@ class MessagingAttributesExtractorTest {
     underTest.onStart(startAttributes, context, request);
 
     AttributesBuilder endAttributes = Attributes.builder();
-    underTest.onEnd(endAttributes, context, request, "42", null);
+    underTest.onEnd(endAttributes, context, request, "42", new IllegalStateException());
 
     // then
     List<MapEntry<AttributeKey<?>, Object>> expectedEntries = new ArrayList<>();
     expectedEntries.add(entry(MESSAGING_SYSTEM, "myQueue"));
-    expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, expectedDestination));
     if (temporary) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPORARY, true));
+      if (emitStableMessagingSemconv()) {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+        expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
+      } else {
+        expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, "(temporary)"));
+      }
     } else {
-      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, expectedDestination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_NAME, destination));
+      expectedEntries.add(entry(MESSAGING_DESTINATION_TEMPLATE, destination));
     }
     if (anonymous) {
       expectedEntries.add(entry(MESSAGING_DESTINATION_ANONYMOUS, true));
@@ -95,22 +113,143 @@ class MessagingAttributesExtractorTest {
     expectedEntries.add(entry(MESSAGING_MESSAGE_CONVERSATION_ID, "42"));
     expectedEntries.add(entry(MESSAGING_MESSAGE_BODY_SIZE, 100L));
     expectedEntries.add(entry(MESSAGING_MESSAGE_ENVELOPE_SIZE, 120L));
-    expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
-    expectedEntries.add(entry(MESSAGING_OPERATION, operation.operationName()));
+    if (emitOldMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client_id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION, operationType.defaultOperationName()));
+    }
+    if (emitStableMessagingSemconv()) {
+      expectedEntries.add(entry(stringKey("messaging.client.id"), "43"));
+      expectedEntries.add(entry(MESSAGING_OPERATION_NAME, operationName));
+      expectedEntries.add(entry(MESSAGING_OPERATION_TYPE, operationType.value()));
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     MapEntry<? extends AttributeKey<?>, ?>[] expectedEntriesArr =
         expectedEntries.toArray(new MapEntry[0]);
     assertThat(startAttributes.build()).containsOnly(expectedEntriesArr);
 
-    assertThat(endAttributes.build())
-        .containsOnly(entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    if (emitStableMessagingSemconv()) {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"),
+              entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L),
+              entry(ERROR_TYPE, IllegalStateException.class.getName()));
+    } else {
+      assertThat(endAttributes.build())
+          .containsOnly(
+              entry(MESSAGING_MESSAGE_ID, "42"), entry(MESSAGING_BATCH_MESSAGE_COUNT, 2L));
+    }
   }
 
   static Stream<Arguments> destinations() {
     return Stream.of(
-        Arguments.of(false, false, "destination", MessageOperation.RECEIVE, "destination"),
-        Arguments.of(true, true, null, MessageOperation.PROCESS, "(temporary)"));
+        argumentSet(
+            "create operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.CREATE,
+            "create"),
+        argumentSet(
+            "regular destination",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.RECEIVE,
+            "poll"),
+        argumentSet(
+            "temporary anonymous destination",
+            true,
+            true,
+            "generated-destination",
+            MessagingOperationType.PROCESS,
+            "process"),
+        argumentSet(
+            "settle operation",
+            false,
+            false,
+            "destination",
+            MessagingOperationType.SETTLE,
+            "settle"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("spanKeys")
+  void shouldReturnSpanKey(MessagingOperationType operationType, SpanKey spanKey) {
+    MessagingAttributesExtractor<Map<String, String>, String> underTest =
+        new MessagingAttributesExtractor<>(
+            TestGetter.INSTANCE,
+            operationType,
+            operationType.defaultOperationName(),
+            true,
+            new ArrayList<>());
+
+    assertThat(underTest.internalGetSpanKey()).isSameAs(spanKey);
+  }
+
+  static Stream<Arguments> spanKeys() {
+    return Stream.of(
+        argumentSet("create", MessagingOperationType.CREATE, SpanKey.PRODUCER_CREATE),
+        argumentSet("send", MessagingOperationType.SEND, SpanKey.PRODUCER),
+        argumentSet("receive", MessagingOperationType.RECEIVE, SpanKey.CONSUMER_RECEIVE),
+        argumentSet("process", MessagingOperationType.PROCESS, SpanKey.CONSUMER_PROCESS),
+        argumentSet("settle", MessagingOperationType.SETTLE, SpanKey.CONSUMER_SETTLE));
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldSupportDeprecatedMessageOperation() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.create(TestGetter.INSTANCE, MessageOperation.PUBLISH);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), singletonMap("anonymousDestination", "y"));
+
+    assertThat(attributes.build())
+        .containsOnly(
+            entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
+  }
+
+  @Test
+  void shouldExtractOperationNameWithoutOperationType() {
+    MessagingOperationType operationType = null;
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, operationType)
+            .setOperationName("ack")
+            .build();
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), emptyMap());
+
+    Attributes expected =
+        emitStableMessagingSemconv()
+            ? Attributes.of(MESSAGING_OPERATION_NAME, "ack")
+            : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldRequireOperationNameForStableSemconv() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builderForOperationType(TestGetter.INSTANCE, null)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("operationName");
+  }
+
+  @Test
+  void shouldExtractErrorTypeFromResponse() {
+    AttributesExtractor<Map<String, String>, String> underTest =
+        MessagingAttributesExtractor.createForOperationType(
+            TestGetter.INSTANCE, MessagingOperationType.RECEIVE);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onEnd(attributes, Context.root(), emptyMap(), "failure", null);
+
+    Attributes expected =
+        emitStableMessagingSemconv() ? Attributes.of(ERROR_TYPE, "failure") : Attributes.empty();
+    assertThat(attributes.build()).isEqualTo(expected);
   }
 
   @Test
@@ -118,20 +257,24 @@ class MessagingAttributesExtractorTest {
     // given
     AttributesExtractor<Map<String, String>, String> underTest =
         MessagingAttributesExtractor.create(TestGetter.INSTANCE, null);
+    AttributesExtractor<Map<String, String>, String> builtUnderTest =
+        MessagingAttributesExtractor.builder(TestGetter.INSTANCE, null).build();
 
     Context context = Context.root();
 
     // when
     AttributesBuilder startAttributes = Attributes.builder();
     underTest.onStart(startAttributes, context, emptyMap());
+    AttributesBuilder builtStartAttributes = Attributes.builder();
+    builtUnderTest.onStart(builtStartAttributes, context, emptyMap());
 
     AttributesBuilder endAttributes = Attributes.builder();
     underTest.onEnd(endAttributes, context, emptyMap(), null, null);
 
     // then
-    assertThat(startAttributes.build().isEmpty()).isTrue();
-
-    assertThat(endAttributes.build().isEmpty()).isTrue();
+    assertThat(startAttributes.build()).isEmpty();
+    assertThat(builtStartAttributes.build()).isEmpty();
+    assertThat(endAttributes.build()).isEmpty();
   }
 
   enum TestGetter implements MessagingAttributesGetter<Map<String, String>, String> {
@@ -184,7 +327,7 @@ class MessagingAttributesExtractorTest {
 
     @Override
     public String getMessageId(Map<String, String> request, String response) {
-      return response;
+      return request.get("messageId");
     }
 
     @Nullable
@@ -198,6 +341,11 @@ class MessagingAttributesExtractorTest {
     public Long getBatchMessageCount(Map<String, String> request, @Nullable String response) {
       String payloadSize = request.get("batchMessageCount");
       return payloadSize == null ? null : Long.valueOf(payloadSize);
+    }
+
+    @Override
+    public String getErrorType(Map<String, String> request, String response, Throwable error) {
+      return "failure".equals(response) ? response : null;
     }
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -210,6 +210,17 @@ class MessagingAttributesExtractorTest {
             entry(MESSAGING_DESTINATION_ANONYMOUS, true), entry(MESSAGING_OPERATION, "publish"));
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void shouldRejectOperationNameForDeprecatedMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingAttributesExtractor.builder(TestGetter.INSTANCE, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
+  }
+
   @Test
   void shouldExtractOperationNameWithoutOperationType() {
     MessagingOperationType operationType = null;

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -263,6 +263,7 @@ class MessagingAttributesExtractorTest {
     assertThat(attributes.build()).isEqualTo(expected);
   }
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetricsTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingConsumerMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void collectsMetricsAndCountsBatchOnce() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_CONSUMER_GROUP_NAME, "group")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "subscription")
+            .build();
+    Attributes responseAttributes =
+        Attributes.builder()
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 3)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 2 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
+
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of receive operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Measures the number of received messages.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION, "receive"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null)))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.2)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "receive")))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.consumed.messages")
+                      .hasUnit("{message}")
+                      .hasDescription("Number of messages that were delivered to the application.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(3)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, "group"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                                                  "subscription")))));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void failedReceiveWithoutBatchCountCountsNoConsumedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes requestAttributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Attributes responseAttributes =
+        Attributes.of(ERROR_TYPE, IllegalStateException.class.getName());
+
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.receive.messages")
+                      .hasLongSumSatisfying(
+                          sum -> sum.hasPointsSatisfying(point -> point.hasValue(1))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void consumedMessagesOnlyCountsFailedDelivery() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getConsumedMessages().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(
+        context, Attributes.of(ERROR_TYPE, IllegalStateException.class.getName()), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (!emitStableMessagingSemconv()) {
+      assertThat(metrics).isEmpty();
+      return;
+    }
+    assertThat(metrics)
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.client.consumed.messages")
+                    .hasLongSumSatisfying(
+                        sum ->
+                            sum.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasValue(1)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonReceiveOperations")
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void selectsStableMetricsByOperationType(String operationType, boolean recordsClientDuration) {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationType : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() && recordsClientDuration ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.consumed.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.duration"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.receive.messages"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountReceivedMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static Stream<Arguments> nonReceiveOperations() {
+    return Stream.of(
+        argumentSet("process", "process", false), argumentSet("settle", "settle", true));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingConsumerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.consumed.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingConsumerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "receive"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(300));
+
+    assertThat(metricReader.collectAllMetrics())
+        .hasSize(2)
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.duration"))
+        .anySatisfy(metric -> assertThat(metric).hasName("messaging.receive.messages"));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingMetricsAdviceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+class MessagingMetricsAdviceTest {
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void filtersHighCardinalityDestinationNames() {
+    Attributes lowCardinality = Attributes.of(MESSAGING_DESTINATION_NAME, "orders");
+    assertThat(MessagingMetricsAdvice.filterAttributes(lowCardinality)).isSameAs(lowCardinality);
+
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "orders-42")
+                    .put(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}")
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPLATE, "orders-{id}"));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "tmp-42")
+                    .put(MESSAGING_DESTINATION_TEMPORARY, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_TEMPORARY, true));
+    assertThat(
+            MessagingMetricsAdvice.filterAttributes(
+                Attributes.builder()
+                    .put(MESSAGING_DESTINATION_NAME, "generated-42")
+                    .put(MESSAGING_DESTINATION_ANONYMOUS, true)
+                    .build()))
+        .isEqualTo(Attributes.of(MESSAGING_DESTINATION_ANONYMOUS, true));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProcessMetricsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessMetricsTest {
+
+  private static final double[] DURATION_BUCKETS =
+      MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void emitsProcessDurationAccordingToConfiguration() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProcessMetrics.get().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null)
+            .build();
+
+    Context root = Context.root();
+    Context context = listener.onStart(root, attributes, nanos(100));
+    Attributes endAttributes =
+        Attributes.builder()
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
+            .build();
+    listener.onEnd(context, endAttributes, nanos(350));
+
+    if (!emitStableMessagingSemconv()) {
+      assertThat(context).isSameAs(root);
+      assertThat(metricReader.collectAllMetrics()).isEmpty();
+      return;
+    }
+
+    assertThat(metricReader.collectAllMetrics())
+        .satisfiesExactly(
+            metric ->
+                assertThat(metric)
+                    .hasName("messaging.process.duration")
+                    .hasUnit("s")
+                    .hasDescription("Duration of processing operation.")
+                    .hasHistogramSatisfying(
+                        histogram ->
+                            histogram.hasPointsSatisfying(
+                                point ->
+                                    point
+                                        .hasSum(0.25)
+                                        .hasBucketBoundaries(DURATION_BUCKETS)
+                                        .hasAttributesSatisfyingExactly(
+                                            equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                            equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                            equalTo(
+                                                ERROR_TYPE,
+                                                IllegalStateException.class.getName())))));
+  }
+
+  private static long nanos(int millis) {
+    return MILLISECONDS.toNanos(millis);
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetricsTest.java
@@ -5,26 +5,30 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.TraceFlags;
-import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 class MessagingProducerMetricsTest {
@@ -32,89 +36,234 @@ class MessagingProducerMetricsTest {
   private static final double[] DURATION_BUCKETS =
       MessagingMetricsAdvice.DURATION_SECONDS_BUCKETS.stream().mapToDouble(d -> d).toArray();
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
   void collectsMetrics() {
-    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
     SdkMeterProvider meterProvider =
         SdkMeterProvider.builder().registerMetricReader(metricReader).build();
-
-    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
     Attributes requestAttributes =
         Attributes.builder()
             .put(MESSAGING_SYSTEM, "pulsar")
-            .put(MESSAGING_DESTINATION_NAME, "persistent://public/default/topic")
-            .put(MESSAGING_OPERATION, "publish")
-            .put(SERVER_PORT, 6650)
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
             .put(SERVER_ADDRESS, "localhost")
+            .put(SERVER_PORT, 6650)
             .build();
-
     Attributes responseAttributes =
         Attributes.builder()
-            .put(MESSAGING_MESSAGE_ID, "1:1:0:0")
             .put(MESSAGING_DESTINATION_PARTITION_ID, "1")
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 2)
+            .put(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() ? IllegalStateException.class.getName() : null)
             .build();
 
-    Context parent =
-        Context.root()
-            .with(
-                Span.wrap(
-                    SpanContext.create(
-                        "ff01020304050600ff0a0b0c0d0e0f00",
-                        "090a0b0c0d0e0f00",
-                        TraceFlags.getSampled(),
-                        TraceState.getDefault())));
+    Context context = listener.onStart(Context.root(), requestAttributes, nanos(100));
+    listener.onEnd(context, responseAttributes, nanos(250));
 
-    Context context1 = listener.onStart(parent, requestAttributes, nanos(100));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(metrics)
+        .hasSize((emitOldMessagingSemconv() ? 1 : 0) + (emitStableMessagingSemconv() ? 2 : 0));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    if (emitOldMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.publish.duration")
+                      .hasUnit("s")
+                      .hasDescription("Measures the duration of publish operation.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                                              equalTo(MESSAGING_OPERATION, "publish"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  emitStableMessagingSemconv()
+                                                      ? IllegalStateException.class.getName()
+                                                      : null),
+                                              equalTo(SERVER_PORT, 6650),
+                                              equalTo(SERVER_ADDRESS, "localhost")))));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.operation.duration")
+                      .hasUnit("s")
+                      .hasDescription(
+                          "Duration of messaging operation initiated by a producer or consumer client.")
+                      .hasHistogramSatisfying(
+                          histogram ->
+                              histogram.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasSum(0.15)
+                                          .hasBucketBoundaries(DURATION_BUCKETS)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_OPERATION_TYPE, "send"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))))
+          .anySatisfy(
+              metric ->
+                  assertThat(metric)
+                      .hasName("messaging.client.sent.messages")
+                      .hasUnit("{message}")
+                      .hasDescription(
+                          "Number of messages producer attempted to send to the broker.")
+                      .hasLongSumSatisfying(
+                          sum ->
+                              sum.hasPointsSatisfying(
+                                  point ->
+                                      point
+                                          .hasValue(2)
+                                          .hasAttributesSatisfyingExactly(
+                                              equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                              equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                              equalTo(
+                                                  ERROR_TYPE,
+                                                  IllegalStateException.class.getName()),
+                                              equalTo(MESSAGING_DESTINATION_TEMPLATE, "topic-{id}"),
+                                              equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
+                                              equalTo(SERVER_ADDRESS, "localhost"),
+                                              equalTo(SERVER_PORT, 6650)))));
+    }
+  }
 
-    Context context2 = listener.onStart(Context.root(), requestAttributes, nanos(150));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void createDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationTypeWithOldMetrics()
+            .create(meterProvider.get("test"));
 
-    assertThat(metricReader.collectAllMetrics()).isEmpty();
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "create" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "create" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
-    listener.onEnd(context1, responseAttributes, nanos(250));
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.operation.duration"))
+                .count())
+        .isEqualTo(emitStableMessagingSemconv() ? 1 : 0);
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.client.sent.messages"))
+                .count())
+        .isZero();
+    assertThat(
+            metrics.stream()
+                .filter(metric -> metric.getName().equals("messaging.publish.duration"))
+                .count())
+        .isZero();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void zeroBatchDoesNotCountSentMessages() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_BATCH_MESSAGE_COUNT, 0)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasUnit("s")
-                    .hasDescription("Measures the duration of publish operation.")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point ->
-                                    point
-                                        .hasSum(0.15 /* seconds */)
-                                        .hasAttributesSatisfying(
-                                            equalTo(MESSAGING_SYSTEM, "pulsar"),
-                                            equalTo(MESSAGING_DESTINATION_PARTITION_ID, "1"),
-                                            equalTo(
-                                                MESSAGING_DESTINATION_NAME,
-                                                "persistent://public/default/topic"),
-                                            equalTo(SERVER_PORT, 6650),
-                                            equalTo(SERVER_ADDRESS, "localhost"))
-                                        .hasExemplarsSatisfying(
-                                            exemplar ->
-                                                exemplar
-                                                    .hasTraceId("ff01020304050600ff0a0b0c0d0e0f00")
-                                                    .hasSpanId("090a0b0c0d0e0f00"))
-                                        .hasBucketBoundaries(DURATION_BUCKETS))));
+        .noneSatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"));
+  }
 
-    listener.onEnd(context2, responseAttributes, nanos(300));
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void operationTypeEntryPointNeverCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener =
+        MessagingProducerMetrics.getForOperationType().create(meterProvider.get("test"));
+
+    Attributes attributes =
+        Attributes.builder()
+            .put(MESSAGING_SYSTEM, "pulsar")
+            .put(MESSAGING_DESTINATION_NAME, "topic")
+            .put(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null)
+            .put(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null)
+            .put(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)
+            .build();
+    Context context = listener.onStart(Context.root(), attributes, nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
+
+    Collection<MetricData> metrics = metricReader.collectAllMetrics();
+    if (emitStableMessagingSemconv()) {
+      assertThat(metrics)
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.operation.duration"))
+          .anySatisfy(metric -> assertThat(metric).hasName("messaging.client.sent.messages"))
+          .noneSatisfy(metric -> assertThat(metric).hasName("messaging.publish.duration"));
+    } else {
+      // the stable-only entry point must be completely inert on the default path
+      assertThat(metrics).isEmpty();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void legacyEntryPointAlwaysCollectsLegacyMetrics() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.createDelta();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    OperationListener listener = MessagingProducerMetrics.get().create(meterProvider.get("test"));
+
+    Context context =
+        listener.onStart(
+            Context.root(),
+            Attributes.of(MESSAGING_SYSTEM, "pulsar", MESSAGING_OPERATION, "publish"),
+            nanos(100));
+    listener.onEnd(context, Attributes.empty(), nanos(250));
 
     assertThat(metricReader.collectAllMetrics())
-        .satisfiesExactlyInAnyOrder(
-            metric ->
-                assertThat(metric)
-                    .hasName("messaging.publish.duration")
-                    .hasHistogramSatisfying(
-                        histogram ->
-                            histogram.hasPointsSatisfying(
-                                point -> point.hasSum(0.3 /* seconds */))));
+        .satisfiesExactly(metric -> assertThat(metric).hasName("messaging.publish.duration"));
   }
 
   private static long nanos(int millis) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -40,6 +40,7 @@ class MessagingSpanKindExtractorTest {
     assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
   }
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void messageOperationUsesLegacySpanKind() {
     SpanKind receiveKind =

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingSpanKindExtractorTest {
+
+  @ParameterizedTest
+  @MethodSource("spanKinds")
+  void extractsSpanKind(
+      MessagingOperationType operationType,
+      boolean isSpanContextPropagated,
+      SpanKind oldKind,
+      SpanKind kind) {
+    SpanKind actualKind =
+        MessagingSpanKindExtractor.create(operationType, isSpanContextPropagated)
+            .extract(new Object());
+
+    assertThat(actualKind).isEqualTo(emitStableMessagingSemconv() ? kind : oldKind);
+  }
+
+  @Test
+  void sendDefaultsToPropagatedSpanContext() {
+    SpanKind spanKind =
+        MessagingSpanKindExtractor.create(MessagingOperationType.SEND).extract(new Object());
+
+    assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
+  }
+
+  @Test
+  void messageOperationUsesLegacySpanKind() {
+    SpanKind receiveKind =
+        MessagingSpanKindExtractor.create(MessageOperation.RECEIVE).extract(new Object());
+
+    assertThat(receiveKind).isEqualTo(SpanKind.CONSUMER);
+  }
+
+  private static Stream<Arguments> spanKinds() {
+    return Stream.of(
+        argumentSet(
+            "create", MessagingOperationType.CREATE, true, SpanKind.PRODUCER, SpanKind.PRODUCER),
+        argumentSet(
+            "send with propagated context",
+            MessagingOperationType.SEND,
+            true,
+            SpanKind.PRODUCER,
+            SpanKind.PRODUCER),
+        argumentSet(
+            "send without propagated context",
+            MessagingOperationType.SEND,
+            false,
+            SpanKind.PRODUCER,
+            SpanKind.CLIENT),
+        argumentSet(
+            "receive", MessagingOperationType.RECEIVE, true, SpanKind.CONSUMER, SpanKind.CLIENT),
+        argumentSet(
+            "process", MessagingOperationType.PROCESS, true, SpanKind.CONSUMER, SpanKind.CONSUMER),
+        argumentSet(
+            "settle", MessagingOperationType.SETTLE, true, SpanKind.CLIENT, SpanKind.CLIENT));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,36 +27,118 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
+  @Test
+  void shouldKeepLegacyNameForMessageOperation() {
+    Message message = new Message();
+    when(getter.isTemporaryDestination(message)).thenReturn(false);
+    when(getter.getDestination(message)).thenReturn("destination");
+
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
+
+    assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
   @ParameterizedTest
   @MethodSource("spanNameParams")
   void shouldExtractSpanName(
       boolean isTemporaryQueue,
+      boolean isAnonymousQueue,
       String destinationName,
-      MessageOperation operation,
-      String expectedSpanName) {
+      String destinationTemplate,
+      MessagingOperationType operationType,
+      String operationName,
+      String oldSpanName,
+      String spanName) {
     // given
     Message message = new Message();
 
-    if (isTemporaryQueue) {
-      when(getter.isTemporaryDestination(message)).thenReturn(true);
+    if (emitStableMessagingSemconv()) {
+      when(getter.getDestinationTemplate(message)).thenReturn(destinationTemplate);
+      if (destinationTemplate == null) {
+        when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+        if (!isTemporaryQueue) {
+          when(getter.isAnonymousDestination(message)).thenReturn(isAnonymousQueue);
+          if (!isAnonymousQueue) {
+            when(getter.getDestination(message)).thenReturn(destinationName);
+          }
+        }
+      }
     } else {
-      when(getter.getDestination(message)).thenReturn(destinationName);
+      when(getter.isTemporaryDestination(message)).thenReturn(isTemporaryQueue);
+      if (!isTemporaryQueue) {
+        when(getter.getDestination(message)).thenReturn(destinationName);
+      }
     }
 
-    SpanNameExtractor<Message> underTest = MessagingSpanNameExtractor.create(getter, operation);
+    SpanNameExtractor<Message> underTest =
+        MessagingSpanNameExtractor.builder(getter, operationType)
+            .setOperationName(operationName)
+            .build();
 
     // when
-    String spanName = underTest.extract(message);
+    String actualSpanName = underTest.extract(message);
 
     // then
-    assertThat(spanName).isEqualTo(expectedSpanName);
+    assertThat(actualSpanName).isEqualTo(emitStableMessagingSemconv() ? spanName : oldSpanName);
+    if (emitStableMessagingSemconv() && destinationTemplate != null) {
+      verify(getter, never()).isTemporaryDestination(message);
+      verify(getter, never()).isAnonymousDestination(message);
+    }
   }
 
   static Stream<Arguments> spanNameParams() {
     return Stream.of(
-        Arguments.of(false, "destination", MessageOperation.PUBLISH, "destination publish"),
-        Arguments.of(true, null, MessageOperation.PROCESS, "(temporary) process"),
-        Arguments.of(false, null, MessageOperation.RECEIVE, "unknown receive"));
+        argumentSet(
+            "operation name override",
+            false,
+            false,
+            "destination",
+            null,
+            MessagingOperationType.SEND,
+            "send",
+            "destination publish",
+            "send destination"),
+        argumentSet(
+            "temporary destination",
+            true,
+            false,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "(temporary) process",
+            "process generated-{id}"),
+        argumentSet(
+            "missing destination",
+            false,
+            false,
+            null,
+            null,
+            MessagingOperationType.RECEIVE,
+            "receive",
+            "unknown receive",
+            "receive"),
+        argumentSet(
+            "destination template",
+            false,
+            false,
+            "customer-42",
+            "customer-{id}",
+            MessagingOperationType.SEND,
+            "send",
+            "customer-42 publish",
+            "send customer-{id}"),
+        argumentSet(
+            "anonymous destination",
+            false,
+            true,
+            "generated",
+            "generated-{id}",
+            MessagingOperationType.PROCESS,
+            "process",
+            "generated process",
+            "process generated-{id}"));
   }
 
   static class Message {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -37,6 +38,16 @@ class MessagingSpanNameExtractorTest {
         MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH);
 
     assertThat(underTest.extract(message)).isEqualTo("destination publish");
+  }
+
+  @Test
+  void shouldRejectOperationNameForMessageOperation() {
+    assertThatThrownBy(
+            () ->
+                MessagingSpanNameExtractor.builder(getter, MessageOperation.PUBLISH)
+                    .setOperationName("send"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Operation name is not configurable for legacy builders");
   }
 
   @ParameterizedTest

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -28,6 +28,7 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void shouldKeepLegacyNameForMessageOperation() {
     Message message = new Message();
@@ -40,6 +41,7 @@ class MessagingSpanNameExtractorTest {
     assertThat(underTest.extract(message)).isEqualTo("destination publish");
   }
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void shouldRejectOperationNameForMessageOperation() {
     assertThatThrownBy(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessContextCustomizerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MessagingProcessContextCustomizerTest {
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  private static final ContextCustomizer<Map<String, String>> underTest =
+      MessagingProcessContextCustomizer.create(W3CTraceContextPropagator.getInstance(), getter);
+
+  @Test
+  void preservesAmbientParent() {
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+    Span ambientSpan = Span.fromContext(ambient);
+
+    Context result = underTest.onStart(ambient, carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result)).isSameAs(ambientSpan);
+  }
+
+  @Test
+  void preservesPropagatedFieldsWithAmbientParent() {
+    ContextKey<String> propagatedKey = ContextKey.named("propagated");
+    ContextCustomizer<String> customizer =
+        MessagingProcessContextCustomizer.create(
+            (parent, request) -> parent.with(propagatedKey, request));
+    Context ambient = context("11111111111111111111111111111111", "1111111111111111");
+
+    Context result = customizer.onStart(ambient, "value", Attributes.empty());
+
+    assertThat(result.get(propagatedKey)).isEqualTo("value");
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(Span.fromContext(ambient).getSpanContext());
+  }
+
+  @Test
+  void usesProducerWhenAmbientParentIsMissing() {
+    Context result = underTest.onStart(Context.root(), carrier(), Attributes.empty());
+
+    assertThat(Span.fromContext(result).getSpanContext())
+        .isEqualTo(spanContext("22222222222222222222222222222222", "2222222222222222"));
+  }
+
+  private static Map<String, String> carrier() {
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    return Collections.unmodifiableMap(carrier);
+  }
+
+  private static Context context(String traceId, String spanId) {
+    return Context.root().with(Span.wrap(spanContext(traceId, spanId)));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingProcessInstrumenterFactoryTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingProcessInstrumenterFactoryTest {
+
+  private static final SpanContext ambientParent =
+      spanContext("11111111111111111111111111111111", "1111111111111111");
+  private static final SpanContext producer =
+      spanContext("22222222222222222222222222222222", "2222222222222222");
+
+  private static final TextMapGetter<Map<String, String>> getter =
+      new TextMapGetter<Map<String, String>>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+          return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+          return carrier.get(key);
+        }
+      };
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @Test
+  void stableUsesProducerAsParentWithoutLink() {
+    assumeTrue(emitStableMessagingSemconv());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root(), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @Test
+  void stableDoesNotLinkAmbientParent() {
+    assumeTrue(emitStableMessagingSemconv());
+    SpanContext localProducer =
+        SpanContext.create(
+            producer.getTraceId(),
+            producer.getSpanId(),
+            producer.getTraceFlags(),
+            producer.getTraceState());
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            false);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(localProducer)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("process")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasTraceId(producer.getTraceId())
+                            .hasParentSpanId(producer.getSpanId())
+                            .hasLinks()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("receiveInstrumentationSettings")
+  void usesExpectedParentAndLink(boolean receiveInstrumentationEnabled, boolean producerIsParent) {
+    Instrumenter<Map<String, String>, Void> instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            Instrumenter.<Map<String, String>, Void>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "process"),
+            W3CTraceContextPropagator.getInstance(),
+            getter,
+            receiveInstrumentationEnabled);
+
+    Map<String, String> carrier =
+        singletonMap("traceparent", "00-22222222222222222222222222222222-2222222222222222-01");
+    Context context = instrumenter.start(Context.root().with(Span.wrap(ambientParent)), carrier);
+    instrumenter.end(context, carrier, null, null);
+
+    SpanContext expectedParent = producerIsParent ? producer : ambientParent;
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      span.hasName("process")
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasTraceId(expectedParent.getTraceId())
+                          .hasParentSpanId(expectedParent.getSpanId());
+                      if (producerIsParent) {
+                        span.hasLinks();
+                      } else {
+                        span.hasLinks(LinkData.create(producer));
+                      }
+                    }));
+  }
+
+  private static Stream<Arguments> receiveInstrumentationSettings() {
+    boolean stable = emitStableMessagingSemconv();
+    String semconv = stable ? "stable" : "old";
+    return Stream.of(
+        argumentSet(semconv + " receive disabled", false, !stable),
+        argumentSet(semconv + " receive enabled", true, false));
+  }
+
+  private static SpanContext spanContext(String traceId, String spanId) {
+    return SpanContext.createFromRemoteParent(
+        traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
@@ -89,12 +89,12 @@ class SemconvSelectionResolver {
   }
 
   SemconvMode messaging() {
-    return resolveSemconvSelection(
+    SemconvDomain.Builder domain =
         SemconvDomain.builder("messaging")
-            .defaultMode(SemconvMode.V0_STABLE)
             .otherSupportedModes(
-                SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit())
-            .build());
+                SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit());
+    domain.defaultMode(v3Preview ? SemconvMode.V1_EXPERIMENTAL : SemconvMode.V0_STABLE);
+    return resolveSemconvSelection(domain.build());
   }
 
   SemconvMode servicePeer() {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -169,11 +169,14 @@ public final class SemconvStability {
     return mode.version() >= 1;
   }
 
-  public static boolean emitOldMessagingSemconv() {
+  public static boolean emitOldMessagingSemconv() { // to be removed in 3.0
     return emitOldMessagingSemconv;
   }
 
-  public static boolean emitStableMessagingSemconv() {
+  // Returns whether the selected v1 experimental messaging semantic conventions should be emitted.
+  // The method name follows the existing pattern; it does not indicate that the messaging
+  // conventions are stable.
+  public static boolean emitStableMessagingSemconv() { // to be removed in 3.0
     return emitStableMessagingSemconv;
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SpanKey.java
@@ -43,12 +43,16 @@ public final class SpanKey {
   private static final ContextKey<Span> DB_CLIENT_KEY =
       ContextKey.named("opentelemetry-traces-span-key-db-client");
 
+  private static final ContextKey<Span> PRODUCER_CREATE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-producer-create");
   private static final ContextKey<Span> PRODUCER_KEY =
       ContextKey.named("opentelemetry-traces-span-key-producer");
   private static final ContextKey<Span> CONSUMER_RECEIVE_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-receive");
   private static final ContextKey<Span> CONSUMER_PROCESS_KEY =
       ContextKey.named("opentelemetry-traces-span-key-consumer-process");
+  private static final ContextKey<Span> CONSUMER_SETTLE_KEY =
+      ContextKey.named("opentelemetry-traces-span-key-consumer-settle");
 
   /* Span keys */
 
@@ -66,9 +70,11 @@ public final class SpanKey {
   public static final SpanKey RPC_CLIENT = new SpanKey(RPC_CLIENT_KEY);
   public static final SpanKey DB_CLIENT = new SpanKey(DB_CLIENT_KEY);
 
+  public static final SpanKey PRODUCER_CREATE = new SpanKey(PRODUCER_CREATE_KEY);
   public static final SpanKey PRODUCER = new SpanKey(PRODUCER_KEY);
   public static final SpanKey CONSUMER_RECEIVE = new SpanKey(CONSUMER_RECEIVE_KEY);
   public static final SpanKey CONSUMER_PROCESS = new SpanKey(CONSUMER_PROCESS_KEY);
+  public static final SpanKey CONSUMER_SETTLE = new SpanKey(CONSUMER_SETTLE_KEY);
 
   private final ContextKey<Span> key;
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -9,6 +9,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.common.ComponentLoader;
@@ -22,6 +23,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class SemconvStabilityTest {
@@ -377,6 +380,69 @@ class SemconvStabilityTest {
     assertThat(rpc).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(servicePeer).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
     assertThat(messaging).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
+  }
+
+  @ParameterizedTest
+  @MethodSource("messagingSelectionModes")
+  void messagingSelectionMatrix(
+      boolean v3Preview, Set<String> stableOptIn, Set<String> preview, SemconvMode expectedMode) {
+    SemconvMode messaging =
+        new SemconvSelectionResolver(general(), v3Preview, stableOptIn, preview).messaging();
+
+    assertThat(messaging).isEqualTo(expectedMode);
+  }
+
+  private static List<Arguments> messagingSelectionModes() {
+    return asList(
+        argumentSet("legacy default", false, noStableOptIn(), noPreview(), SemconvMode.V0_STABLE),
+        argumentSet(
+            "legacy opt-in property",
+            false,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "preview property",
+            false,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "legacy opt-in dual emit",
+            false,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "preview dual emit",
+            false,
+            noStableOptIn(),
+            preview("messaging/dup"),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
+        argumentSet(
+            "v3 activation remains staged",
+            true,
+            noStableOptIn(),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in property",
+            true,
+            stableOptIn("messaging"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 ignores legacy opt-in dual emit",
+            true,
+            stableOptIn("messaging/dup"),
+            noPreview(),
+            SemconvMode.V0_STABLE),
+        argumentSet(
+            "v3 with explicit preview",
+            true,
+            noStableOptIn(),
+            preview("messaging"),
+            SemconvMode.V1_EXPERIMENTAL));
   }
 
   @SafeVarargs

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -356,7 +356,7 @@ class SemconvStabilityTest {
 
     assertThat(rpc).isEqualTo(SemconvMode.V0_STABLE);
     assertThat(servicePeer).isEqualTo(SemconvMode.V0_STABLE);
-    assertThat(messaging).isEqualTo(SemconvMode.V0_STABLE);
+    assertThat(messaging).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
   }
 
   @ParameterizedTest
@@ -420,29 +420,35 @@ class SemconvStabilityTest {
             preview("messaging/dup"),
             SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
         argumentSet(
-            "v3 activation remains staged",
+            "v3 activates messaging preview",
             true,
             noStableOptIn(),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 ignores legacy opt-in property",
             true,
             stableOptIn("messaging"),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 ignores legacy opt-in dual emit",
             true,
             stableOptIn("messaging/dup"),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 with explicit preview",
             true,
             noStableOptIn(),
             preview("messaging"),
-            SemconvMode.V1_EXPERIMENTAL));
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "v3 with explicit preview dual emit",
+            true,
+            noStableOptIn(),
+            preview("messaging/dup"),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()));
   }
 
   @SafeVarargs

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -58,6 +58,18 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SqsSuppressReceiveSpansTest.testAbandonedIteratorDoesNotParentNextProcessSpan")
+      includeTestsMatching("SqsTracingTest.testReceiveSpanLinksToProducer")
+      includeTestsMatching("SqsTracingTest.testBatchSendMessageCount")
+      includeTestsMatching("SqsTracingTest.testSimpleSqsProducerConsumerServicesWithParentSpan")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   val testExceptionSignalLogs = register<Test>("testExceptionSignalLogs") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -65,6 +77,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testStableSemconv, testExceptionSignalLogs)
+    dependsOn(testing.suites, testStableSemconv, testMessagingPreview, testExceptionSignalLogs)
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -18,12 +19,15 @@ import com.amazonaws.Response;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessContextCustomizer;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -96,50 +100,79 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> messagingAttributesExtractor(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }
 
   public Instrumenter<SqsReceiveRequest, Response<?>> consumerReceiveInstrumenter() {
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
     SqsReceiveRequestAttributesGetter getter = new SqsReceiveRequestAttributesGetter();
     AttributesExtractor<SqsReceiveRequest, Response<?>> messagingAttributeExtractor =
-        messagingAttributesExtractor(getter, operation);
+        messagingAttributesExtractor(getter, operationType);
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
-        SpanKindExtractor.alwaysConsumer(),
+        MessagingSpanNameExtractor.create(getter, operationType),
+        MessagingSpanKindExtractor.create(operationType),
         toSqsRequestExtractors(attributesExtractors()),
         singletonList(messagingAttributeExtractor),
-        builder -> setMessagingReceiveExceptionEventExtractor(builder),
+        builder -> {
+          setMessagingReceiveExceptionEventExtractor(builder);
+          if (emitStableMessagingSemconv()) {
+            builder.addSpanLinksExtractor(
+                (spanLinks, parentContext, request) -> {
+                  for (SqsMessage message : request.getMessages()) {
+                    SpanContext spanContext =
+                        Span.fromContext(message.getCreationContext()).getSpanContext();
+                    if (spanContext.isValid()) {
+                      spanLinks.addLink(spanContext);
+                    }
+                  }
+                });
+          }
+        },
         messagingReceiveInstrumentationEnabled);
   }
 
   public Instrumenter<SqsProcessRequest, Response<?>> consumerProcessInstrumenter() {
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
     SqsProcessRequestAttributesGetter getter = new SqsProcessRequestAttributesGetter();
     AttributesExtractor<SqsProcessRequest, Response<?>> messagingAttributeExtractor =
-        messagingAttributesExtractor(getter, operation);
+        messagingAttributesExtractor(getter, operationType);
 
     InstrumenterBuilder<SqsProcessRequest, Response<?>> builder =
         Instrumenter.<SqsProcessRequest, Response<?>>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractors(toSqsRequestExtractors(attributesExtractors()))
             .addAttributesExtractor(messagingAttributeExtractor);
     setMessagingProcessExceptionEventExtractor(builder);
 
-    if (messagingReceiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv() || messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
           (spanLinks, parentContext, request) -> {
-            Context extracted =
-                SqsParentContext.ofSystemAttributes(request.getMessage().getAttributes());
-            spanLinks.addLink(Span.fromContext(extracted).getSpanContext());
+            SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+            SpanContext creationSpanContext =
+                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
+            if (creationSpanContext.isValid()
+                && (!emitStableMessagingSemconv()
+                    || (parentSpanContext.isValid()
+                        && (!creationSpanContext.getTraceId().equals(parentSpanContext.getTraceId())
+                            || !creationSpanContext
+                                .getSpanId()
+                                .equals(parentSpanContext.getSpanId()))))) {
+              spanLinks.addLink(creationSpanContext);
+            }
           });
+    }
+    if (emitStableMessagingSemconv()) {
+      builder.addContextCustomizer(
+          MessagingProcessContextCustomizer.create(
+              (parentContext, request) ->
+                  parentContext.with(Span.fromContext(request.getMessage().getCreationContext()))));
     }
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
@@ -173,14 +206,14 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   public Instrumenter<Request<?>, Response<?>> producerInstrumenter() {
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
     SqsAttributesGetter getter = new SqsAttributesGetter();
     AttributesExtractor<Request<?>, Response<?>> messagingAttributeExtractor =
-        messagingAttributesExtractor(getter, operation);
+        messagingAttributesExtractor(getter, operationType);
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
+        MessagingSpanNameExtractor.create(getter, operationType),
         SpanKindExtractor.alwaysProducer(),
         attributesExtractors(),
         singletonList(messagingAttributeExtractor),

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsAccess.java
@@ -34,6 +34,12 @@ final class SqsAccess {
 
   @NoMuzzle
   @Nullable
+  static Long getBatchMessageCount(Request<?> request) {
+    return enabled ? SqsImpl.getBatchMessageCount(request) : null;
+  }
+
+  @NoMuzzle
+  @Nullable
   static String getMessageAttribute(Request<?> request, String name) {
     return enabled ? SqsImpl.getMessageAttribute(request, name) : null;
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -84,7 +85,7 @@ class SqsAttributesGetter implements MessagingAttributesGetter<Request<?>, Respo
   @Nullable
   @Override
   public Long getBatchMessageCount(Request<?> request, @Nullable Response<?> response) {
-    return null;
+    return emitStableMessagingSemconv() ? SqsAccess.getBatchMessageCount(request) : null;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
@@ -12,6 +14,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import io.opentelemetry.context.Context;
@@ -78,8 +81,9 @@ public final class SqsImpl {
               timer.now());
     }
 
+    Context processParentContext = emitStableMessagingSemconv() ? parentContext : receiveContext;
     addTracing(
-        receiveMessageResult, request, response, consumerProcessInstrumenter, receiveContext);
+        receiveMessageResult, request, response, consumerProcessInstrumenter, processParentContext);
   }
 
   @Nullable private static final Field messagesField = getMessagesField();
@@ -100,7 +104,7 @@ public final class SqsImpl {
       Request<?> request,
       Response<?> response,
       Instrumenter<SqsProcessRequest, Response<?>> consumerProcessInstrumenter,
-      @Nullable Context receiveContext) {
+      @Nullable Context processParentContext) {
     if (messagesField == null) {
       return;
     }
@@ -114,7 +118,7 @@ public final class SqsImpl {
               consumerProcessInstrumenter,
               request,
               response,
-              receiveContext));
+              processParentContext));
     } catch (IllegalAccessException ignored) {
       // should not happen, we call setAccessible on the field
     }
@@ -129,6 +133,14 @@ public final class SqsImpl {
       return true;
     }
     return false;
+  }
+
+  @Nullable
+  static Long getBatchMessageCount(Request<?> request) {
+    if (request.getOriginalRequest() instanceof SendMessageBatchRequest) {
+      return (long) ((SendMessageBatchRequest) request.getOriginalRequest()).getEntries().size();
+    }
+    return null;
   }
 
   @Nullable

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsMessage.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsMessage.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
+import io.opentelemetry.context.Context;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -13,6 +14,8 @@ import javax.annotation.Nullable;
  * avoids muzzle failure when sqs classes are not present.
  */
 interface SqsMessage {
+
+  Context getCreationContext();
 
   Map<String, String> getAttributes();
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsMessageImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsMessageImpl.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import io.opentelemetry.context.Context;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,11 @@ final class SqsMessageImpl implements SqsMessage {
       result.add(wrap(message));
     }
     return result;
+  }
+
+  @Override
+  public Context getCreationContext() {
+    return SqsParentContext.ofSystemAttributes(message.getAttributes());
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsParentContext.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsParentContext.java
@@ -35,9 +35,13 @@ final class SqsParentContext {
   static final String AWS_TRACE_SYSTEM_ATTRIBUTE = "AWSTraceHeader";
 
   static Context ofSystemAttributes(Map<String, String> systemAttributes) {
+    return ofSystemAttributes(Context.root(), systemAttributes);
+  }
+
+  static Context ofSystemAttributes(Context parentContext, Map<String, String> systemAttributes) {
     String traceHeader = systemAttributes.get(AWS_TRACE_SYSTEM_ATTRIBUTE);
     return AwsXrayPropagator.getInstance()
-        .extract(Context.root(), singletonMap("X-Amzn-Trace-Id", traceHeader), new MapGetter());
+        .extract(parentContext, singletonMap("X-Amzn-Trace-Id", traceHeader), new MapGetter());
   }
 
   private SqsParentContext() {}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingIterator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingIterator.java
@@ -5,22 +5,16 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
-import com.amazonaws.Request;
-import com.amazonaws.Response;
 import com.amazonaws.services.sqs.model.Message;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.Iterator;
 import javax.annotation.Nullable;
 
 class TracingIterator implements Iterator<Message> {
 
   private final Iterator<Message> delegateIterator;
-  private final Instrumenter<SqsProcessRequest, Response<?>> instrumenter;
-  private final Request<?> request;
-  private final Response<?> response;
-  @Nullable private final Context receiveContext;
+  private final TracingList tracingList;
 
   /*
    * Note: this may potentially create problems if this iterator is used from different threads. But
@@ -30,26 +24,13 @@ class TracingIterator implements Iterator<Message> {
   @Nullable private Context currentContext;
   @Nullable private Scope currentScope;
 
-  private TracingIterator(
-      Iterator<Message> delegateIterator,
-      Instrumenter<SqsProcessRequest, Response<?>> instrumenter,
-      Request<?> request,
-      Response<?> response,
-      @Nullable Context receiveContext) {
+  private TracingIterator(Iterator<Message> delegateIterator, TracingList tracingList) {
     this.delegateIterator = delegateIterator;
-    this.instrumenter = instrumenter;
-    this.request = request;
-    this.response = response;
-    this.receiveContext = receiveContext;
+    this.tracingList = tracingList;
   }
 
-  static Iterator<Message> wrap(
-      Iterator<Message> delegateIterator,
-      Instrumenter<SqsProcessRequest, Response<?>> instrumenter,
-      Request<?> request,
-      Response<?> response,
-      @Nullable Context receiveContext) {
-    return new TracingIterator(delegateIterator, instrumenter, request, response, receiveContext);
+  static Iterator<Message> wrap(Iterator<Message> delegateIterator, TracingList tracingList) {
+    return new TracingIterator(delegateIterator, tracingList);
   }
 
   @Override
@@ -70,13 +51,14 @@ class TracingIterator implements Iterator<Message> {
     // (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1947)
     Message next = delegateIterator.next();
     if (next != null) {
-      Context parentContext = receiveContext;
+      SqsMessage sqsMessage = SqsMessageImpl.wrap(next);
+      Context parentContext = tracingList.getProcessParentContext();
       if (parentContext == null) {
-        parentContext = SqsParentContext.ofSystemAttributes(next.getAttributes());
+        parentContext = sqsMessage.getCreationContext();
       }
 
-      currentRequest = SqsProcessRequest.create(request, SqsMessageImpl.wrap(next));
-      currentContext = instrumenter.start(parentContext, currentRequest);
+      currentRequest = SqsProcessRequest.create(tracingList.getRequest(), sqsMessage);
+      currentContext = tracingList.getInstrumenter().start(parentContext, currentRequest);
       currentScope = currentContext.makeCurrent();
     }
     return next;
@@ -85,7 +67,9 @@ class TracingIterator implements Iterator<Message> {
   private void closeScopeAndEndSpan() {
     if (currentScope != null) {
       currentScope.close();
-      instrumenter.end(currentContext, currentRequest, response, null);
+      tracingList
+          .getInstrumenter()
+          .end(currentContext, currentRequest, tracingList.getResponse(), null);
       currentScope = null;
       currentRequest = null;
       currentContext = null;

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingList.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingList.java
@@ -23,29 +23,29 @@ class TracingList extends SdkInternalList<Message> {
   private final transient Instrumenter<SqsProcessRequest, Response<?>> instrumenter;
   private final transient Request<?> request;
   private final transient Response<?> response;
-  @Nullable private final transient Context receiveContext;
+  @Nullable private final transient Context processParentContext;
   private boolean firstIterator = true;
 
-  private TracingList(
-      List<Message> list,
+  static SdkInternalList<Message> wrap(
+      List<Message> messages,
       Instrumenter<SqsProcessRequest, Response<?>> instrumenter,
       Request<?> request,
       Response<?> response,
-      @Nullable Context receiveContext) {
-    super(list);
+      @Nullable Context processParentContext) {
+    return new TracingList(messages, instrumenter, request, response, processParentContext);
+  }
+
+  private TracingList(
+      List<Message> messages,
+      Instrumenter<SqsProcessRequest, Response<?>> instrumenter,
+      Request<?> request,
+      Response<?> response,
+      @Nullable Context processParentContext) {
+    super(messages);
     this.instrumenter = instrumenter;
     this.request = request;
     this.response = response;
-    this.receiveContext = receiveContext;
-  }
-
-  static SdkInternalList<Message> wrap(
-      List<Message> list,
-      Instrumenter<SqsProcessRequest, Response<?>> instrumenter,
-      Request<?> request,
-      Response<?> response,
-      @Nullable Context receiveContext) {
-    return new TracingList(list, instrumenter, request, response, receiveContext);
+    this.processParentContext = processParentContext;
   }
 
   @Override
@@ -55,13 +55,30 @@ class TracingList extends SdkInternalList<Message> {
     // However, this is not thread-safe, but usually the first (hopefully only) traversal of
     // List is performed in the same thread that called receiveMessage()
     if (firstIterator && !inAwsClient()) {
-      it = TracingIterator.wrap(super.iterator(), instrumenter, request, response, receiveContext);
+      it = TracingIterator.wrap(super.iterator(), this);
       firstIterator = false;
     } else {
       it = super.iterator();
     }
 
     return it;
+  }
+
+  Instrumenter<SqsProcessRequest, Response<?>> getInstrumenter() {
+    return instrumenter;
+  }
+
+  Request<?> getRequest() {
+    return request;
+  }
+
+  Response<?> getResponse() {
+    return response;
+  }
+
+  @Nullable
+  Context getProcessParentContext() {
+    return processParentContext;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/TracingRequestHandler.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
@@ -34,6 +36,8 @@ public final class TracingRequestHandler extends RequestHandler2 {
       ContextKey.named(TracingRequestHandler.class.getName() + ".Timer");
   private static final ContextKey<Boolean> REQUEST_SPAN_SUPPRESSED_KEY =
       ContextKey.named(TracingRequestHandler.class.getName() + ".RequestSpanSuppressed");
+  private static final String SEND_MESSAGE_BATCH_REQUEST_CLASS =
+      "com.amazonaws.services.sqs.model.SendMessageBatchRequest";
   private static final String SEND_MESSAGE_REQUEST_CLASS =
       "com.amazonaws.services.sqs.model.SendMessageRequest";
   private static final String DYNAMODBV2_CLASS_PREFIX = "com.amazonaws.services.dynamodbv2.model.";
@@ -168,7 +172,8 @@ public final class TracingRequestHandler extends RequestHandler2 {
     if (className.startsWith(DYNAMODBV2_CLASS_PREFIX)) {
       return dynamoDbInstrumenter;
     }
-    if (className.equals(SEND_MESSAGE_REQUEST_CLASS)) {
+    if (className.equals(SEND_MESSAGE_REQUEST_CLASS)
+        || (emitStableMessagingSemconv() && className.equals(SEND_MESSAGE_BATCH_REQUEST_CLASS))) {
       return producerInstrumenter;
     }
     return requestInstrumenter;

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsParentContextTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsParentContextTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import org.junit.jupiter.api.Test;
+
+class SqsParentContextTest {
+
+  private static final ContextKey<String> TEST_CONTEXT_KEY = ContextKey.named("test-context-key");
+  private static final String TRACE_HEADER =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
+
+  @Test
+  void preservesParentContextValues() {
+    Context parentContext = Context.root().with(TEST_CONTEXT_KEY, "test-value");
+
+    Context extractedContext =
+        SqsParentContext.ofSystemAttributes(
+            parentContext, singletonMap(SqsParentContext.AWS_TRACE_SYSTEM_ATTRIBUTE, TRACE_HEADER));
+
+    assertThat(extractedContext.get(TEST_CONTEXT_KEY)).isEqualTo("test-value");
+    assertThat(Span.fromContext(extractedContext).getSpanContext().isValid()).isTrue();
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsSuppressReceiveSpansTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -25,6 +26,7 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_ME
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SERVICE;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -32,12 +34,14 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.util.Iterator;
 import org.elasticmq.rest.sqs.SQSRestServer;
 import org.elasticmq.rest.sqs.SQSRestServerBuilder;
 import org.junit.jupiter.api.AfterEach;
@@ -172,6 +176,41 @@ public abstract class AbstractSqsSuppressReceiveSpansTest {
                         span.hasName("process child")
                             .hasParent(trace.getSpan(1))
                             .hasTotalAttributeCount(0)));
+  }
+
+  @Test
+  void testAbandonedIteratorDoesNotParentNextProcessSpan() {
+    assumeTrue(emitStableMessagingSemconv());
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+    sqsClient.createQueue("testSdkSqs");
+
+    sqsClient.sendMessage(new SendMessageRequest(queueUrl, "first"));
+    ReceiveMessageResult firstResponse = sqsClient.receiveMessage(queueUrl);
+    sqsClient.sendMessage(new SendMessageRequest(queueUrl, "second"));
+    ReceiveMessageResult secondResponse = sqsClient.receiveMessage(queueUrl);
+
+    Iterator<Message> firstIterator = firstResponse.getMessages().iterator();
+    Iterator<Message> secondIterator = secondResponse.getMessages().iterator();
+    assertThat(firstIterator.hasNext()).isTrue();
+    firstIterator.next();
+    assertThat(secondIterator.hasNext()).isTrue();
+    secondIterator.next();
+    assertThat(secondIterator.hasNext()).isFalse();
+    assertThat(firstIterator.hasNext()).isFalse();
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("SQS.CreateQueue").hasNoParent()),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("publish testSdkSqs").hasNoParent(),
+                    span -> span.hasName("process testSdkSqs").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("publish testSdkSqs").hasNoParent(),
+                    span -> span.hasName("process testSdkSqs").hasParent(trace.getSpan(0))));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -22,6 +23,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
@@ -29,6 +32,7 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SE
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SYSTEM;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -40,6 +44,8 @@ import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
@@ -275,6 +281,87 @@ public abstract class AbstractSqsTracingTest {
   }
 
   @Test
+  void testReceiveSpanLinksToProducer() {
+    assumeTrue(emitStableMessagingSemconv());
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+    sqsClient.createQueue("testSdkSqs");
+    sqsClient.sendMessage(new SendMessageRequest(queueUrl, "hello"));
+    sqsClient.receiveMessage(queueUrl);
+
+    AtomicReference<SpanData> publishSpan = new AtomicReference<>();
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("SQS.CreateQueue").hasKind(SpanKind.CLIENT)),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      publishSpan.set(trace.getSpan(0));
+                      span.hasName("publish testSdkSqs").hasKind(SpanKind.PRODUCER);
+                    }),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("receive testSdkSqs")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(publishSpan.get().getSpanId())))));
+  }
+
+  @Test
+  void testBatchSendMessageCount() {
+    assumeTrue(emitStableMessagingSemconv());
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+    sqsClient.createQueue("testSdkSqs");
+    sqsClient.sendMessageBatch(
+        new SendMessageBatchRequest()
+            .withQueueUrl(queueUrl)
+            .withEntries(
+                new SendMessageBatchRequestEntry("i1", "e1"),
+                new SendMessageBatchRequestEntry("i2", "e2"),
+                new SendMessageBatchRequestEntry("i3", "e3")));
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("SQS.CreateQueue").hasKind(SpanKind.CLIENT)),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("publish testSdkSqs")
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasNoParent()
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+                                equalTo(AWS_SQS_QUEUE_URL, queueUrl),
+                                satisfies(
+                                    AWS_REQUEST_ID, AbstractSqsTracingTest::assertAwsRequestId),
+                                equalTo(RPC_SYSTEM, "aws-api"),
+                                equalTo(RPC_SERVICE, "AmazonSQS"),
+                                equalTo(RPC_METHOD, "SendMessageBatch"),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                equalTo(URL_FULL, "http://localhost:" + sqsPort),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION_NAME, "publish"),
+                                equalTo(MESSAGING_OPERATION_TYPE, "send"),
+                                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3),
+                                equalTo(NETWORK_PROTOCOL_VERSION, "1.1"))));
+  }
+
+  @Test
   void testSimpleSqsProducerConsumerServicesWithParentSpan() {
     sqsClient.createQueue("testSdkSqs");
     SendMessageRequest sendMessageRequest =
@@ -293,6 +380,69 @@ public abstract class AbstractSqsTracingTest {
                   .getMessages()
                   .forEach(message -> testing().runWithSpan("process child", () -> {}));
             });
+
+    if (emitStableMessagingSemconv()) {
+      AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+      testing()
+          .waitAndAssertTraces(
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("SQS.CreateQueue").hasKind(SpanKind.CLIENT)),
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span -> {
+                        producerSpan.set(trace.getSpan(0));
+                        span.hasName("publish testSdkSqs").hasKind(SpanKind.PRODUCER);
+                      }),
+              trace -> {
+                Consumer<SpanDataAssert> receiveSpanAssertion =
+                    span ->
+                        span.hasName("receive testSdkSqs")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0))
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(producerSpan.get().getSpanId())));
+                Consumer<SpanDataAssert> sdkSpanAssertion =
+                    span ->
+                        span.hasName("SQS.ReceiveMessage")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasParent(trace.getSpan(0));
+                Consumer<SpanDataAssert> processSpanAssertion =
+                    span ->
+                        span.hasName("process testSdkSqs")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(0))
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(producerSpan.get().getSpanId())));
+
+                List<Consumer<SpanDataAssert>> assertions =
+                    new ArrayList<>(
+                        asList(
+                            span -> span.hasName("parent").hasNoParent(),
+                            receiveSpanAssertion,
+                            sdkSpanAssertion,
+                            processSpanAssertion,
+                            span -> span.hasName("process child")));
+                if ("SQS.ReceiveMessage".equals(trace.getSpan(1).getName())) {
+                  assertions.set(1, sdkSpanAssertion);
+                  assertions.set(2, receiveSpanAssertion);
+                }
+                trace.hasSpansSatisfyingExactly(assertions);
+              });
+      return;
+    }
 
     testing()
         .waitAndAssertTraces(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -82,6 +82,18 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("Aws2SqsSuppressReceiveSpansW3cPropagatorTest.testAbandonedIteratorDoesNotParentNextProcessSpan")
+      includeTestsMatching("Aws2SqsDefaultPropagatorTest.testReceiveSpanLinksToProducer")
+      includeTestsMatching("Aws2SqsDefaultPropagatorTest.testBatchSendMessageCount")
+      includeTestsMatching("Aws2SqsDefaultPropagatorTest.testSimpleSqsProducerConsumerServicesWithParentSync")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   val testCoreOnlyStableSemconv = register<Test>("testCoreOnlyStableSemconv") {
     val testCoreOnlySourceSet = sourceSets["testCoreOnly"]
     testClassesDirs = testCoreOnlySourceSet.output.classesDirs
@@ -98,6 +110,12 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testStableSemconv, testCoreOnlyStableSemconv, testExceptionSignalLogs)
+    dependsOn(
+      testing.suites,
+      testStableSemconv,
+      testMessagingPreview,
+      testCoreOnlyStableSemconv,
+      testExceptionSignalLogs,
+    )
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -18,16 +19,19 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiSpanNameExtractor;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessContextCustomizer;
 import io.opentelemetry.instrumentation.api.incubator.semconv.rpc.RpcClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -125,49 +129,81 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> messagingAttributesExtractor(
-      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+      MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }
 
   public Instrumenter<SqsReceiveRequest, Response> consumerReceiveInstrumenter() {
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
     SqsReceiveRequestAttributesGetter getter = new SqsReceiveRequestAttributesGetter();
     AttributesExtractor<SqsReceiveRequest, Response> messagingAttributeExtractor =
-        messagingAttributesExtractor(getter, operation);
+        messagingAttributesExtractor(getter, operationType);
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
-        SpanKindExtractor.alwaysConsumer(),
+        MessagingSpanNameExtractor.create(getter, operationType),
+        MessagingSpanKindExtractor.create(operationType),
         toSqsRequestExtractors(consumerAttributesExtractors()),
         singletonList(messagingAttributeExtractor),
-        builder -> setMessagingReceiveExceptionEventExtractor(builder),
+        builder -> {
+          setMessagingReceiveExceptionEventExtractor(builder);
+          if (emitStableMessagingSemconv()) {
+            builder.addSpanLinksExtractor(
+                (spanLinks, parentContext, request) -> {
+                  for (SqsMessage message : request.getMessages()) {
+                    SpanContext spanContext =
+                        Span.fromContext(message.getCreationContext()).getSpanContext();
+                    if (spanContext.isValid()) {
+                      spanLinks.addLink(spanContext);
+                    }
+                  }
+                });
+          }
+        },
         messagingReceiveInstrumentationEnabled);
   }
 
   public Instrumenter<SqsProcessRequest, Response> consumerProcessInstrumenter() {
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
     SqsProcessRequestAttributesGetter getter = new SqsProcessRequestAttributesGetter();
 
     InstrumenterBuilder<SqsProcessRequest, Response> builder =
         Instrumenter.<SqsProcessRequest, Response>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractors(toSqsRequestExtractors(consumerAttributesExtractors()))
-            .addAttributesExtractor(messagingAttributesExtractor(getter, operation));
+            .addAttributesExtractor(messagingAttributesExtractor(getter, operationType));
     setMessagingProcessExceptionEventExtractor(builder);
 
-    if (messagingReceiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv() || messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
           (spanLinks, parentContext, request) -> {
-            Context extracted =
-                SqsParentContext.ofMessage(
-                    request.getMessage(), messagingPropagator, useXrayPropagator);
-            spanLinks.addLink(Span.fromContext(extracted).getSpanContext());
+            SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+            SpanContext creationSpanContext =
+                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
+            if (creationSpanContext.isValid()
+                && (!emitStableMessagingSemconv()
+                    || (parentSpanContext.isValid()
+                        && (!creationSpanContext.getTraceId().equals(parentSpanContext.getTraceId())
+                            || !creationSpanContext
+                                .getSpanId()
+                                .equals(parentSpanContext.getSpanId()))))) {
+              spanLinks.addLink(creationSpanContext);
+            }
           });
+    }
+    if (emitStableMessagingSemconv()) {
+      builder.addContextCustomizer(
+          MessagingProcessContextCustomizer.create(
+              (parentContext, request) ->
+                  SqsParentContext.ofMessage(
+                      parentContext,
+                      request.getMessage(),
+                      messagingPropagator,
+                      useXrayPropagator)));
     }
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
@@ -201,14 +237,14 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   public Instrumenter<ExecutionAttributes, Response> producerInstrumenter() {
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
     SqsAttributesGetter getter = new SqsAttributesGetter();
     AttributesExtractor<ExecutionAttributes, Response> messagingAttributeExtractor =
-        messagingAttributesExtractor(getter, operation);
+        messagingAttributesExtractor(getter, operationType);
 
     return createInstrumenter(
         openTelemetry,
-        MessagingSpanNameExtractor.create(getter, operation),
+        MessagingSpanNameExtractor.create(getter, operationType),
         SpanKindExtractor.alwaysProducer(),
         attributesExtractors(),
         singletonList(messagingAttributeExtractor),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAccess.java
@@ -58,6 +58,11 @@ final class SqsAccess {
   }
 
   @NoMuzzle
+  static Long getBatchMessageCount(SdkRequest request) {
+    return enabled ? SqsImpl.getBatchMessageCount(request) : null;
+  }
+
+  @NoMuzzle
   static String getMessageAttribute(SdkRequest request, String name) {
     return enabled ? SqsImpl.getMessageAttribute(request, name) : null;
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -91,7 +92,8 @@ class SqsAttributesGetter implements MessagingAttributesGetter<ExecutionAttribut
   @Nullable
   @Override
   public Long getBatchMessageCount(ExecutionAttributes request, @Nullable Response response) {
-    return null;
+    SdkRequest sdkRequest = request.getAttribute(TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE);
+    return emitStableMessagingSemconv() ? SqsAccess.getBatchMessageCount(sdkRequest) : null;
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.TracingExecutionInterceptor.SDK_HTTP_REQUEST_ATTRIBUTE;
 import static io.opentelemetry.instrumentation.awssdk.v2_2.internal.TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE;
 
@@ -76,7 +77,8 @@ public final class SqsImpl {
         config.getConsumerReceiveInstrumenter();
     io.opentelemetry.context.Context receiveContext = null;
     SqsReceiveRequest receiveRequest =
-        SqsReceiveRequest.create(executionAttributes, SqsMessageImpl.wrap(response.messages()));
+        SqsReceiveRequest.create(
+            executionAttributes, SqsMessageImpl.wrap(response.messages(), config));
     if (timer != null && consumerReceiveInstrumenter.shouldStart(parentContext, receiveRequest)) {
       receiveContext =
           InstrumenterUtil.startAndEnd(
@@ -88,6 +90,8 @@ public final class SqsImpl {
               timer.startTime(),
               timer.now());
     }
+    io.opentelemetry.context.Context processParentContext =
+        emitStableMessagingSemconv() ? parentContext : receiveContext;
     // copy ExecutionAttributes as these will get cleared before the process spans are created
     ExecutionAttributes copy = new ExecutionAttributes();
     copy.putAttribute(
@@ -108,7 +112,7 @@ public final class SqsImpl {
             copy,
             new Response(context.httpResponse(), response),
             config,
-            receiveContext);
+            processParentContext);
 
     // store tracing list in context so that our proxied SqsClient/SqsAsyncClient could pick it up
     SqsTracingContext.set(parentContext, tracingList);
@@ -260,6 +264,13 @@ public final class SqsImpl {
       return ((SendMessageBatchRequest) request).queueUrl();
     } else if (request instanceof ReceiveMessageRequest) {
       return ((ReceiveMessageRequest) request).queueUrl();
+    }
+    return null;
+  }
+
+  static Long getBatchMessageCount(SdkRequest request) {
+    if (request instanceof SendMessageBatchRequest) {
+      return (long) ((SendMessageBatchRequest) request).entries().size();
     }
     return null;
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsMessage.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsMessage.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import io.opentelemetry.context.Context;
 import java.util.Map;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 
@@ -16,6 +17,8 @@ import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
  * at any time.
  */
 public interface SqsMessage {
+
+  Context getCreationContext();
 
   Map<String, MessageAttributeValue> messageAttributes();
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsMessageImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsMessageImpl.java
@@ -5,9 +5,11 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import io.opentelemetry.context.Context;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 
@@ -18,21 +20,37 @@ import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 public final class SqsMessageImpl implements SqsMessage {
 
   private final Message message;
+  @Nullable private final TracingExecutionInterceptor config;
 
   private SqsMessageImpl(Message message) {
     this.message = message;
+    this.config = null;
+  }
+
+  private SqsMessageImpl(Message message, TracingExecutionInterceptor config) {
+    this.message = message;
+    this.config = config;
   }
 
   public static SqsMessage wrap(Message message) {
     return new SqsMessageImpl(message);
   }
 
-  static List<SqsMessage> wrap(List<Message> messages) {
+  public static SqsMessage wrap(Message message, TracingExecutionInterceptor config) {
+    return new SqsMessageImpl(message, config);
+  }
+
+  static List<SqsMessage> wrap(List<Message> messages, TracingExecutionInterceptor config) {
     List<SqsMessage> result = new ArrayList<>();
     for (Message message : messages) {
-      result.add(wrap(message));
+      result.add(wrap(message, config));
     }
     return result;
+  }
+
+  @Override
+  public Context getCreationContext() {
+    return config != null ? SqsParentContext.ofMessage(this, config) : Context.root();
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsParentContext.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsParentContext.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import static java.util.Collections.singletonMap;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
@@ -65,34 +66,60 @@ public final class SqsParentContext {
 
   static Context ofMessageAttributes(
       Map<String, MessageAttributeValue> messageAttributes, TextMapPropagator propagator) {
+    return ofMessageAttributes(Context.root(), messageAttributes, propagator);
+  }
+
+  static Context ofMessageAttributes(
+      Context parentContext,
+      Map<String, MessageAttributeValue> messageAttributes,
+      TextMapPropagator propagator) {
     return propagator.extract(
-        Context.root(), messageAttributes, MessageAttributeValueMapGetter.INSTANCE);
+        parentContext, messageAttributes, MessageAttributeValueMapGetter.INSTANCE);
   }
 
   static Context ofSystemAttributes(Map<String, String> systemAttributes) {
+    return ofSystemAttributes(Context.root(), systemAttributes);
+  }
+
+  static Context ofSystemAttributes(Context parentContext, Map<String, String> systemAttributes) {
     String traceHeader = systemAttributes.get(AWS_TRACE_SYSTEM_ATTRIBUTE);
     return AwsXrayPropagator.getInstance()
         .extract(
-            Context.root(), singletonMap("X-Amzn-Trace-Id", traceHeader), StringMapGetter.INSTANCE);
+            parentContext, singletonMap("X-Amzn-Trace-Id", traceHeader), StringMapGetter.INSTANCE);
   }
 
   public static Context ofMessage(SqsMessage message, TracingExecutionInterceptor config) {
-    return ofMessage(message, config.getMessagingPropagator(), config.shouldUseXrayPropagator());
+    return ofMessage(Context.root(), message, config);
+  }
+
+  public static Context ofMessage(
+      Context parentContext, SqsMessage message, TracingExecutionInterceptor config) {
+    return ofMessage(
+        parentContext, message, config.getMessagingPropagator(), config.shouldUseXrayPropagator());
   }
 
   static Context ofMessage(
       SqsMessage message, TextMapPropagator messagingPropagator, boolean shouldUseXrayPropagator) {
-    Context parentContext = Context.root();
+    return ofMessage(Context.root(), message, messagingPropagator, shouldUseXrayPropagator);
+  }
+
+  static Context ofMessage(
+      Context parentContext,
+      SqsMessage message,
+      TextMapPropagator messagingPropagator,
+      boolean shouldUseXrayPropagator) {
+    Context extractedContext = parentContext;
 
     if (messagingPropagator != null) {
-      parentContext = ofMessageAttributes(message.messageAttributes(), messagingPropagator);
+      extractedContext =
+          ofMessageAttributes(parentContext, message.messageAttributes(), messagingPropagator);
     }
 
-    if (shouldUseXrayPropagator && parentContext == Context.root()) {
-      parentContext = ofSystemAttributes(message.attributesAsStrings());
+    if (shouldUseXrayPropagator && !Span.fromContext(extractedContext).getSpanContext().isValid()) {
+      extractedContext = ofSystemAttributes(extractedContext, message.attributesAsStrings());
     }
 
-    return parentContext;
+    return extractedContext;
   }
 
   private SqsParentContext() {}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingIterator.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingIterator.java
@@ -7,20 +7,14 @@ package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.Iterator;
 import javax.annotation.Nullable;
-import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 class TracingIterator implements Iterator<Message> {
 
   private final Iterator<Message> delegateIterator;
-  private final Instrumenter<SqsProcessRequest, Response> instrumenter;
-  private final ExecutionAttributes request;
-  private final Response response;
-  private final TracingExecutionInterceptor config;
-  private final Context receiveContext;
+  private final TracingList tracingList;
 
   /*
    * Note: this may potentially create problems if this iterator is used from different threads. But
@@ -30,30 +24,14 @@ class TracingIterator implements Iterator<Message> {
   @Nullable private Context currentContext;
   @Nullable private Scope currentScope;
 
-  private TracingIterator(
-      Iterator<Message> delegateIterator,
-      Instrumenter<SqsProcessRequest, Response> instrumenter,
-      ExecutionAttributes request,
-      Response response,
-      TracingExecutionInterceptor config,
-      Context receiveContext) {
+  private TracingIterator(Iterator<Message> delegateIterator, TracingList tracingList) {
     this.delegateIterator = delegateIterator;
-    this.instrumenter = instrumenter;
-    this.request = request;
-    this.response = response;
-    this.config = config;
-    this.receiveContext = receiveContext;
+    this.tracingList = tracingList;
   }
 
   public static Iterator<Message> wrap(
-      Iterator<Message> delegateIterator,
-      Instrumenter<SqsProcessRequest, Response> instrumenter,
-      ExecutionAttributes request,
-      Response response,
-      TracingExecutionInterceptor config,
-      Context receiveContext) {
-    return new TracingIterator(
-        delegateIterator, instrumenter, request, response, config, receiveContext);
+      Iterator<Message> delegateIterator, TracingList tracingList) {
+    return new TracingIterator(delegateIterator, tracingList);
   }
 
   @Override
@@ -74,14 +52,14 @@ class TracingIterator implements Iterator<Message> {
     // (https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1947)
     Message next = delegateIterator.next();
     if (next != null) {
-      SqsMessage sqsMessage = SqsMessageImpl.wrap(next);
-      Context parentContext = receiveContext;
+      SqsMessage sqsMessage = SqsMessageImpl.wrap(next, tracingList.getConfig());
+      Context parentContext = tracingList.getProcessParentContext();
       if (parentContext == null) {
-        parentContext = SqsParentContext.ofMessage(sqsMessage, config);
+        parentContext = sqsMessage.getCreationContext();
       }
 
-      currentRequest = SqsProcessRequest.create(request, sqsMessage);
-      currentContext = instrumenter.start(parentContext, currentRequest);
+      currentRequest = SqsProcessRequest.create(tracingList.getRequest(), sqsMessage);
+      currentContext = tracingList.getInstrumenter().start(parentContext, currentRequest);
       currentScope = currentContext.makeCurrent();
     }
     return next;
@@ -90,7 +68,9 @@ class TracingIterator implements Iterator<Message> {
   private void closeScopeAndEndSpan() {
     if (currentScope != null) {
       currentScope.close();
-      instrumenter.end(currentContext, currentRequest, response, null);
+      tracingList
+          .getInstrumenter()
+          .end(currentContext, currentRequest, tracingList.getResponse(), null);
       currentScope = null;
       currentRequest = null;
       currentContext = null;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingList.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/TracingList.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.sqs.model.Message;
 
@@ -25,32 +26,32 @@ public final class TracingList extends ArrayList<Message> {
   private final ExecutionAttributes request;
   private final Response response;
   private final TracingExecutionInterceptor config;
-  private final Context receiveContext;
+  @Nullable private final Context processParentContext;
   private boolean firstIterator = true;
 
-  private TracingList(
-      List<Message> list,
+  public static TracingList wrap(
+      List<Message> messages,
       Instrumenter<SqsProcessRequest, Response> instrumenter,
       ExecutionAttributes request,
       Response response,
       TracingExecutionInterceptor config,
-      Context receiveContext) {
-    super(list);
+      @Nullable Context processParentContext) {
+    return new TracingList(messages, instrumenter, request, response, config, processParentContext);
+  }
+
+  private TracingList(
+      List<Message> messages,
+      Instrumenter<SqsProcessRequest, Response> instrumenter,
+      ExecutionAttributes request,
+      Response response,
+      TracingExecutionInterceptor config,
+      @Nullable Context processParentContext) {
+    super(messages);
     this.instrumenter = instrumenter;
     this.request = request;
     this.response = response;
     this.config = config;
-    this.receiveContext = receiveContext;
-  }
-
-  public static TracingList wrap(
-      List<Message> list,
-      Instrumenter<SqsProcessRequest, Response> instrumenter,
-      ExecutionAttributes request,
-      Response response,
-      TracingExecutionInterceptor config,
-      Context receiveContext) {
-    return new TracingList(list, instrumenter, request, response, config, receiveContext);
+    this.processParentContext = processParentContext;
   }
 
   public void disableTracing() {
@@ -65,9 +66,7 @@ public final class TracingList extends ArrayList<Message> {
     // However, this is not thread-safe, but usually the first (hopefully only) traversal of
     // List is performed in the same thread that called receiveMessage()
     if (firstIterator) {
-      it =
-          TracingIterator.wrap(
-              super.iterator(), instrumenter, request, response, config, receiveContext);
+      it = TracingIterator.wrap(super.iterator(), this);
       firstIterator = false;
     } else {
       it = super.iterator();
@@ -99,7 +98,8 @@ public final class TracingList extends ArrayList<Message> {
     return config;
   }
 
-  public Context getReceiveContext() {
-    return receiveContext;
+  @Nullable
+  public Context getProcessParentContext() {
+    return processParentContext;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsParentContextTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsParentContextTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+class SqsParentContextTest {
+
+  private static final ContextKey<String> TEST_CONTEXT_KEY = ContextKey.named("test-context-key");
+  private static final String TRACE_HEADER =
+      "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1";
+
+  @Test
+  void preservesParentContextValues() {
+    Context parentContext = Context.root().with(TEST_CONTEXT_KEY, "test-value");
+
+    Context extractedContext =
+        SqsParentContext.ofMessage(parentContext, messageWithTraceHeader(), null, true);
+
+    assertThat(extractedContext.get(TEST_CONTEXT_KEY)).isEqualTo("test-value");
+    assertThat(Span.fromContext(extractedContext).getSpanContext().isValid()).isTrue();
+  }
+
+  @Test
+  void preservesNonSpanExtractedValuesWhenUsingXrayFallback() {
+    TextMapPropagator propagator =
+        new TextMapPropagator() {
+          @Override
+          public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {}
+
+          @Override
+          public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+            return context.with(TEST_CONTEXT_KEY, "extracted-value");
+          }
+
+          @Override
+          public List<String> fields() {
+            return emptyList();
+          }
+        };
+
+    Context extractedContext =
+        SqsParentContext.ofMessage(Context.root(), messageWithTraceHeader(), propagator, true);
+
+    assertThat(extractedContext.get(TEST_CONTEXT_KEY)).isEqualTo("extracted-value");
+    assertThat(Span.fromContext(extractedContext).getSpanContext().isValid()).isTrue();
+  }
+
+  private static SqsMessage messageWithTraceHeader() {
+    return new SqsMessage() {
+      @Override
+      public Context getCreationContext() {
+        return Context.root();
+      }
+
+      @Override
+      public Map<String, MessageAttributeValue> messageAttributes() {
+        return emptyMap();
+      }
+
+      @Override
+      public Map<String, String> attributesAsStrings() {
+        return singletonMap(SqsParentContext.AWS_TRACE_SYSTEM_ATTRIBUTE, TRACE_HEADER);
+      }
+
+      @Override
+      public String getMessageAttribute(String name) {
+        return "";
+      }
+
+      @Override
+      public String getMessageId() {
+        return "";
+      }
+    };
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsSuppressReceiveSpansTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -26,16 +27,19 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SY
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -91,6 +95,43 @@ public abstract class AbstractAws2SqsSuppressReceiveSpansTest extends AbstractAw
     }
 
     getTesting().waitAndAssertTraces(traceAsserts);
+  }
+
+  @Test
+  void testAbandonedIteratorDoesNotParentNextProcessSpan() {
+    assumeTrue(emitStableMessagingSemconv());
+    SqsClientBuilder builder = SqsClient.builder();
+    configureSdkClient(builder);
+    SqsClient client = configureSqsClient(builder.build());
+
+    client.createQueue(createQueueRequest);
+    client.sendMessage(sendMessageRequest.toBuilder().messageBody("first").build());
+    ReceiveMessageResponse firstResponse = client.receiveMessage(receiveMessageRequest);
+    client.sendMessage(sendMessageRequest.toBuilder().messageBody("second").build());
+    ReceiveMessageResponse secondResponse = client.receiveMessage(receiveMessageRequest);
+
+    Iterator<Message> firstIterator = firstResponse.messages().iterator();
+    Iterator<Message> secondIterator = secondResponse.messages().iterator();
+    assertThat(firstIterator.hasNext()).isTrue();
+    firstIterator.next();
+    assertThat(secondIterator.hasNext()).isTrue();
+    secondIterator.next();
+    assertThat(secondIterator.hasNext()).isFalse();
+    assertThat(firstIterator.hasNext()).isFalse();
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("Sqs.CreateQueue").hasNoParent()),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("publish testSdkSqs").hasNoParent(),
+                    span -> span.hasName("process testSdkSqs").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("publish testSdkSqs").hasNoParent(),
+                    span -> span.hasName("process testSdkSqs").hasParent(trace.getSpan(0))));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -20,6 +21,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
@@ -28,6 +31,7 @@ import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_SY
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -87,10 +91,16 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                   equalTo(SERVER_PORT, sqsPort),
                                   equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                   equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
-                                  equalTo(MESSAGING_OPERATION, "publish"),
                                   satisfies(
                                       MESSAGING_MESSAGE_ID,
                                       val -> val.isInstanceOf(String.class))));
+
+                      if (emitStableMessagingSemconv()) {
+                        attributes.add(equalTo(MESSAGING_OPERATION_NAME, "publish"));
+                        attributes.add(equalTo(MESSAGING_OPERATION_TYPE, "send"));
+                      } else {
+                        attributes.add(equalTo(MESSAGING_OPERATION, "publish"));
+                      }
 
                       if (captureHeaders) {
                         attributes.add(
@@ -98,7 +108,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                 headerAttributeKey("Test-Message-Header"),
                                 val -> val.isEqualTo(ImmutableList.of("test"))));
                       }
-                      span.hasName("testSdkSqs publish")
+                      span.hasName(
+                              emitStableMessagingSemconv()
+                                  ? "publish testSdkSqs"
+                                  : "testSdkSqs publish")
                           .hasKind(SpanKind.PRODUCER)
                           .hasNoParent()
                           .hasAttributesSatisfyingExactly(attributes);
@@ -161,8 +174,14 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                     equalTo(SERVER_PORT, sqsPort),
                                     equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                     equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
-                                    equalTo(MESSAGING_OPERATION, "receive"),
                                     equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+
+                        if (emitStableMessagingSemconv()) {
+                          attributes.add(equalTo(MESSAGING_OPERATION_NAME, "receive"));
+                          attributes.add(equalTo(MESSAGING_OPERATION_TYPE, "receive"));
+                        } else {
+                          attributes.add(equalTo(MESSAGING_OPERATION, "receive"));
+                        }
 
                         if (captureHeaders) {
                           attributes.add(
@@ -177,10 +196,25 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                           span.hasNoParent();
                         }
 
-                        span.hasName("testSdkSqs receive")
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasTotalRecordedLinks(0)
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "receive testSdkSqs"
+                                    : "testSdkSqs receive")
+                            .hasKind(
+                                emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                             .hasAttributesSatisfyingExactly(attributes);
+                        if (emitStableMessagingSemconv()) {
+                          span.hasLinksSatisfying(
+                              links ->
+                                  assertThat(links)
+                                      .singleElement()
+                                      .satisfies(
+                                          link ->
+                                              assertThat(link.getSpanContext().getSpanId())
+                                                  .isEqualTo(publishSpan.get().getSpanId())));
+                        } else {
+                          span.hasTotalRecordedLinks(0);
+                        }
                       },
                       span -> {
                         List<AttributeAssertion> attributes =
@@ -199,10 +233,16 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                     equalTo(SERVER_PORT, sqsPort),
                                     equalTo(MESSAGING_SYSTEM, AWS_SQS),
                                     equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
-                                    equalTo(MESSAGING_OPERATION, "process"),
                                     satisfies(
                                         MESSAGING_MESSAGE_ID,
                                         val -> val.isInstanceOf(String.class))));
+
+                        if (emitStableMessagingSemconv()) {
+                          attributes.add(equalTo(MESSAGING_OPERATION_NAME, "process"));
+                          attributes.add(equalTo(MESSAGING_OPERATION_TYPE, "process"));
+                        } else {
+                          attributes.add(equalTo(MESSAGING_OPERATION, "process"));
+                        }
 
                         if (captureHeaders) {
                           attributes.add(
@@ -211,8 +251,14 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                   val -> val.isEqualTo(singletonList("test"))));
                         }
 
-                        span.hasName("testSdkSqs process")
-                            .hasParent(trace.getSpan(0 + offset))
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "process testSdkSqs"
+                                    : "testSdkSqs process")
+                            .hasParent(
+                                emitStableMessagingSemconv() && withParent
+                                    ? trace.getSpan(0)
+                                    : trace.getSpan(0 + offset))
                             .hasKind(SpanKind.CONSUMER)
                             .hasLinksSatisfying(
                                 links ->
@@ -259,6 +305,90 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
 
     response.messages().forEach(message -> getTesting().runWithSpan("process child", () -> {}));
     assertSqsTraces(false, true);
+  }
+
+  @Test
+  void testReceiveSpanLinksToProducer() {
+    assumeTrue(emitStableMessagingSemconv());
+    SqsClientBuilder builder = SqsClient.builder();
+    configureSdkClient(builder);
+    SqsClient client = configureSqsClient(builder.build());
+
+    client.createQueue(createQueueRequest);
+    client.sendMessage(sendMessageRequest);
+    client.receiveMessage(receiveMessageRequest);
+
+    AtomicReference<SpanData> publishSpan = new AtomicReference<>();
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("Sqs.CreateQueue").hasKind(SpanKind.CLIENT)),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      publishSpan.set(trace.getSpan(0));
+                      span.hasName("publish testSdkSqs").hasKind(SpanKind.PRODUCER);
+                    }),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("receive testSdkSqs")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(publishSpan.get().getSpanId())))));
+  }
+
+  @Test
+  void testBatchSendMessageCount() {
+    assumeTrue(emitStableMessagingSemconv());
+    SqsClientBuilder builder = SqsClient.builder();
+    configureSdkClient(builder);
+    SqsClient client = configureSqsClient(builder.build());
+
+    client.createQueue(createQueueRequest);
+    client.sendMessageBatch(sendMessageBatchRequest);
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("Sqs.CreateQueue").hasKind(SpanKind.CLIENT)),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("publish testSdkSqs")
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasNoParent()
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(stringKey("aws.agent"), "java-aws-sdk"),
+                                equalTo(AWS_SQS_QUEUE_URL, queueUrl),
+                                satisfies(
+                                    AWS_REQUEST_ID,
+                                    val ->
+                                        val.matches(
+                                            "\\s*00000000-0000-0000-0000-000000000000\\s*|UNKNOWN")),
+                                equalTo(RPC_SYSTEM, "aws-api"),
+                                equalTo(RPC_SERVICE, "Sqs"),
+                                equalTo(RPC_METHOD, "SendMessageBatch"),
+                                equalTo(HTTP_REQUEST_METHOD, "POST"),
+                                equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                satisfies(
+                                    URL_FULL, val -> val.startsWith("http://localhost:" + sqsPort)),
+                                equalTo(SERVER_ADDRESS, "localhost"),
+                                equalTo(SERVER_PORT, sqsPort),
+                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
+                                equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),
+                                equalTo(MESSAGING_OPERATION_NAME, "publish"),
+                                equalTo(MESSAGING_OPERATION_TYPE, "send"),
+                                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3))));
   }
 
   @Test

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -70,6 +70,42 @@ tasks {
     include("**/Jms1SuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    filter {
+      excludeTestsMatching("Jms1SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testJms2V3Preview = register<Test>("testJms2V3Preview") {
+    testClassesDirs = sourceSets["jms2Test"].output.classesDirs
+    classpath = sourceSets["jms2Test"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    filter {
+      includeTestsMatching("Jms1InstrumentationTest")
+    }
+    include("**/Jms1InstrumentationTest.*")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     filter {
@@ -83,7 +119,13 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(
+      testing.suites,
+      testReceiveSpansDisabled,
+      testV3Preview,
+      testJms2V3Preview,
+      testBothSemconv,
+    )
   }
 }
 

--- a/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -148,13 +153,20 @@ class Jms2InstrumentationTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(destinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? destinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + destinationName
+                              : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(destinationName, isTemporary),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -164,14 +176,21 @@ class Jms2InstrumentationTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
@@ -211,23 +230,37 @@ class Jms2InstrumentationTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
@@ -257,6 +290,26 @@ class Jms2InstrumentationTest {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  private static AttributeAssertion messagingDestinationName(
+      String destinationName, boolean isTemporary) {
+    return emitStableMessagingSemconv() && isTemporary
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -6,14 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -114,23 +119,37 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
@@ -194,13 +213,20 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -210,13 +236,20 @@ abstract class AbstractJms1Test {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -264,26 +297,40 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
@@ -292,6 +339,25 @@ abstract class AbstractJms1Test {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  static AttributeAssertion messagingDestinationName(String destinationName, boolean isTemporary) {
+    return emitStableMessagingSemconv() && isTemporary
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,13 +60,20 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(destinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? destinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + destinationName
+                              : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(destinationName, isTemporary),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -76,14 +83,21 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,24 +56,38 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->

--- a/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
@@ -51,6 +51,18 @@ tasks {
     include("**/Jms3SuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("Jms3SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("Jms3SuppressReceiveSpansTest")
@@ -63,6 +75,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(testing.suites, testReceiveSpansDisabled, testV3Preview)
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -131,23 +135,38 @@ abstract class AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(actualDestinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + actualDestinationName
+                                : actualDestinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
@@ -212,13 +231,21 @@ abstract class AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -228,13 +255,20 @@ abstract class AbstractJms3Test {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName(actualDestinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + actualDestinationName
+                                : actualDestinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -249,6 +283,26 @@ abstract class AbstractJms3Test {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  static AttributeAssertion messagingDestinationName(
+      String oldDestinationName, String stableDestinationName) {
+    return equalTo(
+        MESSAGING_DESTINATION_NAME,
+        emitStableMessagingSemconv() ? stableDestinationName : oldDestinationName);
+  }
+
+  static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,13 +63,20 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(producerDestinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? producerDestinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + producerDestinationName
+                              : producerDestinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(producerDestinationName, actualDestinationName),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -79,14 +86,21 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(actualDestinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + actualDestinationName
+                                : actualDestinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(actualDestinationName, actualDestinationName),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId))));
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,24 +59,39 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(actualDestinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + actualDestinationName
+                                : actualDestinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(actualDestinationName, actualDestinationName),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId))),
         trace ->
             trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer parent").hasNoParent()));

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -12,13 +12,14 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,28 +52,28 @@ public class JmsInstrumenterFactory {
 
   public Instrumenter<MessageWithDestination, Void> createProducerInstrumenter() {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new MessagePropertySetter());
   }
 
   public Instrumenter<MessageWithDestination, Void> createConsumerReceiveInstrumenter() {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingReceiveExceptionEventExtractor(builder);
     if (messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
@@ -80,34 +81,32 @@ public class JmsInstrumenterFactory {
               openTelemetry.getPropagators().getTextMapPropagator(),
               MessagePropertyGetter.INSTANCE));
     }
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return builder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   public Instrumenter<MessageWithDestination, Void> createConsumerProcessInstrumenter(
       boolean canHaveReceiveInstrumentation) {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingProcessExceptionEventExtractor(builder);
-    if (canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled) {
-      builder.addSpanLinksExtractor(
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(),
-              MessagePropertyGetter.INSTANCE));
-      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    }
-    return builder.buildConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        MessagePropertyGetter.INSTANCE,
+        canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled);
   }
 
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
-      MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(new JmsMessageAttributesGetter(), operation)
+      MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(
+            new JmsMessageAttributesGetter(), operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
@@ -53,6 +53,28 @@ tasks {
     include("**/KafkaClientSuppressReceiveSpansTest.*")
   }
 
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientDefaultTest.testKafkaProducerAndConsumerSpan")
+      includeTestsMatching("KafkaClientDefaultTest.testAbandonedIteratorDoesNotParentNextProcessSpan")
+      includeTestsMatching("KafkaClientDefaultTest.testReceiveDoesNotParentProcessSpan")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+  }
+
+  val testMessagingPreviewDup = register<Test>("testMessagingPreviewDup") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientDefaultTest.testReceiveDoesNotParentProcessSpan")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging/dup")
+  }
+
   val testExperimental = register<Test>("testExperimental") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -67,7 +89,34 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
-  val testStableSemconv = register<Test>("testStableSemconv") {
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaClientPropagationDisabledTest")
+      excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    // kafka metrics are disabled by default with v3-preview enabled
+    jvmArgs("-Dotel.instrumentation.kafka-clients-metrics.enabled=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    include("**/KafkaClientSuppressReceiveSpansTest.*")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
@@ -75,15 +124,15 @@ tasks {
       excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     // kafka metrics are disabled by default with v3-preview enabled
     jvmArgs("-Dotel.instrumentation.kafka-clients-metrics.enabled=true")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testV3Preview, testV3PreviewReceiveSpansDisabled, testBothSemconv)
   }
 
   test {
@@ -95,7 +144,13 @@ tasks {
   }
 
   check {
-    dependsOn(testPropagationDisabled, testReceiveSpansDisabled, testExperimental)
+    dependsOn(
+      testPropagationDisabled,
+      testReceiveSpansDisabled,
+      testMessagingPreview,
+      testMessagingPreviewDup,
+      testExperimental,
+    )
   }
 }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.consumerReceiveInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -67,15 +68,15 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      Context parentContext = currentContext();
+      Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(currentContext());
       KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
 
       // disable process tracing and store the receive span for each individual record too
       boolean previousValue = KafkaClientsConsumerProcessTracing.setWrappingEnabled(false);
       try {
-        Context context = null;
+        Context receiveContext = null;
         if (consumerReceiveInstrumenter().shouldStart(parentContext, request)) {
-          context =
+          receiveContext =
               InstrumenterUtil.startAndEnd(
                   consumerReceiveInstrumenter(),
                   parentContext,
@@ -86,16 +87,14 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
                   timer.now());
         }
 
-        // we're storing the context of the receive span so that process spans can use it as
-        // parent context even though the span has ended
-        // this is the suggested behavior according to the spec batch receive scenario:
-        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#batch-receiving
+        Context processParentContext =
+            emitStableMessagingSemconv() ? parentContext : receiveContext;
         // we're attaching the consumer to the records to be able to retrieve things like consumer
         // group or clientId later
-        KafkaConsumerContextUtil.set(records, context, consumer);
+        KafkaConsumerContextUtil.set(records, processParentContext, consumer);
 
         for (ConsumerRecord<?, ?> record : records) {
-          KafkaConsumerContextUtil.set(record, context, consumer);
+          KafkaConsumerContextUtil.set(record, processParentContext, consumer);
         }
       } finally {
         KafkaClientsConsumerProcessTracing.setWrappingEnabled(previousValue);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaProducerInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.PRODUCER_PROPAGATION_ENABLED;
+import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED;
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.producerInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -79,8 +80,8 @@ class KafkaProducerInstrumentation implements TypeInstrumentation {
       }
 
       public ProducerRecord<?, ?> propagateContext(
-          ApiVersions apiVersions, ProducerRecord<?, ?> record) {
-        if (PRODUCER_PROPAGATION_ENABLED && KafkaPropagation.shouldPropagate(apiVersions)) {
+          ProducerRecord<?, ?> record, boolean shouldPropagate) {
+        if (shouldPropagate) {
           return KafkaPropagation.propagateContext(context, record);
         }
         return record;
@@ -112,13 +113,20 @@ class KafkaProducerInstrumentation implements TypeInstrumentation {
       String bootstrapServers =
           KafkaUtil.extractBootstrapServers(
               producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+      boolean shouldPropagate =
+          PRODUCER_PROPAGATION_ENABLED && KafkaPropagation.shouldPropagate(apiVersions);
       KafkaProducerRequest request =
-          KafkaProducerRequest.create(record, clientId, bootstrapServers);
+          KafkaProducerRequest.create(
+              record,
+              clientId,
+              bootstrapServers,
+              PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED
+                  && KafkaPropagation.shouldPropagate(apiVersions));
       AdviceScope adviceScope = AdviceScope.start(request);
       if (adviceScope == null) {
         return new Object[] {null, record, callback};
       }
-      record = adviceScope.propagateContext(apiVersions, record);
+      record = adviceScope.propagateContext(record, shouldPropagate);
       callback = adviceScope.wrapCallback(callback);
       return new Object[] {adviceScope, record, callback};
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -6,11 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProducerRequest;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaPropagation;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -22,20 +24,30 @@ public class KafkaSingletons {
       DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
           .get("producer_propagation")
           .getBoolean("enabled", true);
+  public static final boolean PRODUCER_SPAN_CONTEXT_PROPAGATION_ENABLED =
+      PRODUCER_PROPAGATION_ENABLED
+          && KafkaPropagation.propagatesSpanContext(
+              GlobalOpenTelemetry.getPropagators().getTextMapPropagator());
 
   private static final Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter;
   private static final Instrumenter<KafkaReceiveRequest, Void> consumerReceiveInstrumenter;
   private static final Instrumenter<KafkaProcessRequest, Void> consumerProcessInstrumenter;
 
   static {
+    DeclarativeConfigProperties commonConfig =
+        DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "common");
+    Boolean messagingReceiveInstrumentationEnabled =
+        commonConfig.get("messaging").get("receive_telemetry/development").getBoolean("enabled");
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
             .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setCaptureExperimentalSpanAttributes(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
-                    .getBoolean("experimental_span_attributes/development", false))
-            .setMessagingReceiveTelemetryEnabled(
-                ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
+                    .getBoolean("experimental_span_attributes/development", false));
+    if (messagingReceiveInstrumentationEnabled != null) {
+      instrumenterFactory.setMessagingReceiveTelemetryEnabled(
+          messagingReceiveInstrumentationEnabled);
+    }
     producerInstrumenter = instrumenterFactory.createProducerInstrumenter();
     consumerReceiveInstrumenter = instrumenterFactory.createConsumerReceiveInstrumenter();
     consumerProcessInstrumenter = instrumenterFactory.createConsumerProcessInstrumenter();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -5,12 +5,16 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientPropagationBaseTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -18,6 +22,7 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,13 +81,53 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           });
     }
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes("10", greeting, testHeaders));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes("10", greeting, testHeaders, false)),
+                  span -> span.hasName("processing").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, testHeaders)),
@@ -95,18 +140,97 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             processAttributes("10", greeting, testHeaders, false)),
                 span -> span.hasName("processing").hasParent(trace.getSpan(1))));
+  }
+
+  @Test
+  void testReceiveDoesNotParentProcessSpan() throws Exception {
+    assumeTrue(emitStableMessagingSemconv());
+    producer.send(new ProducerRecord<>(SHARED_TOPIC, 10, "Hello Kafka!")).get(5, SECONDS);
+
+    awaitUntilConsumerIsReady();
+    ConsumerRecords<?, ?> records = poll(Duration.ofSeconds(5));
+    assertThat(records.count()).isEqualTo(1);
+
+    for (ConsumerRecord<?, ?> ignored : records) {
+      testing.runWithSpan("processing", () -> {});
+    }
+
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> {
+                  span.hasName("send " + SHARED_TOPIC).hasKind(SpanKind.PRODUCER).hasNoParent();
+                  producerSpan.set(span.actual());
+                },
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0)),
+                span -> span.hasName("processing").hasParent(trace.getSpan(1))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + SHARED_TOPIC).hasKind(SpanKind.CLIENT).hasNoParent()));
+  }
+
+  @Test
+  void testAbandonedIteratorDoesNotParentNextProcessSpan() throws Exception {
+    assumeTrue(emitStableMessagingSemconv());
+    producer.send(new ProducerRecord<>(SHARED_TOPIC, "first")).get(5, SECONDS);
+    awaitUntilConsumerIsReady();
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          Iterator<? extends ConsumerRecord<?, ?>> firstIterator =
+              poll(Duration.ofSeconds(5)).iterator();
+          assertThat(firstIterator.hasNext()).isTrue();
+          firstIterator.next();
+
+          try (Scope ignored = Context.root().makeCurrent()) {
+            producer.send(new ProducerRecord<>(SHARED_TOPIC, "second")).get(5, SECONDS);
+          }
+          Iterator<? extends ConsumerRecord<?, ?>> secondIterator =
+              poll(Duration.ofSeconds(5)).iterator();
+          assertThat(secondIterator.hasNext()).isTrue();
+          secondIterator.next();
+          assertThat(secondIterator.hasNext()).isFalse();
+          assertThat(firstIterator.hasNext()).isFalse();
+        });
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("send " + SHARED_TOPIC).hasNoParent()),
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("parent").hasNoParent(),
+                span -> span.hasName("poll " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("process " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("poll " + SHARED_TOPIC).hasParent(trace.getSpan(0)),
+                span -> span.hasName("process " + SHARED_TOPIC).hasParent(trace.getSpan(0))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("send " + SHARED_TOPIC).hasNoParent()));
   }
 
   @DisplayName("test pass through tombstone")
@@ -124,12 +248,44 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     }
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(sendAttributes(null, null, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(null, null, false, false))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(sendAttributes(null, null, false)));
@@ -138,12 +294,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
@@ -183,12 +345,44 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     }
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.PRODUCER, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(null, greeting, false, false))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false)));
@@ -197,12 +391,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
@@ -247,13 +447,51 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
           });
     }
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span -> {
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false));
+                    producerSpan.set(span.actual());
+                  },
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes("10", greeting, false, false)),
+                  span -> span.hasName("processing").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes(false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(SHARED_TOPIC + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + SHARED_TOPIC
+                              : SHARED_TOPIC + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false)),
@@ -266,12 +504,18 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "poll " + SHARED_TOPIC
+                                : SHARED_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes(false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,12 +68,12 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(sendAttributes("10", greeting, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -104,12 +105,12 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(sendAttributes(null, null, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -139,15 +140,21 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(spanName("publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(sendAttributes(null, greeting, false)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(spanName("process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             processAttributes(null, greeting, false, false))));
+  }
+
+  private static String spanName(String oldOperation, String operationName) {
+    return emitStableMessagingSemconv()
+        ? operationName + " " + SHARED_TOPIC
+        : SHARED_TOPIC + " " + oldOperation;
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaClientBaseTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testL
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
@@ -23,6 +24,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -74,7 +77,7 @@ public abstract class KafkaClientBaseTest {
   @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected static final String SHARED_TOPIC = "shared.topic";
-  protected static final AttributeKey<String> MESSAGING_CLIENT_ID =
+  protected static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
       AttributeKey.stringKey("messaging.client_id");
 
   private KafkaContainer kafka;
@@ -181,9 +184,11 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "producer");
     if (emitOldMessagingSemconv()) {
       assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
     }
@@ -215,12 +220,17 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
                 satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
+    addClientIdAssertions(assertions, "consumer");
     // consumer group is not available in version 0.11
     if (testLatestDeps()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(
+          equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null));
+      assertions.add(
+          equalTo(MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null));
     }
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
@@ -236,9 +246,11 @@ public abstract class KafkaClientBaseTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "consumer");
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
@@ -251,7 +263,10 @@ public abstract class KafkaClientBaseTest {
     }
     // consumer group is not available in version 0.11
     if (testLatestDeps()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      assertions.add(
+          equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null));
+      assertions.add(
+          equalTo(MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null));
     }
     if (messageKey != null) {
       assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
@@ -270,5 +285,16 @@ public abstract class KafkaClientBaseTest {
       assertions.add(equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2"));
     }
     return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/build.gradle.kts
@@ -34,8 +34,16 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testExceptionSignalLogs)
+    dependsOn(testExceptionSignalLogs, testV3Preview)
   }
 }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -34,6 +34,7 @@ public final class KafkaTelemetryBuilder {
   private boolean captureExperimentalSpanAttributes = false;
   private boolean propagationEnabled = true;
   private boolean messagingReceiveInstrumentationEnabled = false;
+  private boolean messagingReceiveInstrumentationConfigured = false;
 
   KafkaTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = requireNonNull(openTelemetry);
@@ -106,6 +107,7 @@ public final class KafkaTelemetryBuilder {
   public KafkaTelemetryBuilder setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    this.messagingReceiveInstrumentationConfigured = true;
     return this;
   }
 
@@ -113,8 +115,11 @@ public final class KafkaTelemetryBuilder {
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
             .setCapturedHeaders(capturedHeaders)
-            .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
-            .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
+            .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes);
+    if (messagingReceiveInstrumentationConfigured) {
+      instrumenterFactory.setMessagingReceiveTelemetryEnabled(
+          messagingReceiveInstrumentationEnabled);
+    }
 
     return new KafkaTelemetry(
         openTelemetry,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyMap;
 
 import io.opentelemetry.context.Context;
@@ -12,6 +13,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaUtil;
@@ -75,11 +77,11 @@ public class KafkaConsumerTelemetry {
     if (records.isEmpty()) {
       return null;
     }
-    Context parentContext = Context.current();
+    Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumerGroup, clientId);
-    Context context = null;
+    Context receiveContext = null;
     if (consumerReceiveInstrumenter.shouldStart(parentContext, request)) {
-      context =
+      receiveContext =
           InstrumenterUtil.startAndEnd(
               consumerReceiveInstrumenter,
               parentContext,
@@ -90,16 +92,12 @@ public class KafkaConsumerTelemetry {
               timer.now());
     }
 
-    // we're returning the context of the receive span so that process spans can use it as
-    // parent context even though the span has ended
-    // this is the suggested behavior according to the spec batch receive scenario:
-    // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md#batch-receiving
-    return context;
+    return emitStableMessagingSemconv() ? parentContext : receiveContext;
   }
 
   public <K, V> void buildAndFinishErrorSpan(
       Consumer<K, V> consumer, Timer timer, Throwable error) {
-    Context parentContext = Context.current();
+    Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     ConsumerRecords<K, V> records = new ConsumerRecords<>(emptyMap());
     KafkaReceiveRequest request =
         KafkaReceiveRequest.create(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaProducerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaProducerTelemetry.java
@@ -29,6 +29,7 @@ public class KafkaProducerTelemetry {
   private final TextMapPropagator propagator;
   private final Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter;
   private final boolean producerPropagationEnabled;
+  private final boolean producerSpanContextPropagationEnabled;
 
   public KafkaProducerTelemetry(
       TextMapPropagator propagator,
@@ -37,6 +38,8 @@ public class KafkaProducerTelemetry {
     this.propagator = propagator;
     this.producerInstrumenter = producerInstrumenter;
     this.producerPropagationEnabled = producerPropagationEnabled;
+    this.producerSpanContextPropagationEnabled =
+        producerPropagationEnabled && KafkaPropagation.propagatesSpanContext(propagator);
   }
 
   /**
@@ -48,7 +51,9 @@ public class KafkaProducerTelemetry {
       ProducerRecord<K, V> record, @Nullable String clientId, @Nullable String bootstrapServers) {
     Context parentContext = Context.current();
 
-    KafkaProducerRequest request = KafkaProducerRequest.create(record, clientId, bootstrapServers);
+    KafkaProducerRequest request =
+        KafkaProducerRequest.create(
+            record, clientId, bootstrapServers, producerSpanContextPropagationEnabled);
     if (!producerInstrumenter.shouldStart(parentContext, request)) {
       return record;
     }
@@ -79,7 +84,9 @@ public class KafkaProducerTelemetry {
       String bootstrapServers) {
     Context parentContext = Context.current();
 
-    KafkaProducerRequest request = KafkaProducerRequest.create(record, producer, bootstrapServers);
+    KafkaProducerRequest request =
+        KafkaProducerRequest.create(
+            record, producer, bootstrapServers, producerSpanContextPropagationEnabled);
     if (!producerInstrumenter.shouldStart(parentContext, request)) {
       return sendFn.apply(record, callback);
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -32,6 +38,7 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -112,6 +119,53 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
 
   void assertTraces() {
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanName("parent", "poll " + SHARED_TOPIC, "producer callback"),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            publishAttributes(captureExperimentalSpanAttributes())),
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks()
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(captureExperimentalSpanAttributes())),
+                span ->
+                    span.hasName("process child")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(2)));
+            SpanContext spanContext = trace.getSpan(1).getSpanContext();
+            producerSpanContext.set(
+                SpanContext.createFromRemoteParent(
+                    spanContext.getTraceId(),
+                    spanContext.getSpanId(),
+                    spanContext.getTraceFlags(),
+                    spanContext.getTraceState()));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpanContext.get()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes())),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("producer callback").hasKind(SpanKind.INTERNAL).hasNoParent()));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName("parent", SHARED_TOPIC + " receive", "producer callback"),
         trace -> {
@@ -159,49 +213,86 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
   }
 
   private static List<AttributeAssertion> publishAttributes(boolean experimental) {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "publish"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-        satisfies(
-            stringKey("messaging.kafka.bootstrap.servers"),
-            val -> {
-              if (experimental) {
-                val.matches("^localhost:\\d+(,localhost:\\d+)*$");
-              }
-            }));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+                satisfies(
+                    stringKey("messaging.kafka.bootstrap.servers"),
+                    val -> {
+                      if (experimental) {
+                        val.matches("^localhost:\\d+(,localhost:\\d+)*$");
+                      }
+                    })));
+    addClientIdAssertions(assertions, "producer");
+    return assertions;
   }
 
   private static List<AttributeAssertion> receiveAttributes() {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "receive"),
-        equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-        equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    addClientIdAssertions(assertions, "consumer");
+    return assertions;
   }
 
   private static List<AttributeAssertion> processAttributes(boolean experimental) {
-    return asList(
-        equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
-        equalTo(MESSAGING_SYSTEM, "kafka"),
-        equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-        equalTo(MESSAGING_OPERATION, "process"),
-        equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-        satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-        satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-        equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-        satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-        satisfies(
-            longKey("kafka.record.queue_time_ms"),
-            val -> {
-              if (experimental) {
-                val.isNotNegative();
-              }
-            }));
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")),
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                satisfies(
+                    longKey("kafka.record.queue_time_ms"),
+                    val -> {
+                      if (experimental) {
+                        val.isNotNegative();
+                      }
+                    })));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+      assertions.add(equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"));
+      assertions.add(equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2"));
+    }
+    addClientIdAssertions(assertions, "consumer");
+    return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -6,25 +6,38 @@
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
 
   private static final KafkaTelemetry kafkaTelemetry =
-      KafkaTelemetry.create(testing.getOpenTelemetry());
+      KafkaTelemetry.builder(testing.getOpenTelemetry())
+          .setMessagingReceiveTelemetryEnabled(false)
+          .build();
 
   @Override
   protected KafkaTelemetry kafkaTelemetry() {
@@ -36,7 +49,6 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
     return false;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Override
   void assertTraces() {
     testing.waitAndAssertTraces(
@@ -44,32 +56,21 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer"))),
+                        .hasAttributesSatisfyingExactly(sendAttributes()),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                            satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
-                            equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"),
-                            equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2")),
+                        .hasAttributesSatisfyingExactly(processAttributes()),
                 span ->
                     span.hasName("process child")
                         .hasKind(SpanKind.INTERNAL)
@@ -80,5 +81,55 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("producer callback").hasKind(SpanKind.INTERNAL).hasNoParent()));
+  }
+
+  private static List<AttributeAssertion> sendAttributes() {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)));
+    addClientIdAssertion(assertions, "producer");
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> processAttributes() {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
+                equalTo(stringKey("test-baggage-key-1"), "test-baggage-value-1"),
+                equalTo(stringKey("test-baggage-key-2"), "test-baggage-value-2")));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    addClientIdAssertion(assertions, "consumer");
+    return assertions;
+  }
+
+  private static void addClientIdAssertion(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperPropagationDisabledTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperPropagationDisabledTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.List;
@@ -18,13 +20,56 @@ class WrapperPropagationDisabledTest extends AbstractWrapperTest {
 
   @Override
   void assertTraces(boolean testHeaders, boolean testExperimental) {
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      span.hasName("send " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              sendAttributes(testHeaders, testExperimental)),
+                  span ->
+                      span.hasName("producer callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks()
+                          .hasAttributesSatisfyingExactly(
+                              WrapperTest.receiveAttributes(testHeaders))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("process " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasNoParent()
+                          .hasLinks()
+                          .hasAttributesSatisfyingExactly(
+                              processAttributes(greeting, testHeaders, testExperimental)),
+                  span ->
+                      span.hasName("process child")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
-                        .hasKind(SpanKind.PRODUCER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(testHeaders, testExperimental)),
@@ -35,7 +80,10 @@ class WrapperPropagationDisabledTest extends AbstractWrapperTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks()

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSendExceptionTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSendExceptionTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -46,7 +47,8 @@ class WrapperSendExceptionTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("test-topic publish")
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "send test-topic" : "test-topic publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -5,28 +5,11 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
-import static io.opentelemetry.api.common.AttributeKey.longKey;
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.util.ArrayList;
 import java.util.List;
-import org.assertj.core.api.AbstractLongAssert;
-import org.assertj.core.api.AbstractStringAssert;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
@@ -43,13 +26,19 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(SHARED_TOPIC + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send " + SHARED_TOPIC
+                                : SHARED_TOPIC + " publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(testHeaders, testExperimental)),
                 span ->
-                    span.hasName(SHARED_TOPIC + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + SHARED_TOPIC
+                                : SHARED_TOPIC + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -65,47 +54,11 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
   }
 
   static List<AttributeAssertion> sendAttributes(boolean testHeaders, boolean testExperimental) {
-    List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
-    if (testHeaders) {
-      assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
-    }
-    if (testExperimental) {
-      assertions.add(
-          satisfies(
-              stringKey("messaging.kafka.bootstrap.servers"),
-              val -> val.matches("^localhost:\\d+(,localhost:\\d+)*$")));
-    }
-    return assertions;
+    return WrapperTest.sendAttributes(testHeaders, testExperimental);
   }
 
   static List<AttributeAssertion> processAttributes(
       String greeting, boolean testHeaders, boolean testExperimental) {
-    List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
-                equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
-    if (testHeaders) {
-      assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
-    }
-    if (testExperimental) {
-      assertions.add(
-          satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
-    }
-    return assertions;
+    return WrapperTest.processAttributes(greeting, testHeaders, testExperimental);
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -9,16 +9,23 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -55,6 +62,52 @@ class WrapperTest extends AbstractWrapperTest {
   @Override
   void assertTraces(boolean testHeaders, boolean testExperimental) {
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("send " + SHARED_TOPIC)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(testHeaders, testExperimental)),
+                span ->
+                    span.hasName("process " + SHARED_TOPIC)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks()
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(greeting, testHeaders, testExperimental)),
+                span ->
+                    span.hasName("process child")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(2)),
+                span ->
+                    span.hasName("producer callback")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0)));
+            SpanContext spanContext = trace.getSpan(1).getSpanContext();
+            producerSpanContext.set(
+                SpanContext.createFromRemoteParent(
+                    spanContext.getTraceId(),
+                    spanContext.getSpanId(),
+                    spanContext.getTraceFlags(),
+                    spanContext.getTraceState()));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("poll " + SHARED_TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpanContext.get()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes(testHeaders))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace -> {
           trace.hasSpansSatisfyingExactly(
@@ -105,10 +158,12 @@ class WrapperTest extends AbstractWrapperTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty)));
+    addClientIdAssertions(assertions, "producer");
+    addOffsetAssertions(assertions);
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -123,19 +178,23 @@ class WrapperTest extends AbstractWrapperTest {
     return assertions;
   }
 
-  private static List<AttributeAssertion> processAttributes(
+  static List<AttributeAssertion> processAttributes(
       String greeting, boolean testHeaders, boolean testExperimental) {
     List<AttributeAssertion> assertions =
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "process"),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, greeting.getBytes(UTF_8).length),
                 satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer"))));
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null)));
+    addClientIdAssertions(assertions, "consumer");
+    addOffsetAssertions(assertions);
     if (testHeaders) {
       assertions.add(
           equalTo(
@@ -154,16 +213,40 @@ class WrapperTest extends AbstractWrapperTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "kafka"),
                 equalTo(MESSAGING_DESTINATION_NAME, SHARED_TOPIC),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"),
-                satisfies(MESSAGING_CLIENT_ID, val -> val.startsWith("consumer")),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "poll" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null),
+                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, emitOldMessagingSemconv() ? "test" : null),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? "test" : null),
                 equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    addClientIdAssertions(assertions, "consumer");
     if (testHeaders) {
       assertions.add(
           equalTo(
               MessageHeaderUtil.headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
     return assertions;
+  }
+
+  private static void addClientIdAssertions(
+      List<AttributeAssertion> assertions, String clientIdPrefix) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_CLIENT_ID_OLD, val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+  }
+
+  private static void addOffsetAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
   }
 
   @Test
@@ -182,14 +265,26 @@ class WrapperTest extends AbstractWrapperTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("unknown receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(emitStableMessagingSemconv() ? "poll" : "unknown receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
                         .hasException(emitExceptionAsSpanEvents() ? error : null)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            equalTo(
+                                MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "poll" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "receive" : null),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableMessagingSemconv()
+                                    ? IllegalStateException.class.getName()
+                                    : null),
                             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 0))));
 
     if (emitExceptionAsLogs()) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class KafkaConsumerContextUtilTest {
+
+  @RegisterExtension static final OpenTelemetryExtension testing = OpenTelemetryExtension.create();
+
+  @Test
+  void restoresProcessParentWithoutSuppressionMarker() {
+    assumeTrue(emitStableMessagingSemconv());
+    Span parentSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("parent").startSpan();
+    Span processSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("process").startSpan();
+    try {
+      Context parentContext = Context.root().with(parentSpan);
+      Context processContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(
+              parentContext.with(processSpan), parentContext);
+
+      Context restored = KafkaConsumerContextUtil.withoutLeakedProcessSpan(processContext);
+
+      assertThat(Span.fromContext(restored)).isSameAs(parentSpan);
+      assertThat(Span.fromContext(restored).isRecording()).isTrue();
+    } finally {
+      processSpan.end();
+      parentSpan.end();
+    }
+  }
+
+  @Test
+  void leavesUnrelatedCurrentSpanUntouched() {
+    assumeTrue(emitStableMessagingSemconv());
+    Span parentSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("parent").startSpan();
+    Span processSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("process").startSpan();
+    Span unrelatedSpan =
+        testing.getOpenTelemetry().getTracer("test").spanBuilder("unrelated").startSpan();
+    try {
+      Context parentContext = Context.root().with(parentSpan);
+      Context processContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(
+              parentContext.with(processSpan), parentContext);
+      Context unrelatedContext = processContext.with(unrelatedSpan);
+
+      assertThat(KafkaConsumerContextUtil.withoutLeakedProcessSpan(unrelatedContext))
+          .isSameAs(unrelatedContext);
+    } finally {
+      unrelatedSpan.end();
+      processSpan.end();
+      parentSpan.end();
+    }
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaPropagationTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaPropagationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaPropagation;
+import org.junit.jupiter.api.Test;
+
+class KafkaPropagationTest {
+
+  @Test
+  void detectsSpanContextPropagation() {
+    assertThat(KafkaPropagation.propagatesSpanContext(W3CTraceContextPropagator.getInstance()))
+        .isTrue();
+    assertThat(KafkaPropagation.propagatesSpanContext(TextMapPropagator.noop())).isFalse();
+    assertThat(KafkaPropagation.propagatesSpanContext(W3CBaggagePropagator.getInstance()))
+        .isFalse();
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerAttributesExtractor.java
@@ -24,6 +24,8 @@ final class KafkaConsumerAttributesExtractor
       AttributeKey.stringKey("messaging.destination.partition.id");
   private static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       AttributeKey.stringKey("messaging.kafka.consumer.group");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
   private static final AttributeKey<String> MESSAGING_KAFKA_MESSAGE_KEY =
       AttributeKey.stringKey("messaging.kafka.message.key");
   private static final AttributeKey<Long> MESSAGING_KAFKA_MESSAGE_OFFSET =
@@ -54,7 +56,12 @@ final class KafkaConsumerAttributesExtractor
       attributes.put(MESSAGING_KAFKA_MESSAGE_TOMBSTONE, true);
     }
 
-    attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    }
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+    }
   }
 
   private static boolean canSerialize(Class<?> keyClass) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -5,7 +5,11 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -17,6 +21,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
  * any time.
  */
 public final class KafkaConsumerContextUtil {
+  private static final ContextKey<Span> processSpanKey =
+      ContextKey.named("opentelemetry-kafka-process-span");
+  private static final ContextKey<Span> processParentSpanKey =
+      ContextKey.named("opentelemetry-kafka-process-parent-span");
   // these fields can be used for multiple instrumentations because of that we don't use a helper
   // class as field type
   private static final VirtualField<ConsumerRecord<?, ?>, Context> recordContextField =
@@ -27,6 +35,26 @@ public final class KafkaConsumerContextUtil {
       VirtualField.find(ConsumerRecords.class, Context.class);
   private static final VirtualField<ConsumerRecords<?, ?>, String[]> recordsConsumerInfoField =
       VirtualField.find(ConsumerRecords.class, String[].class);
+
+  public static Context withoutLeakedProcessSpan(Context context) {
+    if (!emitStableMessagingSemconv()) {
+      return context;
+    }
+
+    Span currentSpan = Span.fromContext(context);
+    if (currentSpan != context.get(processSpanKey)) {
+      return context;
+    }
+
+    Span parentSpan = context.get(processParentSpanKey);
+    return context.with(parentSpan != null ? parentSpan : Span.getInvalid());
+  }
+
+  public static Context withProcessParentSpan(Context context, Context parentContext) {
+    return context
+        .with(processSpanKey, Span.fromContext(context))
+        .with(processParentSpanKey, Span.fromContext(parentContext));
+  }
 
   public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {
     Context receiveContext = recordContextField.get(records);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -8,20 +8,23 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,12 +36,16 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  */
 public final class KafkaInstrumenterFactory {
 
+  private static final String SEND_OPERATION_NAME = "send";
+  private static final String POLL_OPERATION_NAME = "poll";
+
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private List<String> capturedHeaders = emptyList();
   private boolean captureExperimentalSpanAttributes = false;
   private boolean messagingReceiveInstrumentationEnabled = false;
+  private boolean messagingReceiveInstrumentationConfigured = false;
 
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
@@ -68,6 +75,7 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory setMessagingReceiveTelemetryEnabled(
       boolean messagingReceiveInstrumentationEnabled) {
     this.messagingReceiveInstrumentationEnabled = messagingReceiveInstrumentationEnabled;
+    this.messagingReceiveInstrumentationConfigured = true;
     return this;
   }
 
@@ -79,15 +87,18 @@ public final class KafkaInstrumenterFactory {
       Iterable<AttributesExtractor<KafkaProducerRequest, RecordMetadata>> extractors) {
 
     KafkaProducerAttributesGetter getter = new KafkaProducerAttributesGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     InstrumenterBuilder<KafkaProducerRequest, RecordMetadata> builder =
         Instrumenter.<KafkaProducerRequest, RecordMetadata>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.builder(getter, operationType)
+                    .setOperationName(SEND_OPERATION_NAME)
+                    .build())
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(
+                    getter, operationType, SEND_OPERATION_NAME, capturedHeaders))
             .addAttributesExtractors(extractors)
             .addAttributesExtractor(new KafkaProducerAttributesExtractor())
             .setErrorCauseExtractor(errorCauseExtractor);
@@ -95,7 +106,11 @@ public final class KafkaInstrumenterFactory {
       builder.addAttributesExtractor(new KafkaProducerExperimentalAttributesExtractor());
     }
     setMessagingSendExceptionEventExtractor(builder);
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
+    return builder.buildInstrumenter(
+        request ->
+            emitStableMessagingSemconv() && !request.isSpanContextPropagated()
+                ? SpanKind.CLIENT
+                : SpanKind.PRODUCER);
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createConsumerReceiveInstrumenter() {
@@ -105,21 +120,30 @@ public final class KafkaInstrumenterFactory {
   public Instrumenter<KafkaReceiveRequest, Void> createConsumerReceiveInstrumenter(
       Iterable<AttributesExtractor<KafkaReceiveRequest, Void>> extractors) {
     KafkaReceiveAttributesGetter getter = new KafkaReceiveAttributesGetter();
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
+    boolean receiveInstrumentationEnabled = receiveInstrumentationEnabled();
 
     InstrumenterBuilder<KafkaReceiveRequest, Void> builder =
         Instrumenter.<KafkaReceiveRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.builder(getter, operationType)
+                    .setOperationName(POLL_OPERATION_NAME)
+                    .build())
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(
+                    getter, operationType, POLL_OPERATION_NAME, capturedHeaders))
             .addAttributesExtractor(new KafkaReceiveAttributesExtractor())
             .addAttributesExtractors(extractors)
             .setErrorCauseExtractor(errorCauseExtractor)
-            .setEnabled(messagingReceiveInstrumentationEnabled);
+            .setEnabled(receiveInstrumentationEnabled);
+    if (emitStableMessagingSemconv()) {
+      builder.addSpanLinksExtractor(
+          new KafkaBatchProcessSpanLinksExtractor(
+              openTelemetry.getPropagators().getTextMapPropagator()));
+    }
     setMessagingReceiveExceptionEventExtractor(builder);
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return builder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   public Instrumenter<KafkaProcessRequest, Void> createConsumerProcessInstrumenter() {
@@ -129,15 +153,15 @@ public final class KafkaInstrumenterFactory {
   public Instrumenter<KafkaProcessRequest, Void> createConsumerProcessInstrumenter(
       Iterable<AttributesExtractor<KafkaProcessRequest, Void>> extractors) {
     KafkaConsumerAttributesGetter getter = new KafkaConsumerAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<KafkaProcessRequest, Void> builder =
         Instrumenter.<KafkaProcessRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(getter, operationType, capturedHeaders))
             .addAttributesExtractor(new KafkaConsumerAttributesExtractor())
             .addAttributesExtractors(extractors)
             .setErrorCauseExtractor(errorCauseExtractor);
@@ -146,28 +170,30 @@ public final class KafkaInstrumenterFactory {
     }
     setMessagingProcessExceptionEventExtractor(builder);
 
-    if (messagingReceiveInstrumentationEnabled) {
-      builder.addSpanLinksExtractor(
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(),
-              new KafkaConsumerRecordGetter()));
-      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    } else {
-      return builder.buildConsumerInstrumenter(new KafkaConsumerRecordGetter());
-    }
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new KafkaConsumerRecordGetter(),
+        receiveInstrumentationEnabled());
+  }
+
+  private boolean receiveInstrumentationEnabled() {
+    return messagingReceiveInstrumentationConfigured
+        ? messagingReceiveInstrumentationEnabled
+        : emitStableMessagingSemconv();
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
     KafkaReceiveAttributesGetter getter = new KafkaReceiveAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<KafkaReceiveRequest, Void> builder =
         Instrumenter.<KafkaReceiveRequest, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders))
+                buildMessagingAttributesExtractor(getter, operationType, capturedHeaders))
             .addAttributesExtractor(new KafkaReceiveAttributesExtractor())
             .addSpanLinksExtractor(
                 new KafkaBatchProcessSpanLinksExtractor(
@@ -180,9 +206,21 @@ public final class KafkaInstrumenterFactory {
   private static <REQUEST, RESPONSE>
       AttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
           MessagingAttributesGetter<REQUEST, RESPONSE> getter,
-          MessageOperation operation,
+          MessagingOperationType operationType,
+          String operationName,
           List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
+        .setOperationName(operationName)
+        .setCapturedHeaders(capturedHeaders)
+        .build();
+  }
+
+  private static <REQUEST, RESPONSE>
+      AttributesExtractor<REQUEST, RESPONSE> buildMessagingAttributesExtractor(
+          MessagingAttributesGetter<REQUEST, RESPONSE> getter,
+          MessagingOperationType operationType,
+          List<String> capturedHeaders) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProducerRequest.java
@@ -22,22 +22,43 @@ public final class KafkaProducerRequest {
   private final ProducerRecord<?, ?> record;
   @Nullable private final String clientId;
   @Nullable private final String bootstrapServers;
+  private final boolean spanContextPropagated;
 
   public static KafkaProducerRequest create(
       ProducerRecord<?, ?> record, Producer<?, ?> producer, @Nullable String bootstrapServers) {
-    return create(record, extractClientId(producer), bootstrapServers);
+    return create(record, extractClientId(producer), bootstrapServers, true);
+  }
+
+  public static KafkaProducerRequest create(
+      ProducerRecord<?, ?> record,
+      Producer<?, ?> producer,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
+    return create(record, extractClientId(producer), bootstrapServers, spanContextPropagated);
   }
 
   public static KafkaProducerRequest create(
       ProducerRecord<?, ?> record, @Nullable String clientId, @Nullable String bootstrapServers) {
-    return new KafkaProducerRequest(record, clientId, bootstrapServers);
+    return create(record, clientId, bootstrapServers, true);
+  }
+
+  public static KafkaProducerRequest create(
+      ProducerRecord<?, ?> record,
+      @Nullable String clientId,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
+    return new KafkaProducerRequest(record, clientId, bootstrapServers, spanContextPropagated);
   }
 
   private KafkaProducerRequest(
-      ProducerRecord<?, ?> record, @Nullable String clientId, @Nullable String bootstrapServers) {
+      ProducerRecord<?, ?> record,
+      @Nullable String clientId,
+      @Nullable String bootstrapServers,
+      boolean spanContextPropagated) {
     this.record = record;
     this.clientId = clientId;
     this.bootstrapServers = bootstrapServers;
+    this.spanContextPropagated = spanContextPropagated;
   }
 
   public ProducerRecord<?, ?> getRecord() {
@@ -52,6 +73,10 @@ public final class KafkaProducerRequest {
   @Nullable
   public String getBootstrapServers() {
     return bootstrapServers;
+  }
+
+  public boolean isSpanContextPropagated() {
+    return spanContextPropagated;
   }
 
   @Nullable

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaPropagation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaPropagation.java
@@ -6,9 +6,17 @@
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.record.RecordBatch;
@@ -32,6 +40,36 @@ public final class KafkaPropagation {
   public static boolean shouldPropagate(ApiVersions apiVersions) {
     return !HAS_MAX_USABLE_PRODUCE_MAGIC
         || maxUsableProduceMagic(apiVersions) >= RecordBatch.MAGIC_VALUE_V2;
+  }
+
+  public static boolean propagatesSpanContext(TextMapPropagator propagator) {
+    SpanContext expected =
+        SpanContext.create(
+            "00000000000000000000000000000001",
+            "0000000000000001",
+            TraceFlags.getSampled(),
+            TraceState.getDefault());
+    Map<String, String> carrier = new HashMap<>();
+    propagator.inject(Context.root().with(Span.wrap(expected)), carrier, Map::put);
+    Context extracted =
+        propagator.extract(
+            Context.root(),
+            carrier,
+            new TextMapGetter<Map<String, String>>() {
+              @Override
+              public Iterable<String> keys(Map<String, String> carrier) {
+                return carrier.keySet();
+              }
+
+              @Nullable
+              @Override
+              public String get(@Nullable Map<String, String> carrier, String key) {
+                return carrier == null ? null : carrier.get(key);
+              }
+            });
+    SpanContext actual = Span.fromContext(extracted).getSpanContext();
+    return expected.getTraceId().equals(actual.getTraceId())
+        && expected.getSpanId().equals(actual.getSpanId());
   }
 
   @NoMuzzle

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveAttributesExtractor.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -17,11 +20,18 @@ final class KafkaReceiveAttributesExtractor
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<String> MESSAGING_KAFKA_CONSUMER_GROUP =
       AttributeKey.stringKey("messaging.kafka.consumer.group");
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
 
   @Override
   public void onStart(
       AttributesBuilder attributes, Context parentContext, KafkaReceiveRequest request) {
-    attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_KAFKA_CONSUMER_GROUP, request.getConsumerGroup());
+    }
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+    }
   }
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/TracingIterator.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/TracingIterator.java
@@ -44,7 +44,9 @@ public class TracingIterator<K, V> implements Iterator<ConsumerRecord<K, V>> {
 
     Context receiveContext = consumerContext.getContext();
     // use the receive CONSUMER as parent if it's available
-    this.parentContext = receiveContext != null ? receiveContext : Context.current();
+    this.parentContext =
+        KafkaConsumerContextUtil.withoutLeakedProcessSpan(
+            receiveContext != null ? receiveContext : Context.current());
     this.consumerContext = consumerContext;
   }
 
@@ -80,6 +82,8 @@ public class TracingIterator<K, V> implements Iterator<ConsumerRecord<K, V>> {
     if (next != null && wrappingEnabled.getAsBoolean()) {
       currentRequest = KafkaProcessRequest.create(consumerContext, next);
       currentContext = instrumenter.start(parentContext, currentRequest);
+      currentContext =
+          KafkaConsumerContextUtil.withProcessParentSpan(currentContext, parentContext);
       currentScope = currentContext.makeCurrent();
     }
     return next;

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
@@ -9,12 +9,12 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class KafkaConnectSingletons {
 
@@ -33,15 +33,17 @@ public class KafkaConnectSingletons {
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new KafkaConnectAttributesGetter(), MessageOperation.PROCESS))
+                    new KafkaConnectAttributesGetter(), MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new KafkaConnectAttributesGetter(), MessageOperation.PROCESS)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new KafkaConnectAttributesGetter(), MessagingOperationType.PROCESS)
                     .build())
             .addSpanLinksExtractor(spanLinksExtractor);
     setMessagingProcessExceptionEventExtractor(builder);
 
-    instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    instrumenter =
+        builder.buildInstrumenter(
+            MessagingSpanKindExtractor.create(MessagingOperationType.PROCESS));
   }
 
   public static Instrumenter<KafkaConnectTask, Void> instrumenter() {

--- a/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
@@ -43,7 +43,15 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testV3Preview)
   }
 }

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
@@ -5,13 +5,30 @@
 
 package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.groupTraces;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
+import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
@@ -21,7 +38,11 @@ import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.testing.assertj.TracesAssert;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.smoketest.SmokeTestInstrumentationExtension;
 import io.opentelemetry.smoketest.TelemetryRetriever;
@@ -29,8 +50,10 @@ import io.opentelemetry.smoketest.TelemetryRetrieverProvider;
 import io.restassured.http.ContentType;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -128,6 +151,37 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
 
   protected String getKafkaBootstrapServers() {
     return kafka.getHost() + ":" + kafkaExposedPort;
+  }
+
+  protected static String messagingSpanName(
+      String destinationName, String oldOperationName, String stableOperationName) {
+    if (emitStableMessagingSemconv()) {
+      return destinationName == null
+          ? stableOperationName
+          : stableOperationName + " " + destinationName;
+    }
+    return (destinationName == null ? "unknown" : destinationName) + " " + oldOperationName;
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  protected final void waitAndAssertTracesIgnoringStableReceive(
+      Consumer<TraceAssert>... assertions) {
+    await()
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              List<List<SpanData>> traces = groupTraces(testing.spans());
+              if (emitStableMessagingSemconv()) {
+                traces.removeIf(
+                    trace ->
+                        trace.size() == 1
+                            && trace.get(0).getKind() == SpanKind.CLIENT
+                            && (trace.get(0).getName().equals("poll")
+                                || trace.get(0).getName().startsWith("poll ")));
+              }
+              TracesAssert.assertThat(traces).hasTracesSatisfyingExactly(asList(assertions));
+            });
   }
 
   @Override
@@ -263,9 +317,7 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             .withCopyFileToContainer(
                 MountableFile.forHostPath(agentPath), "/opentelemetry-javaagent.jar")
             // Configure the agent to export spans to backend (like smoke tests)
-            .withEnv(
-                "JAVA_TOOL_OPTIONS",
-                "-javaagent:/opentelemetry-javaagent.jar " + "-Dotel.javaagent.debug=true")
+            .withEnv("JAVA_TOOL_OPTIONS", javaToolOptions())
             // Disable test exporter and force OTLP exporter
             .withEnv("OTEL_TESTING_EXPORTER_ENABLED", "false")
             .withEnv("OTEL_TRACES_EXPORTER", "otlp")
@@ -278,7 +330,9 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "1000")
             .withEnv(
                 "OTEL_SEMCONV_STABILITY_OPT_IN",
-                System.getProperty("otel.semconv-stability.opt-in"))
+                emitStableMessagingSemconv()
+                    ? "messaging"
+                    : System.getProperty("otel.semconv-stability.opt-in"))
             .withEnv("CONNECT_BOOTSTRAP_SERVERS", getInternalKafkaBootstrapServers())
             .withEnv("CONNECT_REST_ADVERTISED_HOST_NAME", KAFKA_CONNECT_NETWORK_ALIAS)
             .withEnv("CONNECT_PLUGIN_PATH", PLUGIN_PATH_CONTAINER)
@@ -307,6 +361,62 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
                     + " && "
                     + "echo 'Starting Kafka Connect with logging to /var/log/kafka-connect/' && "
                     + "/etc/confluent/docker/run 2>&1 | tee /var/log/kafka-connect/kafka-connect.log");
+  }
+
+  private static String javaToolOptions() {
+    StringBuilder options =
+        new StringBuilder("-javaagent:/opentelemetry-javaagent.jar -Dotel.javaagent.debug=true");
+    appendSystemProperty(options, "otel.instrumentation.common.v3-preview");
+    appendSystemProperty(options, "otel.semconv-stability.preview");
+    return options.toString();
+  }
+
+  private static void appendSystemProperty(StringBuilder options, String propertyName) {
+    String value = System.getProperty(propertyName);
+    if (value != null) {
+      options.append(" -D").append(propertyName).append('=').append(value);
+    }
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected static AttributeAssertion[] processAttributes(String destination, long batchSize) {
+    return processAttributes(destination, batchSize, true);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  protected static AttributeAssertion[] processAttributes(long batchSize) {
+    return processAttributes("", batchSize, false);
+  }
+
+  private static AttributeAssertion[] processAttributes(
+      String destination, long batchSize, boolean hasDestination) {
+    boolean v3Preview = Boolean.getBoolean("otel.instrumentation.common.v3-preview");
+    return new AttributeAssertion[] {
+      equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize),
+      equalTo(MESSAGING_DESTINATION_NAME, hasDestination ? destination : null),
+      equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? PROCESS : null),
+      equalTo(MESSAGING_SYSTEM, KAFKA),
+      satisfies(
+          THREAD_ID,
+          val -> {
+            if (v3Preview) {
+              val.isNull();
+            } else {
+              val.isNotZero();
+            }
+          }),
+      satisfies(
+          THREAD_NAME,
+          val -> {
+            if (v3Preview) {
+              val.isNull();
+            } else {
+              val.isNotBlank();
+            }
+          })
+    };
   }
 
   @BeforeEach

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
@@ -7,16 +7,7 @@ package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.awaitility.Awaitility.await;
@@ -123,40 +114,48 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
     await().atMost(Duration.ofSeconds(60)).until(() -> getRecordCountFromMongo() >= 1);
 
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(testTopicName + " publish").hasKind(SpanKind.PRODUCER).hasNoParent();
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + testTopicName
+                              : testTopicName + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasNoParent();
                   producerSpanContext.set(span.actual().getSpanContext());
                 }),
         trace ->
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))),
         trace ->
             // kafka connect consumer trace, linked to producer span via a span link
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(testTopicName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + testTopicName
+                                : testTopicName + " process")
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpanContext.get()))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
-                            equalTo(MESSAGING_DESTINATION_NAME, testTopicName),
-                            equalTo(MESSAGING_OPERATION, PROCESS),
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            satisfies(THREAD_ID, val -> val.isNotZero()),
-                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                        .hasAttributesSatisfyingExactly(processAttributes(testTopicName, 1)),
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()
@@ -217,36 +216,51 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0)));
 
     AtomicReference<SpanContext> producerSpanContext1 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext2 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext3 = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span -> {
-                  span.hasName(topicName1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName1
+                              : topicName1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext1.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName2
+                              : topicName2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext2.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName3 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName3
+                              : topicName3 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext3.set(span.actual().getSpanContext());
@@ -258,19 +272,14 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect consumer trace, linked to producer span via a span link
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("unknown process")
+                    span.hasName(emitStableMessagingSemconv() ? "process" : "unknown process")
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasLinks(
                             LinkData.create(producerSpanContext1.get()),
                             LinkData.create(producerSpanContext2.get()),
                             LinkData.create(producerSpanContext3.get()))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3),
-                            equalTo(MESSAGING_OPERATION, PROCESS),
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            satisfies(THREAD_ID, val -> val.isNotZero()),
-                            satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                        .hasAttributesSatisfyingExactly(processAttributes(3)),
                 span ->
                     span.hasName(
                             emitStableDatabaseSemconv()

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
@@ -7,16 +7,7 @@ package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues.PROCESS;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
-import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,23 +131,34 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
     await().atMost(Duration.ofSeconds(60)).until(() -> getRecordCountFromPostgres() >= 1);
 
     AtomicReference<SpanContext> producerSpanContext = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(testTopicName + " publish").hasKind(SpanKind.PRODUCER).hasNoParent();
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + testTopicName
+                              : testTopicName + " publish")
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasNoParent();
                   producerSpanContext.set(span.actual().getSpanContext());
                 }),
         trace ->
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))),
         trace -> {
@@ -173,17 +175,14 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
 
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName(testTopicName + " process")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + testTopicName
+                              : testTopicName + " process")
                       .hasKind(CONSUMER)
                       .hasNoParent()
                       .hasLinks(LinkData.create(producerSpanContext.get()))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1),
-                          equalTo(MESSAGING_DESTINATION_NAME, testTopicName),
-                          equalTo(MESSAGING_OPERATION, PROCESS),
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          satisfies(THREAD_ID, val -> val.isNotZero()),
-                          satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                      .hasAttributesSatisfyingExactly(processAttributes(testTopicName, 1)),
               selectAssertion,
               selectAssertion,
               selectAssertion,
@@ -256,36 +255,51 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
             // kafka connect sends message to status topic while processing our message
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("kafka-connect-status publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send kafka-connect-status"
+                                : "kafka-connect-status publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasNoParent(),
                 span ->
-                    span.hasName("kafka-connect-status process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process kafka-connect-status"
+                                : "kafka-connect-status process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0)));
 
     AtomicReference<SpanContext> producerSpanContext1 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext2 = new AtomicReference<>();
     AtomicReference<SpanContext> producerSpanContext3 = new AtomicReference<>();
-    testing.waitAndAssertTraces(
+    waitAndAssertTracesIgnoringStableReceive(
         trace ->
             // producer is in a separate trace, linked to consumer with a span link
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span -> {
-                  span.hasName(topicName1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName1
+                              : topicName1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext1.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName2
+                              : topicName2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext2.set(span.actual().getSpanContext());
                 },
                 span -> {
-                  span.hasName(topicName3 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + topicName3
+                              : topicName3 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0));
                   producerSpanContext3.set(span.actual().getSpanContext());
@@ -307,19 +321,14 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
 
           trace.hasSpansSatisfyingExactly(
               span ->
-                  span.hasName("unknown process")
+                  span.hasName(emitStableMessagingSemconv() ? "process" : "unknown process")
                       .hasKind(CONSUMER)
                       .hasNoParent()
                       .hasLinks(
                           LinkData.create(producerSpanContext1.get()),
                           LinkData.create(producerSpanContext2.get()),
                           LinkData.create(producerSpanContext3.get()))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 3),
-                          equalTo(MESSAGING_OPERATION, PROCESS),
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          satisfies(THREAD_ID, val -> val.isNotZero()),
-                          satisfies(THREAD_NAME, val -> val.isNotBlank())),
+                      .hasAttributesSatisfyingExactly(processAttributes(3)),
               selectAssertion,
               selectAssertion,
               selectAssertion,

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/build.gradle.kts
@@ -54,6 +54,30 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("KafkaStreamsSuppressReceiveSpansTest")
@@ -64,6 +88,8 @@ tasks {
   check {
     dependsOn(testReceiveSpansDisabled)
     dependsOn(testExperimental)
+    dependsOn(testV3Preview)
+    dependsOn(testV3PreviewReceiveSpansDisabled)
   }
 }
 

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.kafkastreams.v0_11;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
 import static java.util.Arrays.asList;
@@ -47,9 +53,9 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @DisplayName("test kafka produce and consume with streams in-between")
   @Test
   void testKafkaProduceAndConsumeWithStreamsInBetween() throws Exception {
@@ -98,33 +104,141 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
     AtomicReference<SpanData> producerPendingRef = new AtomicReference<>();
     AtomicReference<SpanData> producerProcessedRef = new AtomicReference<>();
 
-    // Add your assertTraces logic here
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          TelemetryDataUtil.orderByRootSpanName(
+              "send " + STREAM_PENDING, "poll " + STREAM_PENDING, "poll " + STREAM_PROCESSED),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("send " + STREAM_PENDING)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PENDING, true)),
+                span -> {
+                  List<AttributeAssertion> assertions =
+                      new ArrayList<>(
+                          messagingAttributes(
+                              STREAM_PENDING, "process", "process", "process", "consumer", false));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(stringKey("asdf"), "testing"));
+                  addOffsetAssertions(assertions, 0);
+                  if (EXPERIMENTAL_ATTRIBUTES) {
+                    assertions.add(
+                        satisfies(
+                            longKey("kafka.record.queue_time_ms"),
+                            val -> val.isGreaterThanOrEqualTo(0)));
+                  }
+                  if (testLatestDeps()) {
+                    addGroupAssertions(assertions, "test-application");
+                  }
+                  span.hasName("process " + STREAM_PENDING)
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(0))
+                      .hasLinks()
+                      .hasAttributesSatisfyingExactly(assertions);
+                },
+                span ->
+                    span.hasName("send " + STREAM_PROCESSED)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(1))
+                        .hasTraceId(receivedContext.getTraceId())
+                        .hasSpanId(receivedContext.getSpanId())
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes(STREAM_PROCESSED, false)),
+                span -> {
+                  List<AttributeAssertion> assertions =
+                      new ArrayList<>(
+                          messagingAttributes(
+                              STREAM_PROCESSED, "process", "process", "process", "consumer", true));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(longKey("testing"), 123));
+                  addOffsetAssertions(assertions, 0);
+                  if (EXPERIMENTAL_ATTRIBUTES) {
+                    assertions.add(
+                        satisfies(
+                            longKey("kafka.record.queue_time_ms"),
+                            val -> val.isGreaterThanOrEqualTo(0)));
+                  }
+                  if (testLatestDeps()) {
+                    addGroupAssertions(assertions, "test");
+                  }
+                  span.hasName("process " + STREAM_PROCESSED)
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(2))
+                      .hasLinks()
+                      .hasAttributesSatisfyingExactly(assertions);
+                });
+            producerPendingRef.set(trace.getSpan(0));
+            producerProcessedRef.set(trace.getSpan(2));
+          },
+          trace -> {
+            List<AttributeAssertion> assertions =
+                new ArrayList<>(
+                    messagingAttributes(
+                        STREAM_PENDING, "receive", "poll", "receive", "consumer", false));
+            assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            if (testLatestDeps()) {
+              addGroupAssertions(assertions, "test-application");
+            }
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + STREAM_PENDING)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerPendingRef.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(assertions));
+          },
+          trace -> {
+            List<AttributeAssertion> assertions =
+                new ArrayList<>(
+                    messagingAttributes(
+                        STREAM_PROCESSED, "receive", "poll", "receive", "consumer", true));
+            assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            if (testLatestDeps()) {
+              addGroupAssertions(assertions, "test");
+            }
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("poll " + STREAM_PROCESSED)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerProcessedRef.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(assertions));
+          });
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
         TelemetryDataUtil.orderByRootSpanName(
-            STREAM_PENDING + " publish",
-            STREAM_PENDING + " receive",
-            STREAM_PROCESSED + " receive"),
+            emitStableMessagingSemconv() ? "send " + STREAM_PENDING : STREAM_PENDING + " publish",
+            emitStableMessagingSemconv() ? "poll " + STREAM_PENDING : STREAM_PENDING + " receive",
+            emitStableMessagingSemconv()
+                ? "poll " + STREAM_PROCESSED
+                : STREAM_PROCESSED + " receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               // kafka-clients PRODUCER
               span ->
-                  span.hasName(STREAM_PENDING + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + STREAM_PENDING
+                              : STREAM_PENDING + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasNoParent()
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID,
-                              val -> val.isInstanceOf(String.class)),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PENDING, true)));
           producerPendingRef.set(trace.getSpan(0));
         },
         trace -> {
@@ -133,18 +247,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               span -> {
                 List<AttributeAssertion> assertions =
                     new ArrayList<>(
-                        asList(
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            satisfies(
-                                stringKey("messaging.client_id"), val -> val.endsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                        messagingAttributes(
+                            STREAM_PENDING, "receive", "poll", "receive", "consumer", false));
+                assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
                 if (testLatestDeps()) {
-                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
+                  addGroupAssertions(assertions, "test-application");
                 }
-                span.hasName(STREAM_PENDING + " receive")
-                    .hasKind(SpanKind.CONSUMER)
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "poll " + STREAM_PENDING
+                            : STREAM_PENDING + " receive")
+                    .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                     .hasNoParent()
                     .hasAttributesSatisfyingExactly(assertions);
               },
@@ -152,20 +265,16 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               span -> {
                 List<AttributeAssertion> assertions =
                     new ArrayList<>(
-                        asList(
-                            equalTo(MESSAGING_SYSTEM, KAFKA),
-                            equalTo(MESSAGING_DESTINATION_NAME, STREAM_PENDING),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                stringKey("messaging.client_id"), val -> val.endsWith("consumer")),
-                            satisfies(
-                                MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                val -> val.isInstanceOf(String.class)),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(stringKey("asdf"), "testing")));
+                        messagingAttributes(
+                            STREAM_PENDING, "process", "process", "process", "consumer", false));
+                assertions.add(
+                    satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                assertions.add(
+                    satisfies(
+                        MESSAGING_DESTINATION_PARTITION_ID, val -> val.isInstanceOf(String.class)));
+                assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                assertions.add(equalTo(stringKey("asdf"), "testing"));
+                addOffsetAssertions(assertions, 0);
 
                 if (EXPERIMENTAL_ATTRIBUTES) {
                   assertions.add(
@@ -175,9 +284,12 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 }
 
                 if (testLatestDeps()) {
-                  assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test-application"));
+                  addGroupAssertions(assertions, "test-application");
                 }
-                span.hasName(STREAM_PENDING + " process")
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "process " + STREAM_PENDING
+                            : STREAM_PENDING + " process")
                     .hasKind(SpanKind.CONSUMER)
                     .hasParent(trace.getSpan(0))
                     .hasLinks(LinkData.create(producerPendingRef.get().getSpanContext()))
@@ -185,24 +297,15 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
               },
               // kafka-clients PRODUCER
               span ->
-                  span.hasName(STREAM_PROCESSED + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(1))
                       .hasTraceId(receivedContext.getTraceId())
                       .hasSpanId(receivedContext.getSpanId())
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, KAFKA),
-                          equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.endsWith("producer")),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID,
-                              val -> val.isInstanceOf(String.class)),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes(STREAM_PROCESSED, false)));
 
           producerProcessedRef.set(trace.getSpan(2));
         },
@@ -212,19 +315,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 span -> {
                   List<AttributeAssertion> assertions =
                       new ArrayList<>(
-                          asList(
-                              equalTo(MESSAGING_SYSTEM, KAFKA),
-                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                              equalTo(MESSAGING_OPERATION, "receive"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("consumer")),
-                              equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+                          messagingAttributes(
+                              STREAM_PROCESSED, "receive", "poll", "receive", "consumer", true));
+                  assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
                   if (testLatestDeps()) {
-                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    addGroupAssertions(assertions, "test");
                   }
-                  span.hasName(STREAM_PROCESSED + " receive")
-                      .hasKind(SpanKind.CONSUMER)
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "poll " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " receive")
+                      .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                       .hasNoParent()
                       .hasAttributesSatisfyingExactly(assertions);
                 },
@@ -232,21 +333,17 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                 span -> {
                   List<AttributeAssertion> assertions =
                       new ArrayList<>(
-                          asList(
-                              equalTo(MESSAGING_SYSTEM, KAFKA),
-                              equalTo(MESSAGING_DESTINATION_NAME, STREAM_PROCESSED),
-                              equalTo(MESSAGING_OPERATION, "process"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("consumer")),
-                              satisfies(
-                                  MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  val -> val.isInstanceOf(String.class)),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, 0),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                              equalTo(longKey("testing"), 123)));
+                          messagingAttributes(
+                              STREAM_PROCESSED, "process", "process", "process", "consumer", true));
+                  assertions.add(
+                      satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)));
+                  assertions.add(
+                      satisfies(
+                          MESSAGING_DESTINATION_PARTITION_ID,
+                          val -> val.isInstanceOf(String.class)));
+                  assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"));
+                  assertions.add(equalTo(longKey("testing"), 123));
+                  addOffsetAssertions(assertions, 0);
                   if (EXPERIMENTAL_ATTRIBUTES) {
                     assertions.add(
                         satisfies(
@@ -255,13 +352,94 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                   }
 
                   if (testLatestDeps()) {
-                    assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+                    addGroupAssertions(assertions, "test");
                   }
-                  span.hasName(STREAM_PROCESSED + " process")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + STREAM_PROCESSED
+                              : STREAM_PROCESSED + " process")
                       .hasKind(SpanKind.CONSUMER)
                       .hasParent(trace.getSpan(0))
                       .hasLinks(LinkData.create(producerProcessedRef.get().getSpanContext()))
                       .hasAttributesSatisfyingExactly(assertions);
                 }));
+  }
+
+  private static List<AttributeAssertion> producerAttributes(String topic, boolean includeKey) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            messagingAttributes(topic, "publish", "send", "send", "producer", includeKey));
+    assertions.add(
+        satisfies(MESSAGING_DESTINATION_PARTITION_ID, val -> val.isInstanceOf(String.class)));
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, includeKey ? "10" : null));
+    assertions.add(
+        equalTo(
+            stringKey("messaging.kafka.bootstrap.servers"),
+            EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null));
+    addOffsetAssertions(assertions, 0);
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdSuffix,
+      boolean startsWith) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, KAFKA),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(
+              stringKey("messaging.client_id"),
+              val -> {
+                if (startsWith) {
+                  val.startsWith(clientIdSuffix);
+                } else {
+                  val.endsWith(clientIdSuffix);
+                }
+              }));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(
+              stringKey("messaging.client.id"),
+              val -> {
+                if (startsWith) {
+                  val.startsWith(clientIdSuffix);
+                } else {
+                  val.endsWith(clientIdSuffix);
+                }
+              }));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertions(List<AttributeAssertion> assertions, long offset) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_OFFSET, offset));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_OFFSET, offset));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
   }
 }

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkastreams.v0_11;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -92,6 +93,31 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
     SpanContext receivedContext = Span.fromContext(getContext(receivedHeaders)).getSpanContext();
 
     AtomicReference<SpanData> streamSendSpanRef = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("send " + STREAM_PENDING)
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasNoParent(),
+                  span ->
+                      span.hasName("process " + STREAM_PENDING)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("send " + STREAM_PROCESSED)
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(1))
+                          .hasTraceId(receivedContext.getTraceId())
+                          .hasSpanId(receivedContext.getSpanId()),
+                  span ->
+                      span.hasName("process " + STREAM_PROCESSED)
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(2))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(

--- a/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
@@ -19,8 +19,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }

--- a/instrumentation/nats/nats-2.17/library/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/library/build.gradle.kts
@@ -12,7 +12,18 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -9,9 +9,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import java.util.List;
@@ -30,10 +31,10 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessageOperation.PUBLISH))
+                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessageOperation.PUBLISH)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingSendExceptionEventExtractor(builder);
@@ -47,15 +48,19 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessageOperation.PROCESS))
+                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessageOperation.PROCESS)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);
 
-    return builder.buildConsumerInstrumenter(new NatsRequestTextMapGetter());
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new NatsRequestTextMapGetter(),
+        false);
   }
 
   private NatsInstrumenterFactory() {}

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
@@ -100,7 +101,7 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 messagingAttributes(
@@ -111,7 +112,7 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                                         MessageHeaderUtil.headerAttributeKey("Test-Message-Header"),
                                         singletonList("test")))),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))));
   }
@@ -141,11 +142,11 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0)),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1)),
                     span ->
@@ -153,11 +154,11 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasParent(trace.getSpan(2)),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0)),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(4))
                             .hasAttributesSatisfyingExactly(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.assertTraceparentHeader;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 
@@ -102,7 +103,7 @@ public abstract class AbstractNatsPublishTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.assertTraceparentHeader;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,7 +59,7 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
@@ -305,31 +306,35 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                           // publisher: parent + publish
                           span -> span.hasName("parent").hasNoParent(),
                           span ->
-                              span.hasName("sub publish")
+                              span.hasName(
+                                      emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
                                       messagingAttributes("publish", "sub", clientId)),
                           // subscriber: process + publish(response)
                           span ->
-                              span.hasName("sub process")
+                              span.hasName(
+                                      emitStableMessagingSemconv() ? "process sub" : "sub process")
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(1)),
                           span ->
-                              span.hasName("(temporary) publish")
+                              span.hasName(
+                                      emitStableMessagingSemconv()
+                                          ? "publish _INBOX."
+                                          : "(temporary) publish")
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(2)),
                           // publisher: process
                           span ->
-                              span.hasName("(temporary) process")
+                              span.hasName(
+                                      emitStableMessagingSemconv()
+                                          ? "process _INBOX."
+                                          : "(temporary) process")
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(3))
                                   .hasAttributesSatisfyingExactly(
-                                      messagingAttributes(
-                                          "process",
-                                          "(temporary)",
-                                          clientId,
-                                          equalTo(MESSAGING_DESTINATION_TEMPORARY, true)))));
+                                      messagingAttributes("process", "(temporary)", clientId))));
 
               trace.hasSpansSatisfyingExactly(asserts);
             });
@@ -348,11 +353,19 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasException(exception)
                             .hasAttributesSatisfyingExactly(
-                                messagingAttributes("publish", "sub", clientId))));
+                                messagingAttributes(
+                                    "publish",
+                                    "sub",
+                                    clientId,
+                                    equalTo(
+                                        ERROR_TYPE,
+                                        emitStableMessagingSemconv()
+                                            ? exception.getClass().getName()
+                                            : null)))));
   }
 }

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
@@ -6,10 +6,17 @@
 package io.opentelemetry.instrumentation.nats.v2_17;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,12 +25,16 @@ import io.nats.client.Subscription;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class NatsTestHelper {
 
   // copied from MessagingIncubatingAttributes
-  private static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
+      stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client.id");
 
   static AttributeAssertion[] messagingAttributes(
       String operation, String subject, int clientId, AttributeAssertion other) {
@@ -40,13 +51,35 @@ class NatsTestHelper {
   }
 
   static AttributeAssertion[] messagingAttributes(String operation, String subject, int clientId) {
-    return new AttributeAssertion[] {
-      equalTo(MESSAGING_OPERATION, operation),
-      equalTo(MESSAGING_SYSTEM, "nats"),
-      equalTo(MESSAGING_DESTINATION_NAME, subject),
-      equalTo(MESSAGING_MESSAGE_BODY_SIZE, 1),
-      equalTo(MESSAGING_CLIENT_ID, String.valueOf(clientId))
-    };
+    List<AttributeAssertion> assertions = new ArrayList<>();
+    assertions.add(equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null));
+    assertions.add(
+        equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null));
+    assertions.add(
+        equalTo(
+            MESSAGING_OPERATION_TYPE,
+            emitStableMessagingSemconv()
+                ? operation.equals("publish") ? "send" : operation
+                : null));
+    assertions.add(equalTo(MESSAGING_SYSTEM, "nats"));
+    if (subject.equals("(temporary)") && emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_DESTINATION_NAME, val -> val.startsWith("_INBOX.")));
+      assertions.add(equalTo(MESSAGING_DESTINATION_TEMPLATE, "_INBOX."));
+      assertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
+    } else {
+      assertions.add(equalTo(MESSAGING_DESTINATION_NAME, subject));
+      if (subject.equals("(temporary)")) {
+        assertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
+      }
+    }
+    assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, 1));
+    assertions.add(
+        equalTo(
+            MESSAGING_CLIENT_ID_OLD, emitOldMessagingSemconv() ? String.valueOf(clientId) : null));
+    assertions.add(
+        equalTo(
+            MESSAGING_CLIENT_ID, emitStableMessagingSemconv() ? String.valueOf(clientId) : null));
+    return assertions.toArray(new AttributeAssertion[0]);
   }
 
   static void assertTraceparentHeader(Subscription subscription) throws InterruptedException {

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/SpanKeyBridging.java
@@ -51,6 +51,7 @@ public class SpanKeyBridging {
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.DB_CLIENT,
         SpanKey.DB_CLIENT);
 
+    putIfPresent(map, "PRODUCER_CREATE", SpanKey.PRODUCER_CREATE);
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.PRODUCER,
         SpanKey.PRODUCER);
@@ -60,7 +61,24 @@ public class SpanKeyBridging {
     map.put(
         application.io.opentelemetry.instrumentation.api.internal.SpanKey.CONSUMER_PROCESS,
         SpanKey.CONSUMER_PROCESS);
+    putIfPresent(map, "CONSUMER_SETTLE", SpanKey.CONSUMER_SETTLE);
     return map;
+  }
+
+  private static void putIfPresent(
+      Map<application.io.opentelemetry.instrumentation.api.internal.SpanKey, SpanKey> map,
+      String fieldName,
+      SpanKey agentSpanKey) {
+    try {
+      application.io.opentelemetry.instrumentation.api.internal.SpanKey applicationSpanKey =
+          (application.io.opentelemetry.instrumentation.api.internal.SpanKey)
+              application.io.opentelemetry.instrumentation.api.internal.SpanKey.class
+                  .getField(fieldName)
+                  .get(null);
+      map.put(applicationSpanKey, agentSpanKey);
+    } catch (ReflectiveOperationException ignored) {
+      // The application may use an instrumentation-api version from before this key was added.
+    }
   }
 
   @Nullable

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/instrumentationapi/v1_14/ContextBridgeTest.java
@@ -68,9 +68,11 @@ class ContextBridgeTest {
                   SpanKey.HTTP_CLIENT,
                   SpanKey.RPC_CLIENT,
                   SpanKey.DB_CLIENT,
+                  SpanKey.PRODUCER_CREATE,
                   SpanKey.PRODUCER,
                   SpanKey.CONSUMER_RECEIVE,
-                  SpanKey.CONSUMER_PROCESS);
+                  SpanKey.CONSUMER_PROCESS,
+                  SpanKey.CONSUMER_SETTLE);
 
           spanKeys.forEach(
               spanKey -> assertThat(spanKey.fromContextOrNull(Context.current())).isNotNull());

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -73,9 +73,11 @@ public class AgentSpanTestingInstrumenter {
       SpanKey.HTTP_CLIENT,
       SpanKey.RPC_CLIENT,
       SpanKey.DB_CLIENT,
+      SpanKey.PRODUCER_CREATE,
       SpanKey.PRODUCER,
       SpanKey.CONSUMER_RECEIVE,
       SpanKey.CONSUMER_PROCESS,
+      SpanKey.CONSUMER_SETTLE,
     };
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/build.gradle.kts
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/build.gradle.kts
@@ -48,6 +48,43 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.pulsar.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("PulsarClientSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpanDisabled = register<Test>("testV3PreviewReceiveSpanDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("PulsarClientSuppressReceiveSpansTest")
+    }
+    include("**/PulsarClientSuppressReceiveSpansTest.*")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("PulsarClientTest.testConsumeNonPartitionedTopic")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   test {
     filter {
       excludeTestsMatching("PulsarClientSuppressReceiveSpansTest")
@@ -60,7 +97,13 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpanDisabled, testExperimental)
+    dependsOn(
+      testReceiveSpanDisabled,
+      testExperimental,
+      testV3Preview,
+      testV3PreviewReceiveSpanDisabled,
+      testBothSemconv,
+    )
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/VirtualFieldStore.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/VirtualFieldStore.java
@@ -18,6 +18,8 @@ import org.apache.pulsar.client.impl.TopicMessageImpl;
 public class VirtualFieldStore {
   private static final VirtualField<Message<?>, Context> MSG_FIELD =
       VirtualField.find(Message.class, Context.class);
+  private static final VirtualField<Message<?>, Boolean> MSG_RECEIVE_TELEMETRY_FIELD =
+      VirtualField.find(Message.class, Boolean.class);
   private static final VirtualField<Producer<?>, ProducerData> PRODUCER_FIELD =
       VirtualField.find(Producer.class, ProducerData.class);
   private static final VirtualField<Consumer<?>, String> CONSUMER_FIELD =
@@ -49,6 +51,24 @@ public class VirtualFieldStore {
     if (instance != null) {
       CALLBACK_FIELD.set(instance, SendCallbackData.create(context, request));
     }
+  }
+
+  public static void markReceiveTelemetryRecorded(Message<?> instance) {
+    if (instance instanceof TopicMessageImpl<?>) {
+      TopicMessageImpl<?> topicMessage = (TopicMessageImpl<?>) instance;
+      instance = topicMessage.getMessage();
+    }
+    if (instance != null) {
+      MSG_RECEIVE_TELEMETRY_FIELD.set(instance, true);
+    }
+  }
+
+  public static boolean wasReceiveTelemetryRecorded(Message<?> instance) {
+    if (instance instanceof TopicMessageImpl<?>) {
+      TopicMessageImpl<?> topicMessage = (TopicMessageImpl<?>) instance;
+      instance = topicMessage.getMessage();
+    }
+    return instance != null && Boolean.TRUE.equals(MSG_RECEIVE_TELEMETRY_FIELD.get(instance));
   }
 
   public static Context extract(Message<?> instance) {

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
@@ -15,17 +16,18 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.internal.Timer;
@@ -77,21 +79,22 @@ public class PulsarSingletons {
         Instrumenter.<PulsarRequest, Void>builder(
                 telemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, MessageOperation.RECEIVE))
+                MessagingSpanNameExtractor.create(getter, MessagingOperationType.RECEIVE))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(getter, MessageOperation.RECEIVE))
-            .addOperationMetrics(MessagingConsumerMetrics.get())
+                createMessagingAttributesExtractor(getter, MessagingOperationType.RECEIVE))
+            .addOperationMetrics(MessagingConsumerMetrics.getForOperationTypeWithOldMetrics())
             .addAttributesExtractor(
                 ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()));
     setMessagingReceiveExceptionEventExtractor(instrumenterBuilder);
 
-    if (receiveInstrumentationEnabled) {
+    if (emitStableMessagingSemconv() || receiveInstrumentationEnabled) {
       return instrumenterBuilder
           .addSpanLinksExtractor(
               new PropagatorBasedSpanLinksExtractor<>(propagator, MessageTextMapGetter.INSTANCE))
-          .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+          .buildInstrumenter(MessagingSpanKindExtractor.create(MessagingOperationType.RECEIVE));
     }
-    return instrumenterBuilder.buildConsumerInstrumenter(MessageTextMapGetter.INSTANCE);
+    return instrumenterBuilder.buildInstrumenter(
+        MessagingSpanKindExtractor.create(MessagingOperationType.RECEIVE));
   }
 
   private static Instrumenter<PulsarBatchRequest, Void> createConsumerBatchReceiveInstrumenter() {
@@ -102,15 +105,16 @@ public class PulsarSingletons {
         Instrumenter.<PulsarBatchRequest, Void>builder(
                 telemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, MessageOperation.RECEIVE))
+                MessagingSpanNameExtractor.create(getter, MessagingOperationType.RECEIVE))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(getter, MessageOperation.RECEIVE))
+                createMessagingAttributesExtractor(getter, MessagingOperationType.RECEIVE))
             .addAttributesExtractor(
                 ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
             .addSpanLinksExtractor(new PulsarBatchRequestSpanLinksExtractor(propagator))
-            .addOperationMetrics(MessagingConsumerMetrics.get());
+            .addOperationMetrics(MessagingConsumerMetrics.getForOperationTypeWithOldMetrics());
     setMessagingReceiveExceptionEventExtractor(instrumenterBuilder);
-    return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return instrumenterBuilder.buildInstrumenter(
+        MessagingSpanKindExtractor.create(MessagingOperationType.RECEIVE));
   }
 
   private static Instrumenter<PulsarRequest, Void> createConsumerProcessInstrumenter() {
@@ -120,18 +124,20 @@ public class PulsarSingletons {
         Instrumenter.<PulsarRequest, Void>builder(
                 telemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, MessageOperation.PROCESS))
+                MessagingSpanNameExtractor.create(getter, MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(getter, MessageOperation.PROCESS));
+                createMessagingAttributesExtractor(getter, MessagingOperationType.PROCESS))
+            .addOperationMetrics(MessagingProcessMetrics.get());
+    if (!receiveInstrumentationEnabled && emitStableMessagingSemconv()) {
+      instrumenterBuilder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
+    }
     setMessagingProcessExceptionEventExtractor(instrumenterBuilder);
 
-    if (receiveInstrumentationEnabled) {
-      SpanLinksExtractor<PulsarRequest> spanLinksExtractor =
-          new PropagatorBasedSpanLinksExtractor<>(propagator, MessageTextMapGetter.INSTANCE);
-      instrumenterBuilder.addSpanLinksExtractor(spanLinksExtractor);
-      return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    }
-    return instrumenterBuilder.buildConsumerInstrumenter(MessageTextMapGetter.INSTANCE);
+    return MessagingProcessInstrumenterFactory.create(
+        instrumenterBuilder,
+        propagator,
+        MessageTextMapGetter.INSTANCE,
+        receiveInstrumentationEnabled);
   }
 
   private static Instrumenter<PulsarRequest, Void> createProducerInstrumenter() {
@@ -141,12 +147,12 @@ public class PulsarSingletons {
         Instrumenter.<PulsarRequest, Void>builder(
                 telemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, MessageOperation.PUBLISH))
+                MessagingSpanNameExtractor.create(getter, MessagingOperationType.SEND))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(getter, MessageOperation.PUBLISH))
+                createMessagingAttributesExtractor(getter, MessagingOperationType.SEND))
             .addAttributesExtractor(
                 ServerAttributesExtractor.create(new PulsarNetClientAttributesGetter()))
-            .addOperationMetrics(MessagingProducerMetrics.get());
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationTypeWithOldMetrics());
 
     if (DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "pulsar")
         .getBoolean("experimental_span_attributes/development", false)) {
@@ -158,8 +164,8 @@ public class PulsarSingletons {
   }
 
   private static <T> AttributesExtractor<T, Void> createMessagingAttributesExtractor(
-      MessagingAttributesGetter<T, Void> getter, MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+      MessagingAttributesGetter<T, Void> getter, MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }
@@ -185,7 +191,9 @@ public class PulsarSingletons {
       if (MessageListenerContext.isProcessing()) {
         return null;
       }
-      parent = propagator.extract(parent, request, MessageTextMapGetter.INSTANCE);
+      if (!emitStableMessagingSemconv()) {
+        parent = propagator.extract(parent, request, MessageTextMapGetter.INSTANCE);
+      }
     }
     Context receiveContext =
         InstrumenterUtil.startAndEnd(
@@ -196,10 +204,12 @@ public class PulsarSingletons {
             throwable,
             timer.startTime(),
             timer.now());
+    Context processParentContext = emitStableMessagingSemconv() ? parent : receiveContext;
+    VirtualFieldStore.markReceiveTelemetryRecorded(message);
     // injected context is used in MessageListenerInstrumentation and also in the spring-pulsar
     // instrumentation
-    VirtualFieldStore.inject(message, receiveContext);
-    return receiveContext;
+    VirtualFieldStore.inject(message, processParentContext);
+    return processParentContext;
   }
 
   @Nullable
@@ -226,12 +236,14 @@ public class PulsarSingletons {
             throwable,
             timer.startTime(),
             timer.now());
+    Context processParentContext = emitStableMessagingSemconv() ? parent : receiveContext;
     // injected context is used in MessageListenerInstrumentation and also in the spring-pulsar
     // instrumentation
     for (Message<?> message : messages) {
-      VirtualFieldStore.inject(message, receiveContext);
+      VirtualFieldStore.markReceiveTelemetryRecorded(message);
+      VirtualFieldStore.inject(message, processParentContext);
     }
-    return receiveContext;
+    return processParentContext;
   }
 
   public static CompletableFuture<Void> wrap(CompletableFuture<Void> future) {

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -6,6 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -18,6 +22,8 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -67,7 +73,7 @@ abstract class AbstractPulsarClientTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractPulsarClientTest.class);
 
-  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.pulsar-2.8";
+  static final String INSTRUMENTATION_NAME = "io.opentelemetry.pulsar-2.8";
 
   private static final DockerImageName DEFAULT_IMAGE_NAME =
       DockerImageName.parse("apachepulsar/pulsar:2.8.0");
@@ -165,7 +171,8 @@ abstract class AbstractPulsarClientTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -176,12 +183,17 @@ abstract class AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("receive-parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             batchReceiveAttributes(topic, null, false))));
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     assertThat(testing.metrics())
         .filteredOn(
@@ -285,7 +297,8 @@ abstract class AbstractPulsarClientTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -297,15 +310,30 @@ abstract class AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("receive-parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(batchReceiveAttributes(topic, null, false)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(1))));
+                        .satisfies(
+                            spanData -> {
+                              if (emitStableMessagingSemconv()) {
+                                assertThat(spanData.getParentSpanId())
+                                    .isIn(
+                                        trace.getSpan(0).getSpanId(), trace.getSpan(1).getSpanId());
+                              } else {
+                                assertThat(spanData.getParentSpanId())
+                                    .isEqualTo(trace.getSpan(1).getSpanId());
+                              }
+                            })));
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     testing.waitAndAssertMetrics(
         INSTRUMENTATION_NAME,
@@ -386,11 +414,12 @@ abstract class AbstractPulsarClientTest {
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MESSAGING_OPERATION, "publish"),
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
                 equalTo(stringKey("messaging.pulsar.message.type"), experimental("normal"))));
-
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
@@ -421,7 +450,9 @@ abstract class AbstractPulsarClientTest {
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MESSAGING_OPERATION, "receive"),
+                oldOperation("receive"),
+                operationName("receive"),
+                operationType("receive"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
@@ -445,7 +476,9 @@ abstract class AbstractPulsarClientTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "pulsar"),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                equalTo(MESSAGING_OPERATION, "process"),
+                oldOperation("process"),
+                operationName("process"),
+                operationType("process"),
                 equalTo(MESSAGING_MESSAGE_ID, messageId),
                 satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
     if (testHeaders) {
@@ -456,6 +489,20 @@ abstract class AbstractPulsarClientTest {
       assertions.add(equalTo(MESSAGING_DESTINATION_PARTITION_ID, String.valueOf(partitionIndex)));
     }
     return assertions;
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   static void acknowledgeMessage(Consumer<String> consumer, Message<String> message) {

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
@@ -5,12 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
@@ -19,6 +30,54 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.junit.jupiter.api.Test;
 
 class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
+
+  @Test
+  void testFailedListenerCountsConsumedMessage() throws Exception {
+    String topic = "persistent://public/default/testFailedListenerCountsConsumedMessage";
+    CountDownLatch latch = new CountDownLatch(1);
+    admin.topics().createNonPartitionedTopic(topic);
+    consumer =
+        client
+            .newConsumer(Schema.STRING)
+            .subscriptionName("test_sub")
+            .topic(topic)
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+            .messageListener(
+                (MessageListener<String>)
+                    (consumer, msg) -> {
+                      latch.countDown();
+                      throw new IllegalStateException("test");
+                    })
+            .subscribe();
+
+    producer = client.newProducer(Schema.STRING).topic(topic).enableBatching(false).create();
+    testing.runWithSpan("parent", () -> producer.send("test"));
+
+    assertThat(latch.await(1, MINUTES)).isTrue();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertMetrics(
+          INSTRUMENTATION_NAME,
+          "messaging.client.consumed.messages",
+          metrics ->
+              metrics.satisfiesExactly(
+                  metric ->
+                      assertThat(metric)
+                          .hasLongSumSatisfying(
+                              sum ->
+                                  sum.hasPointsSatisfying(
+                                      point ->
+                                          point
+                                              .hasValue(1)
+                                              .hasAttributesSatisfyingExactly(
+                                                  equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                  equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                  equalTo(MESSAGING_DESTINATION_NAME, topic),
+                                                  equalTo(
+                                                      ERROR_TYPE,
+                                                      IllegalStateException.class.getName()))))));
+    }
+  }
 
   @Test
   void testConsumeNonPartitionedTopic() throws Exception {
@@ -46,18 +105,43 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
 
     latch.await(1, MINUTES);
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertMetrics(
+          INSTRUMENTATION_NAME,
+          "messaging.client.consumed.messages",
+          metrics ->
+              metrics.satisfiesExactly(
+                  metric ->
+                      assertThat(metric)
+                          .hasUnit("{message}")
+                          .hasDescription(
+                              "Number of messages that were delivered to the application.")
+                          .satisfies(
+                              data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                          .hasLongSumSatisfying(
+                              sum ->
+                                  sum.hasPointsSatisfying(
+                                      point ->
+                                          point
+                                              .hasValue(1)
+                                              .hasAttributesSatisfyingExactly(
+                                                  equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                  equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                  equalTo(MESSAGING_DESTINATION_NAME, topic))))));
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " publish")
+                    span.hasName(spanName("publish", topic))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(topic, msgId.toString(), false)),
                 span ->
-                    span.hasName(topic + " process")
+                    span.hasName(spanName("process", topic))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -83,22 +167,7 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
     Message<String> receivedMsg = consumer.receive();
     consumer.acknowledge(receivedMsg);
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                span ->
-                    span.hasName(topic + " publish")
-                        .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            sendAttributes(topic, msgId.toString(), false)),
-                span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            receiveAttributes(topic, msgId.toString(), false))));
+    assertDirectReceiveTraces(topic, msgId);
   }
 
   @Test
@@ -121,7 +190,7 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
             .whenComplete(
                 (message, throwable) -> {
                   if (message != null) {
-                    testing.runWithSpan("callback", () -> acknowledgeMessage(consumer, message));
+                    acknowledgeMessage(consumer, message);
                   }
                 });
 
@@ -130,26 +199,7 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
 
     result.get(1, MINUTES);
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                span ->
-                    span.hasName(topic + " publish")
-                        .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            sendAttributes(topic, msgId.toString(), false)),
-                span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            receiveAttributes(topic, msgId.toString(), false)),
-                span ->
-                    span.hasName("callback")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(2))));
+    assertDirectReceiveTraces(topic, msgId);
   }
 
   @Test
@@ -172,20 +222,51 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
     Message<String> receivedMsg = consumer.receive(1, MINUTES);
     consumer.acknowledge(receivedMsg);
 
-    testing.waitAndAssertTraces(
+    assertDirectReceiveTraces(topic, msgId);
+  }
+
+  private static void assertDirectReceiveTraces(String topic, MessageId msgId) {
+    if (!emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      span.hasName(spanName("publish", topic))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              sendAttributes(topic, msgId.toString(), false)),
+                  span ->
+                      span.hasName(spanName("receive", topic))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic, msgId.toString(), false))));
+      return;
+    }
+
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+        trace -> {
+          trace.hasSpansSatisfyingExactly(
+              span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+              span ->
+                  span.hasName(spanName("publish", topic))
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          sendAttributes(topic, msgId.toString(), false)));
+          producerSpan.set(trace.getSpan(1));
+        },
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " publish")
-                        .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            sendAttributes(topic, msgId.toString(), false)),
-                span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1))
+                    span.hasName(spanName("receive", topic))
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic, msgId.toString(), false))));
   }
@@ -230,13 +311,13 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " publish")
+                    span.hasName(spanName("publish", topic))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(topic, msgId.toString(), true)),
                 span ->
-                    span.hasName(topic + " process")
+                    span.hasName(spanName("process", topic))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -275,13 +356,13 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + "-partition-0 publish")
+                    span.hasName(spanName("publish", topic + "-partition-0"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(topic + "-partition-0", msgId.toString(), false)),
                 span ->
-                    span.hasName(topic + "-partition-0 process")
+                    span.hasName(spanName("process", topic + "-partition-0"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -322,13 +403,13 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic1 + " publish")
+                    span.hasName(spanName("publish", topic1))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(topic1, msgId1.toString(), false)),
                 span ->
-                    span.hasName(topic1 + " process")
+                    span.hasName(spanName("process", topic1))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -337,16 +418,22 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic2 + " publish")
+                    span.hasName(spanName("publish", topic2))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(topic2, msgId2.toString(), false)),
                 span ->
-                    span.hasName(topic2 + " process")
+                    span.hasName(spanName("process", topic2))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             processAttributes(topic2, msgId2.toString(), false))));
+  }
+
+  private static String spanName(String operation, String destination) {
+    return emitStableMessagingSemconv()
+        ? operation + " " + destination
+        : destination + " " + operation;
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -13,6 +15,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -63,14 +66,95 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     latch.await(1, MINUTES);
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertMetrics(
+          INSTRUMENTATION_NAME,
+          "messaging.process.duration",
+          metrics ->
+              metrics.satisfiesExactly(
+                  metric ->
+                      assertThat(metric)
+                          .hasUnit("s")
+                          .hasDescription("Duration of processing operation.")
+                          .hasHistogramSatisfying(
+                              histogram ->
+                                  histogram.hasPointsSatisfying(
+                                      point ->
+                                          point
+                                              .hasSumGreaterThan(0.0)
+                                              .hasAttributesSatisfyingExactly(
+                                                  equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                  equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                  equalTo(MESSAGING_DESTINATION_NAME, topic))
+                                              .hasBucketBoundaries(DURATION_BUCKETS)))));
+      testing.waitAndAssertMetrics(
+          INSTRUMENTATION_NAME,
+          "messaging.client.consumed.messages",
+          metrics ->
+              metrics.satisfiesExactly(
+                  metric ->
+                      assertThat(metric)
+                          .hasUnit("{message}")
+                          .hasDescription(
+                              "Number of messages that were delivered to the application.")
+                          .satisfies(
+                              data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                          .hasLongSumSatisfying(
+                              sum ->
+                                  sum.hasPointsSatisfying(
+                                      point ->
+                                          point
+                                              .hasValue(1)
+                                              .hasAttributesSatisfyingExactly(
+                                                  equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                  equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                  equalTo(MESSAGING_DESTINATION_NAME, topic),
+                                                  equalTo(SERVER_ADDRESS, brokerHost),
+                                                  equalTo(SERVER_PORT, brokerPort))))));
+    }
+
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("publish " + topic)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(topic, msgId.toString(), false)),
+                span ->
+                    span.hasName("process " + topic)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic, msgId.toString(), false)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + topic)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic, msgId.toString(), false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -81,14 +165,16 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic, msgId.toString(), false)),
                 span ->
-                    span.hasName(topic + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "process " + topic : topic + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -118,12 +204,14 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -134,12 +222,17 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic, msgId.toString(), false))));
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     assertThat(testing.metrics())
         .filteredOn(
@@ -235,33 +328,72 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     result.get(1, MINUTES);
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
-    testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
-        trace -> {
-          trace.hasSpansSatisfyingExactly(
-              span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-              span ->
-                  span.hasName(topic + " publish")
-                      .hasKind(SpanKind.PRODUCER)
-                      .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          sendAttributes(topic, msgId.toString(), false)));
-
-          producerSpan.set(trace.getSpan(1));
-        },
-        trace ->
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanName("parent", "callback", "receive " + topic),
+          trace -> {
             trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasNoParent()
-                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                    span.hasName("publish " + topic)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            receiveAttributes(topic, msgId.toString(), false)),
+                            sendAttributes(topic, msgId.toString(), false)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("callback").hasKind(SpanKind.INTERNAL).hasNoParent()),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + topic)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic, msgId.toString(), false))));
+    } else {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(
+              SpanKind.INTERNAL,
+              emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("callback")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(0))));
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(topic, msgId.toString(), false)));
+
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(
+                              emitStableMessagingSemconv()
+                                  ? "receive " + topic
+                                  : topic + " receive")
+                          .hasKind(
+                              emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic, msgId.toString(), false)),
+                  span ->
+                      span.hasName("callback")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(0))));
+    }
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     assertThat(testing.metrics())
         .filteredOn(
@@ -349,12 +481,14 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -365,12 +499,17 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic, msgId.toString(), false))));
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     assertThat(testing.metrics())
         .filteredOn(
@@ -471,13 +610,47 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     latch.await(1, MINUTES);
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("publish " + topic)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(topic, msgId.toString(), true)),
+                span ->
+                    span.hasName("process " + topic)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic, msgId.toString(), true)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + topic)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic, msgId.toString(), true))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -488,14 +661,16 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic, msgId.toString(), true)),
                 span ->
-                    span.hasName(topic + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "process " + topic : topic + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -531,13 +706,50 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     latch.await(1, MINUTES);
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      String partitionTopic = topic + "-partition-0";
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("publish " + partitionTopic)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(partitionTopic, msgId.toString(), false)),
+                span ->
+                    span.hasName("process " + partitionTopic)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(partitionTopic, msgId.toString(), false)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + partitionTopic)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(partitionTopic, msgId.toString(), false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(
+            SpanKind.INTERNAL, emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic + "-partition-0 publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "publish " + topic + "-partition-0"
+                              : topic + "-partition-0 publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -548,14 +760,20 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic + "-partition-0 receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + topic + "-partition-0"
+                                : topic + "-partition-0 receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic + "-partition-0", msgId.toString(), false)),
                 span ->
-                    span.hasName(topic + "-partition-0 process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + topic + "-partition-0"
+                                : topic + "-partition-0 process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -593,13 +811,76 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     AtomicReference<SpanData> producerSpan2 = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanName("parent1", "receive " + topic1, "parent2", "receive " + topic2),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("publish " + topic1)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(topic1, msgId1.toString(), false)),
+                span ->
+                    span.hasName("process " + topic1)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic1, msgId1.toString(), false)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + topic1)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic1, msgId1.toString(), false))),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("publish " + topic2)
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            sendAttributes(topic2, msgId2.toString(), false)),
+                span ->
+                    span.hasName("process " + topic2)
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            processAttributes(topic2, msgId2.toString(), false)));
+            producerSpan2.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + topic2)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes(topic2, msgId2.toString(), false))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("parent1", topic1 + " receive", "parent2", topic2 + " receive"),
+        orderByRootSpanName(
+            "parent1",
+            emitStableMessagingSemconv() ? "receive " + topic1 : topic1 + " receive",
+            "parent2",
+            emitStableMessagingSemconv() ? "receive " + topic2 : topic2 + " receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic1 : topic1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -610,14 +891,20 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic1 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + topic1
+                                : topic1 + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic1, msgId1.toString(), false)),
                 span ->
-                    span.hasName(topic1 + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + topic1
+                                : topic1 + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -627,7 +914,8 @@ class PulsarClientTest extends AbstractPulsarClientTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic2 : topic2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -638,14 +926,20 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic2 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + topic2
+                                : topic2 + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             receiveAttributes(topic2, msgId2.toString(), false)),
                 span ->
-                    span.hasName(topic2 + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + topic2
+                                : topic2 + " process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
@@ -683,12 +977,17 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     AtomicReference<SpanData> producerSpan2 = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanName("parent1", topic1 + " receive", "parent2", topic2 + " receive"),
+        orderByRootSpanName(
+            "parent1",
+            emitStableMessagingSemconv() ? "receive " + topic1 : topic1 + " receive",
+            "parent2",
+            emitStableMessagingSemconv() ? "receive " + topic2 : topic2 + " receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic1 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic1 : topic1 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -699,8 +998,11 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic1 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + topic1
+                                : topic1 + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
@@ -709,7 +1011,8 @@ class PulsarClientTest extends AbstractPulsarClientTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent2").hasKind(SpanKind.INTERNAL).hasNoParent(),
               span ->
-                  span.hasName(topic2 + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv() ? "publish " + topic2 : topic2 + " publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -720,8 +1023,11 @@ class PulsarClientTest extends AbstractPulsarClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(topic2 + " receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + topic2
+                                : topic2 + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan2.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
@@ -770,6 +1076,10 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     Messages<String> receivedMsg = consumer.batchReceive();
     consumer.acknowledge(receivedMsg);
     assertThat(receivedMsg).hasSize(4);
+
+    if (!emitOldMessagingSemconv()) {
+      return;
+    }
 
     testing.waitAndAssertMetrics(
         "io.opentelemetry.pulsar-2.8",
@@ -824,7 +1134,8 @@ class PulsarClientTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent1").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(topic + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/rabbitmq-2.7/javaagent/build.gradle.kts
@@ -44,7 +44,14 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.rabbitmq.experimental-span-attributes=true")
   }
 
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testMessagingPreview)
   }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitChannelNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitChannelNetAttributesGetter.java
@@ -6,12 +6,25 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import javax.annotation.Nullable;
 
-class RabbitChannelNetAttributesGetter implements NetworkAttributesGetter<ChannelAndMethod, Void> {
+class RabbitChannelNetAttributesGetter
+    implements NetworkAttributesGetter<ChannelAndMethod, Void>,
+        ServerAttributesGetter<ChannelAndMethod> {
+
+  @Override
+  public String getServerAddress(ChannelAndMethod channelAndMethod) {
+    return channelAndMethod.getChannel().getConnection().getAddress().getHostAddress();
+  }
+
+  @Override
+  public Integer getServerPort(ChannelAndMethod channelAndMethod) {
+    return channelAndMethod.getChannel().getConnection().getPort();
+  }
 
   @Nullable
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitDeliveryAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitDeliveryAttributesGetter.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7.RabbitInstrumenterHelper.consumerDestinationName;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7.RabbitInstrumenterHelper.isGeneratedQueueName;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -24,11 +27,13 @@ final class RabbitDeliveryAttributesGetter
   @Nullable
   @Override
   public String getDestination(DeliveryRequest request) {
-    if (request.getEnvelope() != null) {
-      return normalizeExchangeName(request.getEnvelope().getExchange());
-    } else {
-      return null;
+    if (emitStableMessagingSemconv()) {
+      return consumerDestinationName(
+          request.getEnvelope().getExchange(),
+          request.getEnvelope().getRoutingKey(),
+          request.getQueue());
     }
+    return normalizeExchangeName(request.getEnvelope().getExchange());
   }
 
   @Nullable
@@ -48,7 +53,7 @@ final class RabbitDeliveryAttributesGetter
 
   @Override
   public boolean isAnonymousDestination(DeliveryRequest request) {
-    return false;
+    return emitStableMessagingSemconv() && isGeneratedQueueName(request.getQueue());
   }
 
   @Nullable

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitDeliveryNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitDeliveryNetAttributesGetter.java
@@ -6,12 +6,25 @@
 package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import javax.annotation.Nullable;
 
-class RabbitDeliveryNetAttributesGetter implements NetworkAttributesGetter<DeliveryRequest, Void> {
+class RabbitDeliveryNetAttributesGetter
+    implements NetworkAttributesGetter<DeliveryRequest, Void>,
+        ServerAttributesGetter<DeliveryRequest> {
+
+  @Override
+  public String getServerAddress(DeliveryRequest request) {
+    return request.getConnection().getAddress().getHostAddress();
+  }
+
+  @Override
+  public Integer getServerPort(DeliveryRequest request) {
+    return request.getConnection().getPort();
+  }
 
   @Nullable
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitInstrumenterHelper.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitInstrumenterHelper.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7.RabbitSingletons.CHANNEL_AND_METHOD_CONTEXT_KEY;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 
@@ -17,6 +19,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public class RabbitInstrumenterHelper {
   static final AttributeKey<String> RABBITMQ_COMMAND = AttributeKey.stringKey("rabbitmq.command");
@@ -33,8 +36,19 @@ public class RabbitInstrumenterHelper {
 
   public void onPublish(Span span, String exchange, String routingKey) {
     String exchangeName = normalizeExchangeName(exchange);
-    span.setAttribute(MESSAGING_DESTINATION_NAME, exchangeName);
-    span.updateName(exchangeName + " publish");
+    if (emitStableMessagingSemconv()) {
+      String destinationName = producerDestinationName(exchange, routingKey);
+      span.setAttribute(MESSAGING_DESTINATION_NAME, destinationName);
+      boolean anonymousDestination =
+          isDefaultExchange(exchange) && isGeneratedQueueName(routingKey);
+      if (anonymousDestination) {
+        span.setAttribute(MESSAGING_DESTINATION_ANONYMOUS, true);
+      }
+      span.updateName(anonymousDestination ? "publish" : "publish " + destinationName);
+    } else {
+      span.setAttribute(MESSAGING_DESTINATION_NAME, exchangeName);
+      span.updateName(exchangeName + " publish");
+    }
     if (routingKey != null && !routingKey.isEmpty()) {
       span.setAttribute(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routingKey);
     }
@@ -58,7 +72,66 @@ public class RabbitInstrumenterHelper {
   }
 
   private static String normalizeExchangeName(String exchange) {
-    return exchange == null || exchange.isEmpty() ? "<default>" : exchange;
+    return isDefaultExchange(exchange) ? "<default>" : exchange;
+  }
+
+  private static boolean isDefaultExchange(@Nullable String exchange) {
+    return exchange == null || exchange.isEmpty();
+  }
+
+  static boolean isGeneratedQueueName(@Nullable String queue) {
+    if (queue == null) {
+      return false;
+    }
+    if (queue.startsWith("amq.gen-") || queue.startsWith("spring.gen-")) {
+      return true;
+    }
+    return isCanonicalUuid(queue);
+  }
+
+  private static boolean isCanonicalUuid(String value) {
+    if (value.length() != 36) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        if (ch != '-') {
+          return false;
+        }
+      } else if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static String producerDestinationName(String exchange, String routingKey) {
+    StringBuilder destination = new StringBuilder();
+    appendDestinationPart(destination, exchange);
+    appendDestinationPart(destination, routingKey);
+    return destination.length() == 0 ? "amq.default" : destination.toString();
+  }
+
+  @Nullable
+  static String consumerDestinationName(String exchange, String routingKey, String queue) {
+    StringBuilder destination = new StringBuilder();
+    appendDestinationPart(destination, exchange);
+    appendDestinationPart(destination, routingKey);
+    if (queue != null && !queue.equals(routingKey)) {
+      appendDestinationPart(destination, queue);
+    }
+    return destination.length() == 0 ? null : destination.toString();
+  }
+
+  private static void appendDestinationPart(StringBuilder destination, String part) {
+    if (part == null || part.isEmpty()) {
+      return;
+    }
+    if (destination.length() != 0) {
+      destination.append(':');
+    }
+    destination.append(part);
   }
 
   public static void onCommand(Span span, Command command) {

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveAttributesGetter.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7.RabbitInstrumenterHelper.consumerDestinationName;
+import static io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7.RabbitInstrumenterHelper.isGeneratedQueueName;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -25,11 +28,17 @@ final class RabbitReceiveAttributesGetter
   @Nullable
   @Override
   public String getDestination(ReceiveRequest request) {
-    if (request.getResponse() != null) {
-      return normalizeExchangeName(request.getResponse().getEnvelope().getExchange());
-    } else {
+    GetResponse response = request.getResponse();
+    if (emitStableMessagingSemconv()) {
+      return consumerDestinationName(
+          response == null ? null : response.getEnvelope().getExchange(),
+          response == null ? null : response.getEnvelope().getRoutingKey(),
+          request.getQueue());
+    }
+    if (response == null) {
       return null;
     }
+    return normalizeExchangeName(response.getEnvelope().getExchange());
   }
 
   @Nullable
@@ -49,7 +58,7 @@ final class RabbitReceiveAttributesGetter
 
   @Override
   public boolean isAnonymousDestination(ReceiveRequest request) {
-    return false;
+    return emitStableMessagingSemconv() && isGeneratedQueueName(request.getQueue());
   }
 
   @Nullable

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveExtraAttributesExtractor.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveExtraAttributesExtractor.java
@@ -9,36 +9,43 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 
-import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import javax.annotation.Nullable;
 
-class RabbitDeliveryExtraAttributesExtractor implements AttributesExtractor<DeliveryRequest, Void> {
+class RabbitReceiveExtraAttributesExtractor
+    implements AttributesExtractor<ReceiveRequest, GetResponse> {
 
   private static final AttributeKey<Long> MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG =
       longKey("messaging.rabbitmq.message.delivery_tag");
 
   @Override
   public void onStart(
-      AttributesBuilder attributes, Context parentContext, DeliveryRequest request) {
-    Envelope envelope = request.getEnvelope();
-    String routingKey = envelope.getRoutingKey();
-    if (routingKey != null && !routingKey.isEmpty()) {
-      attributes.put(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routingKey);
-    }
-    if (emitStableMessagingSemconv()) {
-      attributes.put(MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, envelope.getDeliveryTag());
-    }
-  }
+      AttributesBuilder attributes, Context parentContext, ReceiveRequest request) {}
 
   @Override
   public void onEnd(
       AttributesBuilder attributes,
       Context context,
-      DeliveryRequest request,
-      @Nullable Void unused,
-      @Nullable Throwable error) {}
+      ReceiveRequest request,
+      @Nullable GetResponse response,
+      @Nullable Throwable error) {
+    if (response == null) {
+      response = request.getResponse();
+      if (response == null) {
+        return;
+      }
+    }
+    if (emitStableMessagingSemconv()) {
+      String routingKey = response.getEnvelope().getRoutingKey();
+      if (routingKey != null && !routingKey.isEmpty()) {
+        attributes.put(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routingKey);
+      }
+      attributes.put(
+          MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, response.getEnvelope().getDeliveryTag());
+    }
+  }
 }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveNetAttributesGetter.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitReceiveNetAttributesGetter.java
@@ -7,13 +7,25 @@ package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 
 import com.rabbitmq.client.GetResponse;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesGetter;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import javax.annotation.Nullable;
 
 class RabbitReceiveNetAttributesGetter
-    implements NetworkAttributesGetter<ReceiveRequest, GetResponse> {
+    implements NetworkAttributesGetter<ReceiveRequest, GetResponse>,
+        ServerAttributesGetter<ReceiveRequest> {
+
+  @Override
+  public String getServerAddress(ReceiveRequest request) {
+    return request.getConnection().getAddress().getHostAddress();
+  }
+
+  @Override
+  public Integer getServerPort(ReceiveRequest request) {
+    return request.getConnection().getPort();
+  }
 
   @Nullable
   @Override

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
@@ -10,23 +10,28 @@ import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import com.rabbitmq.client.GetResponse;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.ContextKey;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
+import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 public class RabbitSingletons {
 
@@ -58,18 +63,23 @@ public class RabbitSingletons {
   }
 
   private static Instrumenter<ChannelAndMethod, Void> createChannelInstrumenter(boolean publish) {
+    RabbitChannelNetAttributesGetter netAttributesGetter = new RabbitChannelNetAttributesGetter();
     InstrumenterBuilder<ChannelAndMethod, Void> builder =
         Instrumenter.<ChannelAndMethod, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, ChannelAndMethod::getMethod)
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(
-                    new RabbitChannelAttributesGetter(), publish ? MessageOperation.PUBLISH : null))
-            .addAttributesExtractor(
-                NetworkAttributesExtractor.create(new RabbitChannelNetAttributesGetter()))
+                publish
+                    ? buildMessagingAttributesExtractor(
+                        new RabbitChannelAttributesGetter(), MessagingOperationType.SEND)
+                    : AttributesExtractor.constant(MESSAGING_SYSTEM, "rabbitmq"))
+            .addAttributesExtractor(NetworkAttributesExtractor.create(netAttributesGetter))
             .addContextCustomizer(
                 (context, request, startAttributes) ->
                     context.with(
                         CHANNEL_AND_METHOD_CONTEXT_KEY, new RabbitChannelAndMethodHolder()));
+    if (publish && emitStableMessagingSemconv()) {
+      builder.addAttributesExtractor(ServerAttributesExtractor.create(netAttributesGetter));
+    }
     if (publish) {
       setMessagingSendExceptionEventExtractor(builder);
     }
@@ -77,18 +87,26 @@ public class RabbitSingletons {
   }
 
   private static Instrumenter<ReceiveRequest, GetResponse> createReceiveInstrumenter() {
+    RabbitReceiveAttributesGetter getter = new RabbitReceiveAttributesGetter();
     List<AttributesExtractor<ReceiveRequest, GetResponse>> extractors = new ArrayList<>();
-    extractors.add(
-        buildMessagingAttributesExtractor(
-            new RabbitReceiveAttributesGetter(), MessageOperation.RECEIVE));
-    extractors.add(NetworkAttributesExtractor.create(new RabbitReceiveNetAttributesGetter()));
+    extractors.add(buildMessagingAttributesExtractor(getter, MessagingOperationType.RECEIVE));
+    extractors.add(new RabbitReceiveExtraAttributesExtractor());
+    RabbitReceiveNetAttributesGetter netAttributesGetter = new RabbitReceiveNetAttributesGetter();
+    extractors.add(NetworkAttributesExtractor.create(netAttributesGetter));
+    if (emitStableMessagingSemconv()) {
+      extractors.add(ServerAttributesExtractor.create(netAttributesGetter));
+    }
     if (RabbitInstrumenterHelper.CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       extractors.add(new RabbitReceiveExperimentalAttributesExtractor());
     }
 
+    SpanNameExtractor<ReceiveRequest> spanNameExtractor =
+        emitStableMessagingSemconv()
+            ? MessagingSpanNameExtractor.create(getter, MessagingOperationType.RECEIVE)
+            : ReceiveRequest::spanName;
     InstrumenterBuilder<ReceiveRequest, GetResponse> builder =
         Instrumenter.<ReceiveRequest, GetResponse>builder(
-                GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, ReceiveRequest::spanName)
+                GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractors(extractors)
             .setEnabled(ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
             .addSpanLinksExtractor(
@@ -96,31 +114,43 @@ public class RabbitSingletons {
                     GlobalOpenTelemetry.getPropagators().getTextMapPropagator(),
                     new ReceiveRequestTextMapGetter()));
     setMessagingReceiveExceptionEventExtractor(builder);
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return builder.buildInstrumenter(
+        MessagingSpanKindExtractor.create(MessagingOperationType.RECEIVE));
   }
 
   private static Instrumenter<DeliveryRequest, Void> createDeliverInstrumenter() {
+    RabbitDeliveryAttributesGetter getter = new RabbitDeliveryAttributesGetter();
     List<AttributesExtractor<DeliveryRequest, Void>> extractors = new ArrayList<>();
-    extractors.add(
-        buildMessagingAttributesExtractor(
-            new RabbitDeliveryAttributesGetter(), MessageOperation.PROCESS));
-    extractors.add(NetworkAttributesExtractor.create(new RabbitDeliveryNetAttributesGetter()));
+    extractors.add(buildMessagingAttributesExtractor(getter, MessagingOperationType.PROCESS));
+    RabbitDeliveryNetAttributesGetter netAttributesGetter = new RabbitDeliveryNetAttributesGetter();
+    extractors.add(NetworkAttributesExtractor.create(netAttributesGetter));
+    if (emitStableMessagingSemconv()) {
+      extractors.add(ServerAttributesExtractor.create(netAttributesGetter));
+    }
     extractors.add(new RabbitDeliveryExtraAttributesExtractor());
     if (RabbitInstrumenterHelper.CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
       extractors.add(new RabbitDeliveryExperimentalAttributesExtractor());
     }
 
+    SpanNameExtractor<DeliveryRequest> spanNameExtractor =
+        emitStableMessagingSemconv()
+            ? MessagingSpanNameExtractor.create(getter, MessagingOperationType.PROCESS)
+            : DeliveryRequest::spanName;
     InstrumenterBuilder<DeliveryRequest, Void> builder =
         Instrumenter.<DeliveryRequest, Void>builder(
-                GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, DeliveryRequest::spanName)
+                GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractors(extractors);
     setMessagingProcessExceptionEventExtractor(builder);
-    return builder.buildConsumerInstrumenter(new DeliveryRequestGetter());
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        GlobalOpenTelemetry.getPropagators().getTextMapPropagator(),
+        new DeliveryRequestGetter(),
+        false);
   }
 
   private static <T, V> AttributesExtractor<T, V> buildMessagingAttributesExtractor(
-      MessagingAttributesGetter<T, V> getter, @Nullable MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+      MessagingAttributesGetter<T, V> getter, MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
         .build();
   }

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitMqTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -17,9 +18,13 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -153,12 +158,29 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                         exchangeName,
                         routingKey,
                         "receive",
-                        "<generated>",
+                        queueName,
                         trace.getSpan(0),
                         producerSpan.get(),
                         null,
                         null,
                         false)));
+  }
+
+  @Test
+  void testReceiveSpanKind() throws IOException {
+    String queueName = channel.queueDeclare().getQueue();
+    channel.basicPublish("", queueName, null, "test".getBytes(Charset.defaultCharset()));
+    testing.clearData();
+
+    testing.runWithSpan("parent", () -> channel.basicGet(queueName, true));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(0))));
   }
 
   @Test
@@ -186,7 +208,14 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                 span -> verifySpan(trace, span, 1, "queue.declare", trace.getSpan(0)),
                 span -> {
                   verifySpan(
-                      trace, span, 2, "<default>", null, "publish", "<default>", trace.getSpan(0));
+                      trace,
+                      span,
+                      2,
+                      "<default>",
+                      queueName,
+                      "publish",
+                      "<default>",
+                      trace.getSpan(0));
                   producerSpan.set(trace.getSpan(2));
                 }),
         trace ->
@@ -198,14 +227,43 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                         span,
                         1,
                         "<default>",
-                        null,
+                        queueName,
                         "receive",
-                        "<generated>",
+                        queueName,
                         trace.getSpan(0),
                         producerSpan.get(),
                         null,
                         null,
                         false)));
+  }
+
+  private static boolean isGeneratedQueueName(String queue) {
+    return queue != null && (queue.startsWith("amq.gen-") || queue.startsWith("spring.gen-"));
+  }
+
+  private static String producerDestinationName(String exchange, String routingKey) {
+    String destination = joinDestination(exchange, routingKey);
+    return destination.isEmpty() ? "amq.default" : destination;
+  }
+
+  private static String consumerDestinationName(String exchange, String routingKey, String queue) {
+    return queue == null || queue.equals(routingKey)
+        ? joinDestination(exchange, routingKey)
+        : joinDestination(exchange, routingKey, queue);
+  }
+
+  private static String joinDestination(String... parts) {
+    StringBuilder destination = new StringBuilder();
+    for (String part : parts) {
+      if (part == null || part.isEmpty()) {
+        continue;
+      }
+      if (destination.length() != 0) {
+        destination.append(':');
+      }
+      destination.append(part);
+    }
+    return destination.toString();
   }
 
   @ParameterizedTest(name = "test rabbit consume {1} messages and setTimestamp={2}")
@@ -246,7 +304,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
       }
     }
 
-    String resource = messageCount % 2 == 0 ? "<generated>" : queueName;
+    String resource = queueName;
 
     List<java.util.function.Consumer<TraceAssert>> traceAssertions = new ArrayList<>();
     traceAssertions.add(
@@ -335,7 +393,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                         exchangeName,
                         null,
                         "process",
-                        "<generated>",
+                        queueName,
                         trace.getSpan(0),
                         null,
                         error,
@@ -472,7 +530,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  verifySpan(trace, span, 0, "<default>", null, "publish", "<default>");
+                  verifySpan(trace, span, 0, "<default>", queueName, "publish", "<default>");
                   span.hasAttributesSatisfying(
                       satisfies(
                           stringArrayKey("messaging.header.Test_Message_Header"),
@@ -484,9 +542,9 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                       span,
                       1,
                       "<default>",
-                      null,
+                      queueName,
                       "process",
-                      "<generated>",
+                      queueName,
                       trace.getSpan(0));
                   span.hasAttributesSatisfying(
                       satisfies(
@@ -538,7 +596,7 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                   }
                 }),
         Arguments.of(
-            "<generated>",
+            "amq.gen-invalid-channel",
             "IOException",
             null,
             "receive",
@@ -610,21 +668,28 @@ class RabbitMqTest extends AbstractRabbitMqTest {
       Throwable exception,
       String errorMsg,
       boolean expectTimestamp) {
-    String spanName = resource;
-    if (operation != null) {
-      spanName += " " + operation;
-    }
+    String destination = destinationName(exchange, routingKey, operation, resource);
+    String legacyResource = normalizeQueueName(resource);
+    boolean anonymousDestination =
+        emitStableMessagingSemconv()
+            && (("publish".equals(operation)
+                    && "<default>".equals(exchange)
+                    && isGeneratedQueueName(routingKey))
+                || (("receive".equals(operation) || "process".equals(operation))
+                    && isGeneratedQueueName(resource)));
+    String spanName =
+        emitStableMessagingSemconv() && operation != null
+            ? anonymousDestination ? operation : operation + " " + destination
+            : legacyResource + (operation == null ? "" : " " + operation);
 
     span.hasName(spanName);
 
     String rabbitCommand = null;
     if (EXPERIMENTAL_ATTRIBUTES) {
       rabbitCommand = trace.getSpan(index).getAttributes().get(stringKey("rabbitmq.command"));
-
-      SpanKind spanKind = captureSpanKind(rabbitCommand);
-
-      span.hasKind(spanKind);
     }
+
+    span.hasKind(expectedSpanKind(operation));
 
     verifyParentAndLink(span, parentSpan, linkSpan);
 
@@ -632,8 +697,8 @@ class RabbitMqTest extends AbstractRabbitMqTest {
       verifyException(span, exception, errorMsg);
     }
 
-    verifyNetAttributes(span);
-    verifyMessagingAttributes(span, exchange, routingKey, operation);
+    verifyNetAttributes(span, operation);
+    verifyMessagingAttributes(span, exchange, routingKey, operation, resource, exception);
 
     if (expectTimestamp) {
       span.hasAttributesSatisfying(
@@ -696,10 +761,19 @@ class RabbitMqTest extends AbstractRabbitMqTest {
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   private static void verifyMessagingAttributes(
-      SpanDataAssert span, String exchange, String routingKey, String operation) {
+      SpanDataAssert span,
+      String exchange,
+      String routingKey,
+      String operation,
+      String resource,
+      Throwable exception) {
     span.hasAttributesSatisfying(
         equalTo(MESSAGING_SYSTEM, "rabbitmq"),
-        satisfies(MESSAGING_DESTINATION_NAME, val -> val.isIn(exchange, null)),
+        equalTo(
+            MESSAGING_DESTINATION_NAME,
+            emitStableMessagingSemconv()
+                ? destinationName(exchange, routingKey, operation, resource)
+                : exchange),
         satisfies(
             MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
             val ->
@@ -707,40 +781,70 @@ class RabbitMqTest extends AbstractRabbitMqTest {
                     v -> assertThat(v).isNull(),
                     v -> assertThat(v).isEqualTo(routingKey),
                     v -> assertThat(v).startsWith("amq.gen-"))),
+        equalTo(MESSAGING_OPERATION, emitStableMessagingSemconv() ? null : operation),
+        equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null),
+        equalTo(
+            MESSAGING_OPERATION_TYPE,
+            emitStableMessagingSemconv() ? "publish".equals(operation) ? "send" : operation : null),
         satisfies(
-            MESSAGING_OPERATION,
+            longKey("messaging.rabbitmq.message.delivery_tag"),
             val -> {
-              if (operation != null && !operation.equals("publish")) {
-                val.isEqualTo(operation);
+              if (emitStableMessagingSemconv()
+                  && ("process".equals(operation)
+                      || ("receive".equals(operation) && exception == null))) {
+                val.isNotNegative();
+              } else {
+                val.isNull();
               }
             }));
   }
 
-  private static SpanKind captureSpanKind(String rabbitCommand) {
-    SpanKind spanKind = SpanKind.CLIENT;
-
-    if (rabbitCommand != null) {
-      switch (rabbitCommand) {
-        case "basic.publish":
-          spanKind = SpanKind.PRODUCER;
-          break;
-        case "basic.get": // fallthrough
-        case "basic.deliver":
-          spanKind = SpanKind.CONSUMER;
-          break;
-        default:
-          break;
-      }
+  private static SpanKind expectedSpanKind(String operation) {
+    if ("publish".equals(operation)) {
+      return SpanKind.PRODUCER;
     }
-
-    return spanKind;
+    if ("process".equals(operation) || "receive".equals(operation)) {
+      return emitStableMessagingSemconv() && "receive".equals(operation)
+          ? SpanKind.CLIENT
+          : SpanKind.CONSUMER;
+    }
+    return SpanKind.CLIENT;
   }
 
-  private static void verifyNetAttributes(SpanDataAssert span) {
+  private static String normalizeQueueName(String queue) {
+    if (queue == null || queue.isEmpty()) {
+      return "<default>";
+    }
+    return queue.startsWith("amq.gen-") || queue.startsWith("spring.gen-") ? "<generated>" : queue;
+  }
+
+  private static String destinationName(
+      String exchange, String routingKey, String operation, String queue) {
+    if (operation == null) {
+      return null;
+    }
+    String actualExchange = "<default>".equals(exchange) ? "" : exchange;
+    return "publish".equals(operation)
+        ? producerDestinationName(actualExchange, routingKey)
+        : consumerDestinationName(actualExchange, routingKey, queue);
+  }
+
+  private static void verifyNetAttributes(SpanDataAssert span, String operation) {
+    boolean stableMessagingOperation = emitStableMessagingSemconv() && operation != null;
     span.hasAttributesSatisfying(
         satisfies(NETWORK_PEER_ADDRESS, val -> val.isIn(rabbitMqIp, null)),
         satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6", null)),
-        satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull));
+        satisfies(NETWORK_PEER_PORT, AbstractAssert::isNotNull),
+        equalTo(SERVER_ADDRESS, stableMessagingOperation ? rabbitMqIp : null),
+        satisfies(
+            SERVER_PORT,
+            val -> {
+              if (stableMessagingOperation) {
+                val.isNotNull();
+              } else {
+                val.isNull();
+              }
+            }));
   }
 
   private static void verifyException(SpanDataAssert span, Throwable exception, String errorMsg) {

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -99,6 +99,26 @@ tasks {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
@@ -109,6 +129,12 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental, testReceiveSpansDisabled)
+    dependsOn(
+      testing.suites,
+      testExperimental,
+      testReceiveSpansDisabled,
+      testV3Preview,
+      testV3PreviewReceiveSpansDisabled,
+    )
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -7,17 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.reactor.kafka.v1_0;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -61,6 +67,7 @@ import reactor.kafka.sender.KafkaSender;
 import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractReactorKafkaTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractReactorKafkaTest.class);
@@ -162,13 +169,44 @@ public abstract class AbstractReactorKafkaTest {
   private static void assertWithReceiveTelemetry(SenderRecord<String, String, Object> record) {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                span ->
+                    span.hasName(spanName("testTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(processAttributes(record)),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(receiveAttributes("testTopic"))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testTopic publish")
+                  span.hasName(spanName("testTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -178,12 +216,12 @@ public abstract class AbstractReactorKafkaTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes("testTopic")),
                 span ->
-                    span.hasName("testTopic process")
+                    span.hasName(spanName("testTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -197,29 +235,23 @@ public abstract class AbstractReactorKafkaTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testTopic publish")
+                    span.hasName(spanName("testTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(sendAttributes(record)),
                 span ->
-                    span.hasName("testTopic process")
+                    span.hasName(spanName("testTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(processAttributes(record)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> sendAttributes(ProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           equalTo(stringKey("messaging.kafka.bootstrap.servers"), kafka.getBootstrapServers()));
@@ -231,35 +263,23 @@ public abstract class AbstractReactorKafkaTest {
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> receiveAttributes(String topic) {
-    ArrayList<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "receive"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)));
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "receive", "poll", "receive", "consumer");
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
     if (HAS_CONSUMER_GROUP) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private static List<AttributeAssertion> processAttributes(ProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, "kafka"),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (HAS_CONSUMER_GROUP) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
@@ -274,5 +294,59 @@ public abstract class AbstractReactorKafkaTest {
       assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, "test"));
+    }
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  private static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/build.gradle.kts
@@ -46,7 +46,23 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.rocketmq-client.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testExperimental)
+    dependsOn(testExperimental, testV3Preview, testBothSemconv)
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
@@ -13,14 +13,34 @@ dependencies {
   testImplementation(project(":instrumentation:rocketmq:rocketmq-client-4.8:testing"))
 }
 
-tasks.test {
-  systemProperty("testLatestDeps", otelProps.testLatestDeps)
-  // required on jdk17
-  jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
-  jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
-  // with default settings tests will fail when disk is 90% full
-  jvmArgs("-Drocketmq.broker.diskSpaceWarningLevelRatio=1.0")
+tasks {
+  withType<Test>().configureEach {
+    systemProperty("testLatestDeps", otelProps.testLatestDeps)
+    // required on jdk17
+    jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
+    jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
+    // with default settings tests will fail when disk is 90% full
+    jvmArgs("-Drocketmq.broker.diskSpaceWarningLevelRatio=1.0")
 
-  // used for experimental attributes test assertion logic which looks for this property
-  jvmArgs("-Dotel.instrumentation.rocketmq-client.experimental-span-attributes=true")
+    // used for experimental attributes test assertion logic which looks for this property
+    jvmArgs("-Dotel.instrumentation.rocketmq-client.experimental-span-attributes=true")
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
+  check {
+    dependsOn(testV3Preview, testBothSemconv)
+  }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/ContextAndScope.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/ContextAndScope.java
@@ -6,17 +6,17 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 
 @AutoValue
 abstract class ContextAndScope {
 
-  static ContextAndScope create(Context context, Scope scope) {
-    return new AutoValue_ContextAndScope(context, scope);
+  static ContextAndScope create(
+      RocketMqConsumerInstrumenter.ConsumerContext consumerContext, Scope scope) {
+    return new AutoValue_ContextAndScope(consumerContext, scope);
   }
 
-  abstract Context getContext();
+  abstract RocketMqConsumerInstrumenter.ConsumerContext getConsumerContext();
 
   abstract Scope getScope();
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerAttributeGetter.java
@@ -11,76 +11,88 @@ import static java.util.Collections.singletonList;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 
-final class RocketMqConsumerAttributeGetter implements MessagingAttributesGetter<MessageExt, Void> {
+final class RocketMqConsumerAttributeGetter
+    implements MessagingAttributesGetter<RocketMqConsumerRequest, ConsumeMessageContext> {
 
   @Override
-  public String getSystem(MessageExt request) {
+  public String getSystem(RocketMqConsumerRequest request) {
     return "rocketmq";
   }
 
   @Override
-  public String getDestination(MessageExt request) {
-    return request.getTopic();
+  public String getDestination(RocketMqConsumerRequest request) {
+    return request.getMessage().getTopic();
   }
 
   @Nullable
   @Override
-  public String getDestinationTemplate(MessageExt request) {
+  public String getDestinationTemplate(RocketMqConsumerRequest request) {
     return null;
   }
 
   @Override
-  public boolean isTemporaryDestination(MessageExt request) {
+  public boolean isTemporaryDestination(RocketMqConsumerRequest request) {
     return false;
   }
 
   @Override
-  public boolean isAnonymousDestination(MessageExt request) {
+  public boolean isAnonymousDestination(RocketMqConsumerRequest request) {
     return false;
   }
 
   @Nullable
   @Override
-  public String getConversationId(MessageExt request) {
+  public String getConversationId(RocketMqConsumerRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long getMessageBodySize(MessageExt request) {
-    byte[] body = request.getBody();
+  public Long getMessageBodySize(RocketMqConsumerRequest request) {
+    byte[] body = request.getMessage().getBody();
     return body == null ? null : (long) body.length;
   }
 
   @Nullable
   @Override
-  public Long getMessageEnvelopeSize(MessageExt request) {
+  public Long getMessageEnvelopeSize(RocketMqConsumerRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public String getMessageId(MessageExt request, @Nullable Void unused) {
-    return request.getMsgId();
+  public String getMessageId(
+      RocketMqConsumerRequest request, @Nullable ConsumeMessageContext unused) {
+    return request.getMessage().getMsgId();
   }
 
   @Nullable
   @Override
-  public String getClientId(MessageExt request) {
+  public String getClientId(RocketMqConsumerRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Long getBatchMessageCount(MessageExt request, @Nullable Void unused) {
+  public Long getBatchMessageCount(
+      RocketMqConsumerRequest request, @Nullable ConsumeMessageContext unused) {
     return null;
   }
 
+  @Nullable
   @Override
-  public List<String> getMessageHeader(MessageExt request, String name) {
-    String value = request.getProperties().get(name);
+  public String getErrorType(
+      RocketMqConsumerRequest request,
+      @Nullable ConsumeMessageContext response,
+      @Nullable Throwable error) {
+    return response != null && !response.isSuccess() ? response.getStatus() : null;
+  }
+
+  @Override
+  public List<String> getMessageHeader(RocketMqConsumerRequest request, String name) {
+    String value = request.getMessage().getProperties().get(name);
     if (value != null) {
       return singletonList(value);
     }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerExperimentalAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerExperimentalAttributeExtractor.java
@@ -11,10 +11,11 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 import org.apache.rocketmq.common.message.MessageExt;
 
 final class RocketMqConsumerExperimentalAttributeExtractor
-    implements AttributesExtractor<MessageExt, Void> {
+    implements AttributesExtractor<RocketMqConsumerRequest, ConsumeMessageContext> {
 
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<String> MESSAGING_ROCKETMQ_MESSAGE_TAG =
@@ -28,7 +29,9 @@ final class RocketMqConsumerExperimentalAttributeExtractor
       AttributeKey.stringKey("messaging.rocketmq.broker_address");
 
   @Override
-  public void onStart(AttributesBuilder attributes, Context parentContext, MessageExt msg) {
+  public void onStart(
+      AttributesBuilder attributes, Context parentContext, RocketMqConsumerRequest request) {
+    MessageExt msg = request.getMessage();
     attributes.put(MESSAGING_ROCKETMQ_MESSAGE_TAG, msg.getTags());
     attributes.put(MESSAGING_ROCKETMQ_QUEUE_ID, msg.getQueueId());
     attributes.put(MESSAGING_ROCKETMQ_QUEUE_OFFSET, msg.getQueueOffset());
@@ -46,7 +49,7 @@ final class RocketMqConsumerExperimentalAttributeExtractor
   public void onEnd(
       AttributesBuilder attributes,
       Context context,
-      MessageExt consumeMessageContext,
-      @Nullable Void unused,
+      RocketMqConsumerRequest request,
+      @Nullable ConsumeMessageContext response,
       @Nullable Throwable error) {}
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerInstrumenter.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerInstrumenter.java
@@ -5,55 +5,147 @@
 
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Collections.emptyList;
+
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 import org.apache.rocketmq.common.message.MessageExt;
 
 final class RocketMqConsumerInstrumenter {
 
-  private final Instrumenter<MessageExt, Void> singleProcessInstrumenter;
-  private final Instrumenter<MessageExt, Void> batchProcessInstrumenter;
-  private final Instrumenter<Void, Void> batchReceiveInstrumenter;
+  private final Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext>
+      singleProcessInstrumenter;
+  private final Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext>
+      batchProcessInstrumenter;
+  private final Instrumenter<RocketMqConsumerRequest, Void> batchReceiveInstrumenter;
 
   RocketMqConsumerInstrumenter(
-      Instrumenter<MessageExt, Void> singleProcessInstrumenter,
-      Instrumenter<MessageExt, Void> batchProcessInstrumenter,
-      Instrumenter<Void, Void> batchReceiveInstrumenter) {
+      Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext> singleProcessInstrumenter,
+      Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext> batchProcessInstrumenter,
+      Instrumenter<RocketMqConsumerRequest, Void> batchReceiveInstrumenter) {
     this.singleProcessInstrumenter = singleProcessInstrumenter;
     this.batchProcessInstrumenter = batchProcessInstrumenter;
     this.batchReceiveInstrumenter = batchReceiveInstrumenter;
   }
 
-  Context start(Context parentContext, List<MessageExt> msgs) {
+  @Nullable
+  ConsumerContext start(
+      Context parentContext,
+      List<MessageExt> msgs,
+      String consumerGroup,
+      @Nullable String namespace) {
+    int batchSize = msgs.size();
     if (msgs.size() == 1) {
-      if (singleProcessInstrumenter.shouldStart(parentContext, msgs.get(0))) {
-        return singleProcessInstrumenter.start(parentContext, msgs.get(0));
+      RocketMqConsumerRequest request =
+          new RocketMqConsumerRequest(msgs.get(0), consumerGroup, batchSize, namespace);
+      if (singleProcessInstrumenter.shouldStart(parentContext, request)) {
+        Context context = singleProcessInstrumenter.start(parentContext, request);
+        return new ConsumerContext(context, request, emptyList(), false);
       }
     } else {
-      if (batchReceiveInstrumenter.shouldStart(parentContext, null)) {
-        Context rootContext = batchReceiveInstrumenter.start(parentContext, null);
-        for (MessageExt message : msgs) {
-          createChildSpan(rootContext, message);
-        }
-        return rootContext;
+      RocketMqConsumerRequest request =
+          new RocketMqConsumerRequest(msgs.get(0), consumerGroup, batchSize, namespace);
+      boolean receiveStarted = batchReceiveInstrumenter.shouldStart(parentContext, request);
+      Context receiveContext =
+          receiveStarted ? batchReceiveInstrumenter.start(parentContext, request) : parentContext;
+      Context processParentContext = emitStableMessagingSemconv() ? parentContext : receiveContext;
+      List<StartedProcessSpan> processSpans = new ArrayList<>(batchSize);
+      for (MessageExt message : msgs) {
+        createChildSpan(
+            processParentContext, message, consumerGroup, batchSize, namespace, processSpans);
+      }
+      if (receiveStarted || !processSpans.isEmpty()) {
+        return new ConsumerContext(receiveContext, request, processSpans, receiveStarted);
       }
     }
-    return parentContext;
+    return null;
   }
 
-  private void createChildSpan(Context parentContext, MessageExt msg) {
-    if (batchProcessInstrumenter.shouldStart(parentContext, msg)) {
-      Context context = batchProcessInstrumenter.start(parentContext, msg);
-      batchProcessInstrumenter.end(context, msg, null, null);
+  private void createChildSpan(
+      Context parentContext,
+      MessageExt msg,
+      String consumerGroup,
+      int batchSize,
+      @Nullable String namespace,
+      List<StartedProcessSpan> processSpans) {
+    RocketMqConsumerRequest request =
+        new RocketMqConsumerRequest(msg, consumerGroup, batchSize, namespace);
+    if (batchProcessInstrumenter.shouldStart(parentContext, request)) {
+      Context context = batchProcessInstrumenter.start(parentContext, request);
+      processSpans.add(new StartedProcessSpan(context, request));
     }
   }
 
-  void end(Context context, List<MessageExt> msgs) {
-    if (msgs.size() == 1) {
-      singleProcessInstrumenter.end(context, msgs.get(0), null, null);
+  void end(ConsumerContext consumerContext, ConsumeMessageContext response) {
+    if (consumerContext.getRequest().getBatchSize() == 1) {
+      singleProcessInstrumenter.end(
+          consumerContext.getContext(), consumerContext.getRequest(), response, null);
     } else {
-      batchReceiveInstrumenter.end(context, null, null, null);
+      for (StartedProcessSpan processSpan : consumerContext.getProcessSpans()) {
+        batchProcessInstrumenter.end(
+            processSpan.getContext(), processSpan.getRequest(), response, null);
+      }
+      if (consumerContext.isReceiveStarted()) {
+        batchReceiveInstrumenter.end(
+            consumerContext.getContext(), consumerContext.getRequest(), null, null);
+      }
+    }
+  }
+
+  static final class ConsumerContext {
+    private final Context context;
+    private final RocketMqConsumerRequest request;
+    private final List<StartedProcessSpan> processSpans;
+    private final boolean receiveStarted;
+
+    private ConsumerContext(
+        Context context,
+        RocketMqConsumerRequest request,
+        List<StartedProcessSpan> processSpans,
+        boolean receiveStarted) {
+      this.context = context;
+      this.request = request;
+      this.processSpans = processSpans;
+      this.receiveStarted = receiveStarted;
+    }
+
+    Context getContext() {
+      return context;
+    }
+
+    RocketMqConsumerRequest getRequest() {
+      return request;
+    }
+
+    private List<StartedProcessSpan> getProcessSpans() {
+      return processSpans;
+    }
+
+    private boolean isReceiveStarted() {
+      return receiveStarted;
+    }
+  }
+
+  private static final class StartedProcessSpan {
+    private final Context context;
+    private final RocketMqConsumerRequest request;
+
+    private StartedProcessSpan(Context context, RocketMqConsumerRequest request) {
+      this.context = context;
+      this.request = request;
+    }
+
+    Context getContext() {
+      return context;
+    }
+
+    RocketMqConsumerRequest getRequest() {
+      return request;
     }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerRequest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import javax.annotation.Nullable;
+import org.apache.rocketmq.common.message.MessageExt;
+
+final class RocketMqConsumerRequest {
+
+  private final MessageExt message;
+  private final String consumerGroup;
+  private final int batchSize;
+  private final String namespace;
+
+  RocketMqConsumerRequest(
+      MessageExt message, String consumerGroup, int batchSize, @Nullable String namespace) {
+    this.message = message;
+    this.consumerGroup = RocketMqNamespaceUtil.withoutNamespace(consumerGroup, namespace);
+    this.batchSize = batchSize;
+    this.namespace = namespace == null ? "" : namespace;
+  }
+
+  MessageExt getMessage() {
+    return message;
+  }
+
+  String getConsumerGroup() {
+    return consumerGroup;
+  }
+
+  int getBatchSize() {
+    return batchSize;
+  }
+
+  String getNamespace() {
+    return namespace;
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -8,32 +8,50 @@ package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
-import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
 import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 import org.apache.rocketmq.client.hook.SendMessageContext;
-import org.apache.rocketmq.common.message.MessageExt;
 
 class RocketMqInstrumenterFactory {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rocketmq-client-4.8";
 
   // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_CONSUMER_GROUP_NAME =
+      AttributeKey.stringKey("messaging.consumer.group.name");
+  private static final AttributeKey<String> MESSAGING_DESTINATION_NAME =
+      AttributeKey.stringKey("messaging.destination.name");
   private static final AttributeKey<String> MESSAGING_OPERATION =
       AttributeKey.stringKey("messaging.operation");
+  private static final AttributeKey<String> MESSAGING_OPERATION_NAME =
+      AttributeKey.stringKey("messaging.operation.name");
+  private static final AttributeKey<String> MESSAGING_OPERATION_TYPE =
+      AttributeKey.stringKey("messaging.operation.type");
   private static final AttributeKey<String> MESSAGING_SYSTEM =
       AttributeKey.stringKey("messaging.system");
+  private static final AttributeKey<String> MESSAGING_ROCKETMQ_NAMESPACE =
+      AttributeKey.stringKey("messaging.rocketmq.namespace");
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
 
   static Instrumenter<SendMessageContext, Void> createProducerInstrumenter(
       OpenTelemetry openTelemetry,
@@ -41,15 +59,34 @@ class RocketMqInstrumenterFactory {
       boolean captureExperimentalSpanAttributes) {
 
     RocketMqProducerAttributeGetter getter = new RocketMqProducerAttributeGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     InstrumenterBuilder<SendMessageContext, Void> instrumenterBuilder =
         Instrumenter.<SendMessageContext, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                buildMessagingAttributesExtractor(getter, operation, capturedHeaders));
+                buildMessagingAttributesExtractor(getter, operationType, capturedHeaders));
+    if (emitStableMessagingSemconv()) {
+      instrumenterBuilder.addAttributesExtractor(
+          new AttributesExtractor<SendMessageContext, Void>() {
+            @Override
+            public void onStart(
+                AttributesBuilder attributes, Context parentContext, SendMessageContext request) {
+              String namespace = RocketMqNamespaceUtil.getNamespace(request);
+              attributes.put(MESSAGING_ROCKETMQ_NAMESPACE, namespace == null ? "" : namespace);
+            }
+
+            @Override
+            public void onEnd(
+                AttributesBuilder attributes,
+                Context context,
+                SendMessageContext request,
+                @Nullable Void unused,
+                @Nullable Throwable error) {}
+          });
+    }
     if (captureExperimentalSpanAttributes) {
       instrumenterBuilder.addAttributesExtractor(
           new RocketMqProducerExperimentalAttributeExtractor());
@@ -64,66 +101,122 @@ class RocketMqInstrumenterFactory {
       List<String> capturedHeaders,
       boolean captureExperimentalSpanAttributes) {
 
-    InstrumenterBuilder<Void, Void> batchReceiveInstrumenterBuilder =
-        Instrumenter.<Void, Void>builder(
+    InstrumenterBuilder<RocketMqConsumerRequest, Void> batchReceiveInstrumenterBuilder =
+        Instrumenter.<RocketMqConsumerRequest, Void>builder(
                 openTelemetry, INSTRUMENTATION_NAME, RocketMqInstrumenterFactory::spanNameOnReceive)
-            .addAttributesExtractor(constant(MESSAGING_SYSTEM, "rocketmq"))
-            .addAttributesExtractor(constant(MESSAGING_OPERATION, "receive"));
+            .addAttributesExtractor(constant(MESSAGING_SYSTEM, "rocketmq"));
+    if (emitOldMessagingSemconv()) {
+      batchReceiveInstrumenterBuilder.addAttributesExtractor(
+          constant(MESSAGING_OPERATION, "receive"));
+    }
+    if (emitStableMessagingSemconv()) {
+      batchReceiveInstrumenterBuilder
+          .addAttributesExtractor(constant(MESSAGING_OPERATION_NAME, "receive"))
+          .addAttributesExtractor(constant(MESSAGING_OPERATION_TYPE, "receive"))
+          .addAttributesExtractor(
+              new AttributesExtractor<RocketMqConsumerRequest, Void>() {
+                @Override
+                public void onStart(
+                    AttributesBuilder attributes,
+                    Context parentContext,
+                    RocketMqConsumerRequest request) {
+                  attributes.put(MESSAGING_BATCH_MESSAGE_COUNT, request.getBatchSize());
+                  attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+                  attributes.put(MESSAGING_DESTINATION_NAME, request.getMessage().getTopic());
+                  attributes.put(MESSAGING_ROCKETMQ_NAMESPACE, request.getNamespace());
+                }
+
+                @Override
+                public void onEnd(
+                    AttributesBuilder attributes,
+                    Context context,
+                    RocketMqConsumerRequest request,
+                    @Nullable Void unused,
+                    @Nullable Throwable error) {}
+              });
+    }
 
     return new RocketMqConsumerInstrumenter(
         createProcessInstrumenter(
             openTelemetry, capturedHeaders, captureExperimentalSpanAttributes, false),
         createProcessInstrumenter(
             openTelemetry, capturedHeaders, captureExperimentalSpanAttributes, true),
-        batchReceiveInstrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer()));
+        batchReceiveInstrumenterBuilder.buildInstrumenter(
+            MessagingSpanKindExtractor.create(MessagingOperationType.RECEIVE)));
   }
 
-  private static Instrumenter<MessageExt, Void> createProcessInstrumenter(
-      OpenTelemetry openTelemetry,
-      List<String> capturedHeaders,
-      boolean captureExperimentalSpanAttributes,
-      boolean batch) {
+  private static Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext>
+      createProcessInstrumenter(
+          OpenTelemetry openTelemetry,
+          List<String> capturedHeaders,
+          boolean captureExperimentalSpanAttributes,
+          boolean batch) {
 
     RocketMqConsumerAttributeGetter getter = new RocketMqConsumerAttributeGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
-    InstrumenterBuilder<MessageExt, Void> builder =
+    InstrumenterBuilder<RocketMqConsumerRequest, ConsumeMessageContext> builder =
         Instrumenter.builder(
             openTelemetry,
             INSTRUMENTATION_NAME,
-            MessagingSpanNameExtractor.create(getter, operation));
+            MessagingSpanNameExtractor.create(getter, operationType));
 
     builder.addAttributesExtractor(
-        buildMessagingAttributesExtractor(getter, operation, capturedHeaders));
+        buildMessagingAttributesExtractor(getter, operationType, capturedHeaders));
+    if (emitStableMessagingSemconv()) {
+      builder.addAttributesExtractor(
+          new AttributesExtractor<RocketMqConsumerRequest, ConsumeMessageContext>() {
+            @Override
+            public void onStart(
+                AttributesBuilder attributes,
+                Context parentContext,
+                RocketMqConsumerRequest request) {
+              attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+              attributes.put(MESSAGING_ROCKETMQ_NAMESPACE, request.getNamespace());
+            }
+
+            @Override
+            public void onEnd(
+                AttributesBuilder attributes,
+                Context context,
+                RocketMqConsumerRequest request,
+                @Nullable ConsumeMessageContext response,
+                @Nullable Throwable error) {}
+          });
+    }
     if (captureExperimentalSpanAttributes) {
       builder.addAttributesExtractor(new RocketMqConsumerExperimentalAttributeExtractor());
     }
+    builder.setSpanStatusExtractor(
+        (spanStatusBuilder, request, response, error) -> {
+          if (response != null && !response.isSuccess()) {
+            spanStatusBuilder.setStatus(StatusCode.ERROR);
+          } else {
+            SpanStatusExtractor.getDefault().extract(spanStatusBuilder, request, response, error);
+          }
+        });
     setMessagingProcessExceptionEventExtractor(builder);
 
-    if (batch) {
-      SpanLinksExtractor<MessageExt> spanLinksExtractor =
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(), new TextMapExtractAdapter());
-
-      return builder
-          .addSpanLinksExtractor(spanLinksExtractor)
-          .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    } else {
-      return builder.buildConsumerInstrumenter(new TextMapExtractAdapter());
-    }
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new TextMapExtractAdapter(),
+        batch);
   }
 
-  private static <T> AttributesExtractor<T, Void> buildMessagingAttributesExtractor(
-      MessagingAttributesGetter<T, Void> getter,
-      MessageOperation operation,
+  private static <T, R> AttributesExtractor<T, R> buildMessagingAttributesExtractor(
+      MessagingAttributesGetter<T, R> getter,
+      MessagingOperationType operationType,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }
 
-  private static String spanNameOnReceive(Void unused) {
-    return "multiple_sources receive";
+  private static String spanNameOnReceive(RocketMqConsumerRequest request) {
+    return emitStableMessagingSemconv()
+        ? "receive " + request.getMessage().getTopic()
+        : "multiple_sources receive";
   }
 
   private RocketMqInstrumenterFactory() {}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqNamespaceUtil.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqNamespaceUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+
+final class RocketMqNamespaceUtil {
+
+  private static final NamespaceAccessor noNamespaceAccessor = context -> null;
+  private static final ClassValue<NamespaceAccessor> namespaceAccessors =
+      new ClassValue<NamespaceAccessor>() {
+        @Override
+        protected NamespaceAccessor computeValue(Class<?> type) {
+          try {
+            Method method = type.getMethod("getNamespace");
+            return context -> invoke(method, context);
+          } catch (NoSuchMethodException ignored) {
+            return noNamespaceAccessor;
+          }
+        }
+      };
+
+  @Nullable
+  static String getNamespace(Object context) {
+    return namespaceAccessors.get(context.getClass()).get(context);
+  }
+
+  @Nullable
+  private static String invoke(Method method, Object context) {
+    try {
+      return (String) method.invoke(context);
+    } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
+  }
+
+  static String withoutNamespace(String resource, @Nullable String namespace) {
+    if (resource.isEmpty() || namespace == null || namespace.isEmpty()) {
+      return resource;
+    }
+
+    String prefix = "";
+    String resourceWithoutPrefix = resource;
+    if (resource.startsWith("%RETRY%")) {
+      prefix = "%RETRY%";
+      resourceWithoutPrefix = resource.substring(prefix.length());
+    } else if (resource.startsWith("%DLQ%")) {
+      prefix = "%DLQ%";
+      resourceWithoutPrefix = resource.substring(prefix.length());
+    }
+
+    String namespacePrefix = namespace + "%";
+    return resourceWithoutPrefix.startsWith(namespacePrefix)
+        ? prefix + resourceWithoutPrefix.substring(namespacePrefix.length())
+        : resource;
+  }
+
+  private RocketMqNamespaceUtil() {}
+
+  private interface NamespaceAccessor {
+    @Nullable
+    String get(Object context);
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqProducerAttributeGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -27,7 +28,14 @@ final class RocketMqProducerAttributeGetter
   @Override
   public String getDestination(SendMessageContext request) {
     Message message = request.getMessage();
-    return message == null ? null : message.getTopic();
+    if (message == null) {
+      return null;
+    }
+    if (!emitStableMessagingSemconv()) {
+      return message.getTopic();
+    }
+    return RocketMqNamespaceUtil.withoutNamespace(
+        message.getTopic(), RocketMqNamespaceUtil.getNamespace(request));
   }
 
   @Nullable
@@ -80,6 +88,14 @@ final class RocketMqProducerAttributeGetter
   @Nullable
   @Override
   public Long getBatchMessageCount(SendMessageContext request, @Nullable Void unused) {
+    Message message = request.getMessage();
+    if (emitStableMessagingSemconv() && message instanceof Iterable<?>) {
+      long batchSize = 0;
+      for (Object ignored : (Iterable<?>) message) {
+        batchSize++;
+      }
+      return batchSize;
+    }
     return null;
   }
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TextMapExtractAdapter.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TextMapExtractAdapter.java
@@ -7,18 +7,17 @@ package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
 import javax.annotation.Nullable;
-import org.apache.rocketmq.common.message.MessageExt;
 
-final class TextMapExtractAdapter implements TextMapGetter<MessageExt> {
+final class TextMapExtractAdapter implements TextMapGetter<RocketMqConsumerRequest> {
 
   @Override
-  public Iterable<String> keys(MessageExt carrier) {
-    return carrier.getProperties().keySet();
+  public Iterable<String> keys(RocketMqConsumerRequest carrier) {
+    return carrier.getMessage().getProperties().keySet();
   }
 
   @Nullable
   @Override
-  public String get(@Nullable MessageExt carrier, String key) {
-    return carrier == null ? null : carrier.getProperties().get(key);
+  public String get(@Nullable RocketMqConsumerRequest carrier, String key) {
+    return carrier == null ? null : carrier.getMessage().getProperties().get(key);
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingConsumeMessageHookImpl.java
@@ -33,15 +33,21 @@ final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
       return;
     }
     Context parentContext = Context.current();
-    Context newContext = instrumenter.start(parentContext, context.getMsgList());
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        instrumenter.start(
+            parentContext,
+            context.getMsgList(),
+            context.getConsumerGroup(),
+            RocketMqNamespaceUtil.getNamespace(context));
 
     // it's safe to store the scope in the rocketMq message context, both before() and after()
     // methods are always called from the same thread; see:
     // - ConsumeMessageConcurrentlyService$ConsumeRequest#run()
     // - ConsumeMessageOrderlyService$ConsumeRequest#run()
-    if (newContext != parentContext) {
+    if (consumerContext != null) {
+      Context newContext = consumerContext.getContext();
       CONTEXT_AND_SCOPE_FIELD.set(
-          context, ContextAndScope.create(newContext, newContext.makeCurrent()));
+          context, ContextAndScope.create(consumerContext, newContext.makeCurrent()));
     }
   }
 
@@ -53,7 +59,7 @@ final class TracingConsumeMessageHookImpl implements ConsumeMessageHook {
     ContextAndScope contextAndScope = CONTEXT_AND_SCOPE_FIELD.get(context);
     if (contextAndScope != null) {
       contextAndScope.close();
-      instrumenter.end(contextAndScope.getContext(), context.getMsgList());
+      instrumenter.end(contextAndScope.getConsumerContext(), context);
     }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerInstrumenterTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqConsumerInstrumenterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RocketMqConsumerInstrumenterTest {
+
+  @Mock
+  private Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext> singleProcessInstrumenter;
+
+  @Mock
+  private Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext> batchProcessInstrumenter;
+
+  @Mock private Instrumenter<RocketMqConsumerRequest, Void> batchReceiveInstrumenter;
+
+  @Test
+  void usesEmptyNamespaceByDefault() {
+    RocketMqConsumerRequest request =
+        new RocketMqConsumerRequest(mock(MessageExt.class), "consumer-group", 1, null);
+
+    assertThat(request.getNamespace()).isEmpty();
+  }
+
+  @Test
+  void endsBatchReceiveWhenAllProcessSpansAreSuppressed() {
+    RocketMqConsumerInstrumenter instrumenter =
+        new RocketMqConsumerInstrumenter(
+            singleProcessInstrumenter, batchProcessInstrumenter, batchReceiveInstrumenter);
+    Context parentContext = Context.root();
+    Context receiveContext = mock(Context.class);
+    when(batchReceiveInstrumenter.shouldStart(same(parentContext), any())).thenReturn(true);
+    when(batchReceiveInstrumenter.start(same(parentContext), any())).thenReturn(receiveContext);
+
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        requireNonNull(
+            instrumenter.start(
+                parentContext,
+                asList(mock(MessageExt.class), mock(MessageExt.class)),
+                "consumer-group",
+                "namespace"));
+    ConsumeMessageContext response = mock(ConsumeMessageContext.class);
+    instrumenter.end(consumerContext, response);
+
+    verify(batchProcessInstrumenter, times(2)).shouldStart(any(), any());
+    verify(batchReceiveInstrumenter)
+        .end(same(receiveContext), same(consumerContext.getRequest()), same(null), same(null));
+    verifyNoInteractions(singleProcessInstrumenter);
+  }
+
+  @Test
+  void startsBatchProcessSpansWhenReceiveSpanIsSuppressed() {
+    RocketMqConsumerInstrumenter instrumenter =
+        new RocketMqConsumerInstrumenter(
+            singleProcessInstrumenter, batchProcessInstrumenter, batchReceiveInstrumenter);
+    Context parentContext = Context.root();
+    Context processContext = mock(Context.class);
+    when(batchReceiveInstrumenter.shouldStart(same(parentContext), any())).thenReturn(false);
+    when(batchProcessInstrumenter.shouldStart(same(parentContext), any())).thenReturn(true);
+    when(batchProcessInstrumenter.start(same(parentContext), any())).thenReturn(processContext);
+
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        requireNonNull(
+            instrumenter.start(
+                parentContext,
+                asList(mock(MessageExt.class), mock(MessageExt.class)),
+                "consumer-group",
+                "namespace"));
+    ConsumeMessageContext response = mock(ConsumeMessageContext.class);
+    instrumenter.end(consumerContext, response);
+
+    assertThat(consumerContext.getContext()).isSameAs(parentContext);
+    verify(batchProcessInstrumenter, times(2)).start(same(parentContext), any());
+    verify(batchProcessInstrumenter, times(2))
+        .end(same(processContext), any(), same(response), same(null));
+    verify(batchReceiveInstrumenter, never()).start(any(), any());
+    verify(batchReceiveInstrumenter, never()).end(any(), any(), any(), any());
+    verifyNoInteractions(singleProcessInstrumenter);
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.apache.rocketmq.client.hook.SendMessageContext;
+import org.apache.rocketmq.common.message.Message;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RocketMqInstrumenterFactoryTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void usesEmptyProducerNamespaceByDefault() {
+    SendMessageContext request = mock(SendMessageContext.class);
+    when(request.getMessage()).thenReturn(new Message("topic", new byte[0]));
+    Instrumenter<SendMessageContext, Void> instrumenter =
+        RocketMqInstrumenterFactory.createProducerInstrumenter(
+            testing.getOpenTelemetry(), emptyList(), false);
+    Context parentContext = Context.root();
+
+    assertThat(instrumenter.shouldStart(parentContext, request)).isTrue();
+    Context context = instrumenter.start(parentContext, request);
+    instrumenter.end(context, request, null, null);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableMessagingSemconv() ? "publish topic" : "topic publish")
+                        .hasKind(PRODUCER)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "topic"),
+                            equalTo(
+                                MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "publish" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "send" : null),
+                            equalTo(
+                                MESSAGING_ROCKETMQ_NAMESPACE,
+                                emitStableMessagingSemconv() ? "" : null))));
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqNamespaceUtilTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqNamespaceUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RocketMqNamespaceUtilTest {
+
+  @Test
+  void readsNamespaceFromSupportedContext() {
+    ContextWithNamespace context = new ContextWithNamespace();
+
+    assertThat(RocketMqNamespaceUtil.getNamespace(context)).isEqualTo("namespace");
+    assertThat(RocketMqNamespaceUtil.getNamespace(context)).isEqualTo("namespace");
+  }
+
+  @Test
+  void handlesContextWithoutNamespace() {
+    Object context = new Object();
+
+    assertThat(RocketMqNamespaceUtil.getNamespace(context)).isNull();
+    assertThat(RocketMqNamespaceUtil.getNamespace(context)).isNull();
+  }
+
+  public static class ContextWithNamespace {
+    public String getNamespace() {
+      return "namespace";
+    }
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/AbstractRocketMqClientTest.java
@@ -7,15 +7,26 @@ package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.rocketmqclient.v4_8.base.BaseConf.NAMESPACE;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -25,7 +36,11 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.rocketmqclient.v4_8.base.BaseConf;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +50,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendCallback;
@@ -60,6 +76,7 @@ abstract class AbstractRocketMqClientTest {
 
   private static final boolean EXPERIMENTAL_ATTRIBUTES =
       Boolean.getBoolean("otel.instrumentation.rocketmq-client.experimental-span-attributes");
+  private static final String CONSUMER_GROUP = "consumerGroup";
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractRocketMqClientTest.class);
 
@@ -165,12 +182,15 @@ abstract class AbstractRocketMqClientTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(sharedTopic + " publish")
+                        span.hasName(producerSpanName())
                             .hasKind(SpanKind.PRODUCER)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "publish"),
+                                namespace(),
+                                equalTo(MESSAGING_DESTINATION_NAME, producerDestination()),
+                                oldOperation("publish"),
+                                operationName("publish"),
+                                operationType("publish"),
                                 satisfies(
                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagA")),
@@ -181,13 +201,20 @@ abstract class AbstractRocketMqClientTest {
                                     stringKey("messaging.rocketmq.send_result"),
                                     experimental("SEND_OK"))),
                     span ->
-                        span.hasName(sharedTopic + " process")
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "process " + sharedTopic
+                                    : sharedTopic + " process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                namespace(),
+                                consumerGroup(),
                                 equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
+                                oldOperation("process"),
+                                operationName("process"),
+                                operationType("process"),
                                 satisfies(
                                     MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
@@ -227,13 +254,16 @@ abstract class AbstractRocketMqClientTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(sharedTopic + " publish")
+                        span.hasName(producerSpanName())
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "publish"),
+                                namespace(),
+                                equalTo(MESSAGING_DESTINATION_NAME, producerDestination()),
+                                oldOperation("publish"),
+                                operationName("publish"),
+                                operationType("publish"),
                                 satisfies(
                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagA")),
@@ -244,13 +274,20 @@ abstract class AbstractRocketMqClientTest {
                                     stringKey("messaging.rocketmq.send_result"),
                                     experimental("SEND_OK"))),
                     span ->
-                        span.hasName(sharedTopic + " process")
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "process " + sharedTopic
+                                    : sharedTopic + " process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                namespace(),
+                                consumerGroup(),
                                 equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
+                                oldOperation("process"),
+                                operationName("process"),
+                                operationType("process"),
                                 satisfies(
                                     MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
@@ -274,6 +311,16 @@ abstract class AbstractRocketMqClientTest {
 
   @Test
   void testRocketmqProduceAndBatchConsume() throws Exception {
+    runBatchConsumeTest(false);
+  }
+
+  @Test
+  void testBatchConsumeFailure() throws Exception {
+    consumer.setMaxReconsumeTimes(0);
+    runBatchConsumeTest(true);
+  }
+
+  private void runBatchConsumeTest(boolean failConsumption) throws Exception {
     // context propagation doesn't work for batch messages in 5.3.4
     Assumptions.assumeFalse(testLatestDeps());
 
@@ -285,6 +332,9 @@ abstract class AbstractRocketMqClientTest {
     int maxAttempts = 5;
     for (int i = 0; i < maxAttempts; i++) {
       tracingMessageListener.reset();
+      if (failConsumption) {
+        tracingMessageListener.failNextMessage();
+      }
 
       testing().runWithSpan("parent", () -> producer.send(msgs));
 
@@ -304,16 +354,31 @@ abstract class AbstractRocketMqClientTest {
     testing()
         .waitAndAssertTraces(
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
+              SpanContext spanContext = trace.getSpan(1).getSpanContext();
+              producerSpanContext.set(
+                  SpanContext.createFromRemoteParent(
+                      spanContext.getTraceId(),
+                      spanContext.getSpanId(),
+                      spanContext.getTraceFlags(),
+                      spanContext.getTraceState()));
+
+              List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+              assertions.add(span -> span.hasName("parent").hasKind(SpanKind.INTERNAL));
+              assertions.add(
                   span ->
-                      span.hasName(sharedTopic + " publish")
+                      span.hasName(producerSpanName())
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
                               equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                              equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                              equalTo(MESSAGING_OPERATION, "publish"),
+                              namespace(),
+                              equalTo(MESSAGING_DESTINATION_NAME, producerDestination()),
+                              equalTo(
+                                  MESSAGING_BATCH_MESSAGE_COUNT,
+                                  emitStableMessagingSemconv() ? Long.valueOf(2) : null),
+                              oldOperation("publish"),
+                              operationName("publish"),
+                              operationType("publish"),
                               satisfies(
                                   MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                               satisfies(
@@ -322,75 +387,110 @@ abstract class AbstractRocketMqClientTest {
                               equalTo(
                                   stringKey("messaging.rocketmq.send_result"),
                                   experimental("SEND_OK"))));
-
-              SpanContext spanContext = trace.getSpan(1).getSpanContext();
-              producerSpanContext.set(
-                  SpanContext.createFromRemoteParent(
-                      spanContext.getTraceId(),
-                      spanContext.getSpanId(),
-                      spanContext.getTraceFlags(),
-                      spanContext.getTraceState()));
+              if (emitStableMessagingSemconv()) {
+                assertions.add(
+                    span ->
+                        assertBatchProcessSpan(
+                            span,
+                            trace.getSpan(1),
+                            producerSpanContext.get(),
+                            "TagA",
+                            failConsumption));
+                assertions.add(
+                    span ->
+                        assertBatchProcessSpan(
+                            span,
+                            trace.getSpan(1),
+                            producerSpanContext.get(),
+                            "TagB",
+                            failConsumption));
+              }
+              trace.hasSpansSatisfyingExactly(assertions);
             },
-            trace ->
-                trace.hasSpansSatisfyingExactly(
+            trace -> {
+              List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+              assertions.add(
+                  span ->
+                      span.hasName(
+                              emitStableMessagingSemconv()
+                                  ? "receive " + sharedTopic
+                                  : "multiple_sources receive")
+                          .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                              namespace(),
+                              consumerGroup(),
+                              equalTo(
+                                  MESSAGING_DESTINATION_NAME,
+                                  emitStableMessagingSemconv() ? sharedTopic : null),
+                              equalTo(
+                                  MESSAGING_BATCH_MESSAGE_COUNT,
+                                  emitStableMessagingSemconv() ? Long.valueOf(2) : null),
+                              oldOperation("receive"),
+                              operationName("receive"),
+                              operationType("receive")));
+              if (!emitStableMessagingSemconv()) {
+                assertions.add(
                     span ->
-                        span.hasName("multiple_sources receive")
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_OPERATION, "receive")),
+                        assertBatchProcessSpan(
+                            span,
+                            trace.getSpan(0),
+                            producerSpanContext.get(),
+                            "TagA",
+                            failConsumption));
+                assertions.add(
                     span ->
-                        span.hasName(sharedTopic + " process")
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasParent(trace.getSpan(0))
-                            .hasLinksSatisfying(links(producerSpanContext.get()))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                satisfies(
-                                    MESSAGING_MESSAGE_BODY_SIZE,
-                                    val -> val.isInstanceOf(Long.class)),
-                                satisfies(
-                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagA")),
-                                satisfies(
-                                    stringKey("messaging.rocketmq.broker_address"),
-                                    val -> experimentalString(val)),
-                                satisfies(
-                                    longKey("messaging.rocketmq.queue_id"),
-                                    val -> experimentalLong(val)),
-                                satisfies(
-                                    longKey("messaging.rocketmq.queue_offset"),
-                                    val -> experimentalLong(val))),
-                    span ->
-                        span.hasName(sharedTopic + " process")
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasParent(trace.getSpan(0))
-                            .hasLinksSatisfying(links(producerSpanContext.get()))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                satisfies(
-                                    MESSAGING_MESSAGE_BODY_SIZE,
-                                    val -> val.isInstanceOf(Long.class)),
-                                satisfies(
-                                    MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagB")),
-                                satisfies(
-                                    stringKey("messaging.rocketmq.broker_address"),
-                                    val -> experimentalString(val)),
-                                satisfies(
-                                    longKey("messaging.rocketmq.queue_id"),
-                                    val -> experimentalLong(val)),
-                                satisfies(
-                                    longKey("messaging.rocketmq.queue_offset"),
-                                    val -> experimentalLong(val))),
-                    span ->
-                        span.hasName("messageListener")
-                            .hasParent(trace.getSpan(0))
-                            .hasKind(SpanKind.INTERNAL)));
+                        assertBatchProcessSpan(
+                            span,
+                            trace.getSpan(0),
+                            producerSpanContext.get(),
+                            "TagB",
+                            failConsumption));
+              }
+              assertions.add(
+                  span ->
+                      span.hasName("messageListener")
+                          .hasParent(trace.getSpan(0))
+                          .hasKind(SpanKind.INTERNAL));
+              trace.hasSpansSatisfyingExactly(assertions);
+            });
+  }
+
+  private void assertBatchProcessSpan(
+      SpanDataAssert span,
+      SpanData parentSpan,
+      SpanContext producerSpanContext,
+      String messageTag,
+      boolean failed) {
+    span.hasName(emitStableMessagingSemconv() ? "process " + sharedTopic : sharedTopic + " process")
+        .hasKind(SpanKind.CONSUMER)
+        .hasParent(parentSpan)
+        .hasStatus(failed ? StatusData.error() : StatusData.unset())
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+            namespace(),
+            consumerGroup(),
+            equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
+            oldOperation("process"),
+            operationName("process"),
+            operationType("process"),
+            equalTo(
+                ERROR_TYPE,
+                emitStableMessagingSemconv() && failed
+                    ? ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT.name()
+                    : null),
+            satisfies(MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
+            satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
+            equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental(messageTag)),
+            satisfies(
+                stringKey("messaging.rocketmq.broker_address"), val -> experimentalString(val)),
+            satisfies(longKey("messaging.rocketmq.queue_id"), val -> experimentalLong(val)),
+            satisfies(longKey("messaging.rocketmq.queue_offset"), val -> experimentalLong(val)));
+    if (emitStableMessagingSemconv()) {
+      span.hasTotalRecordedLinks(0);
+    } else {
+      span.hasLinksSatisfying(links(producerSpanContext));
+    }
   }
 
   @Test
@@ -417,13 +517,16 @@ abstract class AbstractRocketMqClientTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(sharedTopic + " publish")
+                        span.hasName(producerSpanName())
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "publish"),
+                                namespace(),
+                                equalTo(MESSAGING_DESTINATION_NAME, producerDestination()),
+                                oldOperation("publish"),
+                                operationName("publish"),
+                                operationType("publish"),
                                 satisfies(
                                     MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagA")),
@@ -437,13 +540,20 @@ abstract class AbstractRocketMqClientTest {
                                     headerAttributeKey("Test-Message-Header"),
                                     singletonList("test"))),
                     span ->
-                        span.hasName(sharedTopic + " process")
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "process " + sharedTopic
+                                    : sharedTopic + " process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                namespace(),
+                                consumerGroup(),
                                 equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
+                                oldOperation("process"),
+                                operationName("process"),
+                                operationType("process"),
                                 satisfies(
                                     MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
@@ -480,25 +590,35 @@ abstract class AbstractRocketMqClientTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(sharedTopic + " publish")
+                        span.hasName(producerSpanName())
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "publish"),
+                                namespace(),
+                                equalTo(MESSAGING_DESTINATION_NAME, producerDestination()),
+                                oldOperation("publish"),
+                                operationName("publish"),
+                                operationType("publish"),
                                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, experimental("TagA")),
                                 satisfies(
                                     stringKey("messaging.rocketmq.broker_address"),
                                     val -> experimentalString(val))),
                     span ->
-                        span.hasName(sharedTopic + " process")
+                        span.hasName(
+                                emitStableMessagingSemconv()
+                                    ? "process " + sharedTopic
+                                    : sharedTopic + " process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                namespace(),
+                                consumerGroup(),
                                 equalTo(MESSAGING_DESTINATION_NAME, sharedTopic),
-                                equalTo(MESSAGING_OPERATION, "process"),
+                                oldOperation("process"),
+                                operationName("process"),
+                                operationType("process"),
                                 satisfies(
                                     MESSAGING_MESSAGE_BODY_SIZE,
                                     val -> val.isInstanceOf(Long.class)),
@@ -537,5 +657,39 @@ abstract class AbstractRocketMqClientTest {
                 });
       }
     };
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion consumerGroup() {
+    return equalTo(
+        MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? CONSUMER_GROUP : null);
+  }
+
+  private String producerSpanName() {
+    return emitStableMessagingSemconv()
+        ? "publish " + sharedTopic
+        : producerDestination() + " publish";
+  }
+
+  private String producerDestination() {
+    // the rocketmq client prefixes the topic with the namespace before the send hook runs; the
+    // namespace is only split out into messaging.rocketmq.namespace under the stable semconv
+    return emitStableMessagingSemconv() ? sharedTopic : NAMESPACE + "%" + sharedTopic;
+  }
+
+  private static AttributeAssertion namespace() {
+    return equalTo(MESSAGING_ROCKETMQ_NAMESPACE, emitStableMessagingSemconv() ? NAMESPACE : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingMessageListener.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/TracingMessageListener.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
 import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
@@ -19,6 +20,7 @@ import org.apache.rocketmq.common.message.MessageExt;
 
 class TracingMessageListener implements MessageListenerOrderly {
 
+  private final AtomicBoolean failurePending = new AtomicBoolean();
   private final AtomicInteger lastBatchSize = new AtomicInteger();
   private volatile CountDownLatch messageReceived = new CountDownLatch(1);
 
@@ -28,12 +30,19 @@ class TracingMessageListener implements MessageListenerOrderly {
     lastBatchSize.set(list.size());
     messageReceived.countDown();
     runWithSpan("messageListener", () -> {});
+    if (failurePending.compareAndSet(true, false)) {
+      return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
+    }
     return ConsumeOrderlyStatus.SUCCESS;
   }
 
   void reset() {
     messageReceived = new CountDownLatch(1);
     lastBatchSize.set(0);
+  }
+
+  void failNextMessage() {
+    failurePending.set(true);
   }
 
   void waitForMessages() throws InterruptedException {

--- a/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/base/BaseConf.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/testing/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/base/BaseConf.java
@@ -18,6 +18,7 @@ import org.apache.rocketmq.test.util.MQRandomUtils;
 import org.apache.rocketmq.test.util.RandomUtil;
 
 public class BaseConf {
+  public static final String NAMESPACE = "namespace";
   public static final String nsAddr;
   private static final String clusterName;
   private static final NamesrvController namesrvController;
@@ -36,7 +37,7 @@ public class BaseConf {
 
   public static String initTopic() {
     String topic = MQRandomUtils.getRandomTopic();
-    IntegrationTestBase.initTopic(topic, nsAddr, clusterName);
+    IntegrationTestBase.initTopic(NAMESPACE + "%" + topic, nsAddr, clusterName);
     return topic;
   }
 
@@ -46,6 +47,7 @@ public class BaseConf {
     DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("consumerGroup");
     consumer.setInstanceName(RandomUtil.getStringByUUID());
     consumer.setNamesrvAddr(nsAddr);
+    consumer.setNamespace(NAMESPACE);
     consumer.subscribe(topic, subExpression);
     consumer.setMessageListener(listener);
     consumer.start();
@@ -56,6 +58,7 @@ public class BaseConf {
     DefaultMQProducer producer = new DefaultMQProducer(RandomUtil.getStringByUUID());
     producer.setInstanceName(UUID.randomUUID().toString());
     producer.setNamesrvAddr(ns);
+    producer.setNamespace(NAMESPACE);
     producer.start();
     return producer;
   }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
@@ -35,6 +35,31 @@ tasks {
     include("**/RocketMqClientSuppressReceiveSpanTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("RocketMqClientTest.testSendAndConsumeNormalMessage")
+      includeTestsMatching("RocketMqClientTest.testConsumeFailure")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   test {
     filter {
       excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
@@ -47,7 +72,7 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpanDisabled)
+    dependsOn(testReceiveSpanDisabled, testV3Preview, testBothSemconv)
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ProducerImplInstrumentation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ProducerImplInstrumentation.java
@@ -25,6 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.rocketmq.client.apis.producer.SendReceipt;
 import org.apache.rocketmq.client.java.impl.producer.SendReceiptImpl;
 import org.apache.rocketmq.client.java.message.PublishingMessageImpl;
+import org.apache.rocketmq.client.java.route.MessageQueueImpl;
 import org.apache.rocketmq.shaded.com.google.common.util.concurrent.Futures;
 import org.apache.rocketmq.shaded.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.rocketmq.shaded.com.google.common.util.concurrent.SettableFuture;
@@ -67,12 +68,16 @@ final class ProducerImplInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static void onEnter(
         @Advice.Argument(0) SettableFuture<List<SendReceiptImpl>> future0,
+        @Advice.Argument(3) List<MessageQueueImpl> messageQueues,
         @Advice.Argument(4) List<PublishingMessageImpl> messages) {
       Instrumenter<PublishingMessageImpl, SendReceiptImpl> instrumenter = producerInstrumenter();
       int count = messages.size();
       List<SettableFuture<SendReceiptImpl>> futures = FutureConverter.convert(future0, count);
+      String namespace =
+          messageQueues.isEmpty() ? "" : messageQueues.get(0).getTopicResource().getNamespace();
       for (int i = 0; i < count; i++) {
         PublishingMessageImpl message = messages.get(i);
+        VirtualFieldStore.setNamespaceByMessage(message, namespace);
 
         // Try to extract parent context.
         Context parentContext = VirtualFieldStore.getContextByMessage(message);

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ReceiveSpanFinishingCallback.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ReceiveSpanFinishingCallback.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0.RocketMqSingletons.consumerReceiveInstrumenter;
 
 import apache.rocketmq.v2.ReceiveMessageRequest;
@@ -41,6 +42,9 @@ public class ReceiveSpanFinishingCallback implements FutureCallback<ReceiveMessa
     Instrumenter<ReceiveMessageRequest, List<MessageView>> receiveInstrumenter =
         consumerReceiveInstrumenter();
     Context parentContext = Context.current();
+    for (MessageView messageView : messageViews) {
+      VirtualFieldStore.setContextByMessage(messageView, parentContext);
+    }
     if (receiveInstrumenter.shouldStart(parentContext, request)) {
       Context context =
           InstrumenterUtil.startAndEnd(
@@ -51,8 +55,10 @@ public class ReceiveSpanFinishingCallback implements FutureCallback<ReceiveMessa
               null,
               timer.startTime(),
               timer.now());
-      for (MessageView messageView : messageViews) {
-        VirtualFieldStore.setContextByMessage(messageView, context);
+      if (!emitStableMessagingSemconv()) {
+        for (MessageView messageView : messageViews) {
+          VirtualFieldStore.setContextByMessage(messageView, context);
+        }
       }
     }
   }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeExtractor.java
@@ -5,11 +5,15 @@
 
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -18,6 +22,7 @@ import java.util.ArrayList;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.message.MessageView;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
 
 class RocketMqConsumerProcessAttributeExtractor
     implements AttributesExtractor<MessageView, ConsumeResult> {
@@ -34,8 +39,16 @@ class RocketMqConsumerProcessAttributeExtractor
         .getDeliveryTimestamp()
         .ifPresent(s -> attributes.put(MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP, s));
     attributes.put(MESSAGING_ROCKETMQ_MESSAGE_KEYS, new ArrayList<>(messageView.getKeys()));
-    attributes.put(
-        MESSAGING_ROCKETMQ_CLIENT_GROUP, VirtualFieldStore.getConsumerGroupByMessage(messageView));
+    String consumerGroup = VirtualFieldStore.getConsumerGroupByMessage(messageView);
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, consumerGroup);
+      attributes.put(
+          MESSAGING_ROCKETMQ_NAMESPACE,
+          ((MessageViewImpl) messageView).getMessageQueue().getTopicResource().getNamespace());
+    }
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup);
+    }
   }
 
   @Override

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerProcessAttributeGetter.java
@@ -77,6 +77,13 @@ class RocketMqConsumerProcessAttributeGetter
     return null;
   }
 
+  @Nullable
+  @Override
+  public String getErrorType(
+      MessageView messageView, @Nullable ConsumeResult consumeResult, @Nullable Throwable error) {
+    return consumeResult == ConsumeResult.FAILURE ? ConsumeResult.FAILURE.name() : null;
+  }
+
   @Override
   public List<String> getMessageHeader(MessageView messageView, String name) {
     String value = messageView.getProperties().get(name);

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeExtractor.java
@@ -5,7 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -31,6 +35,14 @@ class RocketMqConsumerReceiveAttributeExtractor
       @Nullable List<MessageView> messageViews,
       @Nullable Throwable error) {
     String consumerGroup = request.getGroup().getName();
-    attributes.put(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup);
+    if (emitStableMessagingSemconv()) {
+      attributes.put(MESSAGING_CONSUMER_GROUP_NAME, consumerGroup);
+      attributes.put(
+          MESSAGING_ROCKETMQ_NAMESPACE,
+          request.getMessageQueue().getTopic().getResourceNamespace());
+    }
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup);
+    }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -12,17 +12,16 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.List;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.message.MessageView;
@@ -37,16 +36,16 @@ final class RocketMqInstrumenterFactory {
   public static Instrumenter<PublishingMessageImpl, SendReceiptImpl> createProducerInstrumenter(
       OpenTelemetry openTelemetry, List<String> capturedHeaders) {
     RocketMqProducerAttributeGetter getter = new RocketMqProducerAttributeGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     AttributesExtractor<PublishingMessageImpl, SendReceiptImpl> attributesExtractor =
-        buildMessagingAttributesExtractor(getter, operation, capturedHeaders);
+        buildMessagingAttributesExtractor(getter, operationType, capturedHeaders);
 
     InstrumenterBuilder<PublishingMessageImpl, SendReceiptImpl> instrumenterBuilder =
         Instrumenter.<PublishingMessageImpl, SendReceiptImpl>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(new RocketMqProducerAttributeExtractor());
     setMessagingSendExceptionEventExtractor(instrumenterBuilder);
@@ -57,21 +56,21 @@ final class RocketMqInstrumenterFactory {
       createConsumerReceiveInstrumenter(
           OpenTelemetry openTelemetry, List<String> capturedHeaders, boolean enabled) {
     RocketMqConsumerReceiveAttributeGetter getter = new RocketMqConsumerReceiveAttributeGetter();
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
 
     AttributesExtractor<ReceiveMessageRequest, List<MessageView>> attributesExtractor =
-        buildMessagingAttributesExtractor(getter, operation, capturedHeaders);
+        buildMessagingAttributesExtractor(getter, operationType, capturedHeaders);
 
     InstrumenterBuilder<ReceiveMessageRequest, List<MessageView>> instrumenterBuilder =
         Instrumenter.<ReceiveMessageRequest, List<MessageView>>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .setEnabled(enabled)
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(new RocketMqConsumerReceiveAttributeExtractor());
     setMessagingReceiveExceptionEventExtractor(instrumenterBuilder);
-    return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return instrumenterBuilder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   public static Instrumenter<MessageView, ConsumeResult> createConsumerProcessInstrumenter(
@@ -79,16 +78,16 @@ final class RocketMqInstrumenterFactory {
       List<String> capturedHeaders,
       boolean receiveInstrumentationEnabled) {
     RocketMqConsumerProcessAttributeGetter getter = new RocketMqConsumerProcessAttributeGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     AttributesExtractor<MessageView, ConsumeResult> attributesExtractor =
-        buildMessagingAttributesExtractor(getter, operation, capturedHeaders);
+        buildMessagingAttributesExtractor(getter, operationType, capturedHeaders);
 
     InstrumenterBuilder<MessageView, ConsumeResult> instrumenterBuilder =
         Instrumenter.<MessageView, ConsumeResult>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(new RocketMqConsumerProcessAttributeExtractor())
             .setSpanStatusExtractor(
@@ -102,21 +101,18 @@ final class RocketMqInstrumenterFactory {
                 });
     setMessagingProcessExceptionEventExtractor(instrumenterBuilder);
 
-    if (receiveInstrumentationEnabled) {
-      SpanLinksExtractor<MessageView> spanLinksExtractor =
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(), new MessageMapGetter());
-      instrumenterBuilder.addSpanLinksExtractor(spanLinksExtractor);
-      return instrumenterBuilder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    }
-    return instrumenterBuilder.buildConsumerInstrumenter(new MessageMapGetter());
+    return MessagingProcessInstrumenterFactory.create(
+        instrumenterBuilder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new MessageMapGetter(),
+        receiveInstrumentationEnabled);
   }
 
   private static <T, R> AttributesExtractor<T, R> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<T, R> getter,
-      MessageOperation operation,
+      MessagingOperationType operationType,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqProducerAttributeExtractor.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -26,6 +28,10 @@ class RocketMqProducerAttributeExtractor
   @Override
   public void onStart(
       AttributesBuilder attributes, Context parentContext, PublishingMessageImpl message) {
+    if (emitStableMessagingSemconv()) {
+      attributes.put(
+          MESSAGING_ROCKETMQ_NAMESPACE, VirtualFieldStore.getNamespaceByMessage(message));
+    }
     message.getTag().ifPresent(s -> attributes.put(MESSAGING_ROCKETMQ_MESSAGE_TAG, s));
     message.getMessageGroup().ifPresent(s -> attributes.put(MESSAGING_ROCKETMQ_MESSAGE_GROUP, s));
     message

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/VirtualFieldStore.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/VirtualFieldStore.java
@@ -19,6 +19,8 @@ public class VirtualFieldStore {
       VirtualField.find(MessageView.class, Context.class);
   private static final VirtualField<PublishingMessageImpl, Map<String, String>>
       MESSAGE_EXTRA_PROPERTIES = VirtualField.find(PublishingMessageImpl.class, Map.class);
+  private static final VirtualField<PublishingMessageImpl, String> MESSAGE_NAMESPACE =
+      VirtualField.find(PublishingMessageImpl.class, String.class);
   private static final VirtualField<MessageView, String> MESSAGE_CONSUMER_GROUP =
       VirtualField.find(MessageView.class, String.class);
 
@@ -50,6 +52,15 @@ public class VirtualFieldStore {
   public static void setExtraPropertiesByMessage(
       PublishingMessageImpl message, Map<String, String> extraProperties) {
     MESSAGE_EXTRA_PROPERTIES.set(message, extraProperties);
+  }
+
+  @Nullable
+  public static String getNamespaceByMessage(PublishingMessageImpl message) {
+    return MESSAGE_NAMESPACE.get(message);
+  }
+
+  public static void setNamespaceByMessage(PublishingMessageImpl message, String namespace) {
+    MESSAGE_NAMESPACE.set(message, namespace);
   }
 
   @Nullable

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -5,20 +5,29 @@
 
 package io.opentelemetry.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.DELAY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingRocketmqMessageTypeIncubatingValues.FIFO;
@@ -41,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientException;
@@ -74,6 +84,7 @@ abstract class AbstractRocketMqClientTest {
   @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   private final ClientServiceProvider provider = ClientServiceProvider.loadService();
+  private final AtomicBoolean failurePending = new AtomicBoolean();
   private PushConsumer consumer;
   private Producer producer;
 
@@ -102,6 +113,9 @@ abstract class AbstractRocketMqClientTest {
             .setMessageListener(
                 messageView -> {
                   testing().runWithSpan("messageListener", () -> {});
+                  if (failurePending.compareAndSet(true, false)) {
+                    return ConsumeResult.FAILURE;
+                  }
                   return ConsumeResult.SUCCESS;
                 })
             .build();
@@ -137,34 +151,145 @@ abstract class AbstractRocketMqClientTest {
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                  span ->
-                      assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
-                          .hasParent(trace.getSpan(0)));
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace ->
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
-                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         assertProcessSpan(
                                 span,
-                                sendSpanData.get(),
+                                trace.getSpan(1),
                                 NORMAL_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
                                 keys,
                                 body,
                                 sendReceipt)
-                            // As the child of receive span.
-                            .hasParent(trace.getSpan(0)),
+                            .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(2)));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertProcessSpan(
+                              span,
+                              sendSpanData.get(),
+                              NORMAL_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              body,
+                              sendReceipt)
+                          // As the child of receive span.
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
+  }
+
+  @Test
+  void testConsumeFailure() throws ClientException {
+    String[] keys = new String[] {"yourMessageKey-0", "yourMessageKey-1"};
+    byte[] body = "foobar".getBytes(UTF_8);
+    Message message =
+        provider
+            .newMessageBuilder()
+            .setTopic(NORMAL_TOPIC)
+            .setTag(TAG)
+            .setKeys(keys)
+            .setBody(body)
+            .build();
+
+    failurePending.set(true);
+    SendReceipt sendReceipt =
+        testing()
+            .runWithSpan(
+                "parent",
+                (ThrowingSupplier<SendReceipt, ClientException>) () -> producer.send(message));
+    AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
+                    span ->
+                        assertFailedProcessSpan(
+                                span,
+                                trace.getSpan(1),
+                                NORMAL_TOPIC,
+                                CONSUMER_GROUP,
+                                TAG,
+                                keys,
+                                body,
+                                sendReceipt)
+                            .hasParent(trace.getSpan(1)),
+                    span ->
+                        span.hasName("messageListener")
+                            .hasKind(SpanKind.INTERNAL)
+                            .hasParent(trace.getSpan(2)));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertFailedProcessSpan(
+                              span,
+                              sendSpanData.get(),
+                              NORMAL_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              body,
+                              sendReceipt)
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
   }
 
   @Test
@@ -195,35 +320,66 @@ abstract class AbstractRocketMqClientTest {
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent"),
-                  span ->
-                      assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
-                          .hasParent(trace.getSpan(0)),
-                  span -> span.hasName("child"));
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace ->
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
-                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                    span -> span.hasName("parent"),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         assertProcessSpan(
                                 span,
-                                sendSpanData.get(),
+                                trace.getSpan(1),
                                 NORMAL_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
                                 keys,
                                 body,
                                 sendReceipt)
-                            // As the child of receive span.
-                            .hasParent(trace.getSpan(0)),
+                            .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(2)),
+                    span -> span.hasName("child"));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent"),
+                    span ->
+                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
+                    span -> span.hasName("child"));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertProcessSpan(
+                              span,
+                              sendSpanData.get(),
+                              NORMAL_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              body,
+                              sendReceipt)
+                          // As the child of receive span.
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
   }
 
   @Test
@@ -249,23 +405,20 @@ abstract class AbstractRocketMqClientTest {
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                  span ->
-                      assertProducerSpanWithFifoMessage(
-                              span, FIFO_TOPIC, TAG, keys, messageGroup, body, sendReceipt)
-                          .hasParent(trace.getSpan(0)));
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace ->
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
-                    span -> assertReceiveSpan(span, FIFO_TOPIC, CONSUMER_GROUP),
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpanWithFifoMessage(
+                                span, FIFO_TOPIC, TAG, keys, messageGroup, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         assertProcessSpanWithFifoMessage(
                                 span,
-                                sendSpanData.get(),
+                                trace.getSpan(1),
                                 FIFO_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
@@ -273,12 +426,47 @@ abstract class AbstractRocketMqClientTest {
                                 messageGroup,
                                 body,
                                 sendReceipt)
-                            // As the child of receive span.
-                            .hasParent(trace.getSpan(0)),
+                            .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(2)));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpanWithFifoMessage(
+                                span, FIFO_TOPIC, TAG, keys, messageGroup, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, FIFO_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, FIFO_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertProcessSpanWithFifoMessage(
+                              span,
+                              sendSpanData.get(),
+                              FIFO_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              messageGroup,
+                              body,
+                              sendReceipt)
+                          // As the child of receive span.
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
   }
 
   @Test
@@ -304,23 +492,20 @@ abstract class AbstractRocketMqClientTest {
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                  span ->
-                      assertProducerSpanWithDelayMessage(
-                              span, DELAY_TOPIC, TAG, keys, deliveryTimestamp, body, sendReceipt)
-                          .hasParent(trace.getSpan(0)));
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace ->
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
-                    span -> assertReceiveSpan(span, DELAY_TOPIC, CONSUMER_GROUP),
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpanWithDelayMessage(
+                                span, DELAY_TOPIC, TAG, keys, deliveryTimestamp, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         assertProcessSpanWithDelayMessage(
                                 span,
-                                sendSpanData.get(),
+                                trace.getSpan(1),
                                 DELAY_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
@@ -328,12 +513,47 @@ abstract class AbstractRocketMqClientTest {
                                 deliveryTimestamp,
                                 body,
                                 sendReceipt)
-                            // As the child of receive span.
-                            .hasParent(trace.getSpan(0)),
+                            .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(2)));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpanWithDelayMessage(
+                                span, DELAY_TOPIC, TAG, keys, deliveryTimestamp, body, sendReceipt)
+                            .hasParent(trace.getSpan(0)));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, DELAY_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, DELAY_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertProcessSpanWithDelayMessage(
+                              span,
+                              sendSpanData.get(),
+                              DELAY_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              deliveryTimestamp,
+                              body,
+                              sendReceipt)
+                          // As the child of receive span.
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
   }
 
   @Test
@@ -359,30 +579,28 @@ abstract class AbstractRocketMqClientTest {
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(
+                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
             trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                  span ->
-                      assertProducerSpan(
-                              span,
-                              NORMAL_TOPIC,
-                              TAG,
-                              keys,
-                              body,
-                              sendReceipt,
-                              equalTo(
-                                  headerAttributeKey("Test-Message-Header"), singletonList("test")))
-                          .hasParent(trace.getSpan(0)));
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace ->
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
-                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(
+                                span,
+                                NORMAL_TOPIC,
+                                TAG,
+                                keys,
+                                body,
+                                sendReceipt,
+                                equalTo(
+                                    headerAttributeKey("Test-Message-Header"),
+                                    singletonList("test")))
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         assertProcessSpan(
                                 span,
-                                sendSpanData.get(),
+                                trace.getSpan(1),
                                 NORMAL_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
@@ -392,12 +610,56 @@ abstract class AbstractRocketMqClientTest {
                                 equalTo(
                                     headerAttributeKey("Test-Message-Header"),
                                     singletonList("test")))
-                            // As the child of receive span.
-                            .hasParent(trace.getSpan(0)),
+                            .hasParent(trace.getSpan(1)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(2)));
+              } else {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        assertProducerSpan(
+                                span,
+                                NORMAL_TOPIC,
+                                TAG,
+                                keys,
+                                body,
+                                sendReceipt,
+                                equalTo(
+                                    headerAttributeKey("Test-Message-Header"),
+                                    singletonList("test")))
+                            .hasParent(trace.getSpan(0)));
+              }
+              sendSpanData.set(trace.getSpan(1));
+            },
+            trace -> {
+              if (emitStableMessagingSemconv()) {
+                trace.hasSpansSatisfyingExactly(
+                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
+                  span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
+                  span ->
+                      assertProcessSpan(
+                              span,
+                              sendSpanData.get(),
+                              NORMAL_TOPIC,
+                              CONSUMER_GROUP,
+                              TAG,
+                              keys,
+                              body,
+                              sendReceipt,
+                              equalTo(
+                                  headerAttributeKey("Test-Message-Header"), singletonList("test")))
+                          // As the child of receive span.
+                          .hasParent(trace.getSpan(0)),
+                  span ->
+                      span.hasName("messageListener")
+                          .hasKind(SpanKind.INTERNAL)
+                          .hasParent(trace.getSpan(1)));
+            });
   }
 
   private static SpanDataAssert assertProducerSpan(
@@ -416,13 +678,16 @@ abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, NORMAL),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "publish")));
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish")));
     attributeAssertions.addAll(asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
-        .hasName(topic + " publish")
+        .hasName(emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
         .hasStatus(StatusData.unset())
         .hasAttributesSatisfyingExactly(attributeAssertions);
   }
@@ -445,13 +710,16 @@ abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, FIFO),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "publish")));
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish")));
     attributeAssertions.addAll(asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
-        .hasName(topic + " publish")
+        .hasName(emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
         .hasStatus(StatusData.unset())
         .hasAttributesSatisfyingExactly(attributeAssertions);
   }
@@ -474,28 +742,59 @@ abstract class AbstractRocketMqClientTest {
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, DELAY),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "publish")));
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish")));
     attributeAssertions.addAll(asList(extraAttributes));
 
     return span.hasKind(SpanKind.PRODUCER)
-        .hasName(topic + " publish")
+        .hasName(emitStableMessagingSemconv() ? "publish " + topic : topic + " publish")
         .hasStatus(StatusData.unset())
         .hasAttributesSatisfyingExactly(attributeAssertions);
   }
 
   private static SpanDataAssert assertReceiveSpan(
       SpanDataAssert span, String topic, String consumerGroup) {
-    return span.hasKind(SpanKind.CONSUMER)
-        .hasName(topic + " receive")
+    return span.hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+        .hasName(emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
         .hasStatus(StatusData.unset())
         .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+            equalTo(
+                MESSAGING_CONSUMER_GROUP_NAME, emitStableMessagingSemconv() ? consumerGroup : null),
+            equalTo(
+                MESSAGING_ROCKETMQ_CLIENT_GROUP, emitOldMessagingSemconv() ? consumerGroup : null),
             equalTo(MESSAGING_SYSTEM, "rocketmq"),
+            namespace(),
             equalTo(MESSAGING_DESTINATION_NAME, topic),
-            equalTo(MESSAGING_OPERATION, "receive"),
+            oldOperation("receive"),
+            operationName("receive"),
+            operationType("receive"),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+  }
+
+  private static SpanDataAssert assertFailedProcessSpan(
+      SpanDataAssert span,
+      SpanData linkedSpan,
+      String topic,
+      String consumerGroup,
+      String tag,
+      String[] keys,
+      byte[] body,
+      SendReceipt sendReceipt) {
+    return assertProcessSpan(
+        span,
+        linkedSpan,
+        topic,
+        consumerGroup,
+        tag,
+        keys,
+        body,
+        sendReceipt,
+        StatusData.error(),
+        equalTo(ERROR_TYPE, emitStableMessagingSemconv() ? "FAILURE" : null));
   }
 
   private static SpanDataAssert assertProcessSpan(
@@ -508,25 +807,59 @@ abstract class AbstractRocketMqClientTest {
       byte[] body,
       SendReceipt sendReceipt,
       AttributeAssertion... extraAttributes) {
+    return assertProcessSpan(
+        span,
+        linkedSpan,
+        topic,
+        consumerGroup,
+        tag,
+        keys,
+        body,
+        sendReceipt,
+        StatusData.unset(),
+        extraAttributes);
+  }
+
+  private static SpanDataAssert assertProcessSpan(
+      SpanDataAssert span,
+      SpanData linkedSpan,
+      String topic,
+      String consumerGroup,
+      String tag,
+      String[] keys,
+      byte[] body,
+      SendReceipt sendReceipt,
+      StatusData status,
+      AttributeAssertion... extraAttributes) {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
-                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME,
+                    emitStableMessagingSemconv() ? consumerGroup : null),
+                equalTo(
+                    MESSAGING_ROCKETMQ_CLIENT_GROUP,
+                    emitOldMessagingSemconv() ? consumerGroup : null),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "process")));
+                oldOperation("process"),
+                operationName("process"),
+                operationType("process")));
     attributeAssertions.addAll(asList(extraAttributes));
 
-    return span.hasKind(SpanKind.CONSUMER)
-        .hasName(topic + " process")
-        .hasStatus(StatusData.unset())
-        // Link to send span.
-        .hasLinks(LinkData.create(linkedSpan.getSpanContext()))
-        .hasAttributesSatisfyingExactly(attributeAssertions);
+    SpanDataAssert result =
+        span.hasKind(SpanKind.CONSUMER)
+            .hasName(emitStableMessagingSemconv() ? "process " + topic : topic + " process")
+            .hasStatus(status)
+            .hasAttributesSatisfyingExactly(attributeAssertions);
+    return emitStableMessagingSemconv()
+        ? result.hasTotalRecordedLinks(0)
+        : result.hasLinks(LinkData.create(linkedSpan.getSpanContext()));
   }
 
   private static SpanDataAssert assertProcessSpanWithFifoMessage(
@@ -543,23 +876,33 @@ abstract class AbstractRocketMqClientTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
-                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME,
+                    emitStableMessagingSemconv() ? consumerGroup : null),
+                equalTo(
+                    MESSAGING_ROCKETMQ_CLIENT_GROUP,
+                    emitOldMessagingSemconv() ? consumerGroup : null),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_GROUP, messageGroup),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "process")));
+                oldOperation("process"),
+                operationName("process"),
+                operationType("process")));
     attributeAssertions.addAll(asList(extraAttributes));
 
-    return span.hasKind(SpanKind.CONSUMER)
-        .hasName(topic + " process")
-        .hasStatus(StatusData.unset())
-        // Link to send span.
-        .hasLinks(LinkData.create(linkedSpan.getSpanContext()))
-        .hasAttributesSatisfyingExactly(attributeAssertions);
+    SpanDataAssert result =
+        span.hasKind(SpanKind.CONSUMER)
+            .hasName(emitStableMessagingSemconv() ? "process " + topic : topic + " process")
+            .hasStatus(StatusData.unset())
+            .hasAttributesSatisfyingExactly(attributeAssertions);
+    return emitStableMessagingSemconv()
+        ? result.hasTotalRecordedLinks(0)
+        : result.hasLinks(LinkData.create(linkedSpan.getSpanContext()));
   }
 
   private static SpanDataAssert assertProcessSpanWithDelayMessage(
@@ -576,22 +919,49 @@ abstract class AbstractRocketMqClientTest {
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
-                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                equalTo(
+                    MESSAGING_CONSUMER_GROUP_NAME,
+                    emitStableMessagingSemconv() ? consumerGroup : null),
+                equalTo(
+                    MESSAGING_ROCKETMQ_CLIENT_GROUP,
+                    emitOldMessagingSemconv() ? consumerGroup : null),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
                 equalTo(MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP, deliveryTimestamp),
                 equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
                 equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                namespace(),
                 equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
                 equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, "process")));
+                oldOperation("process"),
+                operationName("process"),
+                operationType("process")));
     attributeAssertions.addAll(asList(extraAttributes));
 
-    return span.hasKind(SpanKind.CONSUMER)
-        .hasName(topic + " process")
-        .hasStatus(StatusData.unset())
-        // Link to send span.
-        .hasLinks(LinkData.create(linkedSpan.getSpanContext()))
-        .hasAttributesSatisfyingExactly(attributeAssertions);
+    SpanDataAssert result =
+        span.hasKind(SpanKind.CONSUMER)
+            .hasName(emitStableMessagingSemconv() ? "process " + topic : topic + " process")
+            .hasStatus(StatusData.unset())
+            .hasAttributesSatisfyingExactly(attributeAssertions);
+    return emitStableMessagingSemconv()
+        ? result.hasTotalRecordedLinks(0)
+        : result.hasLinks(LinkData.create(linkedSpan.getSpanContext()));
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion namespace() {
+    return equalTo(MESSAGING_ROCKETMQ_NAMESPACE, emitStableMessagingSemconv() ? "" : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/build.gradle.kts
@@ -28,6 +28,21 @@ otelJava {
   minJavaVersionSupported.set(JavaVersion.VERSION_17)
 }
 
+tasks {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("io.opentelemetry.javaagent.instrumentation.spring.cloud.aws.v3_0.AwsSqsTest")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testMessagingPreview)
+  }
+}
+
 if (otelProps.denyUnsafe) {
   // org.elasticmq:elasticmq-rest-sqs_2.13 uses unsafe. Future versions are likely to fix this.
   tasks.withType<Test>().configureEach {

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/SpringAwsUtil.java
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/SpringAwsUtil.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.cloud.aws.v3_0;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -83,10 +84,14 @@ public class SpringAwsUtil {
     if (tracingContext == null) {
       return null;
     }
-    SqsMessage wrappedMessage = SqsMessageImpl.wrap(tracingContext.sqsMessage);
-    Context parentContext = tracingContext.receiveContext;
+    SqsMessage wrappedMessage =
+        SqsMessageImpl.wrap(tracingContext.sqsMessage, tracingContext.config);
+    Context parentContext = tracingContext.processParentContext;
     if (parentContext == null) {
-      parentContext = SqsParentContext.ofMessage(wrappedMessage, tracingContext.config);
+      parentContext = wrappedMessage.getCreationContext();
+    } else if (!Span.fromContext(parentContext).getSpanContext().isValid()) {
+      parentContext =
+          SqsParentContext.ofMessage(parentContext, wrappedMessage, tracingContext.config);
     }
     return parentContext.makeCurrent();
   }
@@ -121,7 +126,7 @@ public class SpringAwsUtil {
     private final Response response;
     private final Instrumenter<SqsProcessRequest, Response> instrumenter;
     private final TracingExecutionInterceptor config;
-    @Nullable private final Context receiveContext;
+    @Nullable private final Context processParentContext;
     private final software.amazon.awssdk.services.sqs.model.Message sqsMessage;
 
     private TracingContext(
@@ -130,16 +135,16 @@ public class SpringAwsUtil {
       this.response = tracingList.getResponse();
       this.instrumenter = tracingList.getInstrumenter();
       this.config = tracingList.getConfig();
-      this.receiveContext = tracingList.getReceiveContext();
+      this.processParentContext = tracingList.getProcessParentContext();
       this.sqsMessage = sqsMessage;
     }
 
     @Nullable
     MessageScope trace() {
-      SqsMessage wrappedMessage = SqsMessageImpl.wrap(sqsMessage);
-      Context parentContext = receiveContext;
+      SqsMessage wrappedMessage = SqsMessageImpl.wrap(sqsMessage, config);
+      Context parentContext = processParentContext;
       if (parentContext == null) {
-        parentContext = SqsParentContext.ofMessage(wrappedMessage, config);
+        parentContext = wrappedMessage.getCreationContext();
       }
       SqsProcessRequest processRequest = SqsProcessRequest.create(request, wrappedMessage);
       if (!instrumenter.shouldStart(parentContext, processRequest)) {

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/AwsSqsTest.java
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/AwsSqsTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.cloud.aws.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -18,6 +19,8 @@ import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SQ
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
@@ -103,7 +106,10 @@ class AwsSqsTest {
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
                             satisfies(AWS_REQUEST_ID, val -> val.isInstanceOf(String.class))),
                 span ->
-                    span.hasName("test-queue publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish test-queue"
+                                : "test-queue publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -121,7 +127,15 @@ class AwsSqsTest {
                                         "http://localhost:" + AwsSqsTestApplication.sqsPort)),
                             equalTo(MESSAGING_SYSTEM, AWS_SQS),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(
+                                MESSAGING_OPERATION,
+                                emitStableMessagingSemconv() ? null : "publish"),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "publish" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "send" : null),
                             equalTo(MESSAGING_DESTINATION_NAME, "test-queue"),
                             equalTo(
                                 AWS_SQS_QUEUE_URL,
@@ -129,27 +143,41 @@ class AwsSqsTest {
                                     + AwsSqsTestApplication.sqsPort
                                     + "/000000000000/test-queue"),
                             satisfies(AWS_REQUEST_ID, val -> val.isInstanceOf(String.class))),
-                span ->
-                    span.hasName("test-queue process")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(2))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(RPC_SYSTEM, "aws-api"),
-                            equalTo(RPC_METHOD, "ReceiveMessage"),
-                            equalTo(RPC_SERVICE, "Sqs"),
-                            equalTo(HTTP_REQUEST_METHOD, POST),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
-                            equalTo(SERVER_ADDRESS, "localhost"),
-                            equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
-                            satisfies(
-                                URL_FULL,
-                                val ->
-                                    val.startsWith(
-                                        "http://localhost:" + AwsSqsTestApplication.sqsPort)),
-                            equalTo(MESSAGING_SYSTEM, AWS_SQS),
-                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "test-queue")),
+                span -> {
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process test-queue"
+                              : "test-queue process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(2))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(RPC_SYSTEM, "aws-api"),
+                          equalTo(RPC_METHOD, "ReceiveMessage"),
+                          equalTo(RPC_SERVICE, "Sqs"),
+                          equalTo(HTTP_REQUEST_METHOD, POST),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                          equalTo(SERVER_ADDRESS, "localhost"),
+                          equalTo(SERVER_PORT, AwsSqsTestApplication.sqsPort),
+                          satisfies(
+                              URL_FULL,
+                              val ->
+                                  val.startsWith(
+                                      "http://localhost:" + AwsSqsTestApplication.sqsPort)),
+                          equalTo(MESSAGING_SYSTEM, AWS_SQS),
+                          satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                          equalTo(
+                              MESSAGING_OPERATION, emitStableMessagingSemconv() ? null : "process"),
+                          equalTo(
+                              MESSAGING_OPERATION_NAME,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          equalTo(
+                              MESSAGING_OPERATION_TYPE,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          equalTo(MESSAGING_DESTINATION_NAME, "test-queue"));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasTotalRecordedLinks(0);
+                  }
+                },
                 span ->
                     span.hasName("callback").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(3)),
                 span ->

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -67,6 +67,21 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.spring-integration.producer.enabled=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringIntegrationAndRabbitTest")
+      excludeTestsMatching("SpringCloudStreamRabbitTest")
+    }
+    jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-integration.producer.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("SpringIntegrationAndRabbitTest")
@@ -77,7 +92,7 @@ tasks {
   }
 
   check {
-    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation)
+    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation, testV3Preview)
   }
 
   withType<Test>().configureEach {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -119,7 +120,10 @@ class SpringIntegrationAndRabbitTest {
                             equalTo(MESSAGING_OPERATION, "process"),
                             satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)),
                             satisfies(
-                                MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class))),
+                                MESSAGING_MESSAGE_BODY_SIZE, val -> val.isInstanceOf(Long.class)),
+                            equalTo(
+                                MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+                                emitStableMessagingSemconv() ? "testTopic" : null)),
                 span ->
                     span.hasName("consumer").hasParent(trace.getSpan(8)).hasTotalAttributeCount(0)),
         trace ->

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -24,9 +24,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }
 

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -12,9 +12,11 @@ import static java.util.Collections.emptyList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
@@ -75,32 +77,37 @@ public final class SpringIntegrationTelemetryBuilder {
    * SpringIntegrationTelemetryBuilder}.
    */
   public SpringIntegrationTelemetry build() {
+    SpringMessagingAttributesGetter consumerGetter = new SpringMessagingAttributesGetter(false);
+    SpringMessagingAttributesGetter consumerNameGetter = new SpringMessagingAttributesGetter(true);
     InstrumenterBuilder<MessageWithChannel, Void> consumerBuilder =
         Instrumenter.<MessageWithChannel, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                SpringIntegrationTelemetryBuilder::consumerSpanName)
+                MessagingSpanNameExtractor.create(
+                    consumerNameGetter, MessagingOperationType.PROCESS))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    new SpringMessagingAttributesGetter(),
-                    MessageOperation.PROCESS,
-                    capturedHeaders));
+                    consumerGetter, MessagingOperationType.PROCESS, capturedHeaders));
     setMessagingProcessExceptionEventExtractor(consumerBuilder);
     Instrumenter<MessageWithChannel, Void> consumerInstrumenter =
-        consumerBuilder.buildConsumerInstrumenter(MessageHeadersGetter.INSTANCE);
+        MessagingProcessInstrumenterFactory.create(
+            consumerBuilder,
+            openTelemetry.getPropagators().getTextMapPropagator(),
+            MessageHeadersGetter.INSTANCE,
+            false);
 
+    SpringMessagingAttributesGetter producerGetter = new SpringMessagingAttributesGetter(false);
+    SpringMessagingAttributesGetter producerNameGetter = new SpringMessagingAttributesGetter(true);
     InstrumenterBuilder<MessageWithChannel, Void> producerBuilder =
         Instrumenter.<MessageWithChannel, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                SpringIntegrationTelemetryBuilder::producerSpanName)
+                MessagingSpanNameExtractor.create(producerNameGetter, MessagingOperationType.SEND))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    new SpringMessagingAttributesGetter(),
-                    MessageOperation.PUBLISH,
-                    capturedHeaders));
+                    producerGetter, MessagingOperationType.SEND, capturedHeaders));
     setMessagingSendExceptionEventExtractor(producerBuilder);
     Instrumenter<MessageWithChannel, Void> producerInstrumenter =
         producerBuilder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
@@ -111,19 +118,11 @@ public final class SpringIntegrationTelemetryBuilder {
         producerSpanEnabled);
   }
 
-  private static String consumerSpanName(MessageWithChannel messageWithChannel) {
-    return messageWithChannel.getChannelName() + " process";
-  }
-
-  private static String producerSpanName(MessageWithChannel messageWithChannel) {
-    return messageWithChannel.getChannelName() + " publish";
-  }
-
   private static AttributesExtractor<MessageWithChannel, Void> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<MessageWithChannel, Void> getter,
-      MessageOperation operation,
+      MessagingOperationType operationType,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -16,16 +17,24 @@ import javax.annotation.Nullable;
 final class SpringMessagingAttributesGetter
     implements MessagingAttributesGetter<MessageWithChannel, Void> {
 
-  @Override
-  @Nullable
-  public String getSystem(MessageWithChannel messageWithChannel) {
-    return null;
+  private final boolean spanNameGetter;
+
+  SpringMessagingAttributesGetter(boolean spanNameGetter) {
+    this.spanNameGetter = spanNameGetter;
   }
 
-  @Override
   @Nullable
+  @Override
+  public String getSystem(MessageWithChannel messageWithChannel) {
+    return emitStableMessagingSemconv() ? "spring_integration" : null;
+  }
+
+  @Nullable
+  @Override
   public String getDestination(MessageWithChannel messageWithChannel) {
-    return null;
+    return spanNameGetter || emitStableMessagingSemconv()
+        ? messageWithChannel.getChannelName()
+        : null;
   }
 
   @Nullable

--- a/instrumentation/spring/spring-integration-4.1/metadata.yaml
+++ b/instrumentation/spring/spring-integration-4.1/metadata.yaml
@@ -1,6 +1,8 @@
 display_name: Spring Integration
 description: This instrumentation enables producer and consumer messaging spans for Spring Integration.
 library_link: https://spring.io/projects/spring-integration
+semantic_conventions:
+  - MESSAGING_SPANS
 configurations:
   - name: otel.instrumentation.spring-integration.producer.enabled
     declarative_name: java.spring_integration.producer.enabled

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 
@@ -81,11 +83,23 @@ abstract class AbstractComplexPropagationTest {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("application.sendChannel process").hasKind(SpanKind.CONSUMER),
                 span ->
-                    span.hasName("application.receiveChannel process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process application.sendChannel"
+                                : "application.sendChannel process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "application.sendChannel")),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process application.receiveChannel"
+                                : "application.receiveChannel process")
                         .hasParent(trace.getSpan(0))
-                        .hasKind(SpanKind.CONSUMER),
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "application.receiveChannel")),
                 span -> span.hasName("handler").hasParent(trace.getSpan(1))));
 
     receiveChannel.unsubscribe(messageHandler);

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -38,13 +40,23 @@ abstract class AbstractSpringCloudStreamProducerTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer").hasKind(SpanKind.INTERNAL),
                 span ->
-                    span.hasName("testProducer.output publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish testProducer.output"
+                                : "testProducer.output publish")
                         .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0)),
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("publish", "testProducer.output")),
                 span ->
-                    span.hasName("testConsumer.input process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process testConsumer.input"
+                                : "testConsumer.input process")
                         .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1)),
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "testConsumer.input")),
                 span ->
                     span.hasName("consumer")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamRabbitTest.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
+
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.Test;
@@ -31,9 +34,14 @@ abstract class AbstractSpringCloudStreamRabbitTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer").hasKind(SpanKind.INTERNAL),
                 span ->
-                    span.hasName("testConsumer.input process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process testConsumer.input"
+                                : "testConsumer.input process")
                         .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(0)),
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "testConsumer.input")),
                 span ->
                     span.hasName("consumer")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,12 +74,9 @@ abstract class AbstractSpringIntegrationTracingTest {
 
   @ParameterizedTest
   @CsvSource(
-      value = {
-        "directChannel,application.directChannel process",
-        "executorChannel,executorChannel process"
-      },
+      value = {"directChannel,application.directChannel", "executorChannel,executorChannel"},
       delimiter = ',')
-  void shouldPropagateContext(String channelName, String interceptorSpanName) {
+  void shouldPropagateContext(String channelName, String destinationName) {
     SubscribableChannel channel =
         applicationContext.getBean(channelName, SubscribableChannel.class);
 
@@ -89,7 +91,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(interceptorSpanName).hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + destinationName
+                              : destinationName + " process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", destinationName));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -113,7 +121,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.directChannel2 process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.directChannel2"
+                              : "application.directChannel2 process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", "application.directChannel2"));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -164,7 +178,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.linkedChannel1 process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.linkedChannel1"
+                              : "application.linkedChannel1 process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", "application.linkedChannel1"));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -192,7 +212,18 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.directChannel process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.directChannel"
+                              : "application.directChannel process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes(
+                              "process",
+                              "application.directChannel",
+                              equalTo(
+                                  headerAttributeKey("Test-Message-Header"),
+                                  singletonList("test"))));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+
+final class SpringIntegrationTestHelper {
+
+  static AttributeAssertion[] messagingAttributes(String operation, String destinationName) {
+    return messagingAttributes(operation, destinationName, new AttributeAssertion[0]);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  static AttributeAssertion[] messagingAttributes(
+      String operation, String destinationName, AttributeAssertion... additionalAssertions) {
+    AttributeAssertion[] standard =
+        new AttributeAssertion[] {
+          equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "spring_integration" : null),
+          equalTo(
+              MESSAGING_DESTINATION_NAME, emitStableMessagingSemconv() ? destinationName : null),
+          equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null),
+          equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null),
+          equalTo(
+              MESSAGING_OPERATION_TYPE,
+              emitStableMessagingSemconv()
+                  ? operation.equals("publish") ? "send" : operation
+                  : null)
+        };
+    AttributeAssertion[] result =
+        new AttributeAssertion[standard.length + additionalAssertions.length];
+    System.arraycopy(standard, 0, result, 0, standard.length);
+    System.arraycopy(additionalAssertions, 0, result, standard.length, additionalAssertions.length);
+    return result;
+  }
+
+  private SpringIntegrationTestHelper() {}
+}

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -73,7 +73,16 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testing.suites)
+    dependsOn(testing.suites, testV3Preview)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 
 import io.opentelemetry.instrumentation.spring.jms.v2_0.AbstractJmsTest;
@@ -42,7 +44,7 @@ class SpringListenerTest extends AbstractJmsTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(PRODUCER, CONSUMER),
+        orderByRootSpanKind(PRODUCER, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> assertProducerSpan(span, "SpringListenerJms2", false));

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -179,10 +180,14 @@ class SpringTemplateTest extends AbstractJmsTest {
     AtomicReference<SpanData> tmpProducerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName(
-            "SpringTemplateJms2 publish",
-            "SpringTemplateJms2 receive",
-            "(temporary) publish",
-            "(temporary) receive"),
+            emitStableMessagingSemconv()
+                ? "publish SpringTemplateJms2"
+                : "SpringTemplateJms2 publish",
+            emitStableMessagingSemconv()
+                ? "receive SpringTemplateJms2"
+                : "SpringTemplateJms2 receive",
+            emitStableMessagingSemconv() ? "publish" : "(temporary) publish",
+            emitStableMessagingSemconv() ? "receive" : "(temporary) receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> assertProducerSpan(span, "SpringTemplateJms2", false));

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
@@ -6,14 +6,19 @@
 package io.opentelemetry.instrumentation.spring.jms.v2_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -32,7 +37,10 @@ public abstract class AbstractJmsTest {
       SpanDataAssert span, String destinationName, boolean testHeaders) {
     List<AttributeAssertion> attributeAssertions =
         producerAttributeAssertions(destinationName, testHeaders);
-    span.hasName(destinationName + " publish")
+    span.hasName(
+            emitStableMessagingSemconv()
+                ? destinationName.equals("(temporary)") ? "publish" : "publish " + destinationName
+                : destinationName + " publish")
         .hasKind(PRODUCER)
         .hasNoParent()
         .hasAttributesSatisfyingExactly(attributeAssertions);
@@ -44,8 +52,10 @@ public abstract class AbstractJmsTest {
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "jms"),
-                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MESSAGING_OPERATION, "publish"),
+                messagingDestinationName(destinationName),
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish"),
                 satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
     if (destinationName.equals("(temporary)")) {
       attributeAssertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
@@ -68,7 +78,13 @@ public abstract class AbstractJmsTest {
       String operation,
       boolean testHeaders,
       String msgId) {
-    span.hasName(destinationName + " " + operation).hasKind(CONSUMER);
+    span.hasName(
+            emitStableMessagingSemconv()
+                ? destinationName.equals("(temporary)")
+                    ? operation
+                    : operation + " " + destinationName
+                : destinationName + " " + operation)
+        .hasKind(emitStableMessagingSemconv() && operation.equals("receive") ? CLIENT : CONSUMER);
     if (parent != null) {
       span.hasParent(parent);
     } else {
@@ -87,8 +103,10 @@ public abstract class AbstractJmsTest {
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "jms"),
-                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MESSAGING_OPERATION, operation)));
+                messagingDestinationName(destinationName),
+                oldOperation(operation),
+                operationName(operation),
+                operationType(operation)));
     if (msgId != null) {
       attributeAssertions.add(equalTo(MESSAGING_MESSAGE_ID, msgId));
     } else {
@@ -106,5 +124,24 @@ public abstract class AbstractJmsTest {
               stringArrayKey("messaging.header.Test_Message_Int_Header"), singletonList("1234")));
     }
     return attributeAssertions;
+  }
+
+  private static AttributeAssertion messagingDestinationName(String destinationName) {
+    return emitStableMessagingSemconv() && destinationName.equals("(temporary)")
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -51,6 +51,18 @@ tasks {
     include("**/SpringListenerSuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
@@ -63,6 +75,6 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpansDisabled)
+    dependsOn(testReceiveSpansDisabled, testV3Preview)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -6,20 +6,26 @@
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.jms.ConnectionFactory;
@@ -39,18 +45,23 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
   void assertSpringJmsListener() {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, CONSUMER),
+        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasNoParent(),
               span ->
-                  span.hasName("spring-jms-listener publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "publish spring-jms-listener"
+                              : "spring-jms-listener publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)));
 
           producerSpan.set(trace.getSpan(1));
@@ -58,24 +69,34 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("spring-jms-listener receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive spring-jms-listener"
+                                : "spring-jms-listener receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span ->
-                    span.hasName("spring-jms-listener process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process spring-jms-listener"
+                                : "spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
@@ -113,18 +134,23 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
     assertThat(receivedMessage.get(10, SECONDS)).isEqualTo(message);
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, CONSUMER),
+        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName("spring-jms-listener publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish spring-jms-listener"
+                                : "spring-jms-listener publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -135,13 +161,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("spring-jms-listener receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive spring-jms-listener"
+                                : "spring-jms-listener receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -150,13 +181,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName("spring-jms-listener process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process spring-jms-listener"
+                                : "spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -165,5 +201,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/build.gradle.kts
@@ -83,6 +83,31 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SpringKafkaTest.shouldCreateSpansForSingleRecordProcess")
+      includeTestsMatching("SpringKafkaTest.shouldHandleFailureInKafkaListener")
+      includeTestsMatching("SpringKafkaTest.shouldCreateSpansForBatchReceiveAndProcess")
+      includeTestsMatching("SpringKafkaTest.shouldHandleFailureInKafkaBatchListener")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     systemProperty(
@@ -92,7 +117,7 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }
 

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -7,18 +7,25 @@ package io.opentelemetry.javaagent.instrumentation.spring.kafka.v2_7;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -77,75 +84,67 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testSingleTopic", "10")),
+                span ->
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            singleProcessAttributes("testSingleTopic", "testSingleListener", "10")),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+            producer.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes("testSingleTopic", "testSingleListener", 1))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testSingleTopic publish")
+                  span.hasName(spanName("testSingleTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testSingleTopic", "10")));
 
           producer.set(trace.getSpan(1));
         },
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testSingleTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1)),
+                            receiveAttributes("testSingleTopic", "testSingleListener", 1)),
                 span ->
-                    span.hasName("testSingleTopic process")
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producer.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            satisfies(
-                                MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            satisfies(
-                                longKey("kafka.record.queue_time_ms"),
-                                val -> {
-                                  if (EXPERIMENTAL_ATTRIBUTES) {
-                                    val.isNotNegative();
-                                  }
-                                })),
+                            singleProcessAttributes("testSingleTopic", "testSingleListener", "10")),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -163,64 +162,64 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     Consumer<SpanDataAssert> receiveSpanAssert =
         span ->
-            span.hasName("testSingleTopic receive")
-                .hasKind(SpanKind.CONSUMER)
+            span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                .hasKind(receiveKind())
                 .hasNoParent()
                 .hasAttributesSatisfyingExactly(
-                    equalTo(MESSAGING_SYSTEM, "kafka"),
-                    equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                    equalTo(MESSAGING_OPERATION, "receive"),
-                    equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                    satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                    equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+                    receiveAttributes("testSingleTopic", "testSingleListener", 1));
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            satisfies(
-                longKey("kafka.record.queue_time_ms"),
-                val -> {
-                  if (EXPERIMENTAL_ATTRIBUTES) {
-                    val.isNotNegative();
-                  }
-                }));
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+      assertions.add(
+          trace -> {
+            List<Consumer<SpanDataAssert>> spanAssertions = new ArrayList<>();
+            spanAssertions.add(span -> span.hasName("producer"));
+            spanAssertions.add(
+                span ->
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testSingleTopic", "10")));
+            addSingleProcessAssertions(spanAssertions, trace, 2, true, testLatestDeps());
+            addSingleProcessAssertions(
+                spanAssertions, trace, testLatestDeps() ? 5 : 4, true, testLatestDeps());
+            addSingleProcessAssertions(
+                spanAssertions, trace, testLatestDeps() ? 8 : 6, false, false);
+            trace.hasSpansSatisfyingExactly(spanAssertions);
+            producer.set(trace.getSpan(1));
+          });
+      int receiveCount = testLatestDeps() ? 1 : 3;
+      for (int i = 0; i < receiveCount; i++) {
+        assertions.add(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertStableReceiveSpan(
+                            span, producer.get(), "testSingleTopic", "testSingleListener")));
+      }
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), assertions);
+      return;
+    }
+
     // trace structure differs in latest dep tests because CommonErrorHandler is only set for latest
     // dep tests
     if (testLatestDeps()) {
       testing.waitAndAssertSortedTraces(
-          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+          orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testSingleTopic publish")
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("producer")),
-                            equalTo(
-                                stringKey("messaging.kafka.bootstrap.servers"),
-                                EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                            producerAttributes("testSingleTopic", "10")));
 
             producer.set(trace.getSpan(1));
           },
@@ -228,59 +227,45 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(1)),
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(4)),
                   span -> span.hasName("handle exception").hasParent(trace.getSpan(4)),
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, false)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(7))));
 
     } else {
       testing.waitAndAssertSortedTraces(
-          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+          orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
                 span ->
-                    span.hasName("testSingleTopic publish")
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
-                            satisfies(
-                                MESSAGING_DESTINATION_PARTITION_ID,
-                                AbstractStringAssert::isNotEmpty),
-                            satisfies(
-                                MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("producer")),
-                            equalTo(
-                                stringKey("messaging.kafka.bootstrap.servers"),
-                                EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                            producerAttributes("testSingleTopic", "10")));
 
             producer.set(trace.getSpan(1));
           },
@@ -288,35 +273,35 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasStatus(StatusData.error())
                           .hasException(new IllegalArgumentException("boom"))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   receiveSpanAssert,
                   span ->
-                      span.hasName("testSingleTopic process")
+                      span.hasName(spanName("testSingleTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(0))
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
-                          .hasAttributesSatisfyingExactly(processAttributes),
+                          .hasAttributesSatisfyingExactly(withErrorType(processAttributes, false)),
                   span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
     }
   }
@@ -331,47 +316,67 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
     AtomicReference<SpanData> producer1 = new AtomicReference<>();
     AtomicReference<SpanData> producer2 = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testBatchTopic", "20")));
+            producer1.set(trace.getSpan(1));
+            producer2.set(trace.getSpan(2));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasNoParent()
+                          .hasLinks(
+                              LinkData.create(producer1.get().getSpanContext()),
+                              LinkData.create(producer2.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasNoParent()
+                          .hasLinks(
+                              LinkData.create(producer1.get().getSpanContext()),
+                              LinkData.create(producer2.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              receiveAttributes("testBatchTopic", "testBatchListener", 2))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
         trace -> {
           trace.hasSpansSatisfyingExactlyInAnyOrder(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)),
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "20")));
 
           producer1.set(trace.getSpan(1));
           producer2.set(trace.getSpan(2));
@@ -379,34 +384,20 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("testBatchTopic receive")
-                        .hasKind(SpanKind.CONSUMER)
+                    span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                        .hasKind(receiveKind())
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            receiveAttributes("testBatchTopic", "testBatchListener", 2)),
                 span ->
-                    span.hasName("testBatchTopic process")
+                    span.hasName(spanName("testBatchTopic", "process", "process"))
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(
                             LinkData.create(producer1.get().getSpanContext()),
                             LinkData.create(producer2.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "kafka"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                            satisfies(
-                                stringKey("messaging.client_id"),
-                                val -> val.startsWith("consumer")),
-                            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                            batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
@@ -424,29 +415,47 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+      assertions.add(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testBatchTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            producerAttributes("testBatchTopic", "10")));
+            producer.set(trace.getSpan(1));
+          });
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), true));
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), true));
+      assertions.add(trace -> assertStableBatchProcessTrace(trace, producer.get(), false));
+      int receiveCount = testLatestDeps() ? 1 : 3;
+      for (int i = 0; i < receiveCount; i++) {
+        assertions.add(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertStableReceiveSpan(
+                            span, producer.get(), "testBatchTopic", "testBatchListener")));
+      }
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT), assertions);
+      return;
+    }
+
     List<Consumer<TraceAssert>> assertions = new ArrayList<>();
     assertions.add(
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer"),
               span ->
-                  span.hasName("testBatchTopic publish")
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, "kafka"),
-                          equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
-                          satisfies(
-                              MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                          satisfies(
-                              MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-                          equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                          satisfies(
-                              stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                          equalTo(
-                              stringKey("messaging.kafka.bootstrap.servers"),
-                              EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null)));
+                      .hasAttributesSatisfyingExactly(producerAttributes("testBatchTopic", "10")));
 
           producer.set(trace.getSpan(1));
         });
@@ -484,37 +493,194 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
     }
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER), assertions);
+        orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()), assertions);
   }
 
   private static void assertReceiveSpan(SpanDataAssert span) {
-    span.hasName("testBatchTopic receive")
-        .hasKind(SpanKind.CONSUMER)
+    span.hasName(spanName("testBatchTopic", "receive", "poll"))
+        .hasKind(receiveKind())
         .hasNoParent()
         .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "receive"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            receiveAttributes("testBatchTopic", "testBatchListener", 1));
+  }
+
+  private static void addSingleProcessAssertions(
+      List<Consumer<SpanDataAssert>> assertions,
+      TraceAssert trace,
+      int processIndex,
+      boolean failed,
+      boolean addExceptionHandler) {
+    List<AttributeAssertion> processAttributes =
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
+    assertions.add(
+        span -> {
+          span.hasName(spanName("testSingleTopic", "process", "process"))
+              .hasKind(SpanKind.CONSUMER)
+              .hasParent(trace.getSpan(1))
+              .hasAttributesSatisfyingExactly(withErrorType(processAttributes, failed));
+          if (failed) {
+            span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
+          }
+        });
+    assertions.add(span -> span.hasName("consumer").hasParent(trace.getSpan(processIndex)));
+    if (addExceptionHandler) {
+      assertions.add(
+          span -> span.hasName("handle exception").hasParent(trace.getSpan(processIndex)));
+    }
+  }
+
+  private static void assertStableBatchProcessTrace(
+      TraceAssert trace, SpanData producer, boolean failed) {
+    trace.hasSpansSatisfyingExactly(
+        span -> {
+          span.hasName(spanName("testBatchTopic", "process", "process"))
+              .hasKind(SpanKind.CONSUMER)
+              .hasNoParent()
+              .hasLinks(LinkData.create(producer.getSpanContext()))
+              .hasAttributesSatisfyingExactly(
+                  withErrorType(
+                      batchProcessAttributes("testBatchTopic", "testBatchListener", 1), failed));
+          if (failed) {
+            span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
+          }
+        },
+        span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
+  }
+
+  private static void assertStableReceiveSpan(
+      SpanDataAssert span, SpanData producer, String topic, String group) {
+    span.hasName(spanName(topic, "receive", "poll"))
+        .hasKind(SpanKind.CLIENT)
+        .hasNoParent()
+        .hasLinks(LinkData.create(producer.getSpanContext()))
+        .hasAttributesSatisfyingExactly(receiveAttributes(topic, group, 1));
   }
 
   private static void assertProcessSpan(
       SpanDataAssert span, TraceAssert trace, SpanData producer, boolean failed) {
-    span.hasName("testBatchTopic process")
+    span.hasName(spanName("testBatchTopic", "process", "process"))
         .hasKind(SpanKind.CONSUMER)
         .hasParent(trace.getSpan(0))
         .hasLinks(LinkData.create(producer.getSpanContext()))
         .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+            withErrorType(
+                batchProcessAttributes("testBatchTopic", "testBatchListener", 1), failed));
     if (failed) {
       span.hasStatus(StatusData.error()).hasException(new IllegalArgumentException("boom"));
     }
+  }
+
+  private static List<AttributeAssertion> producerAttributes(String topic, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    assertions.add(
+        equalTo(
+            stringKey("messaging.kafka.bootstrap.servers"),
+            EXPERIMENTAL_ATTRIBUTES ? kafka.getBootstrapServers() : null));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> receiveAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "receive", "poll", "receive", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> singleProcessAttributes(
+      String topic, String group, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative));
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    addGroupAssertions(assertions, group);
+    assertions.add(
+        satisfies(
+            longKey("kafka.record.queue_time_ms"),
+            val -> {
+              if (EXPERIMENTAL_ATTRIBUTES) {
+                val.isNotNegative();
+              }
+            }));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> batchProcessAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
+  }
+
+  private static List<AttributeAssertion> withErrorType(
+      List<AttributeAssertion> assertions, boolean failed) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv() && failed) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  private static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
   }
 }

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -6,19 +6,26 @@
 package io.opentelemetry.testing;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 
@@ -61,44 +68,18 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                equalTo(MESSAGING_OPERATION, "publish"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("producer")),
-                                satisfies(
-                                    MESSAGING_DESTINATION_PARTITION_ID,
-                                    AbstractStringAssert::isNotEmpty),
-                                satisfies(
-                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                    AbstractLongAssert::isNotNegative),
-                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                                sendAttributes("testSingleTopic", "10")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                satisfies(
-                                    MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-                                satisfies(
-                                    MESSAGING_DESTINATION_PARTITION_ID,
-                                    AbstractStringAssert::isNotEmpty),
-                                satisfies(
-                                    MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                    AbstractLongAssert::isNotNegative),
-                                equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("consumer"))),
+                                singleProcessAttributes(
+                                    "testSingleTopic", "testSingleListener", "10")),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 
@@ -116,16 +97,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             });
 
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
-            satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-            satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative),
-            equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testSingleListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")));
+        singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
 
     testing()
         .waitAndAssertTraces(
@@ -135,30 +107,19 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                       asList(
                           span -> span.hasName("producer"),
                           span ->
-                              span.hasName("testSingleTopic publish")
+                              span.hasName(spanName("testSingleTopic", "publish", "send"))
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
-                                      equalTo(MESSAGING_SYSTEM, "kafka"),
-                                      equalTo(MESSAGING_DESTINATION_NAME, "testSingleTopic"),
-                                      equalTo(MESSAGING_OPERATION, "publish"),
-                                      satisfies(
-                                          stringKey("messaging.client_id"),
-                                          val -> val.startsWith("producer")),
-                                      satisfies(
-                                          MESSAGING_DESTINATION_PARTITION_ID,
-                                          AbstractStringAssert::isNotEmpty),
-                                      satisfies(
-                                          MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                          AbstractLongAssert::isNotNegative),
-                                      equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                                      sendAttributes("testSingleTopic", "10")),
                           span ->
-                              span.hasName("testSingleTopic process")
+                              span.hasName(spanName("testSingleTopic", "process", "process"))
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(1))
                                   .hasStatus(StatusData.error())
                                   .hasException(new IllegalArgumentException("boom"))
-                                  .hasAttributesSatisfyingExactly(processAttributes),
+                                  .hasAttributesSatisfyingExactly(
+                                      withErrorType(processAttributes, true)),
                           span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
               if (testLatestDeps()) {
                 assertions.add(
@@ -167,12 +128,13 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               assertions.addAll(
                   asList(
                       span ->
-                          span.hasName("testSingleTopic process")
+                          span.hasName(spanName("testSingleTopic", "process", "process"))
                               .hasKind(SpanKind.CONSUMER)
                               .hasParent(trace.getSpan(1))
                               .hasStatus(StatusData.error())
                               .hasException(new IllegalArgumentException("boom"))
-                              .hasAttributesSatisfyingExactly(processAttributes),
+                              .hasAttributesSatisfyingExactly(
+                                  withErrorType(processAttributes, true)),
                       span ->
                           span.hasName("consumer")
                               .hasParent(trace.getSpan(testLatestDeps() ? 5 : 4))));
@@ -183,7 +145,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               assertions.addAll(
                   asList(
                       span ->
-                          span.hasName("testSingleTopic process")
+                          span.hasName(spanName("testSingleTopic", "process", "process"))
                               .hasKind(SpanKind.CONSUMER)
                               .hasParent(trace.getSpan(1))
                               .hasStatus(StatusData.unset())
@@ -213,41 +175,15 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               trace.hasSpansSatisfyingExactlyInAnyOrder(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")),
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "20")));
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "20")));
 
               producer1.set(trace.getSpan(1));
               producer2.set(trace.getSpan(2));
@@ -255,7 +191,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(
@@ -263,14 +199,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                                     producer1.get().getSpanContext(),
                                     producer2.get().getSpanContext()))
                             .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_SYSTEM, "kafka"),
-                                equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                                equalTo(MESSAGING_OPERATION, "process"),
-                                equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-                                satisfies(
-                                    stringKey("messaging.client_id"),
-                                    val -> val.startsWith("consumer")),
-                                equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 2)),
+                                batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
   }
 
@@ -290,51 +219,33 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
     List<AttributeAssertion> processAttributes =
-        asList(
-            equalTo(MESSAGING_SYSTEM, "kafka"),
-            equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-            equalTo(MESSAGING_OPERATION, "process"),
-            equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "testBatchListener"),
-            satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1));
+        batchProcessAttributes("testBatchTopic", "testBatchListener", 1);
 
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanName("producer", "testBatchTopic process", "consumer"),
+            orderByRootSpanName(
+                "producer", spanName("testBatchTopic", "process", "process"), "consumer"),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(
-                              equalTo(MESSAGING_SYSTEM, "kafka"),
-                              equalTo(MESSAGING_DESTINATION_NAME, "testBatchTopic"),
-                              equalTo(MESSAGING_OPERATION, "publish"),
-                              satisfies(
-                                  stringKey("messaging.client_id"),
-                                  val -> val.startsWith("producer")),
-                              satisfies(
-                                  MESSAGING_DESTINATION_PARTITION_ID,
-                                  AbstractStringAssert::isNotEmpty),
-                              satisfies(
-                                  MESSAGING_KAFKA_MESSAGE_OFFSET,
-                                  AbstractLongAssert::isNotNegative),
-                              equalTo(MESSAGING_KAFKA_MESSAGE_KEY, "10")));
+                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")));
 
               producer.set(trace.getSpan(1));
             },
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes),
+                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
             trace -> {
               if (isLibraryInstrumentationTest() && testLatestDeps()) {
@@ -344,13 +255,13 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               } else {
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes),
+                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
               }
             },
@@ -360,7 +271,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
               } else {
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinksSatisfying(links(producer.get().getSpanContext()))
@@ -369,5 +280,94 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
               }
             });
+  }
+
+  private static List<AttributeAssertion> sendAttributes(String topic, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> singleProcessAttributes(
+      String topic, String group, String messageKey) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative));
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
+    assertions.add(equalTo(MESSAGING_KAFKA_MESSAGE_KEY, messageKey));
+    addGroupAssertions(assertions, group);
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> batchProcessAttributes(
+      String topic, String group, int batchSize) {
+    List<AttributeAssertion> assertions =
+        messagingAttributes(topic, "process", "process", "process", "consumer");
+    addGroupAssertions(assertions, group);
+    assertions.add(equalTo(MESSAGING_BATCH_MESSAGE_COUNT, batchSize));
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, "kafka"),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions, String group) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, group));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, group));
+    }
+  }
+
+  private static List<AttributeAssertion> withErrorType(
+      List<AttributeAssertion> assertions, boolean failed) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv() && failed) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
+  }
+
+  private static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
   }
 }

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -77,8 +77,28 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewReceiveSpansDisabled = register<Test>("testV3PreviewReceiveSpansDisabled") {
+    testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
+    classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testing.suites)
+    dependsOn(testing.suites, testV3Preview, testV3PreviewReceiveSpansDisabled)
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/DefaultPulsarMessageListenerContainerInstrumentation.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/DefaultPulsarMessageListenerContainerInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.VirtualFieldStore;
@@ -40,17 +41,20 @@ class DefaultPulsarMessageListenerContainerInstrumentation implements TypeInstru
   @SuppressWarnings("unused")
   public static class DispatchMessageToListenerAdvice {
     public static class AdviceScope {
+      private final Instrumenter<Message<?>, Void> instrumenter;
       private final Context context;
       private final Scope scope;
 
-      public AdviceScope(Context context, Scope scope) {
+      public AdviceScope(
+          Instrumenter<Message<?>, Void> instrumenter, Context context, Scope scope) {
+        this.instrumenter = instrumenter;
         this.context = context;
         this.scope = scope;
       }
 
       public void end(@Nullable Throwable throwable, Message<?> message) {
         scope.close();
-        instrumenter().end(context, message, null, throwable);
+        instrumenter.end(context, message, null, throwable);
       }
     }
 
@@ -58,11 +62,13 @@ class DefaultPulsarMessageListenerContainerInstrumentation implements TypeInstru
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static AdviceScope onEnter(@Advice.Argument(0) Message<?> message) {
       Context parentContext = VirtualFieldStore.extract(message);
-      if (!instrumenter().shouldStart(parentContext, message)) {
+      Instrumenter<Message<?>, Void> instrumenter =
+          instrumenter(VirtualFieldStore.wasReceiveTelemetryRecorded(message));
+      if (!instrumenter.shouldStart(parentContext, message)) {
         return null;
       }
-      Context context = instrumenter().start(parentContext, message);
-      return new AdviceScope(context, context.makeCurrent());
+      Context context = instrumenter.start(parentContext, message);
+      return new AdviceScope(instrumenter, context, context.makeCurrent());
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
@@ -6,52 +6,70 @@
 package io.opentelemetry.javaagent.instrumentation.spring.pulsar.v1_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import org.apache.pulsar.client.api.Message;
 
 public class SpringPulsarSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-pulsar-1.0";
   private static final Instrumenter<Message<?>, Void> instrumenter;
+  private static final Instrumenter<Message<?>, Void> instrumenterWithConsumedMessages;
 
   static {
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
     SpringPulsarMessageAttributesGetter getter = new SpringPulsarMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
     boolean messagingReceiveInstrumentationEnabled =
         ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
 
+    instrumenter =
+        createInstrumenter(openTelemetry, getter, messagingReceiveInstrumentationEnabled, false);
+    instrumenterWithConsumedMessages =
+        emitStableMessagingSemconv()
+            ? createInstrumenter(
+                openTelemetry, getter, messagingReceiveInstrumentationEnabled, true)
+            : instrumenter;
+  }
+
+  private static Instrumenter<Message<?>, Void> createInstrumenter(
+      OpenTelemetry openTelemetry,
+      SpringPulsarMessageAttributesGetter getter,
+      boolean messagingReceiveInstrumentationEnabled,
+      boolean recordConsumedMessages) {
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
     InstrumenterBuilder<Message<?>, Void> builder =
         Instrumenter.<Message<?>, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(getter, operation)
+                MessagingAttributesExtractor.builderForOperationType(getter, operationType)
                     .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-                    .build());
-    setMessagingProcessExceptionEventExtractor(builder);
-    if (messagingReceiveInstrumentationEnabled) {
-      builder.addSpanLinksExtractor(
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(), new MessageHeaderGetter()));
-      instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    } else {
-      instrumenter = builder.buildConsumerInstrumenter(new MessageHeaderGetter());
+                    .build())
+            .addOperationMetrics(MessagingProcessMetrics.get());
+    if (recordConsumedMessages) {
+      builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     }
+    setMessagingProcessExceptionEventExtractor(builder);
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new MessageHeaderGetter(),
+        messagingReceiveInstrumentationEnabled);
   }
 
-  public static Instrumenter<Message<?>, Void> instrumenter() {
-    return instrumenter;
+  public static Instrumenter<Message<?>, Void> instrumenter(boolean receiveTelemetryRecorded) {
+    return receiveTelemetryRecorded ? instrumenter : instrumenterWithConsumedMessages;
   }
 
   private SpringPulsarSingletons() {}

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarTest.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarTest.java
@@ -5,9 +5,11 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.pulsar.v1_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 
 import io.opentelemetry.instrumentation.spring.pulsar.v1_0.AbstractSpringPulsarTest;
@@ -20,6 +22,35 @@ class SpringPulsarTest extends AbstractSpringPulsarTest {
   @Override
   protected void assertSpringPulsar() {
     AtomicReference<SpanData> producer = new AtomicReference<>();
+
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(INTERNAL, CLIENT),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("parent").hasNoParent(),
+                  span ->
+                      span.hasName("publish " + OTEL_TOPIC)
+                          .hasKind(PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(publishAttributes()),
+                  span ->
+                      span.hasName("process " + OTEL_TOPIC)
+                          .hasKind(CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasTotalRecordedLinks(0)
+                          .hasAttributesSatisfyingExactly(processAttributes()),
+                  span -> span.hasName("consumer").hasParent(trace.getSpan(2))),
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive " + OTEL_TOPIC)
+                          .hasKind(CLIENT)
+                          .hasNoParent()
+                          .hasAttributesSatisfyingExactly(receiveAttributes())));
+      assertStableProcessMetrics(true);
+      return;
+    }
 
     testing.waitAndAssertSortedTraces(
         orderByRootSpanKind(INTERNAL, CONSUMER),
@@ -37,12 +68,12 @@ class SpringPulsarTest extends AbstractSpringPulsarTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(String.format("%s receive", OTEL_TOPIC))
+                    span.hasName(OTEL_TOPIC + " receive")
                         .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(receiveAttributes()),
                 span ->
-                    span.hasName(String.format("%s process", OTEL_TOPIC))
+                    span.hasName(OTEL_TOPIC + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producer.get().getSpanContext()))

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSuppressReceiveSpansTest.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.pulsar.v1_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 
 import io.opentelemetry.instrumentation.spring.pulsar.v1_0.AbstractSpringPulsarTest;
 
@@ -19,12 +21,18 @@ class SpringPulsarSuppressReceiveSpansTest extends AbstractSpringPulsarTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(OTEL_TOPIC + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish " + OTEL_TOPIC
+                                : OTEL_TOPIC + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(publishAttributes()),
                 span ->
-                    span.hasName(String.format("%s process", OTEL_TOPIC))
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process " + OTEL_TOPIC
+                                : OTEL_TOPIC + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
@@ -32,6 +40,12 @@ class SpringPulsarSuppressReceiveSpansTest extends AbstractSpringPulsarTest {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName(String.format("%s receive", OTEL_TOPIC)).hasKind(CONSUMER)));
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive " + OTEL_TOPIC
+                                : OTEL_TOPIC + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)));
+    assertStableProcessMetrics(false);
   }
 }

--- a/instrumentation/spring/spring-pulsar-1.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/pulsar/v1_0/AbstractSpringPulsarTest.java
+++ b/instrumentation/spring/spring-pulsar-1.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/pulsar/v1_0/AbstractSpringPulsarTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.instrumentation.spring.pulsar.v1_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
@@ -15,10 +18,11 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -108,10 +112,72 @@ public abstract class AbstractSpringPulsarTest {
 
   protected abstract void assertSpringPulsar();
 
+  protected void assertStableProcessMetrics(boolean receiveSpansEnabled) {
+    if (!emitStableMessagingSemconv()) {
+      return;
+    }
+
+    testing.waitAndAssertMetrics(
+        "io.opentelemetry.spring-pulsar-1.0",
+        "messaging.process.duration",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("s")
+                        .hasDescription("Duration of processing operation.")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasSumGreaterThan(0.0)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME, OTEL_TOPIC))))));
+
+    if (!receiveSpansEnabled) {
+      testing.waitAndAssertMetrics(
+          "io.opentelemetry.pulsar-2.8",
+          "messaging.client.consumed.messages",
+          metrics ->
+              metrics.satisfiesExactly(
+                  metric ->
+                      assertThat(metric)
+                          .hasUnit("{message}")
+                          .hasDescription(
+                              "Number of messages that were delivered to the application.")
+                          .hasLongSumSatisfying(
+                              sum ->
+                                  sum.hasPointsSatisfying(
+                                      point ->
+                                          point
+                                              .hasValue(1)
+                                              .hasAttributesSatisfyingExactly(
+                                                  equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                  equalTo(MESSAGING_SYSTEM, "pulsar"),
+                                                  equalTo(MESSAGING_DESTINATION_NAME, OTEL_TOPIC),
+                                                  equalTo(SERVER_ADDRESS, brokerHost),
+                                                  equalTo(SERVER_PORT, brokerPort))))));
+      assertThat(testing.metrics())
+          .noneMatch(
+              metric ->
+                  metric
+                          .getInstrumentationScopeInfo()
+                          .getName()
+                          .equals("io.opentelemetry.spring-pulsar-1.0")
+                      && metric.getName().equals("messaging.client.consumed.messages"));
+    }
+  }
+
   protected List<AttributeAssertion> publishAttributes() {
     return asList(
         equalTo(MESSAGING_SYSTEM, "pulsar"),
-        equalTo(MESSAGING_OPERATION, "publish"),
+        oldOperation("publish"),
+        operationName("publish"),
+        operationType("publish"),
         equalTo(MESSAGING_DESTINATION_NAME, OTEL_TOPIC),
         satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
         satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotEmpty),
@@ -127,7 +193,9 @@ public abstract class AbstractSpringPulsarTest {
   protected List<AttributeAssertion> processAttributes() {
     return asList(
         equalTo(MESSAGING_SYSTEM, "pulsar"),
-        equalTo(MESSAGING_OPERATION, "process"),
+        oldOperation("process"),
+        operationName("process"),
+        operationType("process"),
         satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
         satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotEmpty),
         equalTo(MESSAGING_DESTINATION_NAME, OTEL_TOPIC));
@@ -136,12 +204,27 @@ public abstract class AbstractSpringPulsarTest {
   protected List<AttributeAssertion> receiveAttributes() {
     return asList(
         equalTo(MESSAGING_SYSTEM, "pulsar"),
-        equalTo(MESSAGING_OPERATION, "receive"),
+        oldOperation("receive"),
+        operationName("receive"),
+        operationType("receive"),
         equalTo(MESSAGING_DESTINATION_NAME, OTEL_TOPIC),
         satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
         satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isNotNegative),
         equalTo(SERVER_ADDRESS, brokerHost),
         equalTo(SERVER_PORT, brokerPort));
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   @SpringBootConfiguration

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/build.gradle.kts
@@ -29,9 +29,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testMessagingPreview)
   }
 }
 

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitExtraAttributesExtractor.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitExtraAttributesExtractor.java
@@ -3,34 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.rabbitmq.v2_7;
+package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 
-import com.rabbitmq.client.Envelope;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import javax.annotation.Nullable;
+import org.springframework.amqp.core.Message;
 
-class RabbitDeliveryExtraAttributesExtractor implements AttributesExtractor<DeliveryRequest, Void> {
+class SpringRabbitExtraAttributesExtractor implements AttributesExtractor<Message, Void> {
 
   private static final AttributeKey<Long> MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG =
       longKey("messaging.rabbitmq.message.delivery_tag");
 
   @Override
-  public void onStart(
-      AttributesBuilder attributes, Context parentContext, DeliveryRequest request) {
-    Envelope envelope = request.getEnvelope();
-    String routingKey = envelope.getRoutingKey();
-    if (routingKey != null && !routingKey.isEmpty()) {
-      attributes.put(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routingKey);
-    }
+  public void onStart(AttributesBuilder attributes, Context parentContext, Message message) {
     if (emitStableMessagingSemconv()) {
-      attributes.put(MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, envelope.getDeliveryTag());
+      String routingKey = message.getMessageProperties().getReceivedRoutingKey();
+      if (routingKey != null && !routingKey.isEmpty()) {
+        attributes.put(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, routingKey);
+      }
+      attributes.put(
+          MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG, message.getMessageProperties().getDeliveryTag());
     }
   }
 
@@ -38,7 +37,7 @@ class RabbitDeliveryExtraAttributesExtractor implements AttributesExtractor<Deli
   public void onEnd(
       AttributesBuilder attributes,
       Context context,
-      DeliveryRequest request,
+      Message message,
       @Nullable Void unused,
       @Nullable Throwable error) {}
 }

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMessageAttributesGetter.java
@@ -5,15 +5,21 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
 
 class SpringRabbitMessageAttributesGetter implements MessagingAttributesGetter<Message, Void> {
+
+  @Nullable private static final Method getConsumerQueue = getConsumerQueueMethod();
 
   @Override
   public String getSystem(Message message) {
@@ -23,7 +29,52 @@ class SpringRabbitMessageAttributesGetter implements MessagingAttributesGetter<M
   @Override
   @Nullable
   public String getDestination(Message message) {
-    return message.getMessageProperties().getReceivedRoutingKey();
+    MessageProperties properties = message.getMessageProperties();
+    if (!emitStableMessagingSemconv()) {
+      return properties.getReceivedRoutingKey();
+    }
+
+    String exchange = properties.getReceivedExchange();
+    String routingKey = properties.getReceivedRoutingKey();
+    String queue = getConsumerQueue(properties);
+    StringBuilder destination = new StringBuilder();
+    appendDestinationPart(destination, exchange);
+    appendDestinationPart(destination, routingKey);
+    if (queue != null && !queue.equals(routingKey)) {
+      appendDestinationPart(destination, queue);
+    }
+    return destination.length() == 0 ? null : destination.toString();
+  }
+
+  @Nullable
+  private static Method getConsumerQueueMethod() {
+    try {
+      return MessageProperties.class.getMethod("getConsumerQueue");
+    } catch (NoSuchMethodException ignored) {
+      return null;
+    }
+  }
+
+  @Nullable
+  private static String getConsumerQueue(MessageProperties properties) {
+    if (getConsumerQueue == null) {
+      return null;
+    }
+    try {
+      return (String) getConsumerQueue.invoke(properties);
+    } catch (IllegalAccessException | InvocationTargetException ignored) {
+      return null;
+    }
+  }
+
+  private static void appendDestinationPart(StringBuilder destination, String part) {
+    if (part == null || part.isEmpty()) {
+      return;
+    }
+    if (destination.length() != 0) {
+      destination.append(':');
+    }
+    destination.append(part);
   }
 
   @Nullable
@@ -39,7 +90,35 @@ class SpringRabbitMessageAttributesGetter implements MessagingAttributesGetter<M
 
   @Override
   public boolean isAnonymousDestination(Message message) {
-    return false;
+    return emitStableMessagingSemconv()
+        && isGeneratedQueueName(getConsumerQueue(message.getMessageProperties()));
+  }
+
+  private static boolean isGeneratedQueueName(@Nullable String queue) {
+    if (queue == null) {
+      return false;
+    }
+    if (queue.startsWith("amq.gen-") || queue.startsWith("spring.gen-")) {
+      return true;
+    }
+    return isCanonicalUuid(queue);
+  }
+
+  private static boolean isCanonicalUuid(String value) {
+    if (value.length() != 36) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        if (ch != '-') {
+          return false;
+        }
+      } else if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
@@ -8,9 +8,11 @@ package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -23,21 +25,28 @@ public class SpringRabbitSingletons {
   private static final Instrumenter<Message, Void> instrumenter;
 
   static {
+    OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
     SpringRabbitMessageAttributesGetter getter = new SpringRabbitMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<Message, Void> builder =
         Instrumenter.<Message, Void>builder(
-                GlobalOpenTelemetry.get(),
+                openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(getter, operation))
+                MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(getter, operation)
+                MessagingAttributesExtractor.builderForOperationType(getter, operationType)
                     .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
-                    .build());
+                    .build())
+            .addAttributesExtractor(new SpringRabbitExtraAttributesExtractor());
     setMessagingProcessExceptionEventExtractor(builder);
 
-    instrumenter = builder.buildConsumerInstrumenter(new MessageHeaderGetter());
+    instrumenter =
+        MessagingProcessInstrumenterFactory.create(
+            builder,
+            openTelemetry.getPropagators().getTextMapPropagator(),
+            new MessageHeaderGetter(),
+            false);
   }
 
   public static Instrumenter<Message, Void> instrumenter() {

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -5,15 +5,22 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.rabbit.v1_0;
 
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_ANONYMOUS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
@@ -28,6 +35,8 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -39,7 +48,6 @@ import java.util.Map;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -108,22 +116,57 @@ class SpringRabbitMqTest {
             asList(
                 equalTo(MESSAGING_SYSTEM, "rabbitmq"),
                 equalTo(MESSAGING_DESTINATION_NAME, destination),
-                satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative)));
-    if (operation != null) {
-      assertions.add(equalTo(MESSAGING_OPERATION, operation));
-    }
+                satisfies(MESSAGING_MESSAGE_BODY_SIZE, AbstractLongAssert::isNotNegative),
+                equalTo(MESSAGING_OPERATION, emitStableMessagingSemconv() ? null : operation),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv()
+                        ? "publish".equals(operation) ? "send" : operation
+                        : null)));
     if (peerAddress != null) {
       assertions.add(equalTo(NETWORK_TYPE, "ipv4"));
       assertions.add(equalTo(NETWORK_PEER_ADDRESS, peerAddress));
       assertions.add(satisfies(NETWORK_PEER_PORT, AbstractLongAssert::isNotNegative));
+      assertions.add(equalTo(SERVER_ADDRESS, emitStableMessagingSemconv() ? peerAddress : null));
+      assertions.add(
+          satisfies(
+              SERVER_PORT,
+              val -> {
+                if (emitStableMessagingSemconv()) {
+                  val.isNotNegative();
+                } else {
+                  val.isNull();
+                }
+              }));
     }
     if (routingKey) {
       assertions.add(
           satisfies(MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, AbstractStringAssert::isNotBlank));
     }
+    assertions.add(
+        satisfies(
+            longKey("messaging.rabbitmq.message.delivery_tag"),
+            val -> {
+              if (emitStableMessagingSemconv() && "process".equals(operation)) {
+                val.isNotNegative();
+              } else {
+                val.isNull();
+              }
+            }));
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
+    return assertions;
+  }
+
+  private static List<AttributeAssertion> getAnonymousQueueAssertions(
+      String queueName, String operation) {
+    List<AttributeAssertion> assertions =
+        getAssertions(
+            emitStableMessagingSemconv() ? queueName : "<default>", operation, ip, true, false);
+    assertions.add(
+        equalTo(MESSAGING_DESTINATION_ANONYMOUS, emitStableMessagingSemconv() ? true : null));
     return assertions;
   }
 
@@ -157,52 +200,73 @@ class SpringRabbitMqTest {
         });
     testing.waitAndAssertTraces(
         trace -> {
+          SpanData producerSpan = trace.getSpan(1);
+          SpanData firstProcessSpan = trace.getSpan(2);
+          SpanData secondProcessSpan = trace.getSpan(3);
+          SpanData rabbitProcessSpan =
+              "io.opentelemetry.rabbitmq-2.7"
+                      .equals(firstProcessSpan.getInstrumentationScopeInfo().getName())
+                  ? firstProcessSpan
+                  : secondProcessSpan;
+          SpanData springProcessSpan =
+              rabbitProcessSpan == firstProcessSpan ? secondProcessSpan : firstProcessSpan;
+
           trace.hasSpansSatisfyingExactlyInAnyOrder(
               span -> span.hasName("parent"),
               span ->
-                  span.hasName("<default> publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "publish " + ConsumerConfig.TEST_QUEUE
+                              : "<default> publish")
                       .hasKind(SpanKind.PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
-                          getAssertions("<default>", "publish", ip, true, testHeaders)),
+                          getAssertions(
+                              emitStableMessagingSemconv()
+                                  ? ConsumerConfig.TEST_QUEUE
+                                  : "<default>",
+                              "publish",
+                              ip,
+                              true,
+                              testHeaders)),
               // spring-cloud-stream-binder-rabbit listener puts all messages into a
               // BlockingQueue immediately after receiving
               // that's why the rabbitmq CONSUMER span will never have any child span (and
               // propagate context, actually)
-              span ->
-                  span.hasName("testQueue process")
-                      .hasKind(SpanKind.CONSUMER)
-                      .hasParent(trace.getSpan(1))
-                      .hasAttributesSatisfyingExactly(
-                          getAssertions("<default>", "process", ip, true, testHeaders)),
-              // created by spring-rabbit instrumentation
-              span ->
-                  span.hasName("testQueue process")
-                      .hasKind(SpanKind.CONSUMER)
-                      .hasParent(trace.getSpan(1))
-                      .hasAttributesSatisfyingExactly(
-                          getAssertions("testQueue", "process", null, false, testHeaders)),
               span -> {
-                // occasionally "testQueue process" spans have their order swapped, usually
-                // it would be
-                // 0 - parent
-                // 1 - <default> publish
-                // 2 - testQueue process (<default>)
-                // 3 - testQueue process (testQueue)
-                // 4 - consumer
-                // but it could also be
-                // 0 - parent
-                // 1 - <default> publish
-                // 2 - testQueue process (testQueue)
-                // 3 - consumer
-                // 4 - testQueue process (<default>)
-                // determine the correct parent span based on the span name
-                SpanData parentSpan = trace.getSpan(3);
-                if (!"testQueue process".equals(parentSpan.getName())) {
-                  parentSpan = trace.getSpan(2);
-                }
-                span.hasName("consumer").hasParent(parentSpan);
-              });
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "process " + ConsumerConfig.TEST_QUEUE
+                            : "testQueue process")
+                    .hasKind(SpanKind.CONSUMER)
+                    .hasParent(producerSpan)
+                    .hasAttributesSatisfyingExactly(
+                        getAssertions(
+                            emitStableMessagingSemconv() ? ConsumerConfig.TEST_QUEUE : "<default>",
+                            "process",
+                            ip,
+                            true,
+                            testHeaders));
+                verifyLink(span, null);
+              },
+              // created by spring-rabbit instrumentation
+              span -> {
+                span.hasName(
+                        emitStableMessagingSemconv()
+                            ? "process " + ConsumerConfig.TEST_QUEUE
+                            : "testQueue process")
+                    .hasKind(SpanKind.CONSUMER)
+                    .hasParent(producerSpan)
+                    .hasAttributesSatisfyingExactly(
+                        getAssertions(
+                            ConsumerConfig.TEST_QUEUE,
+                            "process",
+                            null,
+                            emitStableMessagingSemconv(),
+                            testHeaders));
+                verifyLink(span, null);
+              },
+              span -> span.hasName("consumer").hasParent(springProcessSpan));
         },
         trace -> {
           trace.hasSpansSatisfyingExactly(
@@ -217,32 +281,48 @@ class SpringRabbitMqTest {
         });
   }
 
-  @Test
-  void testAnonymousQueueSpanName() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"anonymousQueue", "legacyAnonymousQueue"})
+  void testAnonymousQueueSpanName(String queueBeanName) throws Exception {
     Connection connection = connectionFactory.newConnection();
     cleanup.deferCleanup(connection);
     Channel channel = connection.createChannel();
     cleanup.deferCleanup(channel);
 
-    String anonymousQueueName = applicationContext.getBean(AnonymousQueue.class).getName();
+    String anonymousQueueName = applicationContext.getBean(queueBeanName, Queue.class).getName();
     applicationContext.getBean(AmqpTemplate.class).convertAndSend(anonymousQueueName, "test");
     applicationContext.getBean(AmqpTemplate.class).receive(anonymousQueueName, 5000);
 
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("<default> publish"),
+                span ->
+                    span.hasName(emitStableMessagingSemconv() ? "publish" : "<default> publish")
+                        .hasAttributesSatisfyingExactly(
+                            getAnonymousQueueAssertions(anonymousQueueName, "publish")),
                 // Verify that a constant span name is used instead of the randomly generated
                 // anonymous queue name
                 span ->
-                    span.hasName("<generated> process")
-                        .hasAttribute(
-                            equalTo(
-                                MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY, anonymousQueueName))),
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process"
+                                : queueBeanName.equals("anonymousQueue")
+                                    ? "<generated> process"
+                                    : anonymousQueueName + " process")
+                        .hasAttributesSatisfyingExactly(
+                            getAnonymousQueueAssertions(anonymousQueueName, "process"))),
         trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.qos")),
         trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.consume")),
         trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.cancel")),
         trace -> trace.hasSpansSatisfyingExactly(span -> span.hasName("basic.ack")));
+  }
+
+  private static void verifyLink(SpanDataAssert span, SpanData linkSpan) {
+    if (linkSpan == null) {
+      span.hasTotalRecordedLinks(0);
+    } else {
+      span.hasLinks(LinkData.create(linkSpan.getSpanContext()));
+    }
   }
 
   @SpringBootConfiguration
@@ -250,6 +330,7 @@ class SpringRabbitMqTest {
   static class ConsumerConfig {
 
     static final String TEST_QUEUE = "testQueue";
+    static final String LEGACY_ANONYMOUS_QUEUE = "123e4567-e89b-12d3-a456-426614174000";
 
     @Bean
     Queue testQueue() {
@@ -259,6 +340,11 @@ class SpringRabbitMqTest {
     @Bean
     AnonymousQueue anonymousQueue() {
       return new AnonymousQueue();
+    }
+
+    @Bean
+    Queue legacyAnonymousQueue() {
+      return new Queue(LEGACY_ANONYMOUS_QUEUE);
     }
 
     @RabbitListener(queues = TEST_QUEUE)

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
@@ -64,12 +64,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
 
                   // first record
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record1)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(1))
                           .hasAttributesSatisfyingExactly(processAttributes(record1)),
@@ -77,12 +77,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
 
                   // second record
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record2)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(4))
                           .hasAttributesSatisfyingExactly(processAttributes(record2)),
@@ -95,7 +95,7 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinks(
@@ -127,12 +127,12 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)),
                   span ->
-                      span.hasName("testBatchTopic process")
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
                           .hasKind(SpanKind.CONSUMER)
                           .hasParent(trace.getSpan(1))
                           .hasAttributesSatisfyingExactly(processAttributes(record)),
@@ -143,14 +143,14 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasNoParent()
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
                             .hasAttributesSatisfyingExactly(
-                                batchProcessAttributes("testBatchTopic")),
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,22 +52,27 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
         KafkaProducerRecord.create("testBatchTopic", "20", "testSpan2");
     sendBatchMessages(record1, record2);
 
+    if (emitStableMessagingSemconv()) {
+      assertStableBatchSuccess(record1, record2);
+      return;
+    }
+
     AtomicReference<SpanData> producer1 = new AtomicReference<>();
     AtomicReference<SpanData> producer2 = new AtomicReference<>();
 
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactlyInAnyOrder(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record1)),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record2)));
@@ -77,14 +83,14 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactlyInAnyOrder(
                     span ->
-                        span.hasName("testBatchTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic")),
 
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(
@@ -96,7 +102,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
 
                     // single consumer 1
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer1.get().getSpanContext()))
@@ -105,7 +111,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
 
                     // single consumer 2
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer2.get().getSpanContext()))
@@ -124,17 +130,22 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
     // make sure that the consumer eats up any leftover records
     kafkaConsumer.resume();
 
+    if (emitStableMessagingSemconv()) {
+      assertStableBatchFailure(record);
+      return;
+    }
+
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
     // the regular handler is not being called if the batch one fails
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testBatchTopic publish")
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -144,29 +155,135 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testBatchTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic")),
 
                     // batch consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
                             .hasAttributesSatisfyingExactly(
-                                batchProcessAttributes("testBatchTopic")),
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(1)),
 
                     // single consumer
                     span ->
-                        span.hasName("testBatchTopic process")
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(processAttributes(record)),
                     span -> span.hasName("process error").hasParent(trace.getSpan(3))));
+  }
+
+  private void assertStableBatchSuccess(
+      KafkaProducerRecord<String, String> record1, KafkaProducerRecord<String, String> record2) {
+    AtomicReference<SpanData> producer1 = new AtomicReference<>();
+    AtomicReference<SpanData> producer2 = new AtomicReference<>();
+
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+            trace -> {
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("producer"),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record1)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(processAttributes(record1)),
+                  span -> span.hasName("process testSpan1").hasParent(trace.getSpan(2)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record2)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(4))
+                          .hasAttributesSatisfyingExactly(processAttributes(record2)),
+                  span -> span.hasName("process testSpan2").hasParent(trace.getSpan(5)));
+
+              producer1.set(trace.getSpan(1));
+              producer2.set(trace.getSpan(4));
+            },
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasNoParent()
+                            .hasLinks(
+                                LinkData.create(producer1.get().getSpanContext()),
+                                LinkData.create(producer2.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(
+                                batchProcessAttributes("testBatchTopic")),
+                    span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinks(
+                                LinkData.create(producer1.get().getSpanContext()),
+                                LinkData.create(producer2.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic"))));
+  }
+
+  private void assertStableBatchFailure(KafkaProducerRecord<String, String> record) {
+    AtomicReference<SpanData> producer = new AtomicReference<>();
+
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT),
+            trace -> {
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("producer"),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "publish", "send"))
+                          .hasKind(SpanKind.PRODUCER)
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                  span ->
+                      span.hasName(spanName("testBatchTopic", "process", "process"))
+                          .hasKind(SpanKind.CONSUMER)
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(processAttributes(record)),
+                  span -> span.hasName("process error").hasParent(trace.getSpan(2)));
+
+              producer.set(trace.getSpan(1));
+            },
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasNoParent()
+                            .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                            .hasStatus(StatusData.error())
+                            .hasException(new IllegalArgumentException("boom"))
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(batchProcessAttributes("testBatchTopic"))),
+                    span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(spanName("testBatchTopic", "receive", "poll"))
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                            .hasAttributesSatisfyingExactly(receiveAttributes("testBatchTopic"))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
@@ -50,12 +50,12 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(sendAttributes(record)),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasAttributesSatisfyingExactly(processAttributes(record)),
@@ -78,17 +78,18 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("producer"),
                     span ->
-                        span.hasName("testSingleTopic publish")
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(sendAttributes(record)),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,14 +50,47 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+              trace -> {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("producer"),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(1))
+                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                    span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+                producer.set(trace.getSpan(1));
+              },
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                              .hasKind(SpanKind.CLIENT)
+                              .hasNoParent()
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  receiveAttributes("testSingleTopic"))));
+      return;
+    }
+
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testSingleTopic publish")
+                      span.hasName(spanName("testSingleTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -66,12 +100,12 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testSingleTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testSingleTopic")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
@@ -91,14 +125,50 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
+    if (emitStableMessagingSemconv()) {
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+              trace -> {
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("producer"),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "publish", "send"))
+                            .hasKind(SpanKind.PRODUCER)
+                            .hasParent(trace.getSpan(0))
+                            .hasAttributesSatisfyingExactly(sendAttributes(record)),
+                    span ->
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(1))
+                            .hasStatus(StatusData.error())
+                            .hasException(new IllegalArgumentException("boom"))
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
+                    span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+
+                producer.set(trace.getSpan(1));
+              },
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                              .hasKind(SpanKind.CLIENT)
+                              .hasNoParent()
+                              .hasLinks(LinkData.create(producer.get().getSpanContext()))
+                              .hasAttributesSatisfyingExactly(
+                                  receiveAttributes("testSingleTopic"))));
+      return;
+    }
+
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
+            orderByRootSpanKind(SpanKind.INTERNAL, receiveKind()),
             trace -> {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("producer"),
                   span ->
-                      span.hasName("testSingleTopic publish")
+                      span.hasName(spanName("testSingleTopic", "publish", "send"))
                           .hasKind(SpanKind.PRODUCER)
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(sendAttributes(record)));
@@ -108,18 +178,19 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("testSingleTopic receive")
-                            .hasKind(SpanKind.CONSUMER)
+                        span.hasName(spanName("testSingleTopic", "receive", "poll"))
+                            .hasKind(receiveKind())
                             .hasNoParent()
                             .hasAttributesSatisfyingExactly(receiveAttributes("testSingleTopic")),
                     span ->
-                        span.hasName("testSingleTopic process")
+                        span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(0))
                             .hasLinks(LinkData.create(producer.get().getSpanContext()))
                             .hasStatus(StatusData.error())
                             .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(processAttributes(record)),
+                            .hasAttributesSatisfyingExactly(
+                                withErrorType(processAttributes(record))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
@@ -7,16 +7,23 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_CONSUMER_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_KEY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_MESSAGE_OFFSET;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_KAFKA_OFFSET;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.KAFKA;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -24,6 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -53,6 +61,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractVertxKafkaTest {
 
@@ -163,18 +172,12 @@ public abstract class AbstractVertxKafkaTest {
   protected abstract void sendRecord(
       KafkaProducerRecord<String, String> record, Handler<AsyncResult<RecordMetadata>> handler);
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   protected static List<AttributeAssertion> sendAttributes(
       KafkaProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "publish"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("producer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "publish", "send", "send", "producer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(
@@ -196,40 +199,33 @@ public abstract class AbstractVertxKafkaTest {
     return batchConsumerAttributes(topic, "process");
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private List<AttributeAssertion> batchConsumerAttributes(String topic, String operation) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                equalTo(MESSAGING_OPERATION, operation),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive)));
+        messagingAttributes(
+            topic,
+            operation,
+            operation.equals("receive") ? "poll" : operation,
+            operation.equals("receive") ? "receive" : "process",
+            "consumer");
+    assertions.add(satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive));
     if (hasConsumerGroup()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     return assertions;
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   protected List<AttributeAssertion> processAttributes(KafkaProducerRecord<String, String> record) {
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(MESSAGING_SYSTEM, KAFKA),
-                equalTo(MESSAGING_DESTINATION_NAME, record.topic()),
-                equalTo(MESSAGING_OPERATION, "process"),
-                satisfies(stringKey("messaging.client_id"), val -> val.startsWith("consumer")),
-                satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty),
-                satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative)));
+        messagingAttributes(record.topic(), "process", "process", "process", "consumer");
+    assertions.add(satisfies(MESSAGING_DESTINATION_PARTITION_ID, AbstractStringAssert::isNotEmpty));
+    addOffsetAssertion(assertions);
     if (EXPERIMENTAL_ATTRIBUTES) {
       assertions.add(
           satisfies(longKey("kafka.record.queue_time_ms"), AbstractLongAssert::isNotNegative));
     }
     // consumer group is not available in version 0.11
     if (hasConsumerGroup()) {
-      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+      addGroupAssertions(assertions);
     }
     String messageKey = record.key();
     if (messageKey != null) {
@@ -240,5 +236,67 @@ public abstract class AbstractVertxKafkaTest {
       assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, messageValue.getBytes(UTF_8).length));
     }
     return assertions;
+  }
+
+  private static List<AttributeAssertion> messagingAttributes(
+      String topic,
+      String oldOperation,
+      String operationName,
+      String operationType,
+      String clientIdPrefix) {
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(MESSAGING_SYSTEM, KAFKA),
+                equalTo(MESSAGING_DESTINATION_NAME, topic),
+                equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+                equalTo(
+                    MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+                equalTo(
+                    MESSAGING_OPERATION_TYPE,
+                    emitStableMessagingSemconv() ? operationType : null)));
+    if (emitOldMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client_id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(
+          satisfies(stringKey("messaging.client.id"), val -> val.startsWith(clientIdPrefix)));
+    }
+    return assertions;
+  }
+
+  private static void addOffsetAssertion(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_MESSAGE_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_KAFKA_OFFSET, AbstractLongAssert::isNotNegative));
+    }
+  }
+
+  private static void addGroupAssertions(List<AttributeAssertion> assertions) {
+    if (emitOldMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_KAFKA_CONSUMER_GROUP, "test"));
+    }
+    if (emitStableMessagingSemconv()) {
+      assertions.add(equalTo(MESSAGING_CONSUMER_GROUP_NAME, "test"));
+    }
+  }
+
+  protected static String spanName(String topic, String oldOperation, String operationName) {
+    return emitStableMessagingSemconv() ? operationName + " " + topic : topic + " " + oldOperation;
+  }
+
+  protected static SpanKind receiveKind() {
+    return emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.CONSUMER;
+  }
+
+  protected static List<AttributeAssertion> withErrorType(List<AttributeAssertion> assertions) {
+    List<AttributeAssertion> result = new ArrayList<>(assertions);
+    if (emitStableMessagingSemconv()) {
+      result.add(equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()));
+    }
+    return result;
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -57,7 +57,25 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -57,7 +57,24 @@ tasks {
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -57,7 +57,24 @@ tasks {
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  val testV3PreviewNoReceiveTelemetry = register<Test>("testV3PreviewNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
   check {
-    dependsOn(testing.suites, testExperimental)
+    dependsOn(testing.suites, testExperimental, testV3Preview, testV3PreviewNoReceiveTelemetry)
   }
 }


### PR DESCRIPTION
Depends on #19269, #19271, #19272, #19273, #19274, and #19275 (`#19271` includes #19270).

Temporary integration baseline: `ab93cd9d1baf462a333a307f156b3e20a7e6a3d1`.
Activation-only review range: `ab93cd9d1baf462a333a307f156b3e20a7e6a3d1..116ce8963099d7cd31dee65eab321961fb1fa0f0`.

This PR has exactly one activation-owned commit above a fork-only integration branch constructed from current upstream `main` (`304149f749fcb148678f8a933d67bd5285b08e7e`) and the exact final family heads:

- AWS: `b5912bccf4ce39a7b8a67b2821479d8b46d96047`
- Kafka ecosystem (including core): `d7d989b375abb9c64c00547bc084e57518422d7d`
- JMS/NATS/Spring: `41d5292312de90c45dd50db2236332fa4bd7fede`
- Pulsar: `4d5b71ecba150abeabbed8e6618ffffca4fb6a7d`
- RabbitMQ: `572c9d66a2038b6efcbb9d9be3216099c653da54`
- RocketMQ: `3c9153f284176689d30df9059cfcce5b714491d7`

`messaging-v1-43-integration` must never be merged upstream. After dependency PRs merge, this branch will be rebuilt from current `main` with only its activation delta reapplied.

## Scope

- Activates messaging v1.43 under common v3 preview while preserving explicit preview and `/dup` behavior.
- Deprecates `MessageOperation` after integrated production callers migrate.
- Deprecates `MessagingProducerMetrics.get()` and `MessagingConsumerMetrics.get()`, the last
  `MessageOperation` companions in the messaging package that were still unmarked.
- Marks the four transitional `*ForOperationType` names with `// will be renamed in 3.0 to <name>()`.
  The 3.0 cleanup tracked in #18903 greps for removal markers only, so a rename would have been
  missed; the issue now documents this as a second audit pass that runs after the removals free up
  the target names.
- Adds the `Unreleased` deprecation changelog entry and narrowly scoped compatibility suppressions.

Family telemetry behavior remains owned by dependency PRs. This PR touches no instrumentation module:
`MessagingSpanNameExtractor` keeps its plain `create` / `builder` names, so the only production change
is the deprecation of the `MessageOperation` overloads themselves.

## Validation

- `./gradlew :instrumentation:rabbitmq-2.7:javaagent:check spotlessCheck :instrumentation-api-incubator:test compileJava --console=plain`
- AWS SDK 2.2, Spring Integration, Rabbit/Spring Rabbit, and RocketMQ owner checks pass.
- Current upstream `main` and every exact family leaf are ancestors of the integration baseline.
- Activation range contains exactly one commit, passes `git diff --check`, and the worktree is clean.

