### PR TITLE
Fix spring-webflux lambda route detection on jdk 21+

### DIFF
--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/RouteOnSuccess.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/webflux/v5_0/server/RouteOnSuccess.java
@@ -20,6 +20,8 @@ public class RouteOnSuccess implements Consumer<HandlerFunction<?>> {
   private static final Pattern SPACES_REGEX = Pattern.compile("[ \\t]+");
   private static final Pattern METHOD_REGEX =
       Pattern.compile("^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) ");
+  // router function string is "<predicate> -> <handler function>"
+  private static final Pattern HANDLER_FUNCTION_REGEX = Pattern.compile("\\s*->.*");
 
   @Nullable private final String route;
 
@@ -34,15 +36,16 @@ public class RouteOnSuccess implements Consumer<HandlerFunction<?>> {
 
   @Nullable
   private static String parsePredicateString(RouterFunction<?> routerFunction) {
-    String routerFunctionString = routerFunction.toString();
+    // the handler function is frequently a lambda, so it has to be stripped before looking for a
+    // lambda predicate
+    String predicate = HANDLER_FUNCTION_REGEX.matcher(routerFunction.toString()).replaceFirst("");
     // Router functions containing lambda predicates should not end up in span tags since they are
-    // confusing
-    if (routerFunctionString.startsWith(
-        "org.springframework.web.reactive.function.server.RequestPredicates$$Lambda$")) {
+    // confusing. Lambda class names look like "Foo$$Lambda$14/0x..." before jdk 21 and
+    // "Foo$$Lambda/0x..." starting from jdk 21.
+    if (predicate.contains("$$Lambda")) {
       return null;
-    } else {
-      return routerFunctionString.replaceFirst("\\s*->.*$", "");
     }
+    return predicate;
   }
 
   @Nullable

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractControllerSpringWebFluxServerTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.0/testing/src/main/java/io/opentelemetry/instrumentation/spring/webflux/server/AbstractControllerSpringWebFluxServerTest.java
@@ -112,10 +112,5 @@ public abstract class AbstractControllerSpringWebFluxServerTest
     options.setVerifyServerSpanEndTime(false);
 
     options.setResponseCodeOnNonStandardHttpMethod(405);
-
-    // TODO fails on java 21
-    // span name set to "HTTP
-    // org.springframework.web.reactive.function.server.RequestPredicates$$Lambda/0x00007fa574969238@4aaf6fa2"
-    options.disableTestNonStandardHttpMethod();
   }
 }


### PR DESCRIPTION
Resolves #19364

`RouteOnSuccess` avoids putting lambda request predicates into `http.route` by checking the router function string against a hard-coded `RequestPredicates$$Lambda$` prefix. [Lambda class names changed in jdk 21](https://github.com/openjdk/jdk/commit/b527edd3388ad6a0d44a291983b08b2b5c023f8f) — the counter and its preceding `$` were dropped — so the check stopped matching and the lambda's `toString()` flowed into the route, including its identity hash code:

```
http.route = org.springframework.web.reactive.function.server.RequestPredicates$$Lambda/0x00007fa574969238@4aaf6fa2
```

Since that hash code differs per instance, `http.route` became unbounded-cardinality.

Now matching on `$$Lambda` without the trailing `$`, which covers both naming forms. The handler function is stripped first, since it is very often a lambda itself. Also re-enabled `testNonStandardHttpMethod` for the controller tests, which was disabled with a `// TODO fails on java 21` describing exactly this bug.