### PR TITLE
Preserve MessageHeaderAccessor binding in spring-integration TracingChannelInterceptor

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/TracingChannelInterceptorTest.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/TracingChannelInterceptorTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class TracingChannelInterceptorTest extends AbstractTracingChannelInterceptorTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  TracingChannelInterceptorTest() {
+    super(testing, null);
+  }
+}

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/TracingChannelInterceptor.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/TracingChannelInterceptor.java
@@ -22,6 +22,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.ExecutorChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -234,9 +235,29 @@ final class TracingChannelInterceptor implements ExecutorChannelInterceptor {
 
   private static Message<?> createMessageWithHeaders(
       Message<?> message, MessageHeaderAccessor messageHeaderAccessor) {
-    return MessageBuilder.fromMessage(message)
-        .copyHeaders(messageHeaderAccessor.toMessageHeaders())
-        .build();
+    MessageHeaderAccessor boundAccessor =
+        MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
+
+    // an ErrorMessage carries an originalMessage that only MessageBuilder propagates
+    if (boundAccessor == null || message instanceof ErrorMessage) {
+      return MessageBuilder.fromMessage(message)
+          .copyHeaders(messageHeaderAccessor.toMessageHeaders())
+          .build();
+    }
+
+    if (boundAccessor == messageHeaderAccessor) {
+      // getMutableAccessor() hands back the message's own accessor when its headers are mutable,
+      // so the context has already been written into this message
+      return message;
+    }
+
+    // Sealing the copy gives the new message an id and keeps it from sharing mutable headers with
+    // the accessor. Passing the accessor's own MessageHeaders preserves the binding that Spring
+    // components such as StompBrokerRelayMessageHandler recover through
+    // MessageHeaderAccessor.getAccessor().
+    messageHeaderAccessor.setImmutable();
+    return MessageBuilder.createMessage(
+        message.getPayload(), messageHeaderAccessor.getMessageHeaders());
   }
 
   private boolean createProducerSpan(MessageChannel messageChannel) {

--- a/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/TracingChannelInterceptorTest.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/TracingChannelInterceptorTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class TracingChannelInterceptorTest extends AbstractTracingChannelInterceptorTest {
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  TracingChannelInterceptorTest() {
+    super(testing, GlobalInterceptorSpringConfig.class);
+  }
+}

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractTracingChannelInterceptorTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractTracingChannelInterceptorTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.AbstractSpringIntegrationTracingTest.verifyCorrectSpanWasPropagated;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+/**
+ * Covers what the interceptor must preserve while rebuilding a message to carry trace context: the
+ * payload, the existing headers, the message id, the message type, and the {@link
+ * MessageHeaderAccessor} binding, which Spring components such as {@code
+ * StompBrokerRelayMessageHandler} recover via {@link MessageHeaderAccessor#getAccessor(Message,
+ * Class)}.
+ */
+abstract class AbstractTracingChannelInterceptorTest {
+
+  @RegisterExtension static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  private final InstrumentationExtension testing;
+
+  private final Class<?> additionalContextClass;
+
+  private ConfigurableApplicationContext applicationContext;
+
+  AbstractTracingChannelInterceptorTest(
+      InstrumentationExtension testing, Class<?> additionalContextClass) {
+    this.testing = testing;
+    this.additionalContextClass = additionalContextClass;
+  }
+
+  @BeforeEach
+  void setUp() {
+    List<Class<?>> contextClasses = new ArrayList<>();
+    contextClasses.add(AbstractSpringIntegrationTracingTest.MessageChannelsConfig.class);
+    if (additionalContextClass != null) {
+      contextClasses.add(additionalContextClass);
+    }
+    SpringApplication springApplication =
+        new SpringApplication(contextClasses.toArray(new Class<?>[0]));
+    springApplication.setDefaultProperties(
+        singletonMap("spring.main.web-application-type", "none"));
+    applicationContext = springApplication.run();
+    cleanup.deferCleanup(applicationContext);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"directChannel", "executorChannel"})
+  void preservesHeaderAccessorOfImmutableMessage(String channelName) {
+    // messages produced by SimpMessagingTemplate carry immutable headers, so the interceptor has to
+    // take a mutable copy of the accessor rather than mutating the message in place
+    TestHeaderAccessor accessor = new TestHeaderAccessor();
+    accessor.setHeader("testKey", "testValue");
+    Message<?> message = MessageBuilder.createMessage("payload", accessor.getMessageHeaders());
+
+    Message<?> received = sendAndCapture(channelName, message);
+
+    assertThat(received.getPayload()).isEqualTo("payload");
+    assertThat(received.getHeaders()).containsEntry("testKey", "testValue");
+    assertThat(MessageHeaderAccessor.getAccessor(received, TestHeaderAccessor.class)).isNotNull();
+    // a rebuilt message still needs an id, and must not go on sharing mutable headers with the
+    // accessor the interceptor injected into
+    assertThat(received.getHeaders().getId()).isNotNull();
+    assertThat(MessageHeaderAccessor.getAccessor(received, MessageHeaderAccessor.class).isMutable())
+        .isFalse();
+
+    assertContextWasPropagated(received);
+  }
+
+  @Test
+  void preservesHeaderAccessorOfMutableMessage() {
+    TestHeaderAccessor accessor = new TestHeaderAccessor();
+    accessor.setLeaveMutable(true);
+    accessor.setHeader("testKey", "testValue");
+
+    Message<?> received =
+        sendAndCapture(
+            "directChannel", MessageBuilder.createMessage("payload", accessor.getMessageHeaders()));
+
+    assertThat(received.getHeaders()).containsEntry("testKey", "testValue");
+    assertThat(MessageHeaderAccessor.getAccessor(received, TestHeaderAccessor.class)).isNotNull();
+    // sealing the accessor here would seal the caller's message too
+    assertThat(accessor.isMutable()).isTrue();
+
+    assertContextWasPropagated(received);
+  }
+
+  @Test
+  void doesNotShareHeadersBetweenSends() {
+    TestHeaderAccessor accessor = new TestHeaderAccessor();
+    Message<?> message = MessageBuilder.createMessage("payload", accessor.getMessageHeaders());
+
+    Message<?> first = sendAndCapture("directChannel", message);
+    Object firstTraceParent = first.getHeaders().get("traceparent");
+
+    Message<?> second = sendAndCapture("directChannel", first);
+
+    assertThat(second.getHeaders()).isNotSameAs(first.getHeaders());
+    assertThat(first.getHeaders().get("traceparent")).isEqualTo(firstTraceParent);
+  }
+
+  @Test
+  void preservesStompHeaderAccessor() {
+    // the shape SimpMessagingTemplate produces and StompBrokerRelayMessageHandler consumes
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+    accessor.setDestination("/topic/test");
+
+    Message<?> received =
+        sendAndCapture(
+            "directChannel", MessageBuilder.createMessage("payload", accessor.getMessageHeaders()));
+
+    StompHeaderAccessor recovered =
+        MessageHeaderAccessor.getAccessor(received, StompHeaderAccessor.class);
+    assertThat(recovered).isNotNull();
+    assertThat(recovered.getDestination()).isEqualTo("/topic/test");
+    // a STOMP frame only carries native headers, so the context has to reach them too
+    assertThat(recovered.getNativeHeader("traceparent")).isNotNull();
+
+    assertContextWasPropagated(received);
+  }
+
+  @Test
+  void preservesErrorMessage() {
+    // ErrorMessage keeps the MessageBuilder path so that its originalMessage survives
+    IllegalStateException payload = new IllegalStateException("boom");
+    TestHeaderAccessor accessor = new TestHeaderAccessor();
+
+    Message<?> received =
+        sendAndCapture(
+            "directChannel", MessageBuilder.createMessage(payload, accessor.getMessageHeaders()));
+
+    assertThat(received).isInstanceOf(ErrorMessage.class);
+    assertThat(received.getPayload()).isSameAs(payload);
+    assertThat(received.getHeaders().getId()).isNotNull();
+
+    assertContextWasPropagated(received);
+  }
+
+  @Test
+  void preservesErrorMessageOriginalMessage() throws ReflectiveOperationException {
+    // MessageBuilder only carries originalMessage over into a rebuilt ErrorMessage from 5.3 on;
+    // reflection is needed either way because neither the constructor that populates it nor
+    // getOriginalMessage() exists in 4.1, which is the version this module compiles against
+    assumeTrue(testLatestDeps());
+    Constructor<ErrorMessage> constructor =
+        ErrorMessage.class.getConstructor(Throwable.class, MessageHeaders.class, Message.class);
+    Message<?> original = new GenericMessage<>("original");
+    TestHeaderAccessor accessor = new TestHeaderAccessor();
+    Message<?> errorMessage =
+        constructor.newInstance(
+            new IllegalStateException("boom"), accessor.getMessageHeaders(), original);
+
+    Message<?> received = sendAndCapture("directChannel", errorMessage);
+
+    assertThat(ErrorMessage.class.getMethod("getOriginalMessage").invoke(received))
+        .isSameAs(original);
+  }
+
+  @Test
+  void preservesPayloadAndHeadersOfPlainMessage() {
+    Message<?> received =
+        sendAndCapture(
+            "directChannel",
+            MessageBuilder.withPayload("payload").setHeader("testKey", "testValue").build());
+
+    assertThat(received.getPayload()).isEqualTo("payload");
+    assertThat(received.getHeaders()).containsEntry("testKey", "testValue");
+    assertThat(received.getHeaders().getId()).isNotNull();
+
+    assertContextWasPropagated(received);
+  }
+
+  @Test
+  void injectsTraceContextIntoPlainMessage() {
+    Message<?> received = sendAndCapture("directChannel", new GenericMessage<>("payload"));
+
+    assertThat(received.getHeaders()).containsKey("traceparent");
+
+    assertContextWasPropagated(received);
+  }
+
+  /** Sends {@code message} through an intercepted channel and returns what the handler received. */
+  private Message<?> sendAndCapture(String channelName, Message<?> message) {
+    SubscribableChannel channel =
+        applicationContext.getBean(channelName, SubscribableChannel.class);
+    CapturingMessageHandler messageHandler = new CapturingMessageHandler();
+    channel.subscribe(messageHandler);
+    try {
+      channel.send(message);
+      return messageHandler.join();
+    } finally {
+      channel.unsubscribe(messageHandler);
+    }
+  }
+
+  /** Asserts that the delivered message carries the trace context of the interceptor's span. */
+  private void assertContextWasPropagated(Message<?> received) {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> {
+                  span.hasKind(SpanKind.CONSUMER);
+                  verifyCorrectSpanWasPropagated(received, trace.getSpan(0));
+                },
+                span -> span.hasName("handler").hasParent(trace.getSpan(0))));
+  }
+
+  /**
+   * Stands in for accessor subclasses such as {@code SimpMessageHeaderAccessor}, which override
+   * {@link MessageHeaderAccessor#createAccessor(Message)} so that the subclass survives when a
+   * mutable copy is taken of an immutable message.
+   */
+  static class TestHeaderAccessor extends MessageHeaderAccessor {
+
+    TestHeaderAccessor() {
+      super();
+    }
+
+    TestHeaderAccessor(Message<?> message) {
+      super(message);
+    }
+
+    @Override
+    protected MessageHeaderAccessor createAccessor(Message<?> message) {
+      return new TestHeaderAccessor(message);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #6855 (closed by the reporter once they realized they could just disable the feature to stop it from breaking their system)

  ## Problem

  With spring-integration instrumentation enabled, Spring components that recover a
  message's `MessageHeaderAccessor` stop finding it. `StompBrokerRelayMessageHandler`
  is one such component — it requires the accessor and throws:

  ```
  No header accessor (not using the SimpMessagingTemplate?)
  ```

  which breaks STOMP broker relaying. The usual workaround is
  `otel.instrumentation.spring-integration.enabled=false`.

  ## Root cause

  `preSend()` rebuilds the message so it can carry the injected trace context:

  ```java
  return MessageBuilder.fromMessage(message)
      .copyHeaders(messageHeaderAccessor.toMessageHeaders())
      .build();
  ```

  `toMessageHeaders()` returns plain `MessageHeaders`. The link between a message and
  its accessor lives in `MutableMessageHeaders`, so rebuilding this way silently drops
  it and `MessageHeaderAccessor.getAccessor(message, ...)` returns `null` downstream.

  ## Fix

  Rebuilding now distinguishes three cases:

  - **No bound accessor, or an `ErrorMessage`** — keep the existing `MessageBuilder`
    path. `ErrorMessage` does so because from 5.3 on `MessageBuilder` carries its
    `originalMessage` over into the rebuilt message and `createMessage` cannot.
  - **Mutable headers** — `getMutableAccessor()` returns the message's *own* accessor,
    so the context has already been written in place; return the message unchanged.
    Rebuilding here would seal the caller's message.
  - **Otherwise** — seal the accessor copy and hand over its own `MessageHeaders`.
    Sealing gives the new message an `id` and stops it sharing mutable headers with
    the accessor, while `createMessage` preserves the binding.

  All APIs used are public at the 4.1.2 compile floor.

  ## Tests

  `AbstractTracingChannelInterceptorTest` in the `testing` module, with thin subclasses
  in `library` and `javaagent`, following the existing `AbstractSpringIntegrationTracingTest`
  pattern. Messages are sent through a real channel and asserted on what the handler
  receives, over both a direct and an executor channel.

  Covers context propagation, payload/header preservation, message `id`, header
  immutability, cross-send header isolation, `ErrorMessage` type and `originalMessage`,
  STOMP native headers, and accessor preservation for mutable and immutable messages.

  Each of the three branches was removed in turn to confirm a test fails for each.

  ## Verification

  | | |
  |---|---|
  | `library` / `javaagent` / `testing` `check` | green |
  | `testLatestDeps` (5.5.20), both modules | green |
  | muzzle | 20 assertions — pass 4.1.0.RELEASE → 7.1.0, fail below the floor |
  | pristine upstream against the new tests | 3 failures |

  `testLatestDeps` is capped at `5.+` by a documented limitation, so muzzle is the only
  coverage of 6.x/7.x. The `assertInverse` boundary is unmoved at 4.1.0.

  ## Behaviour notes

  **Timestamp.** On the sealed path the rebuilt message has no `timestamp`, where the
  previous code generated one. `setEnableTimestamp` is `protected` so it cannot be
  restored externally. This matches Spring's own idiom — accessor-bound messages built
  through `createMessage` carry no timestamp, and the input messages in this shape don't
  either — but it is a change. The message `id` is present; for mutable accessor-bound
  messages `id` was already absent before this change.

  **Accessor subclasses.** Only subclasses that override `createAccessor` are restored,
  because `getMutableAccessor` delegates to it. Every Spring accessor intended to survive
  a mutable copy does so; a subclass that doesn't will still resolve to the base type.

  **ErrorMessage.** `originalMessage` preservation is guaranteed structurally rather than
  by assertion at the baseline: neither the constructor that populates it nor
  `getOriginalMessage()` exists at the 4.1.2 compile floor, so that test is
  reflection-based and gated on `testLatestDeps()`.

  ## Not included

  A test driving `StompBrokerRelayMessageHandler` end to end. Its accessor check sits
  behind an `isBrokerAvailable()` guard, so without a live broker connection the handler
  returns early and such a test would pass vacuously. The `StompHeaderAccessor` scenario
  covers the precondition instead, including the native headers a STOMP frame actually
  transmits. Happy to add a broker-backed test with guidance.

