### PR TITLE
Activate messaging v1.43 in common v3 preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   ([#19397](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19397))
 - Deprecate `MessageOperation` in favor of `MessagingOperationType`.
   ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
+- Deprecate the `MessageOperation`-based factory methods on `MessagingAttributesExtractor`,
+  `MessagingSpanNameExtractor` and `MessagingSpanKindExtractor` in favor of their
+  `MessagingOperationType`-based counterparts.
+  ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
+- Deprecate `MessagingProducerMetrics.get()` and `MessagingConsumerMetrics.get()` in favor of
+  `MessagingProducerMetrics.getForOperationType()` and
+  `MessagingConsumerMetrics.getForOperationType()`.
+  ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
 
 ## Version 2.30.0 (2026-07-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   already expose a max. It is no longer emitted when `otel.instrumentation.common.v3-preview` is
   enabled.
   ([#19397](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19397))
+- Deprecate `MessageOperation` in favor of `MessagingOperationType`.
+  ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
 
 ## Version 2.30.0 (2026-07-22)
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
-/** Represents an operation that may be used in a messaging system. */
+/**
+ * Represents an operation that may be used in a messaging system.
+ *
+ * @deprecated Use {@link MessagingOperationType}. Will be removed in 3.0.
+ */
+@Deprecated // to be removed in 3.0
 public enum MessageOperation {
   PUBLISH(MessagingOperationType.SEND),
   RECEIVE(MessagingOperationType.RECEIVE),

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -82,7 +82,11 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
     return builder(getter, operationType, operationName).build();
   }
 
-  /** Creates the messaging attributes extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #createForOperationType(MessagingAttributesGetter,
+   *     MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
@@ -103,7 +107,11 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
         getter, operationType, requireNonNull(operationName, "operationName"), true);
   }
 
-  /** Returns a new messaging attributes extractor builder for the given operation. */
+  /**
+   * @deprecated Use {@link #builderForOperationType(MessagingAttributesGetter,
+   *     MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return new MessagingAttributesExtractorBuilder<>(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -83,8 +83,8 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   /**
-   * @deprecated Use {@link #createForOperationType(MessagingAttributesGetter,
-   *     MessagingOperationType)}. Will be removed in 3.0.
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType)}. Will be
+   *     removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -108,8 +108,8 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   /**
-   * @deprecated Use {@link #builderForOperationType(MessagingAttributesGetter,
-   *     MessagingOperationType)}. Will be removed in 3.0.
+   * @deprecated Use {@link #builder(MessagingAttributesGetter, MessagingOperationType)}. Will be
+   *     removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -83,8 +83,8 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   /**
-   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType)}. Will be
-   *     removed in 3.0.
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}.
+   *     Will be removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -108,8 +108,8 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   /**
-   * @deprecated Use {@link #builder(MessagingAttributesGetter, MessagingOperationType)}. Will be
-   *     removed in 3.0.
+   * @deprecated Use {@link #builder(MessagingAttributesGetter, MessagingOperationType, String)}.
+   *     Will be removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -78,7 +78,12 @@ public final class MessagingConsumerMetrics implements OperationListener {
             || consumedMessagesCounter != null;
   }
 
-  /** Returns metrics for extractors configured with {@link MessageOperation}. */
+  /**
+   * Returns metrics for extractors configured with {@link MessageOperation}.
+   *
+   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -68,7 +68,12 @@ public final class MessagingProducerMetrics implements OperationListener {
             || sentMessagesCounter != null;
   }
 
-  /** Returns metrics for extractors configured with {@link MessageOperation}. */
+  /**
+   * Returns metrics for extractors configured with {@link MessageOperation}.
+   *
+   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -65,7 +65,10 @@ public final class MessagingSpanKindExtractor {
     return spanKindExtractor;
   }
 
-  /** Returns a span kind extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #create(MessagingOperationType)}. Will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
     SpanKind spanKind;
     switch (operation) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -33,7 +33,11 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
         true);
   }
 
-  /** Returns a messaging span name extractor for the given operation. */
+  /**
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType)}. Will be
+   *     removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
     MessagingOperationType operationType = operation.type();

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -34,8 +34,8 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
   }
 
   /**
-   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType)}. Will be
-   *     removed in 3.0.
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}.
+   *     Will be removed in 3.0.
    */
   @Deprecated // to be removed in 3.0
   public static <REQUEST> SpanNameExtractor<REQUEST> create(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -249,6 +249,7 @@ class MessagingAttributesExtractorTest {
     assertThat(attributes.build()).isEqualTo(expected);
   }
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -52,6 +52,7 @@ class MessagingSpanKindExtractorTest {
     assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
   }
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void messageOperationUsesLegacySpanKind() {
     SpanKind receiveKind =

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -27,6 +27,7 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
+  @SuppressWarnings("OtelDeprecatedApiUsage")
   @Test
   void shouldKeepLegacyNameForMessageOperation() {
     Message message = new Message();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
@@ -89,12 +89,12 @@ class SemconvSelectionResolver {
   }
 
   SemconvMode messaging() {
-    return resolveSemconvSelection(
+    SemconvDomain.Builder domain =
         SemconvDomain.builder("messaging")
-            .defaultMode(SemconvMode.V0_STABLE)
             .otherSupportedModes(
-                SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit())
-            .build());
+                SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit());
+    domain.defaultMode(v3Preview ? SemconvMode.V1_EXPERIMENTAL : SemconvMode.V0_STABLE);
+    return resolveSemconvSelection(domain.build());
   }
 
   SemconvMode servicePeer() {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvSelectionResolver.java
@@ -89,11 +89,16 @@ class SemconvSelectionResolver {
   }
 
   SemconvMode messaging() {
-    SemconvDomain.Builder domain =
-        SemconvDomain.builder("messaging")
-            .otherSupportedModes(
-                SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit());
-    domain.defaultMode(v3Preview ? SemconvMode.V1_EXPERIMENTAL : SemconvMode.V0_STABLE);
+    SemconvDomain.Builder domain = SemconvDomain.builder("messaging");
+    if (v3Preview) {
+      // will be changed in 3.0 to V0_STABLE, which becomes the one and only messaging semconv
+      domain.defaultMode(SemconvMode.V1_EXPERIMENTAL);
+    } else {
+      domain
+          .defaultMode(SemconvMode.V0_STABLE)
+          .otherSupportedModes(
+              SemconvMode.V1_EXPERIMENTAL, SemconvMode.V1_EXPERIMENTAL.withDualEmit());
+    }
     return resolveSemconvSelection(domain.build());
   }
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -356,7 +356,7 @@ class SemconvStabilityTest {
 
     assertThat(rpc).isEqualTo(SemconvMode.V0_STABLE);
     assertThat(servicePeer).isEqualTo(SemconvMode.V0_STABLE);
-    assertThat(messaging).isEqualTo(SemconvMode.V0_STABLE);
+    assertThat(messaging).isEqualTo(SemconvMode.V1_EXPERIMENTAL);
   }
 
   @ParameterizedTest
@@ -420,29 +420,35 @@ class SemconvStabilityTest {
             preview("messaging/dup"),
             SemconvMode.V1_EXPERIMENTAL.withDualEmit()),
         argumentSet(
-            "v3 activation remains staged",
+            "v3 activates messaging preview",
             true,
             noStableOptIn(),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 ignores legacy opt-in property",
             true,
             stableOptIn("messaging"),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 ignores legacy opt-in dual emit",
             true,
             stableOptIn("messaging/dup"),
             noPreview(),
-            SemconvMode.V0_STABLE),
+            SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
             "v3 with explicit preview",
             true,
             noStableOptIn(),
             preview("messaging"),
-            SemconvMode.V1_EXPERIMENTAL));
+            SemconvMode.V1_EXPERIMENTAL),
+        argumentSet(
+            "v3 with explicit preview dual emit",
+            true,
+            noStableOptIn(),
+            preview("messaging/dup"),
+            SemconvMode.V1_EXPERIMENTAL.withDualEmit()));
   }
 
   @SafeVarargs

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/SemconvStabilityTest.java
@@ -444,11 +444,11 @@ class SemconvStabilityTest {
             preview("messaging"),
             SemconvMode.V1_EXPERIMENTAL),
         argumentSet(
-            "v3 with explicit preview dual emit",
+            "v3 ignores explicit preview dual emit",
             true,
             noStableOptIn(),
             preview("messaging/dup"),
-            SemconvMode.V1_EXPERIMENTAL.withDualEmit()));
+            SemconvMode.V1_EXPERIMENTAL));
   }
 
   @SafeVarargs

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/build.gradle.kts
@@ -167,8 +167,9 @@ tasks {
     classpath = sourceSets["testSqs"].runtimeClasspath
 
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+    // with the v3 preview off, the legacy opt-in flag selects the new messaging semconv too
+    jvmArgs("-Dotel.semconv-stability.opt-in=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging/dup")
   }
 
   check {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/build.gradle.kts
@@ -88,6 +88,34 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testMessagingOptIn = register<Test>("testMessagingOptIn") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaClientPropagationDisabledTest")
+      excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    // with the v3 preview off, the legacy opt-in flag selects the new messaging semconv too
+    jvmArgs("-Dotel.semconv-stability.opt-in=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      excludeTestsMatching("KafkaClientPropagationDisabledTest")
+      excludeTestsMatching("KafkaClientSuppressReceiveSpansTest")
+    }
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    // the v3 preview does not support dual emit for messaging, so this degrades to emitting only
+    // the new messaging semconv
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    // kafka metrics are disabled by default with v3-preview enabled
+    jvmArgs("-Dotel.instrumentation.kafka-clients-metrics.enabled=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+  }
+
   val testExperimental = register<Test>("testExperimental") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -129,6 +157,8 @@ tasks {
       testMessagingPreview,
       testMessagingPreviewReceiveSpansDisabled,
       testMessagingPreviewPropagationDisabled,
+      testMessagingOptIn,
+      testV3Preview,
       testExperimental,
       testBothSemconv,
     )


### PR DESCRIPTION
Turns the v1.43 messaging conventions on under `otel.instrumentation.common.v3-preview`, where messaging is stable-only: `messaging/dup` is not offered, consistent with how `database` and `code` behave under v3, and requesting it degrades to stable-only. With the v3 preview off, `otel.semconv-stability.opt-in=messaging` and `messaging/dup` keep working exactly as before.

Also deprecates the `MessageOperation` API surface, now that every in-tree caller has migrated: the enum itself, its factory overloads on `MessagingAttributesExtractor`, `MessagingSpanNameExtractor` and `MessagingSpanKindExtractor`, and `MessagingProducerMetrics.get()` / `MessagingConsumerMetrics.get()` in favor of `getForOperationType()`.

## Test coverage

Both selection behaviors are asserted end to end, not just in `SemconvStabilityTest`. `kafka-clients-0.11` gains a `testV3Preview` suite that runs the full messaging matrix under the v3 preview; it is pointed at `messaging/dup` on purpose, so passing with stable-only assertions is what proves the degradation. `otel.semconv-stability.opt-in` is the flag the generated instrumentation list tells users to set, so it is exercised directly: stable-only on `kafka-clients-0.11`, dual emit on `aws-sdk-1.11`.

## Default-path impact

None. Nothing changes for users who set neither `otel.semconv-stability.opt-in` nor the v3 preview, and the deprecations are source-level only.

Part of #19254.