### PR TITLE
Preload MethodHandle$1 to avoid ClassCircularityError on JDK 17

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -212,19 +212,11 @@ public class AgentInstaller {
     return config == null ? EmptyConfigProperties.INSTANCE : config;
   }
 
-  /**
-   * Loads classes that could otherwise get loaded from inside a {@link
-   * java.lang.instrument.ClassFileTransformer} callback while they are already being loaded, which
-   * makes the jvm fail their resolution with {@link ClassCircularityError}. Because resolution
-   * errors are permanent, see JVMS 5.4.3, such a failure poisons every later use of the class in
-   * the jvm, not just the agent.
-   *
-   * @see <a href="https://bugs.openjdk.org/browse/JDK-8164165">JDK-8164165</a>
-   */
   private static void preloadClasses() {
     // preload ThreadLocalRandom to avoid occasional
     // java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
-    // see https://github.com/raphw/byte-buddy/issues/1666
+    // see https://github.com/raphw/byte-buddy/issues/1666 and
+    // https://bugs.openjdk.org/browse/JDK-8164165
     ThreadLocalRandom.current();
 
     // preload the anonymous class used by MethodHandle.customize() to avoid

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java
@@ -114,11 +114,7 @@ public class AgentInstaller {
     EmbeddedInstrumentationProperties.setPropertiesLoader(extensionClassLoader);
     setDefineClassHandler();
     FieldBackedImplementationConfiguration.configure();
-    // preload ThreadLocalRandom to avoid occasional
-    // java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
-    // see https://github.com/raphw/byte-buddy/issues/1666 and
-    // https://bugs.openjdk.org/browse/JDK-8164165
-    ThreadLocalRandom.current();
+    preloadClasses();
 
     AgentBuilder agentBuilder =
         newAgentBuilder(
@@ -214,6 +210,33 @@ public class AgentInstaller {
   private static ConfigProperties getConfig(AutoConfiguredOpenTelemetrySdk autoConfiguredSdk) {
     ConfigProperties config = AutoConfigureUtil.getConfig(autoConfiguredSdk);
     return config == null ? EmptyConfigProperties.INSTANCE : config;
+  }
+
+  /**
+   * Loads classes that could otherwise get loaded from inside a {@link
+   * java.lang.instrument.ClassFileTransformer} callback while they are already being loaded, which
+   * makes the jvm fail their resolution with {@link ClassCircularityError}. Because resolution
+   * errors are permanent, see JVMS 5.4.3, such a failure poisons every later use of the class in
+   * the jvm, not just the agent.
+   *
+   * @see <a href="https://bugs.openjdk.org/browse/JDK-8164165">JDK-8164165</a>
+   */
+  private static void preloadClasses() {
+    // preload ThreadLocalRandom to avoid occasional
+    // java.lang.ClassCircularityError: java/util/concurrent/ThreadLocalRandom
+    // see https://github.com/raphw/byte-buddy/issues/1666
+    ThreadLocalRandom.current();
+
+    // preload the anonymous class used by MethodHandle.customize() to avoid
+    // java.lang.ClassCircularityError: java/lang/invoke/MethodHandle$1
+    // on jdk 17, which breaks all further invokedynamic call site linking in the jvm.
+    // MethodHandle.customize() only runs after a number of call sites have been linked, so linking
+    // a single call site here would not reliably trigger the load.
+    try {
+      Class.forName("java.lang.invoke.MethodHandle$1", false, null);
+    } catch (ClassNotFoundException ignored) {
+      // this class does not exist on all jdk versions
+    }
   }
 
   private static AgentBuilder newAgentBuilder(ByteBuddy byteBuddy) {


### PR DESCRIPTION
On JDK 17 the agent can crash the JVM during `premain` with:

```
java.lang.ClassCircularityError: java/lang/invoke/MethodHandle$1
    at java.base/java.lang.invoke.MethodHandle.customize(MethodHandle.java:1741)
    at java.base/java.lang.invoke.MethodHandle.maybeCustomize(MethodHandle.java:1731)
    at java.base/java.lang.invoke.Invokers.maybeCustomize(Invokers.java:634)
    at java.base/java.lang.invoke.Invokers.checkCustomized(Invokers.java:628)
    at java.base/java.lang.invoke.BootstrapMethodInvoker.invoke(BootstrapMethodInvoker.java:134)
    at java.base/java.lang.invoke.CallSite.makeSite(CallSite.java:315)
    at java.base/java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:281)
    at java.base/java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:271)
    ...
```

`MethodHandle$1` is the anonymous class created in `MethodHandle.customize()`. It is on the boot class path, so when it happens to be loaded from inside a `ClassFileTransformer` callback while it is already being loaded, the JVM fails its resolution with `ClassCircularityError` — the same failure mode as the `ThreadLocalRandom` issue fixed in #14030, see [JDK-8164165](https://bugs.openjdk.org/browse/JDK-8164165).

Resolution errors are permanent (JVMS 5.4.3), so this doesn't just fail agent startup, it poisons `invokedynamic` call site linking for the whole JVM. In microsoft/ApplicationInsights-Java#4817 the JVM dies in `ResourceBundle.getBundle()` from Karaf's `main()`, long after the agent gave up.

Note that linking a single call site is not enough to force the load, since `MethodHandle.customize()` only runs after a number of call sites have been linked, so this loads the class directly.

### Reproduction

Using the reproducer from elastic/elastic-otel-java#1092 (`eclipse-temurin:17-jdk`, `linux/amd64`, distro built on 2.22.0, `java -version` as the whole application), plus a probe javaagent that only calls `Class.forName("java.lang.invoke.MethodHandle$1", false, null)`, and a no-op javaagent to rule out that merely adding a second agent shifts the timing:

| `-javaagent` | result |
|---|---|
| `javaagent.jar` | `ClassCircularityError` 3/3 |
| `noop.jar`, `javaagent.jar` | `ClassCircularityError` 3/3 |
| `preload.jar`, `javaagent.jar` | clean 3/3 |

The crash site there is `installOpenTelemetrySdk()`, which is in the same method as, and well after, the existing `ThreadLocalRandom` preload that this extends.

This appears to be a regression from #15091 (2.22.0), which removed `setupUnsafe(inst)` — `SunMiscUnsafeGenerator.generateUnsafe()` used to incidentally get `MethodHandle$1` defined early in `premain`. Since then it comes down to class loading order, which is why distros hit it (they load more during `premain`) and the vanilla agent doesn't.
