### PR TITLE
Add regression test for MySQL loadbalance/replication synthetic host parsing (#14150)

### DIFF
--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -199,6 +199,18 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("failover")
             .setHost("::1")
             .setPort(3306)
+            .build(),
+        // Regression test for #14150: MySQL Connector/J's Replication and LoadBalance
+        // connection wrappers report a synthetic, non-URL "**internally_generated**<timestamp>**"
+        // placeholder as their connection URL for the underlying physical connections. This has
+        // no colon, slash, or comma, which previously caused a StringIndexOutOfBoundsException
+        // deep in the non-standard-format parsing path.
+        arg("jdbc:mysql:loadbalance://**internally_generated**1748961526469**")
+            .setShortUrl("mysql:loadbalance://**internally_generated**1748961526469**:3306")
+            .setSystem(MYSQL)
+            .setSubtype("loadbalance")
+            .setHost("**internally_generated**1748961526469**")
+            .setPort(3306)
             .build());
   }
 


### PR DESCRIPTION
Addresses #14150.

#14150 reported a `StringIndexOutOfBoundsException` when parsing a JDBC URL, triggered by MySQL Connector/J's Replication/LoadBalance connection wrappers, which report a synthetic, non-URL `**internally_generated**<timestamp>**` placeholder as their connection URL for each underlying physical connection - a string with no colon, slash, or comma at all.

I traced this against the current `MysqlUrlParser` before writing anything, since the codebase has been substantially refactored since the issue was filed against v2.17.0's anonymous-inner-class-based parser - and **the crash no longer reproduces**. `parseMariaSubProtocol` already guards every offset with explicit `!= -1` / `> 0` checks before using it in a `substring()` call, so this input now safely falls through to treating the whole opaque string as the host, the same way an existing case like `jdbc:mysql:loadbalance://localhost` (no port, no slash) is already handled.

There was no test covering this specific shape of input though, so there was no way to confirm the fix or guard against it regressing. This PR adds one using the exact placeholder string from the issue's arthas trace, so:

1. The fix is locked in with a concrete regression test instead of relying on it being incidental.
2. The issue can be closed with a verifiable answer rather than as stale/unreproducible.

No production code changes - this is test-only, since I couldn't reproduce the actual crash on current `main`. Happy to also dig into part 2 of the issue (extracting real host info from the underlying physical connections) as a separate follow-up if that's still wanted - it looked like a larger, separate scope (would need actual driver-level instrumentation, not just URL string parsing).