### PR TITLE
Fix gh-aw lockfile update workflow syntax

### DIFF
--- a/.github/workflows/auto-update-gh-aw-lockfiles.yml
+++ b/.github/workflows/auto-update-gh-aw-lockfiles.yml
@@ -69,8 +69,7 @@ jobs:
           fi
           while IFS= read -r path; do
             case "$path" in
-              .github/aw/actions-lock.json |
-              .github/workflows/*.lock.yml) ;;
+              .github/aw/actions-lock.json|.github/workflows/*.lock.yml) ;;
               *)
                 echo "Unexpected path in generated patch: $path" >&2
                 exit 1


### PR DESCRIPTION
The `Check patch` step split a Bash `case` pattern across lines after `|`, causing the auto-update workflow to fail with:

```text
syntax error near unexpected token `newline'
```

Keep the two allowed path patterns on the same logical line so Bash can parse the allowlist and proceed with the generated lockfile patch.

This was exposed by #19216 when its `build-common.yml` update triggered the gh-aw lockfile workflow.

Validation:

- Extracted `Check patch` run block passes `bash -n`
- `git diff --check`