### PR TITLE
Clarify that the @Nullable test-code rule covers testing modules

### DIFF
--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -46,4 +46,4 @@ Follow `docs/contributing/style-guide.md`.
   `src/main/` of a test-support module, which is test code despite the path.
   Keep it only where ErrorProne demands it — `ReturnsNullCollection` on a
   collection-returning method and `AutoValueBoxedValues` on a boxed `@AutoValue`
-  property, where the annotation is load-bearing rather than documentation.
+  property.

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -41,4 +41,9 @@ Follow `docs/contributing/style-guide.md`.
   constants locally as `private static final` with a `// copied from <Class>`
   comment; do not depend on the semconv incubating artifact. In
   `javaagent/src/main/` and tests, use semconv constants directly.
-- **`@Nullable` in tests**: do not add it to test code.
+- **`@Nullable` in tests**: do not add it to test code (paths under `src/test/`
+  or modules whose name starts/ends with `testing` or `tests`). This includes
+  `src/main/` of a test-support module, which is test code despite the path.
+  Keep it only where ErrorProne demands it — `ReturnsNullCollection` on a
+  collection-returning method and `AutoValueBoxedValues` on a boxed `@AutoValue`
+  property, where the annotation is load-bearing rather than documentation.

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -161,7 +161,15 @@ Annotate all parameters and fields that can be `null` with `@Nullable`
 
 `@NonNull` is unnecessary as it is the default.
 
-**Test code**: Do not add `@Nullable` annotations in test code.
+**Test code**: Do not add `@Nullable` annotations in test code, meaning paths under `src/test/` and
+modules whose name starts or ends with `testing` or `tests`. Test-support modules count even for
+their `src/main/` sources, which are test code despite the path. Note that
+`otel.nullaway-conventions` only skips compile tasks whose name contains "test" (e.g.
+`compileTestJava`), so it does not enforce this in test-support modules.
+
+Keep `@Nullable` where ErrorProne requires it, since there the annotation is load-bearing rather
+than documentation: `ReturnsNullCollection` on a method with a collection return type that can
+return `null`, and `AutoValueBoxedValues` on a boxed `@AutoValue` property.
 
 **Defensive programming**: Public APIs should still check for `null` parameters even if not
 annotated with `@Nullable`. Internal APIs do not need these checks.

--- a/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
+++ b/instrumentation/cassandra/cassandra-common-4.0/testing/src/main/java/io/opentelemetry/cassandra/common/v4_0/AbstractCassandraTest.java
@@ -53,7 +53,6 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -547,20 +546,20 @@ public abstract class AbstractCassandraTest {
   }
 
   protected static class Parameter {
-    @Nullable public final String keyspace;
+    public final String keyspace;
     public final String queryText;
     public final String expectedQueryText;
     public final String spanName;
     public final String operation;
-    @Nullable public final String table;
+    public final String table;
 
     public Parameter(
-        @Nullable String keyspace,
+        String keyspace,
         String queryText,
         String expectedQueryText,
         String spanName,
         String operation,
-        @Nullable String table) {
+        String table) {
       this.keyspace = keyspace;
       this.queryText = queryText;
       this.expectedQueryText = expectedQueryText;
@@ -570,7 +569,7 @@ public abstract class AbstractCassandraTest {
     }
   }
 
-  protected CqlSession getSession(@Nullable String keyspace) {
+  protected CqlSession getSession(String keyspace) {
     DriverConfigLoader configLoader =
         DefaultDriverConfigLoader.builder()
             .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(0))

--- a/instrumentation/hibernate/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/ExperimentalTestHelper.java
+++ b/instrumentation/hibernate/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/ExperimentalTestHelper.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 
 public class ExperimentalTestHelper {
   public static final boolean EXPERIMENTAL_ATTRIBUTES =
@@ -19,8 +18,7 @@ public class ExperimentalTestHelper {
 
   public static final AttributeKey<String> HIBERNATE_SESSION_ID = stringKey("hibernate.session_id");
 
-  @Nullable
-  public static String experimental(@Nullable String value) {
+  public static String experimental(String value) {
     if (EXPERIMENTAL_ATTRIBUTES) {
       return value;
     }

--- a/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
+++ b/instrumentation/hikaricp-3.0/testing/src/main/java/io/opentelemetry/instrumentation/hikaricp/AbstractHikariInstrumentationTest.java
@@ -23,7 +23,6 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.db.DbConnectionPoolMetricsAssertions;
 import java.sql.Connection;
 import java.sql.SQLException;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.junit.jupiter.api.Test;
@@ -46,8 +45,7 @@ public abstract class AbstractHikariInstrumentationTest {
 
   protected abstract InstrumentationExtension testing();
 
-  protected abstract void configure(
-      HikariConfig poolConfig, @Nullable MetricsTrackerFactory userTracker);
+  protected abstract void configure(HikariConfig poolConfig, MetricsTrackerFactory userTracker);
 
   @Test
   void shouldReportMetrics() throws SQLException, InterruptedException {

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumentation.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumentation.java
@@ -11,7 +11,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -60,8 +59,7 @@ class AgentSpanTestingInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.Thrown @Nullable Throwable throwable,
-        @Advice.Enter @Nullable AdviceScope adviceScope) {
+        @Advice.Thrown Throwable throwable, @Advice.Enter AdviceScope adviceScope) {
       if (adviceScope != null) {
         adviceScope.end();
         AgentSpanTestingInstrumenter.endHttpServer(adviceScope.getContext(), throwable);
@@ -80,8 +78,7 @@ class AgentSpanTestingInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.Thrown @Nullable Throwable throwable,
-        @Advice.Enter @Nullable AdviceScope adviceScope) {
+        @Advice.Thrown Throwable throwable, @Advice.Enter AdviceScope adviceScope) {
       if (adviceScope != null) {
         adviceScope.end();
         AgentSpanTestingInstrumenter.end(adviceScope.getContext(), throwable);

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/AgentSpanTestingInstrumenter.java
@@ -15,7 +15,6 @@ import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
-import javax.annotation.Nullable;
 
 public class AgentSpanTestingInstrumenter {
 
@@ -43,7 +42,7 @@ public class AgentSpanTestingInstrumenter {
     return context;
   }
 
-  public static void endHttpServer(Context context, @Nullable Throwable error) {
+  public static void endHttpServer(Context context, Throwable error) {
     httpServerInstrumenter.end(context, context.get(REQUEST_CONTEXT_KEY), null, error);
   }
 
@@ -56,7 +55,7 @@ public class AgentSpanTestingInstrumenter {
     return context;
   }
 
-  public static void end(Context context, @Nullable Throwable error) {
+  public static void end(Context context, Throwable error) {
     instrumenter.end(context, context.get(REQUEST_CONTEXT_KEY), null, error);
   }
 

--- a/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
+++ b/instrumentation/opentelemetry-instrumentation-api/opentelemetry-instrumentation-api-1.14/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/testing/MockHttpServerAttributesGetter.java
@@ -9,7 +9,6 @@ import static java.util.Collections.emptyList;
 
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import java.util.List;
-import javax.annotation.Nullable;
 
 // only needed so that HttpServerAttributesExtractor can be added to the HTTP server instrumenter,
 // and http.route is properly set
@@ -25,9 +24,8 @@ class MockHttpServerAttributesGetter implements HttpServerAttributesGetter<Strin
     return emptyList();
   }
 
-  @Nullable
   @Override
-  public Integer getHttpResponseStatusCode(String s, Void unused, @Nullable Throwable error) {
+  public Integer getHttpResponseStatusCode(String s, Void unused, Throwable error) {
     return null;
   }
 
@@ -36,19 +34,16 @@ class MockHttpServerAttributesGetter implements HttpServerAttributesGetter<Strin
     return emptyList();
   }
 
-  @Nullable
   @Override
   public String getUrlScheme(String s) {
     return null;
   }
 
-  @Nullable
   @Override
   public String getUrlPath(String s) {
     return null;
   }
 
-  @Nullable
   @Override
   public String getUrlQuery(String s) {
     return null;

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/test/server/http/RequestContextGetter.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/test/server/http/RequestContextGetter.java
@@ -13,13 +13,12 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.testing.internal.armeria.server.ServiceRequestContext;
 import io.opentelemetry.testing.internal.io.netty.util.AsciiString;
 import java.util.Iterator;
-import javax.annotation.Nullable;
 
 public enum RequestContextGetter implements TextMapGetter<ServiceRequestContext> {
   INSTANCE;
 
   @Override
-  public Iterable<String> keys(@Nullable ServiceRequestContext carrier) {
+  public Iterable<String> keys(ServiceRequestContext carrier) {
     if (carrier == null) {
       return emptyList();
     }
@@ -29,8 +28,7 @@ public enum RequestContextGetter implements TextMapGetter<ServiceRequestContext>
   }
 
   @Override
-  @Nullable
-  public String get(@Nullable ServiceRequestContext carrier, String key) {
+  public String get(ServiceRequestContext carrier, String key) {
     if (carrier == null) {
       return null;
     }
@@ -38,7 +36,7 @@ public enum RequestContextGetter implements TextMapGetter<ServiceRequestContext>
   }
 
   @Override
-  public Iterator<String> getAll(@Nullable ServiceRequestContext carrier, String key) {
+  public Iterator<String> getAll(ServiceRequestContext carrier, String key) {
     if (carrier == null) {
       return emptyIterator();
     }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 import org.assertj.core.api.ListAssert;
 import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.ConditionTimeoutException;
@@ -58,7 +57,7 @@ public abstract class InstrumentationTestRunner {
   // Lazy initialized so that test runners can load without triggering Instrumenter construction
   // in the OpenTelemetry API bridging tests where some of the newer OpenTelemetry APIs used by
   // Instrumenter are absent.
-  @Nullable private TestInstrumenters testInstrumenters;
+  private TestInstrumenters testInstrumenters;
   protected Map<InstrumentationScopeInfo, Map<String, MetricData>> metricsByScope = new HashMap<>();
   protected Set<InstrumentationScopeInfo> instrumentationScopes = new HashSet<>();
 
@@ -139,7 +138,7 @@ public abstract class InstrumentationTestRunner {
   }
 
   private <T extends Consumer<TraceAssert>> void waitAndAssertTraces(
-      @Nullable Comparator<List<SpanData>> traceComparator,
+      Comparator<List<SpanData>> traceComparator,
       Iterable<T> assertions,
       boolean verifyScopeVersion) {
     List<T> assertionsList = new ArrayList<>();
@@ -149,7 +148,7 @@ public abstract class InstrumentationTestRunner {
   }
 
   private <T extends Consumer<TraceAssert>> void doAssertTraces(
-      @Nullable Comparator<List<SpanData>> traceComparator,
+      Comparator<List<SpanData>> traceComparator,
       List<T> assertionsList,
       boolean verifyScopeVersion) {
     List<List<SpanData>> traces = waitForTraces(assertionsList.size());

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/TestInstrumenters.java
@@ -26,7 +26,6 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /** {@link Instrumenter}s to use when executing test code. */
 class TestInstrumenters {
@@ -124,11 +123,7 @@ class TestInstrumenters {
 
     @Override
     public void onEnd(
-        AttributesBuilder attributes,
-        Context context,
-        String s,
-        @Nullable Void unused,
-        @Nullable Throwable error) {}
+        AttributesBuilder attributes, Context context, String s, Void unused, Throwable error) {}
 
     @Override
     public SpanKey internalGetSpanKey() {
@@ -149,10 +144,8 @@ class TestInstrumenters {
       return emptyList();
     }
 
-    @Nullable
     @Override
-    public Integer getHttpResponseStatusCode(
-        String unused, Void unused2, @Nullable Throwable error) {
+    public Integer getHttpResponseStatusCode(String unused, Void unused2, Throwable error) {
       return null;
     }
 
@@ -161,19 +154,16 @@ class TestInstrumenters {
       return emptyList();
     }
 
-    @Nullable
     @Override
     public String getUrlScheme(String unused) {
       return null;
     }
 
-    @Nullable
     @Override
     public String getUrlPath(String s) {
       return null;
     }
 
-    @Nullable
     @Override
     public String getUrlQuery(String s) {
       return null;

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -72,7 +72,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-import javax.annotation.Nullable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -1092,11 +1091,7 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   protected SpanDataAssert assertClientSpan(
-      SpanDataAssert span,
-      URI uri,
-      String method,
-      @Nullable Integer responseCode,
-      @Nullable Integer resendCount) {
+      SpanDataAssert span, URI uri, String method, Integer responseCode, Integer resendCount) {
     Set<AttributeKey<?>> httpClientAttributes = options.getHttpAttributes().apply(uri);
     return span.hasName(options.getExpectedClientSpanNameMapper().apply(uri, method))
         .hasKind(SpanKind.CLIENT)

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -117,7 +117,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -1263,8 +1262,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
     return span;
   }
 
-  public String expectedServerSpanName(
-      ServerEndpoint endpoint, String method, @Nullable String route) {
+  public String expectedServerSpanName(ServerEndpoint endpoint, String method, String route) {
     return HttpServerTestOptions.DEFAULT_EXPECTED_SERVER_SPAN_NAME_MAPPER.apply(
         endpoint, method, route);
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
 
 public class HttpServerTestOptions {
 
@@ -241,6 +240,6 @@ public class HttpServerTestOptions {
   @FunctionalInterface
   public interface SpanNameMapper {
 
-    String apply(ServerEndpoint endpoint, String method, @Nullable String route);
+    String apply(ServerEndpoint endpoint, String method, String route);
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/KeysVerifyingPropagator.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/util/KeysVerifyingPropagator.java
@@ -12,7 +12,6 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.Collection;
-import javax.annotation.Nullable;
 
 /**
  * A TextMapPropagator that verifies TextMapGetter methods can be called without errors.
@@ -42,7 +41,7 @@ public class KeysVerifyingPropagator implements TextMapPropagator {
 
   @Override
   @SuppressWarnings("OtelCanIgnoreReturnValueSuggester")
-  public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+  public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
     // Exercise methods to verify no errors
     getter.keys(carrier).forEach(key -> getter.get(carrier, key));
 


### PR DESCRIPTION
The style guide says "do not add `@Nullable` annotations in test code" without defining "test code", so it has been read as `src/test/` only. That leaves the `src/main/` sources of test-support modules (`testing-common`, `instrumentation/*/testing`) outside the rule, and `@Nullable` has been drifting into them. NullAway doesn't catch this either: those modules don't apply `otel.nullaway-conventions`, and where it is applied it only disables itself for compile tasks whose name contains "test".

This gives the `@Nullable` rule the same scope wording the neighbouring `final` rule already uses ("paths under `src/test/` or modules whose name starts/ends with `testing` or `tests`") in both `docs/contributing/style-guide.md` and `.github/instructions/java-style.instructions.md`, and cleans up the existing violations.

A few `@Nullable` annotations are kept because they are load-bearing rather than documentation, and the guidance now calls out these cases:

- ErrorProne `ReturnsNullCollection` — a collection-returning method that returns `null`
- ErrorProne `AutoValueBoxedValues` — a boxed `@AutoValue` property, where dropping `@Nullable` would mean unboxing
- AutoValue properties that callers explicitly set to `null`, which requires `@Nullable` to build