### PR TITLE
Migrate JMS, NATS and Spring Integration messaging telemetry to v1.43

### DIFF
--- a/.github/scripts/instrumentations.sh
+++ b/.github/scripts/instrumentations.sh
@@ -181,6 +181,7 @@ readonly INSTRUMENTATIONS=(
   "jetty-httpclient:jetty-httpclient-9.2:javaagent:test"
   "jetty-httpclient:jetty-httpclient-9.2:javaagent:testStableSemconv"
   "jms:jms-1.1:javaagent:test"
+  "jms:jms-1.1:javaagent:testMessagingPreview"
   "jodd-http-4.2:javaagent:test"
   "jodd-http-4.2:javaagent:testStableSemconv"
   "jsf:jsf-mojarra-1.2:javaagent:mojarra2Test"
@@ -223,6 +224,7 @@ readonly INSTRUMENTATIONS=(
   "mongo:mongo-async-3.3:javaagent:testStableSemconv"
   "mybatis-3.2:javaagent:test"
   "nats:nats-2.17:javaagent:test"
+  "nats:nats-2.17:javaagent:testMessagingPreview"
   "netty:netty-3.8:javaagent:test"
   "netty:netty-3.8:javaagent:testStableSemconv"
   "netty:netty-4.0:javaagent:test"
@@ -292,9 +294,11 @@ readonly INSTRUMENTATIONS=(
   "spring:spring-batch-3.0:javaagent:testExperimental"
   "spring:spring-data:spring-data-1.8:javaagent:test"
   "spring:spring-integration-4.1:javaagent:test"
+  "spring:spring-integration-4.1:javaagent:testMessagingPreview"
   "spring:spring-integration-4.1:javaagent:testWithProducerInstrumentation"
   "spring:spring-integration-4.1:javaagent:testWithRabbitInstrumentation"
   "spring:spring-jms:spring-jms-2.0:javaagent:test"
+  "spring:spring-jms:spring-jms-2.0:javaagent:testMessagingPreview"
   "spring:spring-kafka-2.7:javaagent:test"
   "spring:spring-kafka-2.7:javaagent:testExperimental"
   "spring:spring-kafka-2.7:javaagent:testMessagingPreview"
@@ -372,7 +376,9 @@ readonly COLIMA_INSTRUMENTATIONS=(
   "elasticsearch:elasticsearch-rest-6.4:javaagent:test"
   "elasticsearch:elasticsearch-rest-6.4:javaagent:testStableSemconv"
   "jms:jms-3.0:javaagent:test"
+  "jms:jms-3.0:javaagent:testMessagingPreview"
   "spring:spring-jms:spring-jms-6.0:javaagent:test"
+  "spring:spring-jms:spring-jms-6.0:javaagent:testMessagingPreview"
 )
 
 # Some instrumentation test suites need to run with -PtestLatestDeps=true to collect

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -70,6 +70,42 @@ tasks {
     include("**/Jms1SuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    filter {
+      excludeTestsMatching("Jms1SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testJms2V3Preview = register<Test>("testJms2V3Preview") {
+    testClassesDirs = sourceSets["jms2Test"].output.classesDirs
+    classpath = sourceSets["jms2Test"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    filter {
+      includeTestsMatching("Jms1InstrumentationTest")
+    }
+    include("**/Jms1InstrumentationTest.*")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     filter {
@@ -83,7 +119,13 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(
+      testing.suites,
+      testReceiveSpansDisabled,
+      testV3Preview,
+      testJms2V3Preview,
+      testBothSemconv,
+    )
   }
 }
 

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -70,6 +70,20 @@ tasks {
     include("**/Jms1SuppressReceiveSpansTest.*")
   }
 
+  val testMessagingPreviewReceiveSpansDisabled =
+    register<Test>("testMessagingPreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+      usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+
+      filter {
+        includeTestsMatching("Jms1SuppressReceiveSpansTest")
+      }
+      include("**/Jms1SuppressReceiveSpansTest.*")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -120,6 +134,7 @@ tasks {
       testing.suites,
       testReceiveSpansDisabled,
       testMessagingPreview,
+      testMessagingPreviewReceiveSpansDisabled,
       testJms2MessagingPreview,
       testBothSemconv,
     )

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -70,7 +70,7 @@ tasks {
     include("**/Jms1SuppressReceiveSpansTest.*")
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
@@ -78,18 +78,16 @@ tasks {
       excludeTestsMatching("Jms1SuppressReceiveSpansTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
-  val testJms2V3Preview = register<Test>("testJms2V3Preview") {
+  val testJms2MessagingPreview = register<Test>("testJms2MessagingPreview") {
     testClassesDirs = sourceSets["jms2Test"].output.classesDirs
     classpath = sourceSets["jms2Test"].runtimeClasspath
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
   val testBothSemconv = register<Test>("testBothSemconv") {
@@ -101,7 +99,6 @@ tasks {
     }
     include("**/Jms1InstrumentationTest.*")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
@@ -122,8 +119,8 @@ tasks {
     dependsOn(
       testing.suites,
       testReceiveSpansDisabled,
-      testV3Preview,
-      testJms2V3Preview,
+      testMessagingPreview,
+      testJms2MessagingPreview,
       testBothSemconv,
     )
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
@@ -5,14 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -148,13 +153,20 @@ class Jms2InstrumentationTest {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(destinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? destinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + destinationName
+                              : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(destinationName, isTemporary),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -164,14 +176,21 @@ class Jms2InstrumentationTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
@@ -211,23 +230,37 @@ class Jms2InstrumentationTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
@@ -257,6 +290,26 @@ class Jms2InstrumentationTest {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  private static AttributeAssertion messagingDestinationName(
+      String destinationName, boolean isTemporary) {
+    return emitStableMessagingSemconv() && isTemporary
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/jms2Test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms2InstrumentationTest.java
@@ -156,8 +156,8 @@ class Jms2InstrumentationTest {
                   span.hasName(
                           emitStableMessagingSemconv()
                               ? destinationName.equals("(temporary)")
-                                  ? "publish"
-                                  : "publish " + destinationName
+                                  ? "send"
+                                  : "send " + destinationName
                               : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
@@ -165,8 +165,8 @@ class Jms2InstrumentationTest {
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           messagingDestinationName(destinationName, isTemporary),
                           oldOperation("publish"),
-                          operationName("publish"),
-                          operationType("publish"),
+                          operationName("send"),
+                          operationType("send"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -233,8 +233,8 @@ class Jms2InstrumentationTest {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? destinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + destinationName
+                                    ? "send"
+                                    : "send " + destinationName
                                 : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -242,8 +242,8 @@ class Jms2InstrumentationTest {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
@@ -308,8 +308,7 @@ class Jms2InstrumentationTest {
   }
 
   private static AttributeAssertion operationType(String operation) {
-    String operationType = operation.equals("publish") ? "send" : operation;
-    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -6,14 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -114,23 +119,37 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
@@ -194,13 +213,20 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -210,13 +236,20 @@ abstract class AbstractJms1Test {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName(destinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + destinationName
+                                : destinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -264,26 +297,40 @@ abstract class AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
@@ -292,6 +339,25 @@ abstract class AbstractJms1Test {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  static AttributeAssertion messagingDestinationName(String destinationName, boolean isTemporary) {
+    return emitStableMessagingSemconv() && isTemporary
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -122,8 +122,8 @@ abstract class AbstractJms1Test {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? destinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + destinationName
+                                    ? "send"
+                                    : "send " + destinationName
                                 : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -131,8 +131,8 @@ abstract class AbstractJms1Test {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
@@ -216,8 +216,8 @@ abstract class AbstractJms1Test {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? destinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + destinationName
+                                    ? "send"
+                                    : "send " + destinationName
                                 : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -225,8 +225,8 @@ abstract class AbstractJms1Test {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -300,8 +300,8 @@ abstract class AbstractJms1Test {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? destinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + destinationName
+                                    ? "send"
+                                    : "send " + destinationName
                                 : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -309,8 +309,8 @@ abstract class AbstractJms1Test {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->
@@ -356,8 +356,7 @@ abstract class AbstractJms1Test {
   }
 
   static AttributeAssertion operationType(String operation) {
-    String operationType = operation.equals("publish") ? "send" : operation;
-    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,13 +60,20 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(destinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? destinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + destinationName
+                              : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(destinationName, isTemporary),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -76,14 +83,21 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -63,8 +63,8 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                   span.hasName(
                           emitStableMessagingSemconv()
                               ? destinationName.equals("(temporary)")
-                                  ? "publish"
-                                  : "publish " + destinationName
+                                  ? "send"
+                                  : "send " + destinationName
                               : destinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
@@ -72,8 +72,8 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           messagingDestinationName(destinationName, isTemporary),
                           oldOperation("publish"),
-                          operationName("publish"),
-                          operationType("publish"),
+                          operationName("send"),
+                          operationType("send"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,24 +56,38 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(destinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + destinationName
+                                : destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(destinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? destinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + destinationName
+                                : destinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))),
         trace ->

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -14,6 +14,9 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
@@ -51,17 +54,57 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
 
     String messageId = receivedMessage.getJMSMessageID();
 
+    if (emitStableMessagingSemconv()) {
+      AtomicReference<SpanData> publishSpan = new AtomicReference<>();
+      testing.waitAndAssertTraces(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer parent").hasNoParent(),
+                span ->
+                    span.hasName(
+                            destinationName.equals("(temporary)")
+                                ? "publish"
+                                : "publish " + destinationName)
+                        .hasKind(PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(destinationName, isTemporary),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
+                            messagingTempDestination(isTemporary)));
+            publishSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("consumer parent").hasNoParent(),
+                  span ->
+                      span.hasName(
+                              destinationName.equals("(temporary)")
+                                  ? "receive"
+                                  : "receive " + destinationName)
+                          .hasKind(CLIENT)
+                          .hasParent(trace.getSpan(0))
+                          .hasLinks(LinkData.create(publishSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_SYSTEM, "jms"),
+                              messagingDestinationName(destinationName, isTemporary),
+                              oldOperation("receive"),
+                              operationName("receive"),
+                              operationType("receive"),
+                              equalTo(MESSAGING_MESSAGE_ID, messageId),
+                              messagingTempDestination(isTemporary))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? destinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + destinationName
-                                : destinationName + " publish")
+                    span.hasName(destinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -73,13 +116,8 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? destinationName.equals("(temporary)")
-                                    ? "receive"
-                                    : "receive " + destinationName
-                                : destinationName + " receive")
-                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                    span.hasName(destinationName + " receive")
+                        .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1SuppressReceiveSpansTest.java
@@ -63,16 +63,16 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
                 span ->
                     span.hasName(
                             destinationName.equals("(temporary)")
-                                ? "publish"
-                                : "publish " + destinationName)
+                                ? "send"
+                                : "send " + destinationName)
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)));
             publishSpan.set(trace.getSpan(1));
@@ -111,8 +111,8 @@ class Jms1SuppressReceiveSpansTest extends AbstractJms1Test {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             messagingDestinationName(destinationName, isTemporary),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->

--- a/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
@@ -51,6 +51,18 @@ tasks {
     include("**/Jms3SuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("Jms3SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("Jms3SuppressReceiveSpansTest")
@@ -63,6 +75,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled)
+    dependsOn(testing.suites, testReceiveSpansDisabled, testV3Preview)
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
@@ -62,6 +62,19 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testMessagingPreviewReceiveSpansDisabled =
+    register<Test>("testMessagingPreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+
+      filter {
+        includeTestsMatching("Jms3SuppressReceiveSpansTest")
+      }
+      include("**/Jms3SuppressReceiveSpansTest.*")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -85,6 +98,12 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled, testMessagingPreview, testBothSemconv)
+    dependsOn(
+      testing.suites,
+      testReceiveSpansDisabled,
+      testMessagingPreview,
+      testMessagingPreviewReceiveSpansDisabled,
+      testBothSemconv,
+    )
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-3.0/javaagent/build.gradle.kts
@@ -51,16 +51,26 @@ tasks {
     include("**/Jms3SuppressReceiveSpansTest.*")
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
       excludeTestsMatching("Jms3SuppressReceiveSpansTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("Jms3SuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   test {
@@ -75,6 +85,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testReceiveSpansDisabled, testV3Preview)
+    dependsOn(testing.suites, testReceiveSpansDisabled, testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -131,23 +135,38 @@ abstract class AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(actualDestinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + actualDestinationName
+                                : actualDestinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
   }
@@ -212,13 +231,21 @@ abstract class AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -228,13 +255,20 @@ abstract class AbstractJms3Test {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName(actualDestinationName + " process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "process"
+                                    : "process " + actualDestinationName
+                                : actualDestinationName + " process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -249,6 +283,26 @@ abstract class AbstractJms3Test {
     return isTemporary
         ? equalTo(MESSAGING_DESTINATION_TEMPORARY, true)
         : satisfies(MESSAGING_DESTINATION_TEMPORARY, AbstractAssert::isNull);
+  }
+
+  static AttributeAssertion messagingDestinationName(
+      String oldDestinationName, String stableDestinationName) {
+    return equalTo(
+        MESSAGING_DESTINATION_NAME,
+        emitStableMessagingSemconv() ? stableDestinationName : oldDestinationName);
+  }
+
+  static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -138,8 +138,8 @@ abstract class AbstractJms3Test {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? producerDestinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + producerDestinationName
+                                    ? "send"
+                                    : "send " + producerDestinationName
                                 : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -148,8 +148,8 @@ abstract class AbstractJms3Test {
                             messagingDestinationName(
                                 producerDestinationName, actualDestinationName),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
@@ -234,8 +234,8 @@ abstract class AbstractJms3Test {
                     span.hasName(
                             emitStableMessagingSemconv()
                                 ? producerDestinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + producerDestinationName
+                                    ? "send"
+                                    : "send " + producerDestinationName
                                 : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -244,8 +244,8 @@ abstract class AbstractJms3Test {
                             messagingDestinationName(
                                 producerDestinationName, actualDestinationName),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary),
                             equalTo(
@@ -301,8 +301,7 @@ abstract class AbstractJms3Test {
   }
 
   static AttributeAssertion operationType(String operation) {
-    String operationType = operation.equals("publish") ? "send" : operation;
-    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
   }
 
   private static Stream<Arguments> emptyReceiveArguments() {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,13 +63,20 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("producer parent").hasNoParent(),
               span ->
-                  span.hasName(producerDestinationName + " publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? producerDestinationName.equals("(temporary)")
+                                  ? "publish"
+                                  : "publish " + producerDestinationName
+                              : producerDestinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
-                          equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          messagingDestinationName(producerDestinationName, actualDestinationName),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 
@@ -79,14 +86,21 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("consumer parent").hasNoParent(),
                 span ->
-                    span.hasName(actualDestinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + actualDestinationName
+                                : actualDestinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(actualDestinationName, actualDestinationName),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId))));
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -66,8 +66,8 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                   span.hasName(
                           emitStableMessagingSemconv()
                               ? producerDestinationName.equals("(temporary)")
-                                  ? "publish"
-                                  : "publish " + producerDestinationName
+                                  ? "send"
+                                  : "send " + producerDestinationName
                               : producerDestinationName + " publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
@@ -75,8 +75,8 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           messagingDestinationName(producerDestinationName, actualDestinationName),
                           oldOperation("publish"),
-                          operationName("publish"),
-                          operationType("publish"),
+                          operationName("send"),
+                          operationType("send"),
                           equalTo(MESSAGING_MESSAGE_ID, messageId),
                           messagingTempDestination(isTemporary)));
 

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,24 +59,39 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(producerDestinationName + " publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? producerDestinationName.equals("(temporary)")
+                                    ? "publish"
+                                    : "publish " + producerDestinationName
+                                : producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, producerDestinationName),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(actualDestinationName + " receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? actualDestinationName.equals("(temporary)")
+                                    ? "receive"
+                                    : "receive " + actualDestinationName
+                                : actualDestinationName + " receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, actualDestinationName),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            messagingDestinationName(actualDestinationName, actualDestinationName),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId))),
         trace ->
             trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer parent").hasNoParent()));

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -66,8 +66,8 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                 span ->
                     span.hasName(
                             producerDestinationName.equals("(temporary)")
-                                ? "publish"
-                                : "publish " + producerDestinationName)
+                                ? "send"
+                                : "send " + producerDestinationName)
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -75,8 +75,8 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                             messagingDestinationName(
                                 producerDestinationName, actualDestinationName),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)));
             publishSpan.set(trace.getSpan(1));
@@ -116,8 +116,8 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                             messagingDestinationName(
                                 producerDestinationName, actualDestinationName),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3SuppressReceiveSpansTest.java
@@ -14,11 +14,14 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.TextMessage;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -54,17 +57,58 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
     String producerDestinationName = isTemporary ? "(temporary)" : actualDestinationName;
     String messageId = receivedMessage.getJMSMessageID();
 
+    if (emitStableMessagingSemconv()) {
+      AtomicReference<SpanData> publishSpan = new AtomicReference<>();
+      testing.waitAndAssertTraces(
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer parent").hasNoParent(),
+                span ->
+                    span.hasName(
+                            producerDestinationName.equals("(temporary)")
+                                ? "publish"
+                                : "publish " + producerDestinationName)
+                        .hasKind(PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(
+                                producerDestinationName, actualDestinationName),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
+                            equalTo(MESSAGING_MESSAGE_ID, messageId),
+                            messagingTempDestination(isTemporary)));
+            publishSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("consumer parent").hasNoParent(),
+                  span ->
+                      span.hasName(
+                              actualDestinationName.equals("(temporary)")
+                                  ? "receive"
+                                  : "receive " + actualDestinationName)
+                          .hasKind(CLIENT)
+                          .hasParent(trace.getSpan(0))
+                          .hasLinks(LinkData.create(publishSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_SYSTEM, "jms"),
+                              messagingDestinationName(
+                                  actualDestinationName, actualDestinationName),
+                              oldOperation("receive"),
+                              operationName("receive"),
+                              operationType("receive"),
+                              equalTo(MESSAGING_MESSAGE_ID, messageId))));
+      return;
+    }
+
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer parent").hasNoParent(),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? producerDestinationName.equals("(temporary)")
-                                    ? "publish"
-                                    : "publish " + producerDestinationName
-                                : producerDestinationName + " publish")
+                    span.hasName(producerDestinationName + " publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -77,13 +121,8 @@ class Jms3SuppressReceiveSpansTest extends AbstractJms3Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary)),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? actualDestinationName.equals("(temporary)")
-                                    ? "receive"
-                                    : "receive " + actualDestinationName
-                                : actualDestinationName + " receive")
-                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                    span.hasName(actualDestinationName + " receive")
+                        .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasTotalRecordedLinks(0)
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -12,13 +12,14 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,28 +52,28 @@ public class JmsInstrumenterFactory {
 
   public Instrumenter<MessageWithDestination, Void> createProducerInstrumenter() {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PUBLISH;
+    MessagingOperationType operationType = MessagingOperationType.SEND;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new MessagePropertySetter());
   }
 
   public Instrumenter<MessageWithDestination, Void> createConsumerReceiveInstrumenter() {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.RECEIVE;
+    MessagingOperationType operationType = MessagingOperationType.RECEIVE;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingReceiveExceptionEventExtractor(builder);
     if (messagingReceiveInstrumentationEnabled) {
       builder.addSpanLinksExtractor(
@@ -80,34 +81,32 @@ public class JmsInstrumenterFactory {
               openTelemetry.getPropagators().getTextMapPropagator(),
               MessagePropertyGetter.INSTANCE));
     }
-    return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+    return builder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   public Instrumenter<MessageWithDestination, Void> createConsumerProcessInstrumenter(
       boolean canHaveReceiveInstrumentation) {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
-    MessageOperation operation = MessageOperation.PROCESS;
+    MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
     InstrumenterBuilder<MessageWithDestination, Void> builder =
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operation))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operation));
+                MessagingSpanNameExtractor.create(getter, operationType))
+            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingProcessExceptionEventExtractor(builder);
-    if (canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled) {
-      builder.addSpanLinksExtractor(
-          new PropagatorBasedSpanLinksExtractor<>(
-              openTelemetry.getPropagators().getTextMapPropagator(),
-              MessagePropertyGetter.INSTANCE));
-      return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
-    }
-    return builder.buildConsumerInstrumenter(MessagePropertyGetter.INSTANCE);
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        MessagePropertyGetter.INSTANCE,
+        canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled);
   }
 
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
-      MessageOperation operation) {
-    return MessagingAttributesExtractor.builder(new JmsMessageAttributesGetter(), operation)
+      MessagingOperationType operationType) {
+    return MessagingAttributesExtractor.builderForOperationType(
+            new JmsMessageAttributesGetter(), operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.jms.common.v1_1;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -75,7 +76,9 @@ public class JmsInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operationType))
             .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
     setMessagingReceiveExceptionEventExtractor(builder);
-    if (messagingReceiveInstrumentationEnabled) {
+    // with the stable messaging semantic conventions the producer is always linked, since it is
+    // never used as the parent of the receive span
+    if (messagingReceiveInstrumentationEnabled || emitStableMessagingSemconv()) {
       builder.addSpanLinksExtractor(
           new PropagatorBasedSpanLinksExtractor<>(
               openTelemetry.getPropagators().getTextMapPropagator(),

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -105,8 +105,7 @@ public class JmsInstrumenterFactory {
 
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
       MessagingOperationType operationType) {
-    return MessagingAttributesExtractor.builderForOperationType(
-            new JmsMessageAttributesGetter(), operationType)
+    return MessagingAttributesExtractor.builder(new JmsMessageAttributesGetter(), operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -28,6 +28,11 @@ import java.util.List;
 
 public class JmsInstrumenterFactory {
 
+  // messaging.operation.name values, named after the JMS API operations
+  private static final String SEND_OPERATION_NAME = "send";
+  private static final String RECEIVE_OPERATION_NAME = "receive";
+  private static final String PROCESS_OPERATION_NAME = "process";
+
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
   private List<String> capturedHeaders = emptyList();
@@ -59,8 +64,9 @@ public class JmsInstrumenterFactory {
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operationType))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
+                MessagingSpanNameExtractor.create(getter, operationType, SEND_OPERATION_NAME))
+            .addAttributesExtractor(
+                createMessagingAttributesExtractor(operationType, SEND_OPERATION_NAME));
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new MessagePropertySetter());
   }
@@ -73,8 +79,9 @@ public class JmsInstrumenterFactory {
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operationType))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
+                MessagingSpanNameExtractor.create(getter, operationType, RECEIVE_OPERATION_NAME))
+            .addAttributesExtractor(
+                createMessagingAttributesExtractor(operationType, RECEIVE_OPERATION_NAME));
     setMessagingReceiveExceptionEventExtractor(builder);
     // with the stable messaging semantic conventions the producer is always linked, since it is
     // never used as the parent of the receive span
@@ -96,8 +103,9 @@ public class JmsInstrumenterFactory {
         Instrumenter.<MessageWithDestination, Void>builder(
                 openTelemetry,
                 instrumentationName,
-                MessagingSpanNameExtractor.create(getter, operationType))
-            .addAttributesExtractor(createMessagingAttributesExtractor(operationType));
+                MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
+            .addAttributesExtractor(
+                createMessagingAttributesExtractor(operationType, PROCESS_OPERATION_NAME));
     setMessagingProcessExceptionEventExtractor(builder);
     return MessagingProcessInstrumenterFactory.create(
         builder,
@@ -107,8 +115,9 @@ public class JmsInstrumenterFactory {
   }
 
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
-      MessagingOperationType operationType) {
-    return MessagingAttributesExtractor.builder(new JmsMessageAttributesGetter(), operationType)
+      MessagingOperationType operationType, String operationName) {
+    return MessagingAttributesExtractor.builder(
+            new JmsMessageAttributesGetter(), operationType, operationName)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.common.v1_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -26,8 +28,9 @@ public class JmsReceiveSpanUtil {
       Timer timer,
       @Nullable Throwable throwable) {
     Context parentContext = Context.current();
-    // if receive instrumentation is not enabled we'll use the producer as parent
-    if (!receiveInstrumentationEnabled) {
+    // if receive instrumentation is not enabled we'll use the producer as parent, unless the stable
+    // messaging semantic conventions are enabled, where the producer is linked instead
+    if (!receiveInstrumentationEnabled && !emitStableMessagingSemconv()) {
       parentContext =
           propagators
               .getTextMapPropagator()

--- a/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
@@ -19,8 +19,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", otelProps.collectMetadata)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }

--- a/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/javaagent/build.gradle.kts
@@ -24,15 +24,21 @@ tasks {
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {
-    dependsOn(testV3Preview)
+    dependsOn(testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/ConnectionPublishInstrumentation.java
+++ b/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/ConnectionPublishInstrumentation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.nats.v2_17;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.nats.v2_17.NatsSingletons.producerInstrumenter;
+import static io.opentelemetry.javaagent.instrumentation.nats.v2_17.NatsSingletons.publishInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -144,16 +144,16 @@ class ConnectionPublishInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope start(NatsRequest natsRequest) {
         Context parentContext = Context.current();
-        if (!producerInstrumenter().shouldStart(parentContext, natsRequest)) {
+        if (!publishInstrumenter().shouldStart(parentContext, natsRequest)) {
           return null;
         }
-        Context context = producerInstrumenter().start(parentContext, natsRequest);
+        Context context = publishInstrumenter().start(parentContext, natsRequest);
         return new AdviceScope(natsRequest, context, context.makeCurrent());
       }
 
       public void end(@Nullable Throwable throwable) {
         scope.close();
-        producerInstrumenter().end(context, request, null, throwable);
+        publishInstrumenter().end(context, request, null, throwable);
       }
     }
 

--- a/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/ConnectionRequestInstrumentation.java
+++ b/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/ConnectionRequestInstrumentation.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.nats.v2_17;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.nats.v2_17.NatsSingletons.producerInstrumenter;
+import static io.opentelemetry.javaagent.instrumentation.nats.v2_17.NatsSingletons.requestInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -137,10 +137,10 @@ class ConnectionRequestInstrumentation implements TypeInstrumentation {
     @Nullable
     public static MessageFutureAdviceScope start(NatsRequest request) {
       Context parentContext = Context.current();
-      if (!producerInstrumenter().shouldStart(parentContext, request)) {
+      if (!requestInstrumenter().shouldStart(parentContext, request)) {
         return null;
       }
-      Context context = producerInstrumenter().start(parentContext, request);
+      Context context = requestInstrumenter().start(parentContext, request);
       return new MessageFutureAdviceScope(request, parentContext, context, context.makeCurrent());
     }
 
@@ -150,13 +150,13 @@ class ConnectionRequestInstrumentation implements TypeInstrumentation {
         @Nullable Throwable throwable) {
       scope.close();
       if (throwable != null || messageFuture == null) {
-        producerInstrumenter().end(context, request, null, throwable);
+        requestInstrumenter().end(context, request, null, throwable);
         return messageFuture;
       }
 
       messageFuture =
           messageFuture.whenComplete(
-              new SpanFinisher(producerInstrumenter(), context, connection, request));
+              new SpanFinisher(requestInstrumenter(), context, connection, request));
       return CompletableFutureWrapper.wrap(messageFuture, parentContext);
     }
   }
@@ -202,10 +202,10 @@ class ConnectionRequestInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope start(NatsRequest request) {
         Context parentContext = Context.current();
-        if (!producerInstrumenter().shouldStart(parentContext, request)) {
+        if (!requestInstrumenter().shouldStart(parentContext, request)) {
           return null;
         }
-        Context context = producerInstrumenter().start(parentContext, request);
+        Context context = requestInstrumenter().start(parentContext, request);
         return new AdviceScope(request, context, context.makeCurrent());
       }
 
@@ -218,7 +218,7 @@ class ConnectionRequestInstrumentation implements TypeInstrumentation {
           response = NatsRequest.create(connection, message);
         }
 
-        producerInstrumenter().end(context, request, response, throwable);
+        requestInstrumenter().end(context, request, response, throwable);
       }
     }
 

--- a/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/NatsSingletons.java
+++ b/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/NatsSingletons.java
@@ -6,7 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.nats.v2_17;
 
 import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory.createConsumerProcessInstrumenter;
-import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory.createProducerInstrumenter;
+import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory.createPublishInstrumenter;
+import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory.createRequestInstrumenter;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -19,14 +20,21 @@ class NatsSingletons {
   private static final List<String> capturedHeaders =
       ExperimentalConfig.get().getMessagingHeaders();
 
-  private static final Instrumenter<NatsRequest, NatsRequest> producerInstrumenter =
-      createProducerInstrumenter(GlobalOpenTelemetry.get(), capturedHeaders);
+  private static final Instrumenter<NatsRequest, NatsRequest> publishInstrumenter =
+      createPublishInstrumenter(GlobalOpenTelemetry.get(), capturedHeaders);
+
+  private static final Instrumenter<NatsRequest, NatsRequest> requestInstrumenter =
+      createRequestInstrumenter(GlobalOpenTelemetry.get(), capturedHeaders);
 
   private static final Instrumenter<NatsRequest, Void> consumerProcessInstrumenter =
       createConsumerProcessInstrumenter(GlobalOpenTelemetry.get(), capturedHeaders);
 
-  static Instrumenter<NatsRequest, NatsRequest> producerInstrumenter() {
-    return producerInstrumenter;
+  static Instrumenter<NatsRequest, NatsRequest> publishInstrumenter() {
+    return publishInstrumenter;
+  }
+
+  static Instrumenter<NatsRequest, NatsRequest> requestInstrumenter() {
+    return requestInstrumenter;
   }
 
   static Instrumenter<NatsRequest, Void> consumerProcessInstrumenter() {

--- a/instrumentation/nats/nats-2.17/library/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/library/build.gradle.kts
@@ -12,7 +12,18 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }

--- a/instrumentation/nats/nats-2.17/library/build.gradle.kts
+++ b/instrumentation/nats/nats-2.17/library/build.gradle.kts
@@ -16,14 +16,19 @@ tasks {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testV3Preview)
+    dependsOn(testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetry.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetry.java
@@ -16,7 +16,8 @@ import java.io.IOException;
 
 /** Entrypoint for instrumenting NATS clients. */
 public final class NatsTelemetry {
-  private final Instrumenter<NatsRequest, NatsRequest> producerInstrumenter;
+  private final Instrumenter<NatsRequest, NatsRequest> publishInstrumenter;
+  private final Instrumenter<NatsRequest, NatsRequest> requestInstrumenter;
   private final Instrumenter<NatsRequest, Void> consumerProcessInstrumenter;
 
   /** Returns a new {@link NatsTelemetry} configured with the given {@link OpenTelemetry}. */
@@ -30,9 +31,11 @@ public final class NatsTelemetry {
   }
 
   NatsTelemetry(
-      Instrumenter<NatsRequest, NatsRequest> producerInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> publishInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> requestInstrumenter,
       Instrumenter<NatsRequest, Void> consumerProcessInstrumenter) {
-    this.producerInstrumenter = producerInstrumenter;
+    this.publishInstrumenter = publishInstrumenter;
+    this.requestInstrumenter = requestInstrumenter;
     this.consumerProcessInstrumenter = consumerProcessInstrumenter;
   }
 
@@ -45,7 +48,7 @@ public final class NatsTelemetry {
    */
   public Connection wrap(Connection connection) {
     return OpenTelemetryConnection.wrap(
-        connection, producerInstrumenter, consumerProcessInstrumenter);
+        connection, publishInstrumenter, requestInstrumenter, consumerProcessInstrumenter);
   }
 
   /**

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
@@ -38,7 +38,8 @@ public final class NatsTelemetryBuilder {
   /** Returns a new {@link NatsTelemetry} with the settings of this {@link NatsTelemetryBuilder}. */
   public NatsTelemetry build() {
     return new NatsTelemetry(
-        NatsInstrumenterFactory.createProducerInstrumenter(openTelemetry, capturedHeaders),
+        NatsInstrumenterFactory.createPublishInstrumenter(openTelemetry, capturedHeaders),
+        NatsInstrumenterFactory.createRequestInstrumenter(openTelemetry, capturedHeaders),
         NatsInstrumenterFactory.createConsumerProcessInstrumenter(openTelemetry, capturedHeaders));
   }
 }

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/OpenTelemetryConnection.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/OpenTelemetryConnection.java
@@ -26,28 +26,32 @@ import java.util.concurrent.CompletableFuture;
 final class OpenTelemetryConnection implements InvocationHandler {
 
   private final Connection delegate;
-  private final Instrumenter<NatsRequest, NatsRequest> producerInstrumenter;
+  private final Instrumenter<NatsRequest, NatsRequest> publishInstrumenter;
+  private final Instrumenter<NatsRequest, NatsRequest> requestInstrumenter;
   private final Instrumenter<NatsRequest, Void> consumerProcessInstrumenter;
 
   private OpenTelemetryConnection(
       Connection connection,
-      Instrumenter<NatsRequest, NatsRequest> producerInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> publishInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> requestInstrumenter,
       Instrumenter<NatsRequest, Void> consumerProcessInstrumenter) {
     this.delegate = connection;
-    this.producerInstrumenter = producerInstrumenter;
+    this.publishInstrumenter = publishInstrumenter;
+    this.requestInstrumenter = requestInstrumenter;
     this.consumerProcessInstrumenter = consumerProcessInstrumenter;
   }
 
   static Connection wrap(
       Connection connection,
-      Instrumenter<NatsRequest, NatsRequest> producerInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> publishInstrumenter,
+      Instrumenter<NatsRequest, NatsRequest> requestInstrumenter,
       Instrumenter<NatsRequest, Void> consumerProcessInstrumenter) {
     return (Connection)
         Proxy.newProxyInstance(
             OpenTelemetryConnection.class.getClassLoader(),
             new Class<?>[] {Connection.class},
             new OpenTelemetryConnection(
-                connection, producerInstrumenter, consumerProcessInstrumenter));
+                connection, publishInstrumenter, requestInstrumenter, consumerProcessInstrumenter));
   }
 
   @Override
@@ -142,12 +146,12 @@ final class OpenTelemetryConnection implements InvocationHandler {
       natsRequest = NatsRequest.create(delegate, subject, replyTo, headers, body);
     }
 
-    if (natsRequest == null || !producerInstrumenter.shouldStart(parentContext, natsRequest)) {
+    if (natsRequest == null || !publishInstrumenter.shouldStart(parentContext, natsRequest)) {
       invokeMethod(method, delegate, args);
       return;
     }
 
-    Context context = producerInstrumenter.start(parentContext, natsRequest);
+    Context context = publishInstrumenter.start(parentContext, natsRequest);
     Throwable throwable = null;
     try (Scope ignored = context.makeCurrent()) {
       delegate.publish(subject, replyTo, headers, body);
@@ -155,7 +159,7 @@ final class OpenTelemetryConnection implements InvocationHandler {
       throwable = t;
       throw t;
     } finally {
-      producerInstrumenter.end(context, natsRequest, null, throwable);
+      publishInstrumenter.end(context, natsRequest, null, throwable);
     }
   }
 
@@ -203,11 +207,11 @@ final class OpenTelemetryConnection implements InvocationHandler {
 
     if (timeout == null
         || natsRequest == null
-        || !producerInstrumenter.shouldStart(parentContext, natsRequest)) {
+        || !requestInstrumenter.shouldStart(parentContext, natsRequest)) {
       return (Message) invokeMethod(method, delegate, args);
     }
 
-    Context context = producerInstrumenter.start(parentContext, natsRequest);
+    Context context = requestInstrumenter.start(parentContext, natsRequest);
     NatsRequest response = null;
     Throwable throwable = null;
 
@@ -223,7 +227,7 @@ final class OpenTelemetryConnection implements InvocationHandler {
       throwable = t;
       throw t;
     } finally {
-      producerInstrumenter.end(context, natsRequest, response, throwable);
+      requestInstrumenter.end(context, natsRequest, response, throwable);
     }
   }
 
@@ -290,12 +294,12 @@ final class OpenTelemetryConnection implements InvocationHandler {
       natsRequest = NatsRequest.create(delegate, subject, null, headers, body);
     }
 
-    if (natsRequest == null || !producerInstrumenter.shouldStart(parentContext, natsRequest)) {
+    if (natsRequest == null || !requestInstrumenter.shouldStart(parentContext, natsRequest)) {
       return (CompletableFuture<Message>) invokeMethod(method, delegate, args);
     }
 
     NatsRequest notNullNatsRequest = natsRequest;
-    Context context = producerInstrumenter.start(parentContext, notNullNatsRequest);
+    Context context = requestInstrumenter.start(parentContext, notNullNatsRequest);
 
     CompletableFuture<Message> future;
     try {
@@ -305,7 +309,7 @@ final class OpenTelemetryConnection implements InvocationHandler {
         future = delegate.request(subject, headers, body);
       }
     } catch (Throwable t) {
-      producerInstrumenter.end(context, notNullNatsRequest, null, t);
+      requestInstrumenter.end(context, notNullNatsRequest, null, t);
       throw t;
     }
 
@@ -313,9 +317,9 @@ final class OpenTelemetryConnection implements InvocationHandler {
         (result, exception) -> {
           if (result != null) {
             NatsRequest response = NatsRequest.create(delegate, result);
-            producerInstrumenter.end(context, notNullNatsRequest, response, exception);
+            requestInstrumenter.end(context, notNullNatsRequest, response, exception);
           } else {
-            producerInstrumenter.end(context, notNullNatsRequest, null, exception);
+            requestInstrumenter.end(context, notNullNatsRequest, null, exception);
           }
         });
   }

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -9,9 +9,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import java.util.List;
@@ -30,10 +31,10 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessageOperation.PUBLISH))
+                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessageOperation.PUBLISH)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingSendExceptionEventExtractor(builder);
@@ -47,15 +48,19 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessageOperation.PROCESS))
+                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessageOperation.PROCESS)
+                MessagingAttributesExtractor.builderForOperationType(
+                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);
 
-    return builder.buildConsumerInstrumenter(new NatsRequestTextMapGetter());
+    return MessagingProcessInstrumenterFactory.create(
+        builder,
+        openTelemetry.getPropagators().getTextMapPropagator(),
+        new NatsRequestTextMapGetter(),
+        false);
   }
 
   private NatsInstrumenterFactory() {}

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -24,6 +24,10 @@ import java.util.List;
 public final class NatsInstrumenterFactory {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.nats-2.17";
 
+  // messaging.operation.name values, named after the NATS API operations
+  private static final String PUBLISH_OPERATION_NAME = "publish";
+  private static final String PROCESS_OPERATION_NAME = "process";
+
   public static Instrumenter<NatsRequest, NatsRequest> createProducerInstrumenter(
       OpenTelemetry openTelemetry, List<String> capturedHeaders) {
     InstrumenterBuilder<NatsRequest, NatsRequest> builder =
@@ -31,10 +35,14 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND))
+                    new NatsRequestMessagingAttributesGetter(),
+                    MessagingOperationType.SEND,
+                    PUBLISH_OPERATION_NAME))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND)
+                        new NatsRequestMessagingAttributesGetter(),
+                        MessagingOperationType.SEND,
+                        PUBLISH_OPERATION_NAME)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingSendExceptionEventExtractor(builder);
@@ -48,10 +56,14 @@ public final class NatsInstrumenterFactory {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS))
+                    new NatsRequestMessagingAttributesGetter(),
+                    MessagingOperationType.PROCESS,
+                    PROCESS_OPERATION_NAME))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(
-                        new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS)
+                        new NatsRequestMessagingAttributesGetter(),
+                        MessagingOperationType.PROCESS,
+                        PROCESS_OPERATION_NAME)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -26,10 +26,21 @@ public final class NatsInstrumenterFactory {
 
   // messaging.operation.name values, named after the NATS API operations
   private static final String PUBLISH_OPERATION_NAME = "publish";
+  private static final String REQUEST_OPERATION_NAME = "request";
   private static final String PROCESS_OPERATION_NAME = "process";
 
-  public static Instrumenter<NatsRequest, NatsRequest> createProducerInstrumenter(
+  public static Instrumenter<NatsRequest, NatsRequest> createPublishInstrumenter(
       OpenTelemetry openTelemetry, List<String> capturedHeaders) {
+    return createProducerInstrumenter(openTelemetry, capturedHeaders, PUBLISH_OPERATION_NAME);
+  }
+
+  public static Instrumenter<NatsRequest, NatsRequest> createRequestInstrumenter(
+      OpenTelemetry openTelemetry, List<String> capturedHeaders) {
+    return createProducerInstrumenter(openTelemetry, capturedHeaders, REQUEST_OPERATION_NAME);
+  }
+
+  private static Instrumenter<NatsRequest, NatsRequest> createProducerInstrumenter(
+      OpenTelemetry openTelemetry, List<String> capturedHeaders, String operationName) {
     InstrumenterBuilder<NatsRequest, NatsRequest> builder =
         Instrumenter.<NatsRequest, NatsRequest>builder(
                 openTelemetry,
@@ -37,12 +48,12 @@ public final class NatsInstrumenterFactory {
                 MessagingSpanNameExtractor.create(
                     new NatsRequestMessagingAttributesGetter(),
                     MessagingOperationType.SEND,
-                    PUBLISH_OPERATION_NAME))
+                    operationName))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(
                         new NatsRequestMessagingAttributesGetter(),
                         MessagingOperationType.SEND,
-                        PUBLISH_OPERATION_NAME)
+                        operationName)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
     setMessagingSendExceptionEventExtractor(builder);

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -33,7 +33,7 @@ public final class NatsInstrumenterFactory {
                 MessagingSpanNameExtractor.create(
                     new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builderForOperationType(
+                MessagingAttributesExtractor.builder(
                         new NatsRequestMessagingAttributesGetter(), MessagingOperationType.SEND)
                     .setCapturedHeaders(capturedHeaders)
                     .build());
@@ -50,7 +50,7 @@ public final class NatsInstrumenterFactory {
                 MessagingSpanNameExtractor.create(
                     new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS))
             .addAttributesExtractor(
-                MessagingAttributesExtractor.builderForOperationType(
+                MessagingAttributesExtractor.builder(
                         new NatsRequestMessagingAttributesGetter(), MessagingOperationType.PROCESS)
                     .setCapturedHeaders(capturedHeaders)
                     .build());

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
@@ -100,7 +101,7 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 messagingAttributes(
@@ -111,7 +112,7 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                                         MessageHeaderUtil.headerAttributeKey("Test-Message-Header"),
                                         singletonList("test")))),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1))));
   }
@@ -141,11 +142,11 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0)),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(1)),
                     span ->
@@ -153,11 +154,11 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                             .hasKind(SpanKind.INTERNAL)
                             .hasParent(trace.getSpan(2)),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0)),
                     span ->
-                        span.hasName("sub process")
+                        span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(4))
                             .hasAttributesSatisfyingExactly(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.nats.client.Dispatcher;
@@ -18,6 +19,10 @@ import io.nats.client.impl.Headers;
 import io.nats.client.impl.NatsMessage;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -114,7 +119,8 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                     span ->
                         span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
-                            .hasParent(trace.getSpan(1))));
+                            .hasParent(trace.getSpan(1))
+                            .hasLinksSatisfying(expectedProcessLinks(trace.getSpan(1)))));
   }
 
   void publishAndAssertTraceAndSpans() {
@@ -148,7 +154,8 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                     span ->
                         span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
-                            .hasParent(trace.getSpan(1)),
+                            .hasParent(trace.getSpan(1))
+                            .hasLinksSatisfying(expectedProcessLinks(trace.getSpan(1))),
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
@@ -161,6 +168,7 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
                         span.hasName(emitStableMessagingSemconv() ? "process sub" : "sub process")
                             .hasKind(SpanKind.CONSUMER)
                             .hasParent(trace.getSpan(4))
+                            .hasLinksSatisfying(expectedProcessLinks(trace.getSpan(4)))
                             .hasAttributesSatisfyingExactly(
                                 messagingAttributes("process", "sub", clientId)),
                     span ->
@@ -171,5 +179,28 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
 
   void addChildSpan() {
     testing().runWithSpan("child", () -> {});
+  }
+
+  /**
+   * Returns an assertion for the links expected on a process span whose message was published by
+   * {@code publishSpan}. The new conventions ask for a link to the message creation context, the
+   * old ones do not use links at all.
+   */
+  private static Consumer<List<? extends LinkData>> expectedProcessLinks(SpanData publishSpan) {
+    return links -> {
+      if (!emitStableMessagingSemconv()) {
+        assertThat(links).isEmpty();
+        return;
+      }
+      assertThat(links)
+          .singleElement()
+          .satisfies(
+              link -> {
+                assertThat(link.getSpanContext().getTraceId())
+                    .isEqualTo(publishSpan.getSpanContext().getTraceId());
+                assertThat(link.getSpanContext().getSpanId())
+                    .isEqualTo(publishSpan.getSpanContext().getSpanId());
+              });
+    };
   }
 }

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.assertTraceparentHeader;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 
@@ -102,7 +103,7 @@ public abstract class AbstractNatsPublishTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.assertTraceparentHeader;
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,7 +59,7 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
@@ -305,31 +306,35 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                           // publisher: parent + publish
                           span -> span.hasName("parent").hasNoParent(),
                           span ->
-                              span.hasName("sub publish")
+                              span.hasName(
+                                      emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
                                       messagingAttributes("publish", "sub", clientId)),
                           // subscriber: process + publish(response)
                           span ->
-                              span.hasName("sub process")
+                              span.hasName(
+                                      emitStableMessagingSemconv() ? "process sub" : "sub process")
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(1)),
                           span ->
-                              span.hasName("(temporary) publish")
+                              span.hasName(
+                                      emitStableMessagingSemconv()
+                                          ? "publish _INBOX."
+                                          : "(temporary) publish")
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(2)),
                           // publisher: process
                           span ->
-                              span.hasName("(temporary) process")
+                              span.hasName(
+                                      emitStableMessagingSemconv()
+                                          ? "process _INBOX."
+                                          : "(temporary) process")
                                   .hasKind(SpanKind.CONSUMER)
                                   .hasParent(trace.getSpan(3))
                                   .hasAttributesSatisfyingExactly(
-                                      messagingAttributes(
-                                          "process",
-                                          "(temporary)",
-                                          clientId,
-                                          equalTo(MESSAGING_DESTINATION_TEMPORARY, true)))));
+                                      messagingAttributes("process", "(temporary)", clientId))));
 
               trace.hasSpansSatisfyingExactly(asserts);
             });
@@ -348,11 +353,19 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName("sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasException(exception)
                             .hasAttributesSatisfyingExactly(
-                                messagingAttributes("publish", "sub", clientId))));
+                                messagingAttributes(
+                                    "publish",
+                                    "sub",
+                                    clientId,
+                                    equalTo(
+                                        ERROR_TYPE,
+                                        emitStableMessagingSemconv()
+                                            ? exception.getClass().getName()
+                                            : null)))));
   }
 }

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
@@ -59,11 +59,11 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "request sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
-                                messagingAttributes("publish", "sub", clientId))));
+                                messagingAttributes("request", "sub", clientId))));
     assertTraceparentHeader(subscription);
   }
 
@@ -307,11 +307,11 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                           span -> span.hasName("parent").hasNoParent(),
                           span ->
                               span.hasName(
-                                      emitStableMessagingSemconv() ? "publish sub" : "sub publish")
+                                      emitStableMessagingSemconv() ? "request sub" : "sub publish")
                                   .hasKind(SpanKind.PRODUCER)
                                   .hasParent(trace.getSpan(0))
                                   .hasAttributesSatisfyingExactly(
-                                      messagingAttributes("publish", "sub", clientId)),
+                                      messagingAttributes("request", "sub", clientId)),
                           // subscriber: process + publish(response)
                           span ->
                               span.hasName(
@@ -353,13 +353,13 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasNoParent(),
                     span ->
-                        span.hasName(emitStableMessagingSemconv() ? "publish sub" : "sub publish")
+                        span.hasName(emitStableMessagingSemconv() ? "request sub" : "sub publish")
                             .hasKind(SpanKind.PRODUCER)
                             .hasParent(trace.getSpan(0))
                             .hasException(exception)
                             .hasAttributesSatisfyingExactly(
                                 messagingAttributes(
-                                    "publish",
+                                    "request",
                                     "sub",
                                     clientId,
                                     equalTo(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
@@ -6,10 +6,17 @@
 package io.opentelemetry.instrumentation.nats.v2_17;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPLATE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,12 +25,16 @@ import io.nats.client.Subscription;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class NatsTestHelper {
 
   // copied from MessagingIncubatingAttributes
-  private static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID_OLD =
+      stringKey("messaging.client_id");
+  private static final AttributeKey<String> MESSAGING_CLIENT_ID = stringKey("messaging.client.id");
 
   static AttributeAssertion[] messagingAttributes(
       String operation, String subject, int clientId, AttributeAssertion other) {
@@ -40,13 +51,35 @@ class NatsTestHelper {
   }
 
   static AttributeAssertion[] messagingAttributes(String operation, String subject, int clientId) {
-    return new AttributeAssertion[] {
-      equalTo(MESSAGING_OPERATION, operation),
-      equalTo(MESSAGING_SYSTEM, "nats"),
-      equalTo(MESSAGING_DESTINATION_NAME, subject),
-      equalTo(MESSAGING_MESSAGE_BODY_SIZE, 1),
-      equalTo(MESSAGING_CLIENT_ID, String.valueOf(clientId))
-    };
+    List<AttributeAssertion> assertions = new ArrayList<>();
+    assertions.add(equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null));
+    assertions.add(
+        equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null));
+    assertions.add(
+        equalTo(
+            MESSAGING_OPERATION_TYPE,
+            emitStableMessagingSemconv()
+                ? operation.equals("publish") ? "send" : operation
+                : null));
+    assertions.add(equalTo(MESSAGING_SYSTEM, "nats"));
+    if (subject.equals("(temporary)") && emitStableMessagingSemconv()) {
+      assertions.add(satisfies(MESSAGING_DESTINATION_NAME, val -> val.startsWith("_INBOX.")));
+      assertions.add(equalTo(MESSAGING_DESTINATION_TEMPLATE, "_INBOX."));
+      assertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
+    } else {
+      assertions.add(equalTo(MESSAGING_DESTINATION_NAME, subject));
+      if (subject.equals("(temporary)")) {
+        assertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
+      }
+    }
+    assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, 1));
+    assertions.add(
+        equalTo(
+            MESSAGING_CLIENT_ID_OLD, emitOldMessagingSemconv() ? String.valueOf(clientId) : null));
+    assertions.add(
+        equalTo(
+            MESSAGING_CLIENT_ID, emitStableMessagingSemconv() ? String.valueOf(clientId) : null));
+    return assertions.toArray(new AttributeAssertion[0]);
   }
 
   static void assertTraceparentHeader(Subscription subscription) throws InterruptedException {

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
@@ -72,7 +72,7 @@ class NatsTestHelper {
         assertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
       }
     }
-    assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, 1));
+    assertions.add(equalTo(MESSAGING_MESSAGE_BODY_SIZE, emitOldMessagingSemconv() ? 1L : null));
     assertions.add(
         equalTo(
             MESSAGING_CLIENT_ID_OLD, emitOldMessagingSemconv() ? String.valueOf(clientId) : null));

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTestHelper.java
@@ -51,16 +51,18 @@ class NatsTestHelper {
   }
 
   static AttributeAssertion[] messagingAttributes(String operation, String subject, int clientId) {
+    boolean send = operation.equals("publish") || operation.equals("request");
     List<AttributeAssertion> assertions = new ArrayList<>();
-    assertions.add(equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null));
+    // the old conventions did not distinguish request from publish
+    assertions.add(
+        equalTo(
+            MESSAGING_OPERATION, emitOldMessagingSemconv() ? send ? "publish" : operation : null));
     assertions.add(
         equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null));
     assertions.add(
         equalTo(
             MESSAGING_OPERATION_TYPE,
-            emitStableMessagingSemconv()
-                ? operation.equals("publish") ? "send" : operation
-                : null));
+            emitStableMessagingSemconv() ? send ? "send" : operation : null));
     assertions.add(equalTo(MESSAGING_SYSTEM, "nats"));
     if (subject.equals("(temporary)") && emitStableMessagingSemconv()) {
       assertions.add(satisfies(MESSAGING_DESTINATION_NAME, val -> val.startsWith("_INBOX.")));

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -67,6 +67,21 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.spring-integration.producer.enabled=true")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringIntegrationAndRabbitTest")
+      excludeTestsMatching("SpringCloudStreamRabbitTest")
+    }
+    jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-integration.producer.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("SpringIntegrationAndRabbitTest")
@@ -77,7 +92,7 @@ tasks {
   }
 
   check {
-    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation)
+    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation, testV3Preview)
   }
 
   withType<Test>().configureEach {

--- a/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/build.gradle.kts
@@ -67,7 +67,7 @@ tasks {
     systemProperty("metadataConfig", "otel.instrumentation.spring-integration.producer.enabled=true")
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
@@ -77,9 +77,22 @@ tasks {
     jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=false")
     jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=false")
     jvmArgs("-Dotel.instrumentation.spring-integration.producer.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringIntegrationAndRabbitTest")
+      excludeTestsMatching("SpringCloudStreamRabbitTest")
+    }
+    jvmArgs("-Dotel.instrumentation.rabbitmq.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-rabbit.enabled=false")
+    jvmArgs("-Dotel.instrumentation.spring-integration.producer.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   test {
@@ -92,7 +105,7 @@ tasks {
   }
 
   check {
-    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation, testV3Preview)
+    dependsOn(testWithRabbitInstrumentation, testWithProducerInstrumentation, testMessagingPreview, testBothSemconv)
   }
 
   withType<Test>().configureEach {

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -24,9 +24,20 @@ dependencies {
 }
 
 tasks {
-  test {
+  withType<Test>().configureEach {
     systemProperty("testLatestDeps", otelProps.testLatestDeps)
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testV3Preview)
   }
 }
 

--- a/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
+++ b/instrumentation/spring/spring-integration-4.1/library/build.gradle.kts
@@ -29,15 +29,20 @@ tasks {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testV3Preview)
+    dependsOn(testMessagingPreview, testBothSemconv)
   }
 }
 

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -12,9 +12,11 @@ import static java.util.Collections.emptyList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
@@ -75,32 +77,37 @@ public final class SpringIntegrationTelemetryBuilder {
    * SpringIntegrationTelemetryBuilder}.
    */
   public SpringIntegrationTelemetry build() {
+    SpringMessagingAttributesGetter consumerGetter = new SpringMessagingAttributesGetter(false);
+    SpringMessagingAttributesGetter consumerNameGetter = new SpringMessagingAttributesGetter(true);
     InstrumenterBuilder<MessageWithChannel, Void> consumerBuilder =
         Instrumenter.<MessageWithChannel, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                SpringIntegrationTelemetryBuilder::consumerSpanName)
+                MessagingSpanNameExtractor.create(
+                    consumerNameGetter, MessagingOperationType.PROCESS))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    new SpringMessagingAttributesGetter(),
-                    MessageOperation.PROCESS,
-                    capturedHeaders));
+                    consumerGetter, MessagingOperationType.PROCESS, capturedHeaders));
     setMessagingProcessExceptionEventExtractor(consumerBuilder);
     Instrumenter<MessageWithChannel, Void> consumerInstrumenter =
-        consumerBuilder.buildConsumerInstrumenter(MessageHeadersGetter.INSTANCE);
+        MessagingProcessInstrumenterFactory.create(
+            consumerBuilder,
+            openTelemetry.getPropagators().getTextMapPropagator(),
+            MessageHeadersGetter.INSTANCE,
+            false);
 
+    SpringMessagingAttributesGetter producerGetter = new SpringMessagingAttributesGetter(false);
+    SpringMessagingAttributesGetter producerNameGetter = new SpringMessagingAttributesGetter(true);
     InstrumenterBuilder<MessageWithChannel, Void> producerBuilder =
         Instrumenter.<MessageWithChannel, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                SpringIntegrationTelemetryBuilder::producerSpanName)
+                MessagingSpanNameExtractor.create(producerNameGetter, MessagingOperationType.SEND))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    new SpringMessagingAttributesGetter(),
-                    MessageOperation.PUBLISH,
-                    capturedHeaders));
+                    producerGetter, MessagingOperationType.SEND, capturedHeaders));
     setMessagingSendExceptionEventExtractor(producerBuilder);
     Instrumenter<MessageWithChannel, Void> producerInstrumenter =
         producerBuilder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
@@ -111,19 +118,11 @@ public final class SpringIntegrationTelemetryBuilder {
         producerSpanEnabled);
   }
 
-  private static String consumerSpanName(MessageWithChannel messageWithChannel) {
-    return messageWithChannel.getChannelName() + " process";
-  }
-
-  private static String producerSpanName(MessageWithChannel messageWithChannel) {
-    return messageWithChannel.getChannelName() + " publish";
-  }
-
   private static AttributesExtractor<MessageWithChannel, Void> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<MessageWithChannel, Void> getter,
-      MessageOperation operation,
+      MessagingOperationType operationType,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operation)
+    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -29,6 +29,10 @@ import java.util.List;
 public final class SpringIntegrationTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-integration-4.1";
 
+  // messaging.operation.name values, named after the Spring Messaging API operations
+  private static final String SEND_OPERATION_NAME = "send";
+  private static final String PROCESS_OPERATION_NAME = "process";
+
   private final OpenTelemetry openTelemetry;
   private final List<AttributesExtractor<MessageWithChannel, Void>> additionalAttributeExtractors =
       new ArrayList<>();
@@ -84,11 +88,14 @@ public final class SpringIntegrationTelemetryBuilder {
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(
-                    consumerNameGetter, MessagingOperationType.PROCESS))
+                    consumerNameGetter, MessagingOperationType.PROCESS, PROCESS_OPERATION_NAME))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    consumerGetter, MessagingOperationType.PROCESS, capturedHeaders));
+                    consumerGetter,
+                    MessagingOperationType.PROCESS,
+                    PROCESS_OPERATION_NAME,
+                    capturedHeaders));
     setMessagingProcessExceptionEventExtractor(consumerBuilder);
     Instrumenter<MessageWithChannel, Void> consumerInstrumenter =
         MessagingProcessInstrumenterFactory.create(
@@ -103,11 +110,15 @@ public final class SpringIntegrationTelemetryBuilder {
         Instrumenter.<MessageWithChannel, Void>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
-                MessagingSpanNameExtractor.create(producerNameGetter, MessagingOperationType.SEND))
+                MessagingSpanNameExtractor.create(
+                    producerNameGetter, MessagingOperationType.SEND, SEND_OPERATION_NAME))
             .addAttributesExtractors(additionalAttributeExtractors)
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    producerGetter, MessagingOperationType.SEND, capturedHeaders));
+                    producerGetter,
+                    MessagingOperationType.SEND,
+                    SEND_OPERATION_NAME,
+                    capturedHeaders));
     setMessagingSendExceptionEventExtractor(producerBuilder);
     Instrumenter<MessageWithChannel, Void> producerInstrumenter =
         producerBuilder.buildInstrumenter(SpanKindExtractor.alwaysProducer());
@@ -121,8 +132,9 @@ public final class SpringIntegrationTelemetryBuilder {
   private static AttributesExtractor<MessageWithChannel, Void> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<MessageWithChannel, Void> getter,
       MessagingOperationType operationType,
+      String operationName,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builder(getter, operationType)
+    return MessagingAttributesExtractor.builder(getter, operationType, operationName)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -122,7 +122,7 @@ public final class SpringIntegrationTelemetryBuilder {
       MessagingAttributesGetter<MessageWithChannel, Void> getter,
       MessagingOperationType operationType,
       List<String> capturedHeaders) {
-    return MessagingAttributesExtractor.builderForOperationType(getter, operationType)
+    return MessagingAttributesExtractor.builder(getter, operationType)
         .setCapturedHeaders(capturedHeaders)
         .build();
   }

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringMessagingAttributesGetter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -16,16 +17,24 @@ import javax.annotation.Nullable;
 final class SpringMessagingAttributesGetter
     implements MessagingAttributesGetter<MessageWithChannel, Void> {
 
-  @Override
-  @Nullable
-  public String getSystem(MessageWithChannel messageWithChannel) {
-    return null;
+  private final boolean spanNameGetter;
+
+  SpringMessagingAttributesGetter(boolean spanNameGetter) {
+    this.spanNameGetter = spanNameGetter;
   }
 
-  @Override
   @Nullable
+  @Override
+  public String getSystem(MessageWithChannel messageWithChannel) {
+    return emitStableMessagingSemconv() ? "spring_integration" : null;
+  }
+
+  @Nullable
+  @Override
   public String getDestination(MessageWithChannel messageWithChannel) {
-    return null;
+    return spanNameGetter || emitStableMessagingSemconv()
+        ? messageWithChannel.getChannelName()
+        : null;
   }
 
   @Nullable

--- a/instrumentation/spring/spring-integration-4.1/metadata.yaml
+++ b/instrumentation/spring/spring-integration-4.1/metadata.yaml
@@ -1,6 +1,8 @@
 display_name: Spring Integration
 description: This instrumentation enables producer and consumer messaging spans for Spring Integration.
 library_link: https://spring.io/projects/spring-integration
+semantic_conventions:
+  - MESSAGING_SPANS
 configurations:
   - name: otel.instrumentation.spring-integration.producer.enabled
     declarative_name: java.spring_integration.producer.enabled

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractComplexPropagationTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
 
@@ -81,11 +83,23 @@ abstract class AbstractComplexPropagationTest {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("application.sendChannel process").hasKind(SpanKind.CONSUMER),
                 span ->
-                    span.hasName("application.receiveChannel process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process application.sendChannel"
+                                : "application.sendChannel process")
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "application.sendChannel")),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process application.receiveChannel"
+                                : "application.receiveChannel process")
                         .hasParent(trace.getSpan(0))
-                        .hasKind(SpanKind.CONSUMER),
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "application.receiveChannel")),
                 span -> span.hasName("handler").hasParent(trace.getSpan(1))));
 
     receiveChannel.unsubscribe(messageHandler);

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -38,13 +40,23 @@ abstract class AbstractSpringCloudStreamProducerTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer").hasKind(SpanKind.INTERNAL),
                 span ->
-                    span.hasName("testProducer.output publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish testProducer.output"
+                                : "testProducer.output publish")
                         .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0)),
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("publish", "testProducer.output")),
                 span ->
-                    span.hasName("testConsumer.input process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process testConsumer.input"
+                                : "testConsumer.input process")
                         .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1)),
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "testConsumer.input")),
                 span ->
                     span.hasName("consumer")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -55,6 +56,19 @@ abstract class AbstractSpringCloudStreamProducerTest {
                                 : "testConsumer.input process")
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
+                        .hasLinksSatisfying(
+                            links -> {
+                              if (emitStableMessagingSemconv()) {
+                                assertThat(links)
+                                    .singleElement()
+                                    .satisfies(
+                                        link ->
+                                            assertThat(link.getSpanContext().getSpanId())
+                                                .isEqualTo(trace.getSpan(1).getSpanId()));
+                              } else {
+                                assertThat(links).isEmpty();
+                              }
+                            })
                         .hasAttributesSatisfyingExactly(
                             messagingAttributes("process", "testConsumer.input")),
                 span ->

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
@@ -42,12 +42,12 @@ abstract class AbstractSpringCloudStreamProducerTest {
                 span ->
                     span.hasName(
                             emitStableMessagingSemconv()
-                                ? "publish testProducer.output"
+                                ? "send testProducer.output"
                                 : "testProducer.output publish")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            messagingAttributes("publish", "testProducer.output")),
+                            messagingAttributes("send", "testProducer.output")),
                 span ->
                     span.hasName(
                             emitStableMessagingSemconv()

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamRabbitTest.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
+
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import org.junit.jupiter.api.Test;
@@ -31,9 +34,14 @@ abstract class AbstractSpringCloudStreamRabbitTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer").hasKind(SpanKind.INTERNAL),
                 span ->
-                    span.hasName("testConsumer.input process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process testConsumer.input"
+                                : "testConsumer.input process")
                         .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(0)),
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            messagingAttributes("process", "testConsumer.input")),
                 span ->
                     span.hasName("consumer")
                         .hasKind(SpanKind.INTERNAL)

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,12 +74,9 @@ abstract class AbstractSpringIntegrationTracingTest {
 
   @ParameterizedTest
   @CsvSource(
-      value = {
-        "directChannel,application.directChannel process",
-        "executorChannel,executorChannel process"
-      },
+      value = {"directChannel,application.directChannel", "executorChannel,executorChannel"},
       delimiter = ',')
-  void shouldPropagateContext(String channelName, String interceptorSpanName) {
+  void shouldPropagateContext(String channelName, String destinationName) {
     SubscribableChannel channel =
         applicationContext.getBean(channelName, SubscribableChannel.class);
 
@@ -89,7 +91,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName(interceptorSpanName).hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process " + destinationName
+                              : destinationName + " process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", destinationName));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -113,7 +121,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.directChannel2 process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.directChannel2"
+                              : "application.directChannel2 process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", "application.directChannel2"));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -164,7 +178,13 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.linkedChannel1 process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.linkedChannel1"
+                              : "application.linkedChannel1 process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes("process", "application.linkedChannel1"));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
@@ -192,7 +212,18 @@ abstract class AbstractSpringIntegrationTracingTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> {
-                  span.hasName("application.directChannel process").hasKind(SpanKind.CONSUMER);
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process application.directChannel"
+                              : "application.directChannel process")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasAttributesSatisfyingExactly(
+                          messagingAttributes(
+                              "process",
+                              "application.directChannel",
+                              equalTo(
+                                  headerAttributeKey("Test-Message-Header"),
+                                  singletonList("test"))));
                   verifyCorrectSpanWasPropagated(capturedMessage, trace.getSpan(0));
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+
+final class SpringIntegrationTestHelper {
+
+  static AttributeAssertion[] messagingAttributes(String operation, String destinationName) {
+    return messagingAttributes(operation, destinationName, new AttributeAssertion[0]);
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  static AttributeAssertion[] messagingAttributes(
+      String operation, String destinationName, AttributeAssertion... additionalAssertions) {
+    AttributeAssertion[] standard =
+        new AttributeAssertion[] {
+          equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "spring_integration" : null),
+          equalTo(
+              MESSAGING_DESTINATION_NAME, emitStableMessagingSemconv() ? destinationName : null),
+          equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null),
+          equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null),
+          equalTo(
+              MESSAGING_OPERATION_TYPE,
+              emitStableMessagingSemconv()
+                  ? operation.equals("publish") ? "send" : operation
+                  : null)
+        };
+    AttributeAssertion[] result =
+        new AttributeAssertion[standard.length + additionalAssertions.length];
+    System.arraycopy(standard, 0, result, 0, standard.length);
+    System.arraycopy(additionalAssertions, 0, result, standard.length, additionalAssertions.length);
+    return result;
+  }
+
+  private SpringIntegrationTestHelper() {}
+}

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
@@ -18,25 +18,23 @@ import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 
 final class SpringIntegrationTestHelper {
 
-  static AttributeAssertion[] messagingAttributes(String operation, String destinationName) {
-    return messagingAttributes(operation, destinationName, new AttributeAssertion[0]);
+  static AttributeAssertion[] messagingAttributes(String operationName, String destinationName) {
+    return messagingAttributes(operationName, destinationName, new AttributeAssertion[0]);
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   static AttributeAssertion[] messagingAttributes(
-      String operation, String destinationName, AttributeAssertion... additionalAssertions) {
+      String operationName, String destinationName, AttributeAssertion... additionalAssertions) {
+    // the old semantic conventions used "publish" where the stable ones use "send"
+    String oldOperation = operationName.equals("send") ? "publish" : operationName;
     AttributeAssertion[] standard =
         new AttributeAssertion[] {
           equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "spring_integration" : null),
           equalTo(
               MESSAGING_DESTINATION_NAME, emitStableMessagingSemconv() ? destinationName : null),
-          equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null),
-          equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null),
-          equalTo(
-              MESSAGING_OPERATION_TYPE,
-              emitStableMessagingSemconv()
-                  ? operation.equals("publish") ? "send" : operation
-                  : null)
+          equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? oldOperation : null),
+          equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operationName : null),
+          equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationName : null)
         };
     AttributeAssertion[] result =
         new AttributeAssertion[standard.length + additionalAssertions.length];

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -73,7 +73,16 @@ tasks {
     )
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testing.suites)
+    dependsOn(testing.suites, testV3Preview)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -73,16 +73,23 @@ tasks {
     )
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {
-    dependsOn(testing.suites, testV3Preview)
+    dependsOn(testing.suites, testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 
 import io.opentelemetry.instrumentation.spring.jms.v2_0.AbstractJmsTest;
@@ -42,7 +44,7 @@ class SpringListenerTest extends AbstractJmsTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(PRODUCER, CONSUMER),
+        orderByRootSpanKind(PRODUCER, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> assertProducerSpan(span, "SpringListenerJms2", false));

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -179,10 +180,14 @@ class SpringTemplateTest extends AbstractJmsTest {
     AtomicReference<SpanData> tmpProducerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName(
-            "SpringTemplateJms2 publish",
-            "SpringTemplateJms2 receive",
-            "(temporary) publish",
-            "(temporary) receive"),
+            emitStableMessagingSemconv()
+                ? "publish SpringTemplateJms2"
+                : "SpringTemplateJms2 publish",
+            emitStableMessagingSemconv()
+                ? "receive SpringTemplateJms2"
+                : "SpringTemplateJms2 receive",
+            emitStableMessagingSemconv() ? "publish" : "(temporary) publish",
+            emitStableMessagingSemconv() ? "receive" : "(temporary) receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> assertProducerSpan(span, "SpringTemplateJms2", false));

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringTemplateTest.java
@@ -180,13 +180,11 @@ class SpringTemplateTest extends AbstractJmsTest {
     AtomicReference<SpanData> tmpProducerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName(
-            emitStableMessagingSemconv()
-                ? "publish SpringTemplateJms2"
-                : "SpringTemplateJms2 publish",
+            emitStableMessagingSemconv() ? "send SpringTemplateJms2" : "SpringTemplateJms2 publish",
             emitStableMessagingSemconv()
                 ? "receive SpringTemplateJms2"
                 : "SpringTemplateJms2 receive",
-            emitStableMessagingSemconv() ? "publish" : "(temporary) publish",
+            emitStableMessagingSemconv() ? "send" : "(temporary) publish",
             emitStableMessagingSemconv() ? "receive" : "(temporary) receive"),
         trace -> {
           trace.hasSpansSatisfyingExactly(

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
@@ -6,14 +6,19 @@
 package io.opentelemetry.instrumentation.spring.jms.v2_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -32,7 +37,10 @@ public abstract class AbstractJmsTest {
       SpanDataAssert span, String destinationName, boolean testHeaders) {
     List<AttributeAssertion> attributeAssertions =
         producerAttributeAssertions(destinationName, testHeaders);
-    span.hasName(destinationName + " publish")
+    span.hasName(
+            emitStableMessagingSemconv()
+                ? destinationName.equals("(temporary)") ? "publish" : "publish " + destinationName
+                : destinationName + " publish")
         .hasKind(PRODUCER)
         .hasNoParent()
         .hasAttributesSatisfyingExactly(attributeAssertions);
@@ -44,8 +52,10 @@ public abstract class AbstractJmsTest {
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "jms"),
-                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MESSAGING_OPERATION, "publish"),
+                messagingDestinationName(destinationName),
+                oldOperation("publish"),
+                operationName("publish"),
+                operationType("publish"),
                 satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
     if (destinationName.equals("(temporary)")) {
       attributeAssertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
@@ -68,7 +78,13 @@ public abstract class AbstractJmsTest {
       String operation,
       boolean testHeaders,
       String msgId) {
-    span.hasName(destinationName + " " + operation).hasKind(CONSUMER);
+    span.hasName(
+            emitStableMessagingSemconv()
+                ? destinationName.equals("(temporary)")
+                    ? operation
+                    : operation + " " + destinationName
+                : destinationName + " " + operation)
+        .hasKind(emitStableMessagingSemconv() && operation.equals("receive") ? CLIENT : CONSUMER);
     if (parent != null) {
       span.hasParent(parent);
     } else {
@@ -87,8 +103,10 @@ public abstract class AbstractJmsTest {
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "jms"),
-                equalTo(MESSAGING_DESTINATION_NAME, destinationName),
-                equalTo(MESSAGING_OPERATION, operation)));
+                messagingDestinationName(destinationName),
+                oldOperation(operation),
+                operationName(operation),
+                operationType(operation)));
     if (msgId != null) {
       attributeAssertions.add(equalTo(MESSAGING_MESSAGE_ID, msgId));
     } else {
@@ -106,5 +124,24 @@ public abstract class AbstractJmsTest {
               stringArrayKey("messaging.header.Test_Message_Int_Header"), singletonList("1234")));
     }
     return attributeAssertions;
+  }
+
+  private static AttributeAssertion messagingDestinationName(String destinationName) {
+    return emitStableMessagingSemconv() && destinationName.equals("(temporary)")
+        ? satisfies(MESSAGING_DESTINATION_NAME, val -> val.isNotEmpty())
+        : equalTo(MESSAGING_DESTINATION_NAME, destinationName);
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/jms/v2_0/AbstractJmsTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractJmsTest {
         producerAttributeAssertions(destinationName, testHeaders);
     span.hasName(
             emitStableMessagingSemconv()
-                ? destinationName.equals("(temporary)") ? "publish" : "publish " + destinationName
+                ? destinationName.equals("(temporary)") ? "send" : "send " + destinationName
                 : destinationName + " publish")
         .hasKind(PRODUCER)
         .hasNoParent()
@@ -54,8 +54,8 @@ public abstract class AbstractJmsTest {
                 equalTo(MESSAGING_SYSTEM, "jms"),
                 messagingDestinationName(destinationName),
                 oldOperation("publish"),
-                operationName("publish"),
-                operationType("publish"),
+                operationName("send"),
+                operationType("send"),
                 satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
     if (destinationName.equals("(temporary)")) {
       attributeAssertions.add(equalTo(MESSAGING_DESTINATION_TEMPORARY, true));
@@ -141,7 +141,6 @@ public abstract class AbstractJmsTest {
   }
 
   private static AttributeAssertion operationType(String operation) {
-    String operationType = operation.equals("publish") ? "send" : operation;
-    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -51,6 +51,18 @@ tasks {
     include("**/SpringListenerSuppressReceiveSpansTest.*")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   test {
     filter {
       excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
@@ -63,6 +75,6 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpansDisabled)
+    dependsOn(testReceiveSpansDisabled, testV3Preview)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -51,16 +51,26 @@ tasks {
     include("**/SpringListenerSuppressReceiveSpansTest.*")
   }
 
-  val testV3Preview = register<Test>("testV3Preview") {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
       excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   test {
@@ -75,6 +85,6 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpansDisabled, testV3Preview)
+    dependsOn(testReceiveSpansDisabled, testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -6,20 +6,26 @@
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.jms.ConnectionFactory;
@@ -39,18 +45,23 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
   void assertSpringJmsListener() {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, CONSUMER),
+        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasNoParent(),
               span ->
-                  span.hasName("spring-jms-listener publish")
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "publish spring-jms-listener"
+                              : "spring-jms-listener publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                          equalTo(MESSAGING_OPERATION, "publish"),
+                          oldOperation("publish"),
+                          operationName("publish"),
+                          operationType("publish"),
                           satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)));
 
           producerSpan.set(trace.getSpan(1));
@@ -58,24 +69,34 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("spring-jms-listener receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive spring-jms-listener"
+                                : "spring-jms-listener receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span ->
-                    span.hasName("spring-jms-listener process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process spring-jms-listener"
+                                : "spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
@@ -113,18 +134,23 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
     assertThat(receivedMessage.get(10, SECONDS)).isEqualTo(message);
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, CONSUMER),
+        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName("spring-jms-listener publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "publish spring-jms-listener"
+                                : "spring-jms-listener publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            oldOperation("publish"),
+                            operationName("publish"),
+                            operationType("publish"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -135,13 +161,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("spring-jms-listener receive")
-                        .hasKind(CONSUMER)
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive spring-jms-listener"
+                                : "spring-jms-listener receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "receive"),
+                            oldOperation("receive"),
+                            operationName("receive"),
+                            operationType("receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -150,13 +181,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName("spring-jms-listener process")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process spring-jms-listener"
+                                : "spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "process"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -165,5 +201,18 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
+  }
+
+  private static AttributeAssertion oldOperation(String operation) {
+    return equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationName(String operation) {
+    return equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  private static AttributeAssertion operationType(String operation) {
+    String operationType = operation.equals("publish") ? "send" : operation;
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -52,7 +52,7 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
               span ->
                   span.hasName(
                           emitStableMessagingSemconv()
-                              ? "publish spring-jms-listener"
+                              ? "send spring-jms-listener"
                               : "spring-jms-listener publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
@@ -60,8 +60,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                           equalTo(MESSAGING_SYSTEM, "jms"),
                           equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
                           oldOperation("publish"),
-                          operationName("publish"),
-                          operationType("publish"),
+                          operationName("send"),
+                          operationType("send"),
                           satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)));
 
           producerSpan.set(trace.getSpan(1));
@@ -141,7 +141,7 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                 span ->
                     span.hasName(
                             emitStableMessagingSemconv()
-                                ? "publish spring-jms-listener"
+                                ? "send spring-jms-listener"
                                 : "spring-jms-listener publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
@@ -149,8 +149,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
                             oldOperation("publish"),
-                            operationName("publish"),
-                            operationType("publish"),
+                            operationName("send"),
+                            operationType("send"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             equalTo(
                                 stringArrayKey("messaging.header.Test_Message_Header"),
@@ -212,7 +212,6 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
   }
 
   private static AttributeAssertion operationType(String operation) {
-    String operationType = operation.equals("publish") ? "send" : operation;
-    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operationType : null);
+    return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
   }
 }


### PR DESCRIPTION
Migrates JMS (`jms-common-1.1`), NATS (`nats-2.17`) and Spring Integration (`spring-integration-4.1`) to `MessagingOperationType`, `MessagingSpanKindExtractor` and the shared `MessagingProcessInstrumenterFactory`. Spring JMS and the JMS 1.1 / 3.0 modules pick the change up through `jms-common-1.1` and only gain test coverage here.

Spring Integration builds its `SpringMessagingAttributesGetter` twice, once for attributes and once for span naming. Its span name has always included the channel name, but it never emitted `messaging.destination.name` or `messaging.system`. Keeping the two getters separate lets the span name stay as it is while the attributes appear only under v1.43, so the module can move onto the shared `MessagingSpanNameExtractor` without changing what it emits today.

## Operation names

`messaging.operation.name` names the client API operation the span wraps: `send` / `receive` / `process` for JMS, and `send` / `process` for Spring Integration.

NATS gets `publish`, `request` and `process`. `request` is deliberately not reported as `publish`: NATS documents request-reply as a pattern distinct from publish-subscribe, `Connection.request` is a separate API from `Connection.publish`, and the span covers the round trip rather than the publish. `NatsInstrumenterFactory` therefore exposes a publish and a request instrumenter over one shared producer configuration, and `ConnectionRequestInstrumentation` uses the latter.

## JMS receive spans when receive telemetry is disabled

The JMS receive span used to be reparented onto the producer span extracted from the message. Under v1.43 a receive span is a `CLIENT` span belonging to the caller's trace, so it now keeps its ambient parent and adds the producer as a span link instead. `Jms1SuppressReceiveSpansTest` and `Jms3SuppressReceiveSpansTest` were excluded from every messaging preview test task, so their stable assertions never ran; a `testMessagingPreviewReceiveSpansDisabled` task in both modules now covers the new topology.

## Default-path impact

None. `SpringMessagingAttributesGetter.getSystem` and `getDestination` return their previous values when `emitStableMessagingSemconv()` is unset, the shared factories fall through to the existing consumer instrumenter, the JMS receive span keeps its old parenting, and NATS request spans keep `messaging.operation=publish` and their `<subject> publish` span name.

Part of #19254.
