### PR TITLE
Harden draft release note generation

### DIFF
--- a/.github/scripts/draft-release-notes/fetch.py
+++ b/.github/scripts/draft-release-notes/fetch.py
@@ -28,7 +28,10 @@ AUTHOR_FILTER = r"^(?!renovate\[bot\] )"
 SRC_MAIN_JAVA_PATHSPEC = "*/src/main/**/*.java"
 PR_SUFFIX_RE = re.compile(r"\s*\(#(\d+)\)$")
 VERSION_RE = re.compile(r'val stableVersion = "(\d+\.\d+\.\d+)')
-ISSUE_REF_RE = re.compile(r"(?:issues|pull)/(\d+)|(?<![A-Za-z0-9/])#(\d+)\b")
+ISSUE_REF_RE = re.compile(
+    rf"https?://github\.com/{re.escape(REPO)}/(?:issues|pull)/([1-9]\d*)\b"
+    r"|(?<![A-Za-z0-9/])#([1-9]\d*)\b"
+)
 GH_FETCH_WORKERS = 8
 GH_FETCH_RETRIES = 3
 GH_FETCH_RETRY_DELAY = 5.0

--- a/.github/scripts/draft-release-notes/rules.md
+++ b/.github/scripts/draft-release-notes/rules.md
@@ -21,6 +21,11 @@ by the parser but discouraged — prefer a bare JSON object:
 }
 ```
 
+The response must be parseable by `json.loads`. JSON-escape every special
+character in string values, including `"` as `\"`, `\` as `\\`, and newlines
+as `\n`. Pay particular attention to Java string literals copied into
+`evidence`, and verify the complete object is valid JSON before responding.
+
 ## Core rule
 
 Classify every PR from its diff only. PR titles, manifest `subject`,


### PR DESCRIPTION
Prevent invalid references from aborting draft release-note generation by restricting extraction to positive shorthand references and local issue or pull request URLs. Also require classifier responses to JSON-escape copied code, especially Java string literals in evidence, to reduce malformed Copilot output.