### PR TITLE
Classify high-cardinality metric attribute fixes as bug fixes

### DIFF
--- a/.github/scripts/draft-release-notes/rules.md
+++ b/.github/scripts/draft-release-notes/rules.md
@@ -52,7 +52,9 @@ Emitted-attribute, attribute-value, or span-name changes are Breaking
 **only** when they ship unconditionally. If the change is gated behind
 `otel.instrumentation.common.v3-preview`,
 `otel.semconv-stability.opt-in=…`, or an `experimental` property, the
-entry belongs under Enhancements.
+entry belongs under Enhancements. Unconditional changes to a metric
+attribute value that fix unbounded cardinality belong under Bug fixes —
+see that section.
 
 Deprecate-then-remove across two PRs in one cycle produces two bullets —
 one under Deprecations, one under Breaking.
@@ -101,6 +103,22 @@ propagation, and class-loading fixes. Restoring silently broken
 behavior is a bug fix, not an enhancement — diffs that remove an
 over-restrictive condition, add a fallback branch, or invert an `&&`
 usually belong here. Describe the user-visible symptom.
+
+An unconditional change to a **metric** attribute value is a bug fix, not
+a breaking change, when the previous value caused unbounded cardinality —
+it varied per process, per instance, or per restart (a per-process
+identity hash, a VM-allocated token, a restart-varying counter), so it
+could never aggregate into a stable time series.
+
+This exception is limited to metric attribute values. Span names, span
+attributes, and log attributes are not covered: they are not aggregated
+into time series, so an unstable value there is not a cardinality defect
+and the Breaking rule applies. It also does not cover metric attribute
+values that were stable but merely inconvenient, renamed, or
+reformatted — those remain Breaking.
+
+The bullet must still state that the value changes, so readers who
+aggregated on the old series are not surprised at upgrade.
 
 ## metadata.yaml is documentation, not evidence
 


### PR DESCRIPTION
## Why

Several connection pool instrumentations default an unnamed pool to a value that cannot work as a metric attribute: Alibaba Druid uses `System.identityHashCode(dataSource)` (#19108), c3p0 uses a VM-allocated identity token (#19159), and Tomcat JDBC uses a counter plus identity hash (#19173). These values change on every restart and differ across instances, so `db.client.connection.pool.name` could never aggregate into a stable time series and grew cardinality without bound.

Fixing them changes the emitted attribute value unconditionally, which the current rules classify as a breaking change. That reads wrong: the old values were never usable for correlation, so nothing a user could reasonably depend on is being removed. Without a rule change, each of these fixes lands under "Breaking changes" and the three PRs risk being classified inconsistently.

## What this changes

Adds an exception under Bug fixes for unconditional metric attribute value changes where the previous value had unbounded cardinality, and cross-references it from the Breaking section so the two rules no longer collide.

The exception is deliberately narrow, with three boundaries:

- Metrics only. Span names, span attributes, and log attributes are not aggregated into time series, so an unstable value there is not a cardinality defect and stays Breaking.
- Unbounded cardinality only. The value must vary per process, per instance, or per restart. Stable metric values that are merely renamed or reformatted stay Breaking.
- The bullet must still state that the value changes, so a reader who aggregated on the old series sees it even though the entry sits under Bug fixes.

## Worth noting

The third boundary is the important one. Filing these under Bug fixes means a user scanning only "Breaking changes" will not see them, so the requirement to spell out the value change in the bullet text is what keeps the entry honest. Reviewers may want to weigh that trade-off directly.

This only affects how `classify.py` buckets future PRs. `rules.md` is embedded verbatim into the per-PR classification prompt, so no code change is needed.