### PR TITLE
Support multiple endpoints in clickhouse-client-v2-0.8 instrumentation

### DIFF
--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -54,14 +54,7 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
-      // https://clickhouse.com/docs/integrations/language-clients/java/client#client-configuration
-      // Currently, clientv2 supports only one endpoint. Since the endpoint is not going to change
-      // we'll cache it in a virtual field.
       AddressAndPort addressAndPort = ClickHouseClientV2Singletons.getAddressAndPort(client);
-      if (addressAndPort == null) {
-        String endpoint = client.getEndpoints().stream().findFirst().orElse(null);
-        addressAndPort = ClickHouseClientV2Singletons.setAddressAndPort(client, endpoint);
-      }
 
       String database = client.getConfiguration().get("database");
       Context parentContext = currentContext();

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -10,17 +10,13 @@ import com.clickhouse.client.api.ServerException;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
-import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
-import javax.annotation.Nullable;
 
 public class ClickHouseClientV2Singletons {
 
   private static final String INSTRUMENTER_NAME = "io.opentelemetry.clickhouse-client-v2-0.8";
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
-  private static final VirtualField<Client, AddressAndPort> ADDRESS_AND_PORT =
-      VirtualField.find(Client.class, AddressAndPort.class);
 
   static {
     instrumenter =
@@ -38,20 +34,13 @@ public class ClickHouseClientV2Singletons {
     return instrumenter;
   }
 
-  @Nullable
   public static AddressAndPort getAddressAndPort(Client client) {
-    return ADDRESS_AND_PORT.get(client);
-  }
-
-  public static AddressAndPort setAddressAndPort(Client client, @Nullable String endpoint) {
     AddressAndPort addressAndPort = new AddressAndPort();
-
+    String endpoint = client.getEndpoints().stream().findFirst().orElse(null);
     if (endpoint != null) {
       addressAndPort.setAddress(UrlParser.getHost(endpoint));
       addressAndPort.setPort(UrlParser.getPort(endpoint));
     }
-    ADDRESS_AND_PORT.set(client, addressAndPort);
-
     return addressAndPort;
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -140,6 +140,45 @@ class ClickHouseClientV2Test {
   }
 
   @Test
+  void testClientWithMultipleEndpoints() throws Exception {
+    Client client =
+        new Client.Builder()
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .addEndpoint(Protocol.HTTP, "localhost", 8123, false)
+            .setOption("compress", "false")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    cleanup.deferCleanup(client);
+
+    QueryResponse response = client.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "select test_table"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testQueryWithStringQuery() throws Exception {
     testing.runWithSpan(
         "parent",


### PR DESCRIPTION
## Description

Fixes #19306.

Previously, `ClickHouseClientV2Instrumentation` cached a single `AddressAndPort` in a `VirtualField` on the `Client` instance, based on the assumption that `clientv2` supported only a single endpoint.

When a client is configured with multiple endpoints (e.g. for failover or multi-node clusters), caching the first endpoint permanently on the `Client` object causes `server.address` and `server.port` span attributes to remain locked to that initial endpoint, ignoring other configured endpoints.

### Fix

- Removed the single-endpoint `VirtualField` cache from `ClickHouseClientV2Singletons`.
- Updated `ClickHouseClientV2Singletons.getAddressAndPort(client)` to dynamically resolve the endpoint from `client.getEndpoints()` on each query.

## Testing

Added a unit test `testClientWithMultipleEndpoints` in `ClickHouseClientV2Test` that:
- Configures a `Client` with multiple endpoints (`.addEndpoint(...)`)
- Executes a query and asserts that spans are correctly generated with `server.address` and `server.port` attributes.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>