### PR TITLE
Use a shared script to compile gh-aw workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -410,7 +410,7 @@
       depNameTemplate: 'github/gh-aw',
       versioningTemplate: 'semver-coerced',
       managerFilePatterns: [
-        '.github/workflows/build-common.yml',
+        '.github/scripts/compile-gh-aw-workflows.sh',
       ],
       matchStrings: [
         'gh extension install github/gh-aw --pin (?<currentValue>v\\d+\\.\\d+\\.\\d+)',

--- a/.github/scripts/compile-gh-aw-workflows.sh
+++ b/.github/scripts/compile-gh-aw-workflows.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+# Compiles the agentic workflow (gh-aw) sources into their generated lockfiles.
+#
+# The CI check and the lockfile auto-update workflow both run this script, so that they always use
+# the same pinned compiler and the same options. Compiling them differently produces generated files
+# that the CI check then immediately rewrites, which fails the build.
+#
+# Always compile all gh-aw workflows. The compiler is pinned via `gh extension install --pin` and
+# `--no-check-update`, and action SHAs are pinned via .github/aw/actions-lock.json, so the output is
+# deterministic for a given pinned version. With no arguments, both `gh aw validate` and
+# `gh aw compile` operate on every Markdown file in .github/workflows. Compiling all workflows takes
+# only a couple of seconds.
+#
+# Pass --approve when regenerating after a compiler upgrade. That approves the safe manifest changes
+# (e.g. added or removed actions) that strict mode otherwise refuses. It does not affect which
+# actions the compiler generates, so the output still matches what the CI check produces.
+
+gh extension install github/gh-aw --pin v0.74.0
+
+gh aw validate --no-check-update
+
+gh aw compile --no-check-update "$@"

--- a/.github/workflows/auto-update-gh-aw-lockfiles.yml
+++ b/.github/workflows/auto-update-gh-aw-lockfiles.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'renovate/**'
     paths:
-      - '.github/workflows/build-common.yml'
+      - '.github/scripts/compile-gh-aw-workflows.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,15 +25,7 @@ jobs:
       - name: Regenerate agentic workflow lockfiles
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          version=$(sed -nE 's/.*gh extension install github\/gh-aw --pin (v[0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
-            .github/workflows/build-common.yml)
-          if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Unable to read a single pinned gh-aw version: $version" >&2
-            exit 1
-          fi
-          gh extension install github/gh-aw --pin "$version"
-          gh aw compile --action-tag "$version" --approve --no-check-update
+        run: .github/scripts/compile-gh-aw-workflows.sh --approve
 
       - name: Create generated-files patch
         run: |

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -193,28 +193,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install gh-aw
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh extension install github/gh-aw --pin v0.74.0
-
-      # Always compile all gh-aw workflows. The compiler is pinned via
-      # `gh extension install --pin` and `--no-check-update`, and action
-      # SHAs are pinned via .github/aw/actions-lock.json, so the output is
-      # deterministic for a given pinned version. With no arguments, both
-      # `gh aw validate` and `gh aw compile` operate on every Markdown file
-      # in .github/workflows. Compiling all workflows takes only a couple
-      # of seconds.
-
-      - name: Validate gh-aw workflows
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh aw validate --no-check-update
-
       - name: Compile gh-aw workflows
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh aw compile --no-check-update
+        run: .github/scripts/compile-gh-aw-workflows.sh
 
       - name: Check generated files are committed
         run: |


### PR DESCRIPTION
The `check-gh-aw-lockfiles` CI check and the `auto-update-gh-aw-lockfiles` workflow each invoked the gh-aw compiler with different options, so the auto-update workflow generated lockfiles that the CI check then immediately rewrote.

The auto-update workflow passed `--action-tag "$version"`, which forces the setup action to the `github/gh-aw` repo, while the compiler now defaults to `github/gh-aw-actions`. The `--action-tag` flag was correct when the automation was added, but a later gh-aw migration changed the default and the updater was never adjusted. The result on a Renovate branch is a `git diff --exit-code` failure on `.github/aw/actions-lock.json` and the two `*.lock.yml` files, even after the auto-update workflow has already run and pushed.

This moves the invocation into a single script, `.github/scripts/compile-gh-aw-workflows.sh`, that both workflows run, so they cannot drift apart again:

- The script pins the compiler version and runs `gh aw validate` and `gh aw compile`, passing any extra arguments through.
- No `--action-tag` / `--actions-repo`, so the compiler selects the setup action that matches the pinned version.
- The auto-update workflow passes `--approve`, which only skips strict mode's safe-update enforcement and does not change generated content.
- Renovate's custom manager now reads the pinned version from the script. The `matchStrings` regex is unchanged.
- The auto-update workflow's path filter now watches the script, so it triggers on gh-aw version bumps rather than on any change to `build-common.yml`.