### PR TITLE
Limit concurrency of vaadin tests to avoid npm install conflicts

### DIFF
--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -79,9 +79,19 @@ testing {
   }
 }
 
+// Vaadin's frontend tooling installs node and pnpm into the shared ~/.vaadin directory. Running two
+// test suites at once lets their npm installs clobber each other, which leaves ~/.vaadin corrupted
+// and fails every subsequent attempt with ENOTEMPTY, so only let one suite run at a time.
+abstract class VaadinBuildService : BuildService<BuildServiceParameters.None>
+
+val vaadinBuildService =
+  gradle.sharedServices.registerIfAbsent("vaadinBuildService", VaadinBuildService::class.java) {
+    maxParallelUsages.set(1)
+  }
+
 tasks {
   withType<Test>().configureEach {
-    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    usesService(vaadinBuildService)
 
     jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")
     systemProperty("collectMetadata", otelProps.collectMetadata)

--- a/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
+++ b/instrumentation/vaadin-14.2/javaagent/build.gradle.kts
@@ -91,6 +91,7 @@ val vaadinBuildService =
 
 tasks {
   withType<Test>().configureEach {
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     usesService(vaadinBuildService)
 
     jvmArgs("-Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true")


### PR DESCRIPTION
related to #19317

the metadata update job has been failing the past few nights:
https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/workflows/metadata-update.yml

The past 2 in particular look to happen when two different vaadin test suites run and their npm installs clobber each other


I removed the usage of the testcontainersBuildService, which is registered with `maxParallelUsages.convention(2)` and replaced it with a custom one to ensure only 1 runs at a time to try and avoid this race condition.


this was the [error](https://productionresultssa14.blob.core.windows.net/actions-results/b11e1da5-0585-4b27-a2ad-d704b4ccfa7c/workflow-job-run-17fc3178-0ea1-511c-b95b-155d40c90312/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-07-29T18%3A57%3A37Z&sig=%2FEBa%2F4giaUIlbR%2B8C%2FjDq6iTGgrKxUN%2FmMz6Iz%2BlraI%3D&ske=2026-07-29T22%3A28%3A06Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-07-29T18%3A28%3A06Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-07-29T18%3A47%3A32Z&sv=2025-11-05):

> 2026-07-29T03:09:50.2740319Z npm warn ancient lockfile The package-lock.json file was created with an old version of npm,
2026-07-29T03:09:50.2742796Z npm warn ancient lockfile so supplemental metadata must be fetched from the registry.
2026-07-29T03:09:50.2743897Z npm warn ancient lockfile
2026-07-29T03:09:50.2744742Z npm warn ancient lockfile This is a one-time fix-up, please be patient...
2026-07-29T03:09:50.2745617Z npm warn ancient lockfile
2026-07-29T03:09:50.5782499Z npm error code ENOTEMPTY
2026-07-29T03:09:50.5811923Z npm error syscall rename
2026-07-29T03:09:50.5832015Z npm error path /home/runner/.vaadin/node_modules/pnpm
2026-07-29T03:09:50.5842339Z npm error dest /home/runner/.vaadin/node_modules/.pnpm-gYLsHL3k
2026-07-29T03:09:50.5872359Z npm error errno -39
2026-07-29T03:09:50.5873615Z npm error ENOTEMPTY: directory not empty, rename '/home/runner/.vaadin/node_modules/pnpm' -> '/home/runner/.vaadin/node_modules/.pnpm-gYLsHL3k'
2026-07-29T03:09:50.5902612Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-07-29T03_09_49_912Z-debug-0.log
2026-07-29T03:11:15.1738523Z 
2026-07-29T03:11:15.1743459Z 5 tests completed, 4 failed, 1 skipped
2026-07-29T03:11:15.5737770Z 
2026-07-29T03:11:15.5738945Z FAILURE: Build completed with 2 failures.
2026-07-29T03:11:15.5739430Z 
2026-07-29T03:11:15.5739670Z 1: Task failed with an exception.
2026-07-29T03:11:15.5740121Z -----------
2026-07-29T03:11:15.5740458Z * What went wrong:
2026-07-29T03:11:15.5741645Z Execution failed for task ':instrumentation:vaadin-14.2:javaagent:vaadin142Test'.
2026-07-29T03:11:15.5743100Z > There were failing tests. See the report at: file:///home/runner/work/opentelemetry-java-instrumentation/opentelemetry-java-instrumentation/instrumentation/vaadin-14.2/javaagent/build/reports/tests/vaadin142Test/index.html
2026-07-29T03:11:15.5744114Z ==============================================================================