### PR TITLE
Fix duplicate Maven publication coordinates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,7 +201,6 @@ tasks {
   }
 
   val generateReleaseBundle = register<Zip>("generateReleaseBundle") {
-    dependsOn(checkMavenPublicationCoordinates)
     dependsOn(project.tasks.withType<PublishToMavenRepository>())
     from("releaseRepo")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
+import io.opentelemetry.instrumentation.gradle.CheckMavenPublicationCoordinatesTask
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.asRequestBody
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import java.time.Duration
 import java.util.Base64
 
@@ -67,6 +70,22 @@ if (project.findProperty("skipTests") as String? == "true") {
   }
 }
 
+val mavenPublicationCoordinates = objects.listProperty<String>()
+
+subprojects {
+  val projectPath = path
+  pluginManager.withPlugin("maven-publish") {
+    extensions.getByType<PublishingExtension>().publications
+      .withType<MavenPublication>()
+      .configureEach {
+        val publication = this
+        mavenPublicationCoordinates.add(provider {
+          "${publication.groupId}:${publication.artifactId}:${publication.version}=$projectPath:${publication.name}"
+        })
+      }
+  }
+}
+
 if (gradle.startParameter.taskNames.contains("listTestsInPartition")) {
   tasks {
     register<DefaultTask>("listTestsInPartition") {
@@ -129,6 +148,21 @@ if (gradle.startParameter.taskNames.contains("listTestsInPartition")) {
 tasks {
   val stableVersion = version.toString().replace("-alpha", "")
 
+  val checkMavenPublicationCoordinates = register<CheckMavenPublicationCoordinatesTask>("checkMavenPublicationCoordinates") {
+    group = "Verification"
+    description = "Checks that Maven publications have unique coordinates"
+    publicationCoordinates.set(mavenPublicationCoordinates)
+  }
+
+  subprojects {
+    tasks.matching { it.name == "check" }.configureEach {
+      dependsOn(checkMavenPublicationCoordinates)
+    }
+    tasks.withType<PublishToMavenRepository>().configureEach {
+      dependsOn(checkMavenPublicationCoordinates)
+    }
+  }
+
   register<DefaultTask>("generateFossaConfiguration") {
     group = "Help"
     description = "Generate .fossa.yml configuration file"
@@ -167,6 +201,7 @@ tasks {
   }
 
   val generateReleaseBundle = register<Zip>("generateReleaseBundle") {
+    dependsOn(checkMavenPublicationCoordinates)
     dependsOn(project.tasks.withType<PublishToMavenRepository>())
     from("releaseRepo")
 

--- a/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/CheckMavenPublicationCoordinatesTask.kt
+++ b/conventions/src/main/kotlin/io/opentelemetry/instrumentation/gradle/CheckMavenPublicationCoordinatesTask.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class CheckMavenPublicationCoordinatesTask : DefaultTask() {
+  @get:Input
+  abstract val publicationCoordinates: ListProperty<String>
+
+  @TaskAction
+  fun checkPublicationCoordinates() {
+    val duplicatePublications = publicationCoordinates.get()
+      .groupBy { it.substringBefore('=') }
+      .filterValues { it.size > 1 }
+
+    if (duplicatePublications.isEmpty()) {
+      return
+    }
+
+    val message = buildString {
+      appendLine("Duplicate Maven publication coordinates:")
+      duplicatePublications.toSortedMap().forEach { (coordinates, publications) ->
+        appendLine("  $coordinates")
+        publications.sorted().forEach { publication ->
+          appendLine("    - ${publication.substringAfter('=')}")
+        }
+      }
+    }
+    throw GradleException(message)
+  }
+}

--- a/instrumentation/sofa-rpc-5.4/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/sofa-rpc-5.4/library-autoconfigure/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
   id("otel.library-instrumentation")
 }
 
+base.archivesName.set("${base.archivesName.get()}-autoconfigure")
+
 dependencies {
   implementation(project(":instrumentation:sofa-rpc-5.4:library"))
 


### PR DESCRIPTION
The 2.30.0 Maven Central deployment failed because the Sofa RPC library and library-autoconfigure projects published different artifacts using the same Maven coordinates. Parallel publication into the shared release repository produced mismatched JARs, checksums, and signatures.

This change:

- gives the Sofa RPC autoconfigure artifact the expected `-autoconfigure` suffix
- adds a configuration-cache-compatible task that rejects duplicate Maven publication coordinates
- runs the guard during ordinary `check` tasks and before every `PublishToMavenRepository` task
