### PR TITLE
Don't require application to use OpenTelemetry API for azure-core instrumentation

### DIFF
--- a/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
@@ -15,10 +15,11 @@ muzzle {
   }
 
   pass {
-    name.set("with application using the OpenTelemetry API")
+    name.set("Application using the OpenTelemetry API")
     group.set("com.azure")
     module.set("azure-core")
     versions.set("[1.36.0,1.53.0)")
+    assertInverse.set(true)
     extraDependency("io.opentelemetry:opentelemetry-api:1.27.0")
   }
 }

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/build.gradle.kts
@@ -8,8 +8,17 @@ muzzle {
     module.set("azure-core")
     versions.set("[1.36.0,1.53.0)")
     assertInverse.set(true)
-    // our advice helper bridges an explicitly supplied application parent context to the agent
-    // context, so it references io.opentelemetry.context.{Context,Scope}
+    // this module bridges an explicitly supplied application parent context, so it references the
+    // application's io.opentelemetry.context.{Context,Scope} and only applies when the application
+    // uses the OpenTelemetry API itself; it is verified separately below
+    excludeInstrumentationName("azure-core-1.36-context")
+  }
+
+  pass {
+    name.set("with application using the OpenTelemetry API")
+    group.set("com.azure")
+    module.set("azure-core")
+    versions.set("[1.36.0,1.53.0)")
     extraDependency("io.opentelemetry:opentelemetry-api:1.27.0")
   }
 }

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureContextInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureContextInstrumentationModule.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class AzureContextInstrumentationModule extends InstrumentationModule {
 
   public AzureContextInstrumentationModule() {
-    super("azure-core", "azure-core-1.36");
+    super("azure-core", "azure-core-1.36", "azure-core-1.36-context");
   }
 
   @Override

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureContextInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureContextInstrumentationModule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.azurecore.v1_36;
+
+import static io.opentelemetry.javaagent.instrumentation.azurecore.v1_36.AzureSdkInstrumentationModule.azureCoreClassLoaderMatcher;
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Bridging an explicitly supplied parent context lives in its own module because it references the
+ * application's (unshaded) {@code io.opentelemetry.context} classes. Muzzle therefore requires the
+ * OpenTelemetry API to be present in the application class loader, which is not the case for
+ * applications that use the Azure SDK without using the OpenTelemetry API themselves. Keeping this
+ * in a separate module ensures that such applications still get the rest of the Azure SDK
+ * instrumentation.
+ */
+@AutoService(InstrumentationModule.class)
+public class AzureContextInstrumentationModule extends InstrumentationModule {
+
+  public AzureContextInstrumentationModule() {
+    super("azure-core", "azure-core-1.36");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return azureCoreClassLoaderMatcher();
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new AzureContextInstrumentation());
+  }
+}

--- a/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.36/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/AzureSdkInstrumentationModule.java
@@ -44,8 +44,7 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
         "io.opentelemetry.javaagent.instrumentation.azurecore.v1_36.shaded.com.azure.core.tracing.opentelemetry.OpenTelemetryTracerProvider");
   }
 
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+  static ElementMatcher.Junction<ClassLoader> azureCoreClassLoaderMatcher() {
     // added in 1.36
     return hasClassesNamed("com.azure.core.util.tracing.TracerProvider")
         // added in 1.53
@@ -56,11 +55,13 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return azureCoreClassLoaderMatcher();
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(
-        new EmptyTypeInstrumentation(),
-        new AzureContextInstrumentation(),
-        new AzureHttpClientInstrumentation());
+    return asList(new EmptyTypeInstrumentation(), new AzureHttpClientInstrumentation());
   }
 
   private static class EmptyTypeInstrumentation implements TypeInstrumentation {

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
@@ -8,8 +8,17 @@ muzzle {
     module.set("azure-core")
     versions.set("[1.53.0,)")
     assertInverse.set(true)
-    // our advice helper bridges an explicitly supplied application parent context to the agent
-    // context, so it references io.opentelemetry.context.{Context,Scope}
+    // this module bridges an explicitly supplied application parent context, so it references the
+    // application's io.opentelemetry.context.{Context,Scope} and only applies when the application
+    // uses the OpenTelemetry API itself; it is verified separately below
+    excludeInstrumentationName("azure-core-1.53-context")
+  }
+
+  pass {
+    name.set("with application using the OpenTelemetry API")
+    group.set("com.azure")
+    module.set("azure-core")
+    versions.set("[1.53.0,)")
     extraDependency("io.opentelemetry:opentelemetry-api:1.27.0")
   }
 }

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/build.gradle.kts
@@ -15,10 +15,11 @@ muzzle {
   }
 
   pass {
-    name.set("with application using the OpenTelemetry API")
+    name.set("Application using the OpenTelemetry API")
     group.set("com.azure")
     module.set("azure-core")
     versions.set("[1.53.0,)")
+    assertInverse.set(true)
     extraDependency("io.opentelemetry:opentelemetry-api:1.27.0")
   }
 }

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureContextInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureContextInstrumentationModule.java
@@ -26,7 +26,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class AzureContextInstrumentationModule extends InstrumentationModule {
 
   public AzureContextInstrumentationModule() {
-    super("azure-core", "azure-core-1.53");
+    super("azure-core", "azure-core-1.53", "azure-core-1.53-context");
   }
 
   @Override

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureContextInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureContextInstrumentationModule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.azurecore.v1_53;
+
+import static io.opentelemetry.javaagent.instrumentation.azurecore.v1_53.AzureSdkInstrumentationModule.azureCoreClassLoaderMatcher;
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Bridging an explicitly supplied parent context lives in its own module because it references the
+ * application's (unshaded) {@code io.opentelemetry.context} classes. Muzzle therefore requires the
+ * OpenTelemetry API to be present in the application class loader, which is not the case for
+ * applications that use the Azure SDK without using the OpenTelemetry API themselves. Keeping this
+ * in a separate module ensures that such applications still get the rest of the Azure SDK
+ * instrumentation.
+ */
+@AutoService(InstrumentationModule.class)
+public class AzureContextInstrumentationModule extends InstrumentationModule {
+
+  public AzureContextInstrumentationModule() {
+    super("azure-core", "azure-core-1.53");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return azureCoreClassLoaderMatcher();
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new AzureContextInstrumentation());
+  }
+}

--- a/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureSdkInstrumentationModule.java
+++ b/instrumentation/azure-core/azure-core-1.53/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/AzureSdkInstrumentationModule.java
@@ -44,8 +44,7 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
         "io.opentelemetry.javaagent.instrumentation.azurecore.v1_53.shaded.com.azure.core.tracing.opentelemetry.OpenTelemetryTracerProvider");
   }
 
-  @Override
-  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+  static ElementMatcher.Junction<ClassLoader> azureCoreClassLoaderMatcher() {
     // added in 1.53
     return hasClassesNamed("com.azure.core.util.LibraryTelemetryOptions")
         // artifact presence gate (provides native OTel support)
@@ -54,11 +53,13 @@ public class AzureSdkInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return azureCoreClassLoaderMatcher();
+  }
+
+  @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(
-        new EmptyTypeInstrumentation(),
-        new AzureContextInstrumentation(),
-        new AzureHttpClientInstrumentation());
+    return asList(new EmptyTypeInstrumentation(), new AzureHttpClientInstrumentation());
   }
 
   private static class EmptyTypeInstrumentation implements TypeInstrumentation {


### PR DESCRIPTION
Fixes a regression from #18886, reported downstream in microsoft/ApplicationInsights-Java#4767.

### Problem

#18886 added `AzureContextInstrumentation` / `AzureExplicitParentContextHelper` to the `azure-core-1.36` and `azure-core-1.53` modules. The helper references the application's (unshaded) `io.opentelemetry.context.Context` and `Scope`, which ends up in the module's muzzle references, so muzzle now requires the application class loader to provide the OpenTelemetry API.

When an application uses the Azure SDK but not the OpenTelemetry API, muzzle fails and the **entire** module is skipped — including `registerHelperResources()`, which is what registers the bundled `TracerProvider`/`Tracer`. So azure-core silently produces no telemetry at all.

### Fix

Move the context bridging into its own `InstrumentationModule`. Muzzle references are per-module, so now only the explicit parent context bridging is skipped when the application does not use the OpenTelemetry API. That also matches the behavior before #18886, since an application without the OpenTelemetry API can't pass an explicit OpenTelemetry parent context in the first place.

### Why muzzle didn't catch this

#18886 added `extraDependency("io.opentelemetry:opentelemetry-api:1.27.0")` to the muzzle directive because muzzle failed without it, which silenced the signal instead of surfacing it. The main directive no longer has it and excludes the context bridging module, and a second directive verifies the context bridging module with the OpenTelemetry API present.

Javaagent tests can't catch this on their own, since `opentelemetry-testing-common` always puts the unshaded OpenTelemetry API on the application class path.
