### PR TITLE
influxdb-2.4: capture db.operation.batch.size for BatchPoints writes

### DIFF
--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
@@ -41,6 +41,12 @@ final class InfluxDbAttributesGetter implements DbClientAttributesGetter<InfluxD
     return null;
   }
 
+  @Nullable
+  @Override
+  public Long getDbOperationBatchSize(InfluxDbOperation request) {
+    return request.getBatchSize();
+  }
+
   @Override
   public String getServerAddress(InfluxDbOperation request) {
     return request.getHost();

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbAttributesGetter.java
@@ -41,12 +41,6 @@ final class InfluxDbAttributesGetter implements DbClientAttributesGetter<InfluxD
     return null;
   }
 
-  @Nullable
-  @Override
-  public Long getDbOperationBatchSize(InfluxDbOperation request) {
-    return request.getBatchSize();
-  }
-
   @Override
   public String getServerAddress(InfluxDbOperation request) {
     return request.getHost();

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbImplInstrumentation.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbImplInstrumentation.java
@@ -141,8 +141,6 @@ class InfluxDbImplInstrumentation implements TypeInstrumentation {
               ? ((BatchPoints) arg0).getDatabase()
               // write data by UDP protocol, in this way, can't get database name.
               : arg0 instanceof Integer ? null : String.valueOf(arg0);
-      Long batchSize =
-          (arg0 instanceof BatchPoints) ? (long) ((BatchPoints) arg0).getPoints().size() : null;
 
       String operationName;
       if ("createDatabase".equals(methodName)) {
@@ -156,8 +154,7 @@ class InfluxDbImplInstrumentation implements TypeInstrumentation {
       }
 
       InfluxDbOperation influxDbOperation =
-          InfluxDbOperation.create(
-              httpUrl.host(), httpUrl.port(), database, operationName, batchSize);
+          InfluxDbOperation.create(httpUrl.host(), httpUrl.port(), database, operationName);
 
       if (!requestInstrumenter().shouldStart(parentContext, influxDbOperation)) {
         return null;

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbImplInstrumentation.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbImplInstrumentation.java
@@ -141,6 +141,8 @@ class InfluxDbImplInstrumentation implements TypeInstrumentation {
               ? ((BatchPoints) arg0).getDatabase()
               // write data by UDP protocol, in this way, can't get database name.
               : arg0 instanceof Integer ? null : String.valueOf(arg0);
+      Long batchSize =
+          (arg0 instanceof BatchPoints) ? (long) ((BatchPoints) arg0).getPoints().size() : null;
 
       String operationName;
       if ("createDatabase".equals(methodName)) {
@@ -154,7 +156,8 @@ class InfluxDbImplInstrumentation implements TypeInstrumentation {
       }
 
       InfluxDbOperation influxDbOperation =
-          InfluxDbOperation.create(httpUrl.host(), httpUrl.port(), database, operationName);
+          InfluxDbOperation.create(
+              httpUrl.host(), httpUrl.port(), database, operationName, batchSize);
 
       if (!requestInstrumenter().shouldStart(parentContext, influxDbOperation)) {
         return null;

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbOperation.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbOperation.java
@@ -12,8 +12,12 @@ import javax.annotation.Nullable;
 public abstract class InfluxDbOperation {
 
   public static InfluxDbOperation create(
-      String host, int port, @Nullable String namespace, @Nullable String operation) {
-    return new AutoValue_InfluxDbOperation(host, port, namespace, operation);
+      String host,
+      int port,
+      @Nullable String namespace,
+      @Nullable String operation,
+      @Nullable Long batchSize) {
+    return new AutoValue_InfluxDbOperation(host, port, namespace, operation, batchSize);
   }
 
   public abstract String getHost();
@@ -25,4 +29,7 @@ public abstract class InfluxDbOperation {
 
   @Nullable
   public abstract String getOperation();
+
+  @Nullable
+  public abstract Long getBatchSize();
 }

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbOperation.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbOperation.java
@@ -12,12 +12,8 @@ import javax.annotation.Nullable;
 public abstract class InfluxDbOperation {
 
   public static InfluxDbOperation create(
-      String host,
-      int port,
-      @Nullable String namespace,
-      @Nullable String operation,
-      @Nullable Long batchSize) {
-    return new AutoValue_InfluxDbOperation(host, port, namespace, operation, batchSize);
+      String host, int port, @Nullable String namespace, @Nullable String operation) {
+    return new AutoValue_InfluxDbOperation(host, port, namespace, operation);
   }
 
   public abstract String getHost();
@@ -29,7 +25,4 @@ public abstract class InfluxDbOperation {
 
   @Nullable
   public abstract String getOperation();
-
-  @Nullable
-  public abstract Long getBatchSize();
 }

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -134,9 +133,7 @@ class InfluxDbClientTest {
                             equalTo(SERVER_PORT, port),
                             equalTo(
                                 maybeStable(DB_OPERATION),
-                                emitStableDatabaseSemconv() ? "write" : "WRITE"),
-                            equalTo(
-                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null))),
+                                emitStableDatabaseSemconv() ? "write" : "WRITE"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -133,7 +134,9 @@ class InfluxDbClientTest {
                             equalTo(SERVER_PORT, port),
                             equalTo(
                                 maybeStable(DB_OPERATION),
-                                emitStableDatabaseSemconv() ? "write" : "WRITE"))),
+                                emitStableDatabaseSemconv() ? "write" : "WRITE"),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 2L : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->


### PR DESCRIPTION
Resolves #19264

## Description

`influxdb-2.4` records `db.operation.name` for writes, but a write through `InfluxDB.write(BatchPoints)` sends a whole batch of points in a single request and the point count was never captured. This meant a batch write of, say, 500 points looked identical on the span to a write of a single point.

`db.operation.batch.size` is a stable database semantic-convention attribute, and the point count is readily available on the `BatchPoints` object the instrumentation already has in hand (`BatchPoints.getPoints()`). This follows the same pattern already used by the `hbase-client` instrumentation for its batch operations.

## Changes

- Added a nullable `batchSize` field to `InfluxDbOperation` (the `@AutoValue` request object).
- In `InfluxDbImplInstrumentation.InfluxDbModifyAdvice#onEnter`, when `arg0 instanceof BatchPoints`, read `((BatchPoints) arg0).getPoints().size()` and pass it into `InfluxDbOperation.create(...)`. It stays `null` for the UDP / `createDatabase` / `deleteDatabase` paths, where there is no batch.
- Overrode `getDbOperationBatchSize` in `InfluxDbAttributesGetter` to return that value.
- Updated `InfluxDbClientTest#testQueryAndModifyWithOneArgument` to assert `db.operation.batch.size = 2` on the write span for the existing two-point `BatchPoints` write.

No new configuration is needed. The shared `DbClientAttributesExtractor` already emits `db.operation.batch.size` under stable semconv and treats a size of `1` as a non-batch operation, so single-point writes are unaffected.

## Test plan

- [x] `./gradlew :instrumentation:influxdb-2.4:javaagent:compileJava :instrumentation:influxdb-2.4:javaagent:compileTestJava`
- [x] `./gradlew :instrumentation:influxdb-2.4:javaagent:spotlessCheck :instrumentation:influxdb-2.4:javaagent:checkstyleMain :instrumentation:influxdb-2.4:javaagent:checkstyleTest`
- [ ] `./gradlew :instrumentation:influxdb-2.4:javaagent:test` (requires Docker/testcontainers, run in CI)