### PR TITLE
Check conventions formatting in CI

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Spotless
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-        run: ./gradlew spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
+        run: |
+          ./gradlew spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
+          ./gradlew -p conventions spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
 
   license-check:
     runs-on: ubuntu-latest

--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -27,7 +27,9 @@ spotless {
       // depends on ktlint_standard_wrapping
       "ktlint_standard_trailing-comma-on-declaration-site" to "disabled",
       // also very hard to find out where this happens
-      "ktlint_standard_wrapping" to "disabled"
+      "ktlint_standard_wrapping" to "disabled",
+      // we use constant-style property names in Gradle scripts
+      "ktlint_standard_property-naming" to "disabled"
     ))
     target("**/*.gradle.kts")
   }

--- a/conventions/build.gradle.kts
+++ b/conventions/build.gradle.kts
@@ -27,9 +27,7 @@ spotless {
       // depends on ktlint_standard_wrapping
       "ktlint_standard_trailing-comma-on-declaration-site" to "disabled",
       // also very hard to find out where this happens
-      "ktlint_standard_wrapping" to "disabled",
-      // we use constant-style property names in Gradle scripts
-      "ktlint_standard_property-naming" to "disabled"
+      "ktlint_standard_wrapping" to "disabled"
     ))
     target("**/*.gradle.kts")
   }

--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.base.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.base.gradle.kts
@@ -1,4 +1,4 @@
-/** Common setup for manual instrumentation of libraries and javaagent instrumentation. */
+// Common setup for manual instrumentation of libraries and javaagent instrumentation.
 
 import io.opentelemetry.instrumentation.gradle.OtelPropsExtension
 import io.opentelemetry.javaagent.muzzle.AcceptableVersions
@@ -44,7 +44,7 @@ fun getPinnedVersions(): Map<String, String> {
   if (!rootProject.extra.has(key)) {
     val file = rootProject.file(".github/config/latest-dep-versions.json")
     if (!file.exists()) {
-      throw GradleException("Pinned latest-dep versions file is missing: ${file}.")
+      throw GradleException("Pinned latest-dep versions file is missing: $file.")
     }
     @Suppress("UNCHECKED_CAST")
     rootProject.extra[key] = groovy.json.JsonSlurper().parse(file) as Map<String, String>

--- a/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -52,7 +52,7 @@ if (project.findProperty("otel.stable") == "true" && project.path != ":javaagent
           // the japicmp "new" version is either the user-specified one, or the locally built jar.
           val apiNewVersion = project.findProperty("apiNewVersion") as String?
           val newArtifact = apiNewVersion?.let { findArtifact(it) }
-              ?: file(getByName<Jar>("jar").archiveFile)
+            ?: file(getByName<Jar>("jar").archiveFile)
           newClasspath.from(files(newArtifact))
 
           // only output changes, not everything

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -28,13 +28,13 @@ afterEvaluate {
 }
 
 // Version to use to compile code and run tests.
-val DEFAULT_JAVA_VERSION = JavaVersion.VERSION_21
+val repositoryDefaultJavaVersion = JavaVersion.VERSION_21
 
 java {
   toolchain {
     languageVersion.set(
       otelJava.minJavaVersionSupported.map {
-        val defaultJavaVersion = otelJava.maxJavaVersionSupported.getOrElse(DEFAULT_JAVA_VERSION).majorVersion.toInt()
+        val defaultJavaVersion = otelJava.maxJavaVersionSupported.getOrElse(repositoryDefaultJavaVersion).majorVersion.toInt()
         JavaLanguageVersion.of(Math.max(it.majorVersion.toInt(), defaultJavaVersion))
       }
     )
@@ -407,7 +407,7 @@ afterEvaluate {
       // We default to testing with Java 11 for most tests, but some tests don't support it, where we change
       // the default test task's version so commands like `./gradlew check` can test all projects regardless
       // of Java version.
-      if (!isJavaVersionAllowed(DEFAULT_JAVA_VERSION) && otelJava.maxJavaVersionForTests.isPresent) {
+      if (!isJavaVersionAllowed(repositoryDefaultJavaVersion) && otelJava.maxJavaVersionForTests.isPresent) {
         javaLauncher.set(
           javaToolchains.launcherFor {
             languageVersion.set(JavaLanguageVersion.of(otelJava.maxJavaVersionForTests.get().majorVersion))

--- a/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -326,10 +326,12 @@ tasks.withType<Test>().configureEach {
   val testJavaVersion = otelProps.testJavaVersion
   val useJ9 = otelProps.testJavaVM == "openj9"
   if (useJ9 && testJavaVersion != null && testJavaVersion.isJava8) {
-    jvmArgs("-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*}," +
+    jvmArgs(
+      "-Xjit:exclude={io/opentelemetry/testing/internal/io/netty/buffer/HeapByteBufUtil.*}," +
         "exclude={io/opentelemetry/testing/internal/io/netty/buffer/UnpooledHeapByteBuf.*}," +
         "exclude={io/opentelemetry/testing/internal/io/netty/buffer/AbstractByteBuf.*}," +
-        "exclude={io/opentelemetry/testing/internal/io/netty/handler/codec/base64/Base64.*}")
+        "exclude={io/opentelemetry/testing/internal/io/netty/handler/codec/base64/Base64.*}"
+    )
   }
 
   // There's no real harm in setting this for all tests even if any happen to not be using context
@@ -365,7 +367,7 @@ tasks.withType<Test>().configureEach {
 
   develocity.testRetry {
     // You can see tests that were retried by this mechanism in the collected test reports and build scans.
-    maxRetries.set(maxTestRetries);
+    maxRetries.set(maxTestRetries)
   }
 
   reports {

--- a/conventions/src/main/kotlin/otel.resolve-latest-dep-versions.gradle.kts
+++ b/conventions/src/main/kotlin/otel.resolve-latest-dep-versions.gradle.kts
@@ -22,10 +22,14 @@ tasks {
       // Seed the versions map with the existing JSON so that entries which fail to resolve
       // (broken transitive deps, missing repos, etc.) are preserved rather than deleted.
       val outputFile = file(".github/config/latest-dep-versions.json")
+
       @Suppress("UNCHECKED_CAST")
       val existingVersions: Map<String, String> =
-        if (outputFile.exists()) groovy.json.JsonSlurper().parse(outputFile) as Map<String, String>
-        else emptyMap()
+        if (outputFile.exists()) {
+          groovy.json.JsonSlurper().parse(outputFile) as Map<String, String>
+        } else {
+          emptyMap()
+        }
 
       val versions = sortedMapOf<String, String>()
       versions.putAll(existingVersions)
@@ -52,28 +56,26 @@ tasks {
 
       // Resolve an artifact with a stability filter, rejecting pre-release versions.
       // Results are cached to avoid repeated Maven Central lookups for the same artifact.
-      fun resolveStableVersion(project: Project, group: String, module: String, version: String): String? {
-        return stableVersionCache.getOrPut(Triple(group, module, version)) {
-          val detached = project.configurations.detachedConfiguration(
-            project.dependencies.create("$group:$module:$version")
-          )
-          // Disable transitive resolution: we only need to know the latest stable version of
-          // this artifact itself, not its full dependency graph. Transitive resolution can fail
-          // on classifier-specific native JARs or other platform-specific artifacts, causing
-          // resolveStableVersion() to return null and fall back to a pre-release version.
-          detached.isTransitive = false
-          detached.resolutionStrategy.componentSelection.all {
-            if (!AcceptableVersions.isStable(candidate.version)) {
-              reject("pre-release version")
-            }
+      fun resolveStableVersion(project: Project, group: String, module: String, version: String): String? = stableVersionCache.getOrPut(Triple(group, module, version)) {
+        val detached = project.configurations.detachedConfiguration(
+          project.dependencies.create("$group:$module:$version")
+        )
+        // Disable transitive resolution: we only need to know the latest stable version of
+        // this artifact itself, not its full dependency graph. Transitive resolution can fail
+        // on classifier-specific native JARs or other platform-specific artifacts, causing
+        // resolveStableVersion() to return null and fall back to a pre-release version.
+        detached.isTransitive = false
+        detached.resolutionStrategy.componentSelection.all {
+          if (!AcceptableVersions.isStable(candidate.version)) {
+            reject("pre-release version")
           }
-          val resolutionResult = detached.incoming.resolutionResult
-          resolutionResult.rootComponent.get()
-            .dependencies
-            .filterIsInstance<org.gradle.api.artifacts.result.ResolvedDependencyResult>()
-            .firstOrNull()
-            ?.selected?.moduleVersion?.version
         }
+        val resolutionResult = detached.incoming.resolutionResult
+        resolutionResult.rootComponent.get()
+          .dependencies
+          .filterIsInstance<org.gradle.api.artifacts.result.ResolvedDependencyResult>()
+          .firstOrNull()
+          ?.selected?.moduleVersion?.version
       }
 
       subprojects {
@@ -90,9 +92,12 @@ tasks {
                 if (requested is org.gradle.api.artifacts.component.ModuleComponentSelector) {
                   val reqVersion = requested.version
                   val selectedVersion = dep.selected.moduleVersion?.version ?: return@forEach
-                  val version = if (AcceptableVersions.isStable(selectedVersion)) selectedVersion
-                    else resolveStableVersion(this@subprojects, requested.group, requested.module, reqVersion)
-                    ?: selectedVersion // Fall back to pre-release if no stable version exists in range
+                  val version = if (AcceptableVersions.isStable(selectedVersion)) {
+                    selectedVersion
+                  } else {
+                    resolveStableVersion(this@subprojects, requested.group, requested.module, reqVersion)
+                      ?: selectedVersion // Fall back to pre-release if no stable version exists in range
+                  }
                   if (reqVersion == "latest.release") {
                     recordVersion("${requested.group}:${requested.module}#+", version)
                   } else if (reqVersion.contains("+")) {


### PR DESCRIPTION
The root `spotlessCheck` task does not check the `conventions` directory because it is a separate included Gradle build. As a result, formatting violations in convention plugins are currently not caught by CI.