### PR TITLE
Add Cassandra compaction progress metrics via JMX handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Add Cassandra JMX metrics target system.
   ([#19080](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19080))
+- Add Cassandra compaction byte-progress metrics via a code-based JMX handler. (#0)
 - Add `captureTemplate` and `captureArguments` options to the log4j, java-util-logging, and
   jboss-logmanager logging instrumentations, capturing the log message template and arguments as
   separate `log.body.template` / `log.body.parameters` attributes. This extends the same option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 - Add Cassandra JMX metrics target system.
   ([#19080](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19080))
-- Add Cassandra compaction byte-progress metrics via a code-based JMX handler. (#0)
 - Add `captureTemplate` and `captureArguments` options to the log4j, java-util-logging, and
   jboss-logmanager logging instrumentations, capturing the log message template and arguments as
   separate `log.body.template` / `log.body.parameters` attributes. This extends the same option

--- a/instrumentation/jmx-metrics/library/cassandra.md
+++ b/instrumentation/jmx-metrics/library/cassandra.md
@@ -3,7 +3,7 @@
 Here is the list of metrics based on MBeans exposed by Cassandra.
 
 | Metric Name                          | Type          | Unit      | Attributes                                                          | Description                                                      |
-|--------------------------------------|---------------|-----------|---------------------------------------------------------------------|------------------------------------------------------------------|
+| ------------------------------------ | ------------- | --------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | cassandra.client.request.count       | Counter       | {request} | cassandra.operation                                                 | Number of requests by operation.                                 |
 | cassandra.client.request.error       | Counter       | {error}   | cassandra.operation, cassandra.status                               | Number of request errors by operation.                           |
 | cassandra.client.request.latency.p50 | Gauge         | s         | cassandra.operation                                                 | Request latency 50th percentile by operation.                    |

--- a/instrumentation/jmx-metrics/library/cassandra.md
+++ b/instrumentation/jmx-metrics/library/cassandra.md
@@ -2,15 +2,17 @@
 
 Here is the list of metrics based on MBeans exposed by Cassandra.
 
-| Metric Name                          | Type          | Unit      | Attributes                            | Description                                                      |
-| ------------------------------------ | ------------- | --------- | ------------------------------------- | ---------------------------------------------------------------- |
-| cassandra.client.request.count       | Counter       | {request} | cassandra.operation                   | Number of requests by operation.                                 |
-| cassandra.client.request.error       | Counter       | {error}   | cassandra.operation, cassandra.status | Number of request errors by operation.                           |
-| cassandra.client.request.latency.p50 | Gauge         | s         | cassandra.operation                   | Request latency 50th percentile by operation.                    |
-| cassandra.client.request.latency.p99 | Gauge         | s         | cassandra.operation                   | Request latency 99th percentile by operation.                    |
-| cassandra.client.request.latency.max | Gauge         | s         | cassandra.operation                   | Maximum request latency by operation.                            |
-| cassandra.compaction.tasks.completed | Counter       | {task}    |                                       | Number of completed compactions since server start.              |
-| cassandra.compaction.tasks.pending   | Gauge         | {task}    |                                       | Estimated number of compactions remaining to perform.            |
-| cassandra.storage.load               | UpDownCounter | By        |                                       | Size of the on disk data size this node manages.                 |
-| cassandra.storage.hints.count        | Counter       | {hint}    |                                       | Number of hint messages written to this node since server start. |
-| cassandra.storage.hints.in_progress  | UpDownCounter | {hint}    |                                       | Number of hints attempting to be sent currently.                 |
+| Metric Name                          | Type          | Unit      | Attributes                                                          | Description                                                      |
+|--------------------------------------|---------------|-----------|---------------------------------------------------------------------|------------------------------------------------------------------|
+| cassandra.client.request.count       | Counter       | {request} | cassandra.operation                                                 | Number of requests by operation.                                 |
+| cassandra.client.request.error       | Counter       | {error}   | cassandra.operation, cassandra.status                               | Number of request errors by operation.                           |
+| cassandra.client.request.latency.p50 | Gauge         | s         | cassandra.operation                                                 | Request latency 50th percentile by operation.                    |
+| cassandra.client.request.latency.p99 | Gauge         | s         | cassandra.operation                                                 | Request latency 99th percentile by operation.                    |
+| cassandra.client.request.latency.max | Gauge         | s         | cassandra.operation                                                 | Maximum request latency by operation.                            |
+| cassandra.compaction.progress.bytes  | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Bytes completed for in-flight compactions.                       |
+| cassandra.compaction.progress.total  | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Total bytes for in-flight compactions.                           |
+| cassandra.compaction.tasks.completed | Counter       | {task}    |                                                                     | Number of completed compactions since server start.              |
+| cassandra.compaction.tasks.pending   | Gauge         | {task}    |                                                                     | Estimated number of compactions remaining to perform.            |
+| cassandra.storage.load               | UpDownCounter | By        |                                                                     | Size of the on disk data size this node manages.                 |
+| cassandra.storage.hints.count        | Counter       | {hint}    |                                                                     | Number of hint messages written to this node since server start. |
+| cassandra.storage.hints.in_progress  | UpDownCounter | {hint}    |                                                                     | Number of hints attempting to be sent currently.                 |

--- a/instrumentation/jmx-metrics/library/cassandra.md
+++ b/instrumentation/jmx-metrics/library/cassandra.md
@@ -2,17 +2,17 @@
 
 Here is the list of metrics based on MBeans exposed by Cassandra.
 
-| Metric Name                          | Type          | Unit      | Attributes                                                          | Description                                                      |
-| ------------------------------------ | ------------- | --------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| cassandra.client.request.count       | Counter       | {request} | cassandra.operation                                                 | Number of requests by operation.                                 |
-| cassandra.client.request.error       | Counter       | {error}   | cassandra.operation, cassandra.status                               | Number of request errors by operation.                           |
-| cassandra.client.request.latency.p50 | Gauge         | s         | cassandra.operation                                                 | Request latency 50th percentile by operation.                    |
-| cassandra.client.request.latency.p99 | Gauge         | s         | cassandra.operation                                                 | Request latency 99th percentile by operation.                    |
-| cassandra.client.request.latency.max | Gauge         | s         | cassandra.operation                                                 | Maximum request latency by operation.                            |
-| cassandra.compaction.progress.bytes  | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Bytes completed for in-flight compactions.                       |
-| cassandra.compaction.progress.total  | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Total bytes for in-flight compactions.                           |
-| cassandra.compaction.tasks.completed | Counter       | {task}    |                                                                     | Number of completed compactions since server start.              |
-| cassandra.compaction.tasks.pending   | Gauge         | {task}    |                                                                     | Estimated number of compactions remaining to perform.            |
-| cassandra.storage.load               | UpDownCounter | By        |                                                                     | Size of the on disk data size this node manages.                 |
-| cassandra.storage.hints.count        | Counter       | {hint}    |                                                                     | Number of hint messages written to this node since server start. |
-| cassandra.storage.hints.in_progress  | UpDownCounter | {hint}    |                                                                     | Number of hints attempting to be sent currently.                 |
+| Metric Name                             | Type          | Unit      | Attributes                                                          | Description                                                      |
+|-----------------------------------------|---------------|-----------|---------------------------------------------------------------------|------------------------------------------------------------------|
+| cassandra.client.request.count          | Counter       | {request} | cassandra.operation                                                 | Number of requests by operation.                                 |
+| cassandra.client.request.error          | Counter       | {error}   | cassandra.operation, cassandra.status                               | Number of request errors by operation.                           |
+| cassandra.client.request.latency.p50    | Gauge         | s         | cassandra.operation                                                 | Request latency 50th percentile by operation.                    |
+| cassandra.client.request.latency.p99    | Gauge         | s         | cassandra.operation                                                 | Request latency 99th percentile by operation.                    |
+| cassandra.client.request.latency.max    | Gauge         | s         | cassandra.operation                                                 | Maximum request latency by operation.                            |
+| cassandra.compaction.progress.completed | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Bytes completed for in-flight compactions.                       |
+| cassandra.compaction.progress.size      | Gauge         | By        | cassandra.compaction.task_type, cassandra.keyspace, cassandra.table | Total bytes for in-flight compactions.                           |
+| cassandra.compaction.tasks.completed    | Counter       | {task}    |                                                                     | Number of completed compactions since server start.              |
+| cassandra.compaction.tasks.pending      | Gauge         | {task}    |                                                                     | Estimated number of compactions remaining to perform.            |
+| cassandra.storage.load                  | UpDownCounter | By        |                                                                     | Size of the on disk data size this node manages.                 |
+| cassandra.storage.hints.count           | Counter       | {hint}    |                                                                     | Number of hint messages written to this node since server start. |
+| cassandra.storage.hints.in_progress     | UpDownCounter | {hint}    |                                                                     | Number of hints attempting to be sent currently.                 |

--- a/instrumentation/jmx-metrics/library/cassandra.md
+++ b/instrumentation/jmx-metrics/library/cassandra.md
@@ -3,7 +3,7 @@
 Here is the list of metrics based on MBeans exposed by Cassandra.
 
 | Metric Name                             | Type          | Unit      | Attributes                                                          | Description                                                      |
-|-----------------------------------------|---------------|-----------|---------------------------------------------------------------------|------------------------------------------------------------------|
+| --------------------------------------- | ------------- | --------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | cassandra.client.request.count          | Counter       | {request} | cassandra.operation                                                 | Number of requests by operation.                                 |
 | cassandra.client.request.error          | Counter       | {error}   | cassandra.operation, cassandra.status                               | Number of request errors by operation.                           |
 | cassandra.client.request.latency.p50    | Gauge         | s         | cassandra.operation                                                 | Request latency 50th percentile by operation.                    |

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -126,8 +126,18 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
           continue;
         }
 
-        long completed = parseLong(entry.get("completed"));
-        long total = parseLong(entry.get("total"));
+        long completed;
+        long total;
+        try {
+          completed = parseLong(entry.get("completed"));
+          total = parseLong(entry.get("total"));
+        } catch (ArithmeticException e) {
+          logger.log(
+              WARNING,
+              "cassandra.compaction.progress: byte value overflows long range, skipping entry",
+              e);
+          continue;
+        }
 
         Attributes attrs = buildAttributes(taskType, keyspace, columnFamily);
         groups.merge(
@@ -148,7 +158,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
       return 0;
     }
     try {
-      return new BigInteger(value.toString()).longValue();
+      return new BigInteger(value.toString()).longValueExact();
     } catch (NumberFormatException e) {
       return 0;
     }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jmx.internal.handler;
+
+import static java.util.logging.Level.WARNING;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.instrumentation.jmx.internal.ExperimentalJmxMetricHandler;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+/**
+ * JMX metric handler that reports per-compaction byte progress from Cassandra's CompactionManager.
+ *
+ * <p>Queries {@code org.apache.cassandra.db:type=CompactionManager}, reads the {@code Compactions}
+ * attribute (a list of maps representing in-flight compactions), groups entries by {@code taskType
+ * + keyspace + columnfamily}, and emits two gauges per group:
+ *
+ * <ul>
+ *   <li>{@code cassandra.compaction.progress.bytes} — bytes completed so far
+ *   <li>{@code cassandra.compaction.progress.total} — total bytes for the compaction
+ * </ul>
+ *
+ * <p>Both metrics carry {@code cassandra.compaction.task_type}, {@code cassandra.keyspace}, and
+ * {@code cassandra.table} attributes. Entries missing any of these dimension fields are skipped.
+ * Byte values are string-encoded in the MBean and parsed via {@link BigInteger}.
+ *
+ * <p>Note: these are distinct from {@code cassandra.compaction.tasks.pending/completed}, which are
+ * simple scalar task counts from {@code org.apache.cassandra.metrics:type=Compaction}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class CassandraCompactionProgressHandler implements ExperimentalJmxMetricHandler {
+
+  static final String HANDLER_NAME = "cassandra-compaction-progress";
+  static final String METRIC_CURRENT = "cassandra.compaction.progress.bytes";
+  static final String METRIC_TOTAL = "cassandra.compaction.progress.total";
+
+  private static final String ATTR_TASK_TYPE = "cassandra.compaction.task_type";
+  private static final String ATTR_KEYSPACE = "cassandra.keyspace";
+  private static final String ATTR_TABLE = "cassandra.table";
+
+  private static final Logger logger =
+      Logger.getLogger(CassandraCompactionProgressHandler.class.getName());
+
+  @Override
+  public String getName() {
+    return HANDLER_NAME;
+  }
+
+  @Override
+  public AutoCloseable create(Meter meter, Supplier<Detector> detectorSupplier) {
+    ObservableLongMeasurement currentGauge =
+        meter
+            .gaugeBuilder(METRIC_CURRENT)
+            .setDescription("Bytes completed for in-flight compactions")
+            .setUnit("By")
+            .ofLongs()
+            .buildObserver();
+
+    ObservableLongMeasurement totalGauge =
+        meter
+            .gaugeBuilder(METRIC_TOTAL)
+            .setDescription("Total bytes for in-flight compactions")
+            .setUnit("By")
+            .ofLongs()
+            .buildObserver();
+
+    return meter.batchCallback(
+        () -> {
+          for (Map.Entry<Attributes, long[]> entry : queryGroups(detectorSupplier).entrySet()) {
+            currentGauge.record(entry.getValue()[0], entry.getKey());
+            totalGauge.record(entry.getValue()[1], entry.getKey());
+          }
+        },
+        currentGauge,
+        totalGauge);
+  }
+
+  private static Map<Attributes, long[]> queryGroups(Supplier<Detector> detectorSupplier) {
+    Map<Attributes, long[]> groups = new HashMap<>();
+    Detector detector = detectorSupplier.get();
+    if (detector == null) {
+      return groups;
+    }
+    MBeanServerConnection connection = detector.getConnection();
+    for (ObjectName objectName : detector.getObjectNames()) {
+      queryCompactions(connection, objectName)
+          .forEach(
+              (attrs, values) ->
+                  groups.merge(attrs, values, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]}));
+    }
+    return groups;
+  }
+
+  static Map<Attributes, long[]> queryCompactions(
+      MBeanServerConnection connection, ObjectName objectName) {
+    Map<Attributes, long[]> groups = new HashMap<>();
+    try {
+      // CompactionManager#getCompactions() returns List<Map<String,String>> via Standard MBean
+      @SuppressWarnings("unchecked")
+      List<Map<String, String>> compactions =
+          (List<Map<String, String>>) connection.getAttribute(objectName, "Compactions");
+
+      for (Map<String, String> entry : compactions) {
+        String taskType = entry.get("taskType");
+        String keyspace = entry.get("keyspace");
+        String columnFamily = entry.get("columnfamily");
+        String unit = entry.get("unit");
+
+        if (taskType == null || keyspace == null || columnFamily == null || !isByteUnit(unit)) {
+          continue;
+        }
+
+        long completed = parseLong(entry.get("completed"));
+        long total = parseLong(entry.get("total"));
+
+        Attributes attrs = buildAttributes(taskType, keyspace, columnFamily);
+        groups.merge(
+            attrs, new long[] {completed, total}, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]});
+      }
+    } catch (Exception e) {
+      logger.log(WARNING, "cassandra.compaction.progress: failed to query CompactionManager", e);
+    }
+    return groups;
+  }
+
+  private static boolean isByteUnit(@Nullable String unit) {
+    return unit != null && unit.equalsIgnoreCase("bytes");
+  }
+
+  private static long parseLong(@Nullable Object value) {
+    if (value == null) {
+      return 0;
+    }
+    try {
+      return new BigInteger(value.toString()).longValue();
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private static Attributes buildAttributes(String taskType, String keyspace, String columnFamily) {
+    AttributesBuilder builder = Attributes.builder();
+    builder.put(ATTR_TASK_TYPE, taskType);
+    builder.put(ATTR_KEYSPACE, keyspace);
+    builder.put(ATTR_TABLE, columnFamily);
+    return builder.build();
+  }
+}

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -44,7 +44,7 @@ import javax.management.ObjectName;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class CassandraCompactionProgressHandler implements ExperimentalJmxMetricHandler {
+public class CassandraCompactionProgressHandler implements ExperimentalJmxMetricHandler {
 
   static final String HANDLER_NAME = "cassandra-compaction-progress";
   static final String METRIC_CURRENT = "cassandra.compaction.progress.bytes";

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -168,6 +168,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
   }
 
   private static Attributes buildAttributes(String taskType, String keyspace, String columnFamily) {
-    return Attributes.of(ATTR_TASK_TYPE, taskType, ATTR_KEYSPACE, keyspace, ATTR_TABLE, columnFamily);
+    return Attributes.of(
+        ATTR_TASK_TYPE, taskType, ATTR_KEYSPACE, keyspace, ATTR_TABLE, columnFamily);
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -47,8 +47,8 @@ import javax.management.ObjectName;
 public class CassandraCompactionProgressHandler implements ExperimentalJmxMetricHandler {
 
   static final String HANDLER_NAME = "cassandra-compaction-progress";
-  static final String METRIC_CURRENT = "cassandra.compaction.progress.completed";
-  static final String METRIC_TOTAL = "cassandra.compaction.progress.size";
+  private static final String METRIC_CURRENT = "cassandra.compaction.progress.completed";
+  private static final String METRIC_TOTAL = "cassandra.compaction.progress.size";
 
   private static final String ATTR_TASK_TYPE = "cassandra.compaction.task_type";
   private static final String ATTR_KEYSPACE = "cassandra.keyspace";

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.jmx.internal.handler;
 
-import static java.util.logging.Level.WARNING;
+import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -30,8 +30,8 @@ import javax.management.ObjectName;
  * + keyspace + columnfamily}, and emits two gauges per group:
  *
  * <ul>
- *   <li>{@code cassandra.compaction.progress.bytes} — bytes completed so far
- *   <li>{@code cassandra.compaction.progress.total} — total bytes for the compaction
+ *   <li>{@code cassandra.compaction.progress.completed} — bytes completed so far
+ *   <li>{@code cassandra.compaction.progress.size} — total bytes for the compaction
  * </ul>
  *
  * <p>Both metrics carry {@code cassandra.compaction.task_type}, {@code cassandra.keyspace}, and
@@ -47,8 +47,8 @@ import javax.management.ObjectName;
 public class CassandraCompactionProgressHandler implements ExperimentalJmxMetricHandler {
 
   static final String HANDLER_NAME = "cassandra-compaction-progress";
-  static final String METRIC_CURRENT = "cassandra.compaction.progress.bytes";
-  static final String METRIC_TOTAL = "cassandra.compaction.progress.total";
+  static final String METRIC_CURRENT = "cassandra.compaction.progress.completed";
+  static final String METRIC_TOTAL = "cassandra.compaction.progress.size";
 
   private static final String ATTR_TASK_TYPE = "cassandra.compaction.task_type";
   private static final String ATTR_KEYSPACE = "cassandra.keyspace";
@@ -67,7 +67,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
     ObservableLongMeasurement currentGauge =
         meter
             .gaugeBuilder(METRIC_CURRENT)
-            .setDescription("Bytes completed for in-flight compactions")
+            .setDescription("Bytes completed for in-flight compactions.")
             .setUnit("By")
             .ofLongs()
             .buildObserver();
@@ -75,7 +75,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
     ObservableLongMeasurement totalGauge =
         meter
             .gaugeBuilder(METRIC_TOTAL)
-            .setDescription("Total bytes for in-flight compactions")
+            .setDescription("Total bytes for in-flight compactions.")
             .setUnit("By")
             .ofLongs()
             .buildObserver();
@@ -91,7 +91,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
         totalGauge);
   }
 
-  private static Map<Attributes, long[]> queryGroups(Supplier<Detector> detectorSupplier) {
+  static Map<Attributes, long[]> queryGroups(Supplier<Detector> detectorSupplier) {
     Map<Attributes, long[]> groups = new HashMap<>();
     Detector detector = detectorSupplier.get();
     if (detector == null) {
@@ -131,10 +131,10 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
         try {
           completed = parseLong(entry.get("completed"));
           total = parseLong(entry.get("total"));
-        } catch (ArithmeticException e) {
+        } catch (ArithmeticException | NumberFormatException e) {
           logger.log(
-              WARNING,
-              "cassandra.compaction.progress: byte value overflows long range, skipping entry",
+              FINE,
+              "cassandra.compaction.progress: byte value out of range or malformed, skipping entry",
               e);
           continue;
         }
@@ -144,7 +144,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
             attrs, new long[] {completed, total}, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]});
       }
     } catch (Exception e) {
-      logger.log(WARNING, "cassandra.compaction.progress: failed to query CompactionManager", e);
+      logger.log(FINE, "cassandra.compaction.progress: failed to query CompactionManager", e);
     }
     return groups;
   }
@@ -153,15 +153,11 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
     return unit != null && unit.equalsIgnoreCase("bytes");
   }
 
-  private static long parseLong(@Nullable Object value) {
+  private static long parseLong(@Nullable String value) {
     if (value == null) {
-      return 0;
+      throw new NumberFormatException("null");
     }
-    try {
-      return new BigInteger(value.toString()).longValueExact();
-    } catch (NumberFormatException e) {
-      return 0;
-    }
+    return new BigInteger(value).longValueExact();
   }
 
   private static Attributes buildAttributes(String taskType, String keyspace, String columnFamily) {

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandler.java
@@ -7,14 +7,15 @@ package io.opentelemetry.instrumentation.jmx.internal.handler;
 
 import static java.util.logging.Level.FINE;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import io.opentelemetry.instrumentation.jmx.internal.ExperimentalJmxMetricHandler;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
@@ -50,9 +51,11 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
   private static final String METRIC_CURRENT = "cassandra.compaction.progress.completed";
   private static final String METRIC_TOTAL = "cassandra.compaction.progress.size";
 
-  private static final String ATTR_TASK_TYPE = "cassandra.compaction.task_type";
-  private static final String ATTR_KEYSPACE = "cassandra.keyspace";
-  private static final String ATTR_TABLE = "cassandra.table";
+  private static final AttributeKey<String> ATTR_TASK_TYPE =
+      AttributeKey.stringKey("cassandra.compaction.task_type");
+  private static final AttributeKey<String> ATTR_KEYSPACE =
+      AttributeKey.stringKey("cassandra.keyspace");
+  private static final AttributeKey<String> ATTR_TABLE = AttributeKey.stringKey("cassandra.table");
 
   private static final Logger logger =
       Logger.getLogger(CassandraCompactionProgressHandler.class.getName());
@@ -139,7 +142,7 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
           continue;
         }
 
-        Attributes attrs = buildAttributes(taskType, keyspace, columnFamily);
+        Attributes attrs = buildAttributes(normalizeTaskType(taskType), keyspace, columnFamily);
         groups.merge(
             attrs, new long[] {completed, total}, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]});
       }
@@ -147,6 +150,10 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
       logger.log(FINE, "cassandra.compaction.progress: failed to query CompactionManager", e);
     }
     return groups;
+  }
+
+  private static String normalizeTaskType(String taskType) {
+    return taskType.toLowerCase(Locale.ROOT).replace(' ', '_');
   }
 
   private static boolean isByteUnit(@Nullable String unit) {
@@ -161,10 +168,6 @@ public class CassandraCompactionProgressHandler implements ExperimentalJmxMetric
   }
 
   private static Attributes buildAttributes(String taskType, String keyspace, String columnFamily) {
-    AttributesBuilder builder = Attributes.builder();
-    builder.put(ATTR_TASK_TYPE, taskType);
-    builder.put(ATTR_KEYSPACE, keyspace);
-    builder.put(ATTR_TABLE, columnFamily);
-    return builder.build();
+    return Attributes.of(ATTR_TASK_TYPE, taskType, ATTR_KEYSPACE, keyspace, ATTR_TABLE, columnFamily);
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/resources/META-INF/services/io.opentelemetry.instrumentation.jmx.internal.ExperimentalJmxMetricHandler
+++ b/instrumentation/jmx-metrics/library/src/main/resources/META-INF/services/io.opentelemetry.instrumentation.jmx.internal.ExperimentalJmxMetricHandler
@@ -1,0 +1,1 @@
+io.opentelemetry.instrumentation.jmx.internal.handler.CassandraCompactionProgressHandler

--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/experimental-cassandra.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/experimental-cassandra.yaml
@@ -120,3 +120,9 @@ rules:
         type: *errortype
         unit: *errorunit
         desc: *errordesc
+
+  # Compaction byte progress - uses a code-based handler because the Compactions attribute
+  # returns a list of maps requiring iteration, grouping by composite key, and string-encoded
+  # BigInteger parsing, none of which can be expressed in declarative YAML.
+  - bean: org.apache.cassandra.db:type=CompactionManager
+    handler: cassandra-compaction-progress

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jmx.internal.handler;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import java.util.HashMap;
+import java.util.Map;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CassandraCompactionProgressHandlerTest {
+
+  private static final String ATTR_TASK_TYPE = "cassandra.compaction.task_type";
+  private static final String ATTR_KEYSPACE = "cassandra.keyspace";
+  private static final String ATTR_TABLE = "cassandra.table";
+
+  private MBeanServerConnection connection;
+  private ObjectName objectName;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection = mock(MBeanServerConnection.class);
+    objectName = new ObjectName("org.apache.cassandra.db:type=CompactionManager");
+  }
+
+  @Test
+  void groupsByCompositeKey() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(
+            asList(
+                compactionEntry("COMPACTION", "ks1", "cf1", "100", "200"),
+                compactionEntry("COMPACTION", "ks1", "cf1", "50", "150"),
+                compactionEntry("COMPACTION", "ks2", "cf2", "10", "100")));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(2);
+    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(150L, 350L);
+    assertThat(groups.get(attrs("COMPACTION", "ks2", "cf2"))).containsExactly(10L, 100L);
+  }
+
+  @Test
+  void skipsEntriesMissingDimensionFields() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(
+            asList(
+                compactionEntry("COMPACTION", "ks1", "cf1", "10", "100"),
+                compactionEntry("COMPACTION", null, "cf1", "5", "50"),
+                compactionEntry("COMPACTION", "ks1", null, "5", "50")));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(1);
+    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(10L, 100L);
+  }
+
+  @Test
+  void skipsEntriesWithNonByteUnits() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(
+            asList(
+                compactionEntry("COMPACTION", "ks1", "cf1", "10", "100", "bytes"),
+                compactionEntry("VALIDATION", "ks1", "cf1", "5", "50", "keys"),
+                compactionEntry("ANTICOMPACTION", "ks1", "cf1", "5", "50", "ranges"),
+                compactionEntry("COMPACTION", "ks2", "cf2", "5", "50", null)));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(1);
+    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(10L, 100L);
+  }
+
+  @Test
+  void parsesBigIntegerStringValues() throws Exception {
+    // values larger than Long.MAX_VALUE are truncated but must not throw
+    String big = "99999999999999999999";
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks", "cf", big, big)));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(1);
+  }
+
+  @Test
+  void returnsEmptyMapOnException() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenThrow(new RuntimeException("connection lost"));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).isEmpty();
+  }
+
+  @Test
+  void handlerNameIsStable() {
+    assertThat(new CassandraCompactionProgressHandler().getName())
+        .isEqualTo(CassandraCompactionProgressHandler.HANDLER_NAME);
+  }
+
+  @Test
+  void mergesGroupsAcrossMultipleObjectNames() throws Exception {
+    ObjectName objectName2 = new ObjectName("org.apache.cassandra.db:type=CompactionManager,id=2");
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks1", "cf1", "100", "200")));
+    when(connection.getAttribute(objectName2, "Compactions"))
+        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks1", "cf1", "50", "150")));
+
+    Map<Attributes, long[]> first =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+    Map<Attributes, long[]> second =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName2);
+
+    // Simulate what queryGroups does: merge across ObjectNames using the same merge function
+    Map<Attributes, long[]> merged = new HashMap<>(first);
+    second.forEach(
+        (attrs, values) ->
+            merged.merge(attrs, values, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]}));
+
+    assertThat(merged).hasSize(1);
+    assertThat(merged.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(150L, 350L);
+  }
+
+  private static Map<String, String> compactionEntry(
+      String taskType, String keyspace, String columnfamily, String completed, String total) {
+    return compactionEntry(taskType, keyspace, columnfamily, completed, total, "bytes");
+  }
+
+  private static Map<String, String> compactionEntry(
+      String taskType,
+      String keyspace,
+      String columnfamily,
+      String completed,
+      String total,
+      String unit) {
+    Map<String, String> entry = new HashMap<>();
+    entry.put("taskType", taskType);
+    entry.put("keyspace", keyspace);
+    entry.put("columnfamily", columnfamily);
+    entry.put("completed", completed);
+    entry.put("total", total);
+    entry.put("unit", unit);
+    return entry;
+  }
+
+  private static Attributes attrs(String taskType, String keyspace, String columnFamily) {
+    return Attributes.builder()
+        .put(ATTR_TASK_TYPE, taskType)
+        .put(ATTR_KEYSPACE, keyspace)
+        .put(ATTR_TABLE, columnFamily)
+        .build();
+  }
+}

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
@@ -85,8 +85,8 @@ class CassandraCompactionProgressHandlerTest {
   }
 
   @Test
-  void parsesBigIntegerStringValues() throws Exception {
-    // values larger than Long.MAX_VALUE are truncated but must not throw
+  void skipsEntriesWithValuesExceedingLongRange() throws Exception {
+    // values larger than Long.MAX_VALUE cannot be safely cast to long — entry must be skipped
     String big = "99999999999999999999";
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(singletonList(compactionEntry("COMPACTION", "ks", "cf", big, big)));
@@ -94,7 +94,7 @@ class CassandraCompactionProgressHandlerTest {
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
-    assertThat(groups).hasSize(1);
+    assertThat(groups).isEmpty();
   }
 
   @Test

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.instrumentation.jmx.internal.ExperimentalJmxMetricHandler.Detector;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.management.MBeanServerConnection;
@@ -86,7 +88,6 @@ class CassandraCompactionProgressHandlerTest {
 
   @Test
   void skipsEntriesWithValuesExceedingLongRange() throws Exception {
-    // values larger than Long.MAX_VALUE cannot be safely cast to long — entry must be skipped
     String big = "99999999999999999999";
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(singletonList(compactionEntry("COMPACTION", "ks", "cf", big, big)));
@@ -95,6 +96,21 @@ class CassandraCompactionProgressHandlerTest {
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
     assertThat(groups).isEmpty();
+  }
+
+  @Test
+  void skipsEntriesWithMalformedValues() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(
+            asList(
+                compactionEntry("COMPACTION", "ks1", "cf1", "not-a-number", "100"),
+                compactionEntry("COMPACTION", "ks2", "cf2", "50", "100")));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(1);
+    assertThat(groups.get(attrs("COMPACTION", "ks2", "cf2"))).containsExactly(50L, 100L);
   }
 
   @Test
@@ -122,16 +138,20 @@ class CassandraCompactionProgressHandlerTest {
     when(connection.getAttribute(objectName2, "Compactions"))
         .thenReturn(singletonList(compactionEntry("COMPACTION", "ks1", "cf1", "50", "150")));
 
-    Map<Attributes, long[]> first =
-        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
-    Map<Attributes, long[]> second =
-        CassandraCompactionProgressHandler.queryCompactions(connection, objectName2);
+    Detector detector =
+        new Detector() {
+          @Override
+          public MBeanServerConnection getConnection() {
+            return connection;
+          }
 
-    // Simulate what queryGroups does: merge across ObjectNames using the same merge function
-    Map<Attributes, long[]> merged = new HashMap<>(first);
-    second.forEach(
-        (attrs, values) ->
-            merged.merge(attrs, values, (a, b) -> new long[] {a[0] + b[0], a[1] + b[1]}));
+          @Override
+          public Collection<ObjectName> getObjectNames() {
+            return asList(objectName, objectName2);
+          }
+        };
+
+    Map<Attributes, long[]> merged = CassandraCompactionProgressHandler.queryGroups(() -> detector);
 
     assertThat(merged).hasSize(1);
     assertThat(merged.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(150L, 350L);

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
@@ -41,16 +41,16 @@ class CassandraCompactionProgressHandlerTest {
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(
             asList(
-                compactionEntry("COMPACTION", "ks1", "cf1", "100", "200"),
-                compactionEntry("COMPACTION", "ks1", "cf1", "50", "150"),
-                compactionEntry("COMPACTION", "ks2", "cf2", "10", "100")));
+                compactionEntry("Compaction", "ks1", "cf1", "100", "200"),
+                compactionEntry("Compaction", "ks1", "cf1", "50", "150"),
+                compactionEntry("Compaction", "ks2", "cf2", "10", "100")));
 
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
     assertThat(groups).hasSize(2);
-    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(150L, 350L);
-    assertThat(groups.get(attrs("COMPACTION", "ks2", "cf2"))).containsExactly(10L, 100L);
+    assertThat(groups.get(attrs("compaction", "ks1", "cf1"))).containsExactly(150L, 350L);
+    assertThat(groups.get(attrs("compaction", "ks2", "cf2"))).containsExactly(10L, 100L);
   }
 
   @Test
@@ -58,16 +58,16 @@ class CassandraCompactionProgressHandlerTest {
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(
             asList(
-                compactionEntry("COMPACTION", "ks1", "cf1", "10", "100"),
+                compactionEntry("Compaction", "ks1", "cf1", "10", "100"),
                 compactionEntry(null, "ks1", "cf1", "5", "50"),
-                compactionEntry("COMPACTION", null, "cf1", "5", "50"),
-                compactionEntry("COMPACTION", "ks1", null, "5", "50")));
+                compactionEntry("Compaction", null, "cf1", "5", "50"),
+                compactionEntry("Compaction", "ks1", null, "5", "50")));
 
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
     assertThat(groups).hasSize(1);
-    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(10L, 100L);
+    assertThat(groups.get(attrs("compaction", "ks1", "cf1"))).containsExactly(10L, 100L);
   }
 
   @Test
@@ -75,23 +75,23 @@ class CassandraCompactionProgressHandlerTest {
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(
             asList(
-                compactionEntry("COMPACTION", "ks1", "cf1", "10", "100", "bytes"),
-                compactionEntry("VALIDATION", "ks1", "cf1", "5", "50", "keys"),
-                compactionEntry("ANTICOMPACTION", "ks1", "cf1", "5", "50", "ranges"),
-                compactionEntry("COMPACTION", "ks2", "cf2", "5", "50", null)));
+                compactionEntry("Compaction", "ks1", "cf1", "10", "100", "bytes"),
+                compactionEntry("Validation", "ks1", "cf1", "5", "50", "keys"),
+                compactionEntry("Anti-Compaction", "ks1", "cf1", "5", "50", "ranges"),
+                compactionEntry("Compaction", "ks2", "cf2", "5", "50", null)));
 
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
     assertThat(groups).hasSize(1);
-    assertThat(groups.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(10L, 100L);
+    assertThat(groups.get(attrs("compaction", "ks1", "cf1"))).containsExactly(10L, 100L);
   }
 
   @Test
   void skipsEntriesWithValuesExceedingLongRange() throws Exception {
     String big = "99999999999999999999";
     when(connection.getAttribute(objectName, "Compactions"))
-        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks", "cf", big, big)));
+        .thenReturn(singletonList(compactionEntry("Compaction", "ks", "cf", big, big)));
 
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
@@ -104,14 +104,30 @@ class CassandraCompactionProgressHandlerTest {
     when(connection.getAttribute(objectName, "Compactions"))
         .thenReturn(
             asList(
-                compactionEntry("COMPACTION", "ks1", "cf1", "not-a-number", "100"),
-                compactionEntry("COMPACTION", "ks2", "cf2", "50", "100")));
+                compactionEntry("Compaction", "ks1", "cf1", "not-a-number", "100"),
+                compactionEntry("Compaction", "ks2", "cf2", "50", "100")));
 
     Map<Attributes, long[]> groups =
         CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
 
     assertThat(groups).hasSize(1);
-    assertThat(groups.get(attrs("COMPACTION", "ks2", "cf2"))).containsExactly(50L, 100L);
+    assertThat(groups.get(attrs("compaction", "ks2", "cf2"))).containsExactly(50L, 100L);
+  }
+
+  @Test
+  void normalizesTaskType() throws Exception {
+    when(connection.getAttribute(objectName, "Compactions"))
+        .thenReturn(
+            asList(
+                compactionEntry("Upgrade sstables", "ks1", "cf1", "10", "100"),
+                compactionEntry("Secondary index build", "ks1", "cf2", "20", "200")));
+
+    Map<Attributes, long[]> groups =
+        CassandraCompactionProgressHandler.queryCompactions(connection, objectName);
+
+    assertThat(groups).hasSize(2);
+    assertThat(groups.get(attrs("upgrade_sstables", "ks1", "cf1"))).containsExactly(10L, 100L);
+    assertThat(groups.get(attrs("secondary_index_build", "ks1", "cf2"))).containsExactly(20L, 200L);
   }
 
   @Test
@@ -135,9 +151,9 @@ class CassandraCompactionProgressHandlerTest {
   void mergesGroupsAcrossMultipleObjectNames() throws Exception {
     ObjectName objectName2 = new ObjectName("org.apache.cassandra.db:type=CompactionManager,id=2");
     when(connection.getAttribute(objectName, "Compactions"))
-        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks1", "cf1", "100", "200")));
+        .thenReturn(singletonList(compactionEntry("Compaction", "ks1", "cf1", "100", "200")));
     when(connection.getAttribute(objectName2, "Compactions"))
-        .thenReturn(singletonList(compactionEntry("COMPACTION", "ks1", "cf1", "50", "150")));
+        .thenReturn(singletonList(compactionEntry("Compaction", "ks1", "cf1", "50", "150")));
 
     Detector detector =
         new Detector() {
@@ -155,7 +171,7 @@ class CassandraCompactionProgressHandlerTest {
     Map<Attributes, long[]> merged = CassandraCompactionProgressHandler.queryGroups(() -> detector);
 
     assertThat(merged).hasSize(1);
-    assertThat(merged.get(attrs("COMPACTION", "ks1", "cf1"))).containsExactly(150L, 350L);
+    assertThat(merged.get(attrs("compaction", "ks1", "cf1"))).containsExactly(150L, 350L);
   }
 
   private static Map<String, String> compactionEntry(

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/internal/handler/CassandraCompactionProgressHandlerTest.java
@@ -59,6 +59,7 @@ class CassandraCompactionProgressHandlerTest {
         .thenReturn(
             asList(
                 compactionEntry("COMPACTION", "ks1", "cf1", "10", "100"),
+                compactionEntry(null, "ks1", "cf1", "5", "50"),
                 compactionEntry("COMPACTION", null, "cf1", "5", "50"),
                 compactionEntry("COMPACTION", "ks1", null, "5", "50")));
 
@@ -127,7 +128,7 @@ class CassandraCompactionProgressHandlerTest {
   @Test
   void handlerNameIsStable() {
     assertThat(new CassandraCompactionProgressHandler().getName())
-        .isEqualTo(CassandraCompactionProgressHandler.HANDLER_NAME);
+        .isEqualTo("cassandra-compaction-progress");
   }
 
   @Test

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
@@ -7,19 +7,31 @@ package io.opentelemetry.instrumentation.jmx.rules;
 
 import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAttributes.attribute;
 import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAttributes.attributeGroup;
+import static io.opentelemetry.instrumentation.jmx.rules.assertions.DataPointAttributes.attributeWithAnyValue;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.jmx.rules.assertions.AttributeMatcherGroup;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 class CassandraTest extends TargetSystemTest {
 
   private static final int CASSANDRA_PORT = 9042;
+
+  // 4 batches x 2500 rows x 2 KB = ~20 MB; at 1 MB/s throttle compaction stays visible for ~20s,
+  // well within the 60s await in verifyMetrics().
+  private static final int COMPACTION_BATCHES = 4;
+  private static final int COMPACTION_ROWS_PER_BATCH = 2_500;
+  private static final int COMPACTION_VALUE_BYTES = 2_048;
+
+  private static final Logger logger = Logger.getLogger(CassandraTest.class.getName());
 
   @Test
   void testCassandraMetrics() {
@@ -47,7 +59,101 @@ class CassandraTest extends TargetSystemTest {
 
     startTarget(target);
 
+    seedCompactionData(target);
+    triggerCompaction(target);
+
     verifyMetrics(createMetricsVerifier());
+  }
+
+  private static void seedCompactionData(GenericContainer<?> target) {
+    try {
+      // Throttle compaction to 1 MB/s so it stays active long enough to be observed.
+      nodetool(target, "setcompactionthroughput", "1");
+
+      execOrThrow(
+          target,
+          "cqlsh",
+          "-e",
+          "CREATE KEYSPACE IF NOT EXISTS test"
+              + " WITH replication = {'class':'SimpleStrategy','replication_factor':1};"
+              + "CREATE TABLE IF NOT EXISTS test.data (id uuid PRIMARY KEY, val text)"
+              + " WITH compression = {'enabled':'false'};");
+      nodetool(target, "disableautocompaction", "test", "data");
+
+      for (int ignored = 0; ignored < COMPACTION_BATCHES; ignored++) {
+        seedCompactionBatch(target);
+        nodetool(target, "flush", "test", "data");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Failed to seed Cassandra data", e);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to seed Cassandra data", e);
+    }
+  }
+
+  private static void seedCompactionBatch(GenericContainer<?> target)
+      throws IOException, InterruptedException {
+    execOrThrow(
+        target,
+        "bash",
+        "-c",
+        // value is generated once and reused for all rows - only byte volume matters here.
+        "set -euo pipefail; "
+            + "value=$(head -c "
+            + COMPACTION_VALUE_BYTES
+            + " /dev/zero | tr '\\0' x); "
+            + "rm -f /tmp/cassandra-data.csv; "
+            + "for i in $(seq 1 "
+            + COMPACTION_ROWS_PER_BATCH
+            + "); do "
+            + "printf \"%s,%s\\n\" \"$(cat /proc/sys/kernel/random/uuid)\" \"$value\"; "
+            + "done > /tmp/cassandra-data.csv; "
+            + "cqlsh -e \"COPY test.data (id, val) FROM '/tmp/cassandra-data.csv' "
+            + "WITH HEADER = false AND MINBATCHSIZE = 1 AND MAXBATCHSIZE = 2;\"");
+  }
+
+  private static void triggerCompaction(GenericContainer<?> target) {
+    Thread compactionThread =
+        new Thread(
+            () -> {
+              try {
+                nodetool(target, "compact", "--", "test", "data");
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.warning("Background compaction interrupted");
+              } catch (Exception e) {
+                if (target.isRunning()) {
+                  logger.warning("Background compaction failed: " + e.getMessage());
+                }
+              }
+            },
+            "cassandra-compaction-trigger");
+    compactionThread.setDaemon(true);
+    compactionThread.start();
+  }
+
+  private static void nodetool(GenericContainer<?> target, String... args)
+      throws IOException, InterruptedException {
+    String[] command = new String[args.length + 1];
+    command[0] = "nodetool";
+    System.arraycopy(args, 0, command, 1, args.length);
+    execOrThrow(target, command);
+  }
+
+  private static void execOrThrow(GenericContainer<?> target, String... command)
+      throws IOException, InterruptedException {
+    Container.ExecResult result = target.execInContainer(command);
+    if (result.getExitCode() != 0) {
+      throw new IllegalStateException(
+          String.join(" ", command)
+              + " failed with exit code "
+              + result.getExitCode()
+              + "\nstdout:\n"
+              + result.getStdout()
+              + "\nstderr:\n"
+              + result.getStderr());
+    }
   }
 
   private static MetricsVerifier createMetricsVerifier() {
@@ -153,7 +259,31 @@ class CassandraTest extends TargetSystemTest {
                         errorAttributesGroup("read", "unavailable"),
                         errorAttributesGroup("write", "timeout"),
                         errorAttributesGroup("write", "failure"),
-                        errorAttributesGroup("write", "unavailable")));
+                        errorAttributesGroup("write", "unavailable")))
+        .add(
+            "cassandra.compaction.progress.bytes",
+            metric ->
+                metric
+                    .hasDescription("Bytes completed for in-flight compactions")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("cassandra.compaction.task_type"),
+                            attribute("cassandra.keyspace", "test"),
+                            attribute("cassandra.table", "data"))))
+        .add(
+            "cassandra.compaction.progress.total",
+            metric ->
+                metric
+                    .hasDescription("Total bytes for in-flight compactions")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("cassandra.compaction.task_type"),
+                            attribute("cassandra.keyspace", "test"),
+                            attribute("cassandra.table", "data"))));
   }
 
   private static AttributeMatcherGroup errorAttributesGroup(String operation, String status) {

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
@@ -16,8 +16,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -32,7 +33,7 @@ class CassandraTest extends TargetSystemTest {
   private static final int COMPACTION_ROWS_PER_BATCH = 2_500;
   private static final int COMPACTION_VALUE_BYTES = 2_048;
 
-  private static final Logger logger = Logger.getLogger(CassandraTest.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(CassandraTest.class);
 
   @Test
   void testCassandraMetrics() {
@@ -132,7 +133,7 @@ class CassandraTest extends TargetSystemTest {
                   if (!target.isRunning()) {
                     return;
                   }
-                  logger.warning("Background compaction failed: " + e.getMessage());
+                  logger.warn("Background compaction failed", e);
                   return;
                 }
               }

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
@@ -85,7 +85,7 @@ class CassandraTest extends TargetSystemTest {
               + " WITH compression = {'enabled':'false'};");
       nodetool(target, "disableautocompaction", "test", "data");
 
-      for (int ignored = 0; ignored < COMPACTION_BATCHES; ignored++) {
+      for (int i = 0; i < COMPACTION_BATCHES; i++) {
         seedCompactionBatch(target);
         nodetool(target, "flush", "test", "data");
       }

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CassandraTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
@@ -60,9 +61,13 @@ class CassandraTest extends TargetSystemTest {
     startTarget(target);
 
     seedCompactionData(target);
-    triggerCompaction(target);
-
-    verifyMetrics(createMetricsVerifier());
+    AtomicBoolean keepCompacting = new AtomicBoolean(true);
+    triggerCompaction(target, keepCompacting);
+    try {
+      verifyMetrics(createMetricsVerifier());
+    } finally {
+      keepCompacting.set(false);
+    }
   }
 
   private static void seedCompactionData(GenericContainer<?> target) {
@@ -113,18 +118,22 @@ class CassandraTest extends TargetSystemTest {
             + "WITH HEADER = false AND MINBATCHSIZE = 1 AND MAXBATCHSIZE = 2;\"");
   }
 
-  private static void triggerCompaction(GenericContainer<?> target) {
+  private static void triggerCompaction(GenericContainer<?> target, AtomicBoolean keepCompacting) {
     Thread compactionThread =
         new Thread(
             () -> {
-              try {
-                nodetool(target, "compact", "--", "test", "data");
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                logger.warning("Background compaction interrupted");
-              } catch (Exception e) {
-                if (target.isRunning()) {
+              while (keepCompacting.get()) {
+                try {
+                  nodetool(target, "compact", "--", "test", "data");
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return;
+                } catch (Exception e) {
+                  if (!target.isRunning()) {
+                    return;
+                  }
                   logger.warning("Background compaction failed: " + e.getMessage());
+                  return;
                 }
               }
             },
@@ -261,10 +270,10 @@ class CassandraTest extends TargetSystemTest {
                         errorAttributesGroup("write", "failure"),
                         errorAttributesGroup("write", "unavailable")))
         .add(
-            "cassandra.compaction.progress.bytes",
+            "cassandra.compaction.progress.completed",
             metric ->
                 metric
-                    .hasDescription("Bytes completed for in-flight compactions")
+                    .hasDescription("Bytes completed for in-flight compactions.")
                     .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(
@@ -273,10 +282,10 @@ class CassandraTest extends TargetSystemTest {
                             attribute("cassandra.keyspace", "test"),
                             attribute("cassandra.table", "data"))))
         .add(
-            "cassandra.compaction.progress.total",
+            "cassandra.compaction.progress.size",
             metric ->
                 metric
-                    .hasDescription("Total bytes for in-flight compactions")
+                    .hasDescription("Total bytes for in-flight compactions.")
                     .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(


### PR DESCRIPTION
Adds two Cassandra compaction byte-progress metrics to the `experimental-cassandra` JMX target system, implemented as a code-based `ExperimentalJmxMetricHandler` because the source data can't be expressed in declarative YAML.

- cassandra.compaction.progress.completed — bytes completed for in-flight compactions
- cassandra.compaction.progress.size — total bytes for in-flight compactions

Both carry `cassandra.compaction.task_type`, `cassandra.keyspace`, and `cassandra.table` attributes.

These come from `org.apache.cassandra.db:type=CompactionManager`'s `Compactions` attribute, which returns a list of maps (one per in-flight compaction). Producing the metrics requires iterating that list, grouping entries by the composite key, filtering to byte-measured compactions, and parsing string-encoded `BigInteger` values — none of which the YAML rule syntax supports.

This builds on the `experimental-cassandra` target system added in #19080, and supersedes the handler portion of [open-telemetry/opentelemetry-java-contrib#2912](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2912), which prototyped these metrics in jmx-scraper; that contrib PR will be closed once this lands.