### PR TITLE
Fix RPC duration metric descriptions to match semantic conventions

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetrics.java
@@ -54,7 +54,8 @@ public final class RpcClientMetrics implements OperationListener {
       DoubleHistogramBuilder oldDurationBuilder =
           meter
               .histogramBuilder("rpc.client.duration")
-              .setDescription("The duration of an outbound RPC invocation.")
+              .setDescription(
+                  "Deprecated, use `rpc.client.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
               .setUnit("ms");
       RpcMetricsAdvice.applyClientDurationAdvice(oldDurationBuilder, false);
       oldClientDurationHistogram = oldDurationBuilder.build();
@@ -67,7 +68,7 @@ public final class RpcClientMetrics implements OperationListener {
       DoubleHistogramBuilder stableDurationBuilder =
           meter
               .histogramBuilder("rpc.client.call.duration")
-              .setDescription("Measures the duration of outbound remote procedure calls (RPC).")
+              .setDescription("Measures the duration of an outgoing Remote Procedure Call (RPC).")
               .setUnit("s");
       RpcMetricsAdvice.applyClientDurationAdvice(stableDurationBuilder, true);
       stableClientDurationHistogram = stableDurationBuilder.build();

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetrics.java
@@ -54,7 +54,8 @@ public final class RpcServerMetrics implements OperationListener {
       DoubleHistogramBuilder oldDurationBuilder =
           meter
               .histogramBuilder("rpc.server.duration")
-              .setDescription("The duration of an inbound RPC invocation.")
+              .setDescription(
+                  "Deprecated, use `rpc.server.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
               .setUnit("ms");
       RpcMetricsAdvice.applyServerDurationAdvice(oldDurationBuilder, false);
       oldServerDurationHistogram = oldDurationBuilder.build();
@@ -67,7 +68,7 @@ public final class RpcServerMetrics implements OperationListener {
       DoubleHistogramBuilder stableDurationBuilder =
           meter
               .histogramBuilder("rpc.server.call.duration")
-              .setDescription("Measures the duration of inbound remote procedure calls (RPC).")
+              .setDescription("Measures the duration of an incoming Remote Procedure Call (RPC).")
               .setUnit("s");
       RpcMetricsAdvice.applyServerDurationAdvice(stableDurationBuilder, true);
       stableServerDurationHistogram = stableDurationBuilder.build();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcClientMetricsTest.java
@@ -162,6 +162,8 @@ class RpcClientMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.client.duration")
                       .hasUnit("ms")
+                      .hasDescription(
+                          "Deprecated, use `rpc.client.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -191,6 +193,8 @@ class RpcClientMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.client.call.duration")
                       .hasUnit("s")
+                      .hasDescription(
+                          "Measures the duration of an outgoing Remote Procedure Call (RPC).")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -223,6 +227,8 @@ class RpcClientMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.client.duration")
                       .hasUnit("ms")
+                      .hasDescription(
+                          "Deprecated, use `rpc.client.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -244,6 +250,8 @@ class RpcClientMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.client.call.duration")
                       .hasUnit("s")
+                      .hasDescription(
+                          "Measures the duration of an outgoing Remote Procedure Call (RPC).")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcServerMetricsTest.java
@@ -116,6 +116,8 @@ class RpcServerMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.server.duration")
                       .hasUnit("ms")
+                      .hasDescription(
+                          "Deprecated, use `rpc.server.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -197,6 +199,8 @@ class RpcServerMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.server.call.duration")
                       .hasUnit("s")
+                      .hasDescription(
+                          "Measures the duration of an incoming Remote Procedure Call (RPC).")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -229,6 +233,8 @@ class RpcServerMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.server.duration")
                       .hasUnit("ms")
+                      .hasDescription(
+                          "Deprecated, use `rpc.server.call.duration` instead. Note: the unit also changed from `ms` to `s`.")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(
@@ -250,6 +256,8 @@ class RpcServerMetricsTest {
                   assertThat(metric)
                       .hasName("rpc.server.call.duration")
                       .hasUnit("s")
+                      .hasDescription(
+                          "Measures the duration of an incoming Remote Procedure Call (RPC).")
                       .hasHistogramSatisfying(
                           histogram ->
                               histogram.hasPointsSatisfying(


### PR DESCRIPTION
Fixes #9478.

`rpc.server.duration`, `rpc.client.duration`, `rpc.server.call.duration`, and `rpc.client.call.duration` all had hand-written description strings that had drifted from the current [semantic-conventions](https://github.com/open-telemetry/semantic-conventions) definitions. This isn't just cosmetic - the Collector's Prometheus exporter drops a metric outright if it receives the same metric name with a different description than one it has already seen, so a description mismatch here breaks interop with other language SDKs emitting the same metric names (this is exactly the failure mode the original issue reporter hit and worked around with a custom transform rule).

I checked this against the current source of truth in `open-telemetry/semantic-conventions` rather than just the original 2023 issue text, since the spec itself has moved on:

- `rpc.server.duration` / `rpc.client.duration` are now formally deprecated in the spec in favor of `rpc.server.call.duration` / `rpc.client.call.duration`, and the spec's `brief` for the deprecated metrics is now a deprecation pointer (`"Deprecated, use \`rpc.server.call.duration\` instead. Note: the unit also changed from \`ms\` to \`s\`."`), not the plain functional description the original issue asked for. Updated both old metrics to match the current deprecation brief.
- `rpc.server.call.duration` / `rpc.client.call.duration` (the *stable*, actively-recommended metrics) also had a subtly wrong description ("inbound remote procedure calls" vs the spec's "an incoming Remote Procedure Call") - a second, previously unreported mismatch, arguably more impactful than the deprecated-metric one since it's on the metric people are meant to be migrating to.

**Test coverage:** `RpcServerMetricsTest` and `RpcClientMetricsTest` already asserted `hasDescription(...)` for the size metrics but never for the duration metrics - likely why this drifted unnoticed. Added the missing `hasDescription(...)` assertions for all four duration metric blocks (old + stable semconv, both `onEnd` calls in each test), matching the existing test style exactly.