### PR TITLE
Normalize IPv6 server.address in JDBC URL parsing

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -131,11 +131,12 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     // SQL Server-specific: Extract backslash-separated instance name (host\instance)
     int instanceLoc = serverName.indexOf("\\");
     if (instanceLoc > 0) {
-      if (hostPort.ipv6Address() != null) {
+      String ipv6Address = hostPort.ipv6Address();
+      if (ipv6Address != null) {
         int closingBracket = serverName.lastIndexOf(']');
         int instanceEnd = closingBracket > instanceLoc ? closingBracket : serverName.length();
         instanceName = serverName.substring(instanceLoc + 1, instanceEnd);
-        serverName = "[" + hostPort.ipv6Address() + "]";
+        serverName = ipv6Address;
       } else {
         instanceName = serverName.substring(instanceLoc + 1);
         serverName = serverName.substring(0, instanceLoc);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -93,9 +93,12 @@ public final class ParseContext {
     return host;
   }
 
-  /** Set the host value. */
+  /**
+   * Set the host value. Enclosing brackets are removed from literal IPv6 addresses so that {@code
+   * server.address} always holds the address alone, regardless of which parser produced it.
+   */
   public void host(@Nullable String host) {
-    this.host = host;
+    this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
   }
 
   /** The port value accumulated so far. */
@@ -192,7 +195,7 @@ public final class ParseContext {
       return;
     }
     if (params.containsKey("servername")) {
-      this.host = params.get("servername");
+      host(params.get("servername"));
     }
     Integer port = UrlParsingUtils.parsePort(params.get("portnumber"));
     if (port != null) {
@@ -220,7 +223,7 @@ public final class ParseContext {
 
     String serverName = props.getProperty("serverName");
     if (serverName != null && !serverName.isEmpty()) {
-      this.host = serverName;
+      host(serverName);
     }
 
     Integer parsedPort = UrlParsingUtils.parsePort(props.getProperty("portNumber"));
@@ -300,7 +303,7 @@ public final class ParseContext {
       this.port = hostPort.port();
     }
     if (!hostPort.host().isEmpty()) {
-      this.host = hostPort.host();
+      host(hostPort.host());
     }
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -234,7 +234,7 @@ public final class UrlParsingUtils {
       this.ipv6Address = ipv6Address;
     }
 
-    /** The host, with IPv6 addresses bracketed. */
+    /** The host, with IPv6 addresses unbracketed. */
     public String host() {
       return host;
     }
@@ -254,7 +254,10 @@ public final class UrlParsingUtils {
 
   /**
    * Extract host and port from a server string, handling IPv6 addresses. Supports formats: host,
-   * host:port, [ipv6], [ipv6]:port, ipv6 (auto-bracketed).
+   * host:port, [ipv6], [ipv6]:port, ipv6.
+   *
+   * <p>The returned host never carries the enclosing brackets of a literal IPv6 address, matching
+   * the {@code server.address} semantic convention, which holds the address alone.
    *
    * @param serverName the server string to parse
    * @return the extracted host and port
@@ -268,8 +271,6 @@ public final class UrlParsingUtils {
     if (isIpv6) {
       if (serverName.startsWith("[")) {
         portLoc = serverName.indexOf("]:") + 1;
-      } else {
-        serverName = "[" + serverName + "]";
       }
     } else {
       portLoc = serverName.indexOf(":");
@@ -281,7 +282,21 @@ public final class UrlParsingUtils {
       serverName = serverName.substring(0, portLoc);
     }
 
-    return new HostPort(serverName, port, ipv6Address);
+    return new HostPort(stripIpv6Brackets(serverName), port, ipv6Address);
+  }
+
+  /**
+   * Remove the enclosing brackets from a literal IPv6 address, e.g. {@code [::1]} becomes {@code
+   * ::1}. Any other value is returned unchanged.
+   *
+   * @param host the host to unbracket
+   * @return the host without enclosing brackets
+   */
+  public static String stripIpv6Brackets(String host) {
+    if (host.length() > 1 && host.charAt(0) == '[' && host.endsWith("]")) {
+      return host.substring(1, host.length() - 1);
+    }
+    return host;
   }
 
   /**

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -199,6 +199,14 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("failover")
             .setHost("::1")
             .setPort(3306)
+            .build(),
+        // literal IPv6 address: server.address holds the address without the URL brackets
+        arg("jdbc:mysql://[::1]:3306/mydb")
+            .setShortUrl("mysql://[::1]:3306")
+            .setSystem(MYSQL)
+            .setHost("::1")
+            .setPort(3306)
+            .setName("mydb")
             .build());
   }
 
@@ -324,6 +332,21 @@ class JdbcConnectionUrlParserTest {
             .setShortUrl("postgresql://pg.host:5432")
             .setSystem("postgresql")
             .setHost("pg.host")
+            .setPort(5432)
+            .setName("pgdb")
+            .build(),
+        // literal IPv6 address: server.address holds the address without the URL brackets
+        arg("jdbc:postgresql://[2001:db8::1]:5432/pgdb")
+            .setShortUrl("postgresql://[2001:db8::1]:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("2001:db8::1")
+            .setPort(5432)
+            .setName("pgdb")
+            .build(),
+        arg("jdbc:postgresql://[2001:db8::1]/pgdb")
+            .setShortUrl("postgresql://[2001:db8::1]:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("2001:db8::1")
             .setPort(5432)
             .setName("pgdb")
             .build());
@@ -478,28 +501,28 @@ class JdbcConnectionUrlParserTest {
             .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setHost("3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
             .setPort(1433)
             .build(),
         arg("jdbc:sqlserver://;serverName=2001:0db8:85a3:0000:0000:8a2e:0370:7334")
             .setShortUrl("sqlserver://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1433")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")
+            .setHost("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
             .setPort(1433)
             .build(),
         arg("jdbc:sqlserver://;serverName=[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
             .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setHost("3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
             .setPort(43)
             .build(),
         arg("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\ssinstance")
             .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setHost("3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
             .setPort(1433)
             .setName("ssinstance")
             .build(),
@@ -507,7 +530,7 @@ class JdbcConnectionUrlParserTest {
             .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:43")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setHost("3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
             .setPort(43)
             .setName("ssinstance")
             .build(),
@@ -515,10 +538,18 @@ class JdbcConnectionUrlParserTest {
             .setShortUrl("sqlserver://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1433")
             .setSystem("microsoft.sql_server")
             .setOldSystem("mssql")
-            .setHost("[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            .setHost("3ffe:8311:eeee:f70f:0:5eae:10.203.31.9")
             .setPort(1433)
             .setNamespace("ssinstance|ssdb")
             .setName("ssinstance")
+            .build(),
+        arg("jdbc:sqlserver://[::1]:1433;databaseName=ssdb")
+            .setShortUrl("sqlserver://[::1]:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("::1")
+            .setPort(1433)
+            .setName("ssdb")
             .build(),
         arg("jdbc:microsoft:sqlserver://;")
             .setProperties(stdProps())
@@ -933,6 +964,15 @@ class JdbcConnectionUrlParserTest {
             .setHost("ashost")
             .setPort(66)
             .setName("asdb")
+            .build(),
+        // literal IPv6 address: server.address holds the address without the URL brackets
+        arg("jdbc:db2://[::1]:77/db2db")
+            .setShortUrl("db2://[::1]:77")
+            .setSystem("ibm.db2")
+            .setOldSystem("db2")
+            .setHost("::1")
+            .setPort(77)
+            .setName("db2db")
             .build());
   }
 


### PR DESCRIPTION
`server.address` for JDBC connections was bracketed or bare depending on which parser handled the URL:

| URL | `server.address` before |
| --- | --- |
| `jdbc:mysql://[::1]:3306/db` | `[::1]` |
| `jdbc:mysql:failover://[::1]:3306` | `::1` |
| `jdbc:sqlserver://;serverName=3ffe:...` | `[3ffe:...]` |
| `jdbc:db2://[::1]:50000/db` | `[::1]` |

Brackets are URI syntax for separating a literal IPv6 address from a port within a single string. `server.address` is a standalone field with `server.port` alongside it, so there is nothing to disambiguate, and the semantic convention lists bare addresses (`10.1.2.80`). HTTP instrumentation already strips them in `HttpServerAddressAndPortExtractor`.

`ParseContext.host(...)` now removes the enclosing brackets, and the three call sites that assigned the field directly go through the setter, so every parser produces the same shape. `UrlParsingUtils.extractHostPort` no longer auto-brackets a bare IPv6 address, and `MssqlUrlParser` no longer re-brackets after splitting off a `\instance` suffix.

`db.connection_string` is unchanged — `buildShortUrl` already brackets colon-containing hosts, which is now the only place brackets are added. Tests assert that for every case.

This also gives connection pool instrumentation that derives a pool name from `DbInfo` a predictable value to work with (see #19160).