### PR TITLE
Gate Dubbo registry `server.address`/`server.port` behind stable rpc semconv

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
 import static io.opentelemetry.instrumentation.apachedubbo.v2_7.internal.DubboRegistryUtil.buildServiceTarget;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 
 import io.opentelemetry.instrumentation.apachedubbo.v2_7.DubboRequest;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesGetter;
@@ -24,8 +25,10 @@ public final class DubboClientNetworkAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DubboRequest request) {
+    // the registry address is the logical target only under the stable rpc semconv; keep the
+    // resolved provider host under the old semconv to avoid changing already-emitted attributes
     String registryAddress = request.registryAddress();
-    if (registryAddress != null) {
+    if (registryAddress != null && emitStableRpcSemconv()) {
       return registryAddress + "/" + buildServiceTarget(request.url());
     }
     return request.url().getHost();
@@ -34,7 +37,7 @@ public final class DubboClientNetworkAttributesGetter
   @Nullable
   @Override
   public Integer getServerPort(DubboRequest request) {
-    if (request.registryAddress() != null) {
+    if (request.registryAddress() != null && emitStableRpcSemconv()) {
       return null;
     }
     int port = request.url().getPort();

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboRegistryTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboRegistryTest.java
@@ -180,6 +180,13 @@ public abstract class AbstractDubboRegistryTest {
                                     emitStableRpcSemconv()
                                         ? "org.apache.dubbo.rpc.service.GenericService/$invoke"
                                         : "$invoke"),
+                                equalTo(
+                                    maybeStablePeerService(),
+                                    hasServicePeerName()
+                                            && testLatestDeps()
+                                            && !emitStableRpcSemconv()
+                                        ? "test-peer-service"
+                                        : null),
                                 satisfies(
                                     SERVER_ADDRESS,
                                     val -> {
@@ -187,9 +194,13 @@ public abstract class AbstractDubboRegistryTest {
                                         val.isEqualTo(expectedServerAddress);
                                       } else {
                                         // registry override is gated behind the stable rpc semconv;
-                                        // under the old semconv the resolved provider host is used
-                                        val.isInstanceOf(String.class)
-                                            .isNotEqualTo(expectedServerAddress);
+                                        // under the old semconv the bare provider host is used, not
+                                        // the registry target (the exact host is environment
+                                        // dependent, so assert it is a plain host, not a registry
+                                        // url/target)
+                                        val.asString()
+                                            .isNotEqualTo(expectedServerAddress)
+                                            .doesNotContain("/");
                                       }
                                     }),
                                 equalTo(SERVER_PORT, emitStableRpcSemconv() ? null : (long) port),

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboRegistryTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboRegistryTest.java
@@ -47,9 +47,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Integration test that verifies the registry-mode end-to-end flow: provider registers to
- * ZooKeeper, consumer discovers via ZooKeeper, and the {@code SERVER_ADDRESS} span attribute
- * contains the registry address (with service interface, version, and group) instead of the
- * provider host.
+ * ZooKeeper, consumer discovers via ZooKeeper, and, under the stable rpc semconv, the {@code
+ * SERVER_ADDRESS} span attribute contains the registry address (with service interface, version,
+ * and group) instead of the provider host. Under the old rpc semconv the resolved provider host is
+ * kept.
  */
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractDubboRegistryTest {
@@ -149,8 +150,9 @@ public abstract class AbstractDubboRegistryTest {
 
     assertThat(response).isEqualTo("hello");
 
-    // In registry mode, SERVER_ADDRESS = "registryProtocol://host:port/interface:version:group"
-    // and SERVER_PORT is absent (null).
+    // Under the stable rpc semconv, SERVER_ADDRESS =
+    // "registryProtocol://host:port/interface:version:group" and SERVER_PORT is absent (null).
+    // Under the old rpc semconv the resolved provider host/port are kept.
     // See https://github.com/open-telemetry/semantic-conventions/pull/3317
     String expectedServiceTarget =
         HelloService.class.getName() + ":" + SERVICE_VERSION + ":" + SERVICE_GROUP;
@@ -178,8 +180,19 @@ public abstract class AbstractDubboRegistryTest {
                                     emitStableRpcSemconv()
                                         ? "org.apache.dubbo.rpc.service.GenericService/$invoke"
                                         : "$invoke"),
-                                equalTo(SERVER_ADDRESS, expectedServerAddress),
-                                equalTo(SERVER_PORT, null),
+                                satisfies(
+                                    SERVER_ADDRESS,
+                                    val -> {
+                                      if (emitStableRpcSemconv()) {
+                                        val.isEqualTo(expectedServerAddress);
+                                      } else {
+                                        // registry override is gated behind the stable rpc semconv;
+                                        // under the old semconv the resolved provider host is used
+                                        val.isInstanceOf(String.class)
+                                            .isNotEqualTo(expectedServerAddress);
+                                      }
+                                    }),
+                                equalTo(SERVER_PORT, emitStableRpcSemconv() ? null : (long) port),
                                 satisfies(
                                     NETWORK_PEER_ADDRESS,
                                     val ->


### PR DESCRIPTION
Follow-up to #17244, which changed registry-backed Dubbo client `server.address`/`server.port` unconditionally. That altered already-emitted attributes for all users by default: registry-backed consumers previously reported the resolved provider host/port, and #17244 switched `server.address` to the registry endpoint plus service target (`registry://host:port/interface:version:group`) with `server.port` unset.

This gates that behavior behind `emitStableRpcSemconv()` (`otel.semconv-stability.opt-in=rpc`), matching the gRPC target approach in #16161. Under the old semconv the resolved provider host/port are kept; the registry-address form is only emitted under the stable rpc opt-in. The registry capture itself is unchanged — only the emitted `server.*` attributes are gated.

Prototype for open-telemetry/semantic-conventions#3317.