### PR TITLE
Expose baggage in log4j context data when there is no current span

### DIFF
--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
@@ -66,7 +66,7 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
   public Map<String, String> supplyContextData() {
     Context context = Context.current();
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
-    Baggage baggage = Configuration.baggageEnabled ? Baggage.fromContext(context) : Baggage.empty();
+    Baggage baggage = Baggage.fromContext(context);
     if (!spanContext.isValid() && baggage.isEmpty()) {
       return staticContextData;
     }
@@ -84,9 +84,11 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
       contextData.put(contextDataKeys.getTraceFlagsKey(), spanContext.getTraceFlags().asHex());
     }
 
-    for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
-      // prefix all baggage values to avoid clashes with existing context
-      contextData.put("baggage." + entry.getKey(), entry.getValue().getValue());
+    if (Configuration.baggageEnabled) {
+      for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
+        // prefix all baggage values to avoid clashes with existing context
+        contextData.put("baggage." + entry.getKey(), entry.getValue().getValue());
+      }
     }
 
     return contextData;

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
@@ -67,7 +67,9 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
     Context context = Context.current();
     SpanContext spanContext = Span.fromContext(context).getSpanContext();
     Baggage baggage = Baggage.fromContext(context);
-    if (!spanContext.isValid() && baggage.isEmpty()) {
+    // checking baggage.isEmpty() first to avoid initializing Configuration when possible
+    boolean addBaggage = !baggage.isEmpty() && Configuration.baggageEnabled;
+    if (!spanContext.isValid() && !addBaggage) {
       return staticContextData;
     }
 
@@ -84,7 +86,7 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
       contextData.put(contextDataKeys.getTraceFlagsKey(), spanContext.getTraceFlags().asHex());
     }
 
-    if (Configuration.baggageEnabled) {
+    if (addBaggage) {
       for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
         // prefix all baggage values to avoid clashes with existing context
         contextData.put("baggage." + entry.getKey(), entry.getValue().getValue());

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
@@ -57,16 +57,17 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
   }
 
   /**
-   * Returns context from the current span when available.
+   * Returns context from the current span and baggage when available.
    *
-   * @return A map containing string versions of the traceId, spanId, and traceFlags, which can then
-   *     be accessed from layout components
+   * @return A map containing string versions of the traceId, spanId, traceFlags and baggage entries,
+   *     which can then be accessed from layout components
    */
   @Override
   public Map<String, String> supplyContextData() {
     Context context = Context.current();
-    Span currentSpan = Span.fromContext(context);
-    if (!currentSpan.getSpanContext().isValid()) {
+    SpanContext spanContext = Span.fromContext(context).getSpanContext();
+    Baggage baggage = Configuration.baggageEnabled ? Baggage.fromContext(context) : Baggage.empty();
+    if (!spanContext.isValid() && baggage.isEmpty()) {
       return staticContextData;
     }
 
@@ -77,17 +78,15 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
     }
 
     Map<String, String> contextData = new HashMap<>(staticContextData);
-    SpanContext spanContext = currentSpan.getSpanContext();
-    contextData.put(contextDataKeys.getTraceIdKey(), spanContext.getTraceId());
-    contextData.put(contextDataKeys.getSpanIdKey(), spanContext.getSpanId());
-    contextData.put(contextDataKeys.getTraceFlagsKey(), spanContext.getTraceFlags().asHex());
+    if (spanContext.isValid()) {
+      contextData.put(contextDataKeys.getTraceIdKey(), spanContext.getTraceId());
+      contextData.put(contextDataKeys.getSpanIdKey(), spanContext.getSpanId());
+      contextData.put(contextDataKeys.getTraceFlagsKey(), spanContext.getTraceFlags().asHex());
+    }
 
-    if (Configuration.baggageEnabled) {
-      Baggage baggage = Baggage.fromContext(context);
-      for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
-        // prefix all baggage values to avoid clashes with existing context
-        contextData.put("baggage." + entry.getKey(), entry.getValue().getValue());
-      }
+    for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
+      // prefix all baggage values to avoid clashes with existing context
+      contextData.put("baggage." + entry.getKey(), entry.getValue().getValue());
     }
 
     return contextData;

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/OpenTelemetryContextDataProvider.java
@@ -59,8 +59,8 @@ public final class OpenTelemetryContextDataProvider implements ContextDataProvid
   /**
    * Returns context from the current span and baggage when available.
    *
-   * @return A map containing string versions of the traceId, spanId, traceFlags and baggage entries,
-   *     which can then be accessed from layout components
+   * @return A map containing string versions of the traceId, spanId, traceFlags and baggage
+   *     entries, which can then be accessed from layout components
    */
   @Override
   public Map<String, String> supplyContextData() {

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
@@ -49,24 +49,24 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
     }
 
     Context context = Context.current();
-    Span span = Span.fromContext(context);
-    SpanContext currentContext = span.getSpanContext();
-    if (!currentContext.isValid()) {
+    SpanContext currentContext = Span.fromContext(context).getSpanContext();
+    Baggage baggage = BAGGAGE_ENABLED ? Baggage.fromContext(context) : Baggage.empty();
+    if (!currentContext.isValid() && baggage.isEmpty()) {
       return staticContextData.isEmpty() ? contextData : newContextData(contextData);
     }
 
     StringMap newContextData = newContextData(contextData);
-    newContextData.putValue(TRACE_ID_KEY, currentContext.getTraceId());
-    newContextData.putValue(SPAN_ID_KEY, currentContext.getSpanId());
-    newContextData.putValue(TRACE_FLAGS_KEY, currentContext.getTraceFlags().asHex());
-
-    if (BAGGAGE_ENABLED) {
-      Baggage baggage = Baggage.fromContext(context);
-      for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
-        // prefix all baggage values to avoid clashes with existing context
-        newContextData.putValue("baggage." + entry.getKey(), entry.getValue().getValue());
-      }
+    if (currentContext.isValid()) {
+      newContextData.putValue(TRACE_ID_KEY, currentContext.getTraceId());
+      newContextData.putValue(SPAN_ID_KEY, currentContext.getSpanId());
+      newContextData.putValue(TRACE_FLAGS_KEY, currentContext.getTraceFlags().asHex());
     }
+
+    for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
+      // prefix all baggage values to avoid clashes with existing context
+      newContextData.putValue("baggage." + entry.getKey(), entry.getValue().getValue());
+    }
+
     return newContextData;
   }
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
@@ -50,7 +50,7 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
 
     Context context = Context.current();
     SpanContext currentContext = Span.fromContext(context).getSpanContext();
-    Baggage baggage = BAGGAGE_ENABLED ? Baggage.fromContext(context) : Baggage.empty();
+    Baggage baggage = Baggage.fromContext(context);
     if (!currentContext.isValid() && baggage.isEmpty()) {
       return staticContextData.isEmpty() ? contextData : newContextData(contextData);
     }
@@ -62,9 +62,11 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
       newContextData.putValue(TRACE_FLAGS_KEY, currentContext.getTraceFlags().asHex());
     }
 
-    for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
-      // prefix all baggage values to avoid clashes with existing context
-      newContextData.putValue("baggage." + entry.getKey(), entry.getValue().getValue());
+    if (BAGGAGE_ENABLED) {
+      for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
+        // prefix all baggage values to avoid clashes with existing context
+        newContextData.putValue("baggage." + entry.getKey(), entry.getValue().getValue());
+      }
     }
 
     return newContextData;

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
@@ -51,7 +51,8 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
     Context context = Context.current();
     SpanContext currentContext = Span.fromContext(context).getSpanContext();
     Baggage baggage = Baggage.fromContext(context);
-    if (!currentContext.isValid() && baggage.isEmpty()) {
+    boolean addBaggage = BAGGAGE_ENABLED && !baggage.isEmpty();
+    if (!currentContext.isValid() && !addBaggage) {
       return staticContextData.isEmpty() ? contextData : newContextData(contextData);
     }
 
@@ -62,7 +63,7 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
       newContextData.putValue(TRACE_FLAGS_KEY, currentContext.getTraceFlags().asHex());
     }
 
-    if (BAGGAGE_ENABLED) {
+    if (addBaggage) {
       for (Map.Entry<String, BaggageEntry> entry : baggage.asMap().entrySet()) {
         // prefix all baggage values to avoid clashes with existing context
         newContextData.putValue("baggage." + entry.getKey(), entry.getValue().getValue());

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/log4j/contextdata/v2_7/SpanDecoratingContextDataInjector.java
@@ -50,8 +50,8 @@ public class SpanDecoratingContextDataInjector implements ContextDataInjector {
 
     Context context = Context.current();
     SpanContext currentContext = Span.fromContext(context).getSpanContext();
-    Baggage baggage = Baggage.fromContext(context);
-    boolean addBaggage = BAGGAGE_ENABLED && !baggage.isEmpty();
+    Baggage baggage = BAGGAGE_ENABLED ? Baggage.fromContext(context) : Baggage.empty();
+    boolean addBaggage = !baggage.isEmpty();
     if (!currentContext.isValid() && !addBaggage) {
       return staticContextData.isEmpty() ? contextData : newContextData(contextData);
     }

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/Log4j2Test.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/Log4j2Test.java
@@ -43,8 +43,11 @@ public abstract class Log4j2Test {
   void testNoIdsWhenNoSpan() {
     Logger logger = LogManager.getLogger("TestLogger");
 
-    logger.info("log message 1");
-    logger.info("log message 2");
+    Baggage baggage = Baggage.empty().toBuilder().put("baggage_key", "baggage_value").build();
+    try (Scope unusedScope = baggage.makeCurrent()) {
+      logger.info("log message 1");
+      logger.info("log message 2");
+    }
 
     List<ListAppender.LoggedEvent> events = ListAppender.get().getEvents();
 
@@ -55,12 +58,16 @@ public abstract class Log4j2Test {
               assertThat(event.getContextData().get(getLoggingKey("trace_id"))).isNull();
               assertThat(event.getContextData().get(getLoggingKey("span_id"))).isNull();
               assertThat(event.getContextData().get(getLoggingKey("trace_flags"))).isNull();
+              assertThat(event.getContextData().get("baggage.baggage_key"))
+                  .isEqualTo(expectBaggage() ? "baggage_value" : null);
             },
             event -> {
               assertThat(event.getMessage()).isEqualTo("log message 2");
               assertThat(event.getContextData().get(getLoggingKey("trace_id"))).isNull();
               assertThat(event.getContextData().get(getLoggingKey("span_id"))).isNull();
               assertThat(event.getContextData().get(getLoggingKey("trace_flags"))).isNull();
+              assertThat(event.getContextData().get("baggage.baggage_key"))
+                  .isEqualTo(expectBaggage() ? "baggage_value" : null);
             });
   }
 

--- a/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/Log4j2Test.java
+++ b/instrumentation/log4j/log4j-context-data/log4j-context-data-common/testing/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/Log4j2Test.java
@@ -44,7 +44,7 @@ public abstract class Log4j2Test {
     Logger logger = LogManager.getLogger("TestLogger");
 
     Baggage baggage = Baggage.empty().toBuilder().put("baggage_key", "baggage_value").build();
-    try (Scope unusedScope = baggage.makeCurrent()) {
+    try (Scope ignored = baggage.makeCurrent()) {
       logger.info("log message 1");
       logger.info("log message 2");
     }
@@ -78,7 +78,7 @@ public abstract class Log4j2Test {
     Baggage baggage = Baggage.empty().toBuilder().put("baggage_key", "baggage_value").build();
     AtomicReference<Span> spanParent = new AtomicReference<>();
     AtomicReference<Span> spanChild = new AtomicReference<>();
-    try (Scope unusedScope = baggage.makeCurrent()) {
+    try (Scope ignored = baggage.makeCurrent()) {
       getInstrumentationExtension()
           .runWithSpan(
               "test",


### PR DESCRIPTION
Found while reviewing #19375.

When `otel.instrumentation.log4j-context-data.add-baggage=true`, the log4j instrumentation silently drops baggage if there is no valid current span:

- `OpenTelemetryContextDataProvider` (2.17) returns early on `!spanContext.isValid()`, before the baggage block
- `SpanDecoratingContextDataInjector` (2.7) does the same

The logback MDC instrumentation does not — in both `OpenTelemetryAppender.processEvent()` and `LoggingEventInstrumentation`, `isValid()` only guards the trace/span/flags entries, and baggage is added unconditionally. `AbstractLogbackTest.testNoIdsWhenNoSpan` already asserts baggage is present outside a span.

This aligns log4j with logback: the span validity check now guards only the trace id / span id / trace flags entries, and the early return happens only when there is neither a valid span nor any baggage (preserving the existing fast path).

Pre-existing since #8810 (2023), which added baggage support inside the region guarded by an early return introduced back in #4957.

Testing: `Log4j2Test.testNoIdsWhenNoSpan` now runs inside a baggage scope and asserts the `baggage.` entry, mirroring the logback test. Verified it fails on both modules without the fix.