### PR TITLE
Remove Zipkin support under v3-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### 📈 Enhancements
+
+- When `otel.instrumentation.common.v3-preview` is enabled, the Zipkin span exporter is no longer
+  supported and configuring it fails at startup. Zipkin support will be removed in 3.0.
+
+### 🚫 Deprecations
+
+- Deprecate the `opentelemetry-zipkin-spring-boot-starter` artifact. Use
+  `opentelemetry-spring-boot-starter` with the OTLP exporter instead. It will be removed in 3.0.
+
 ## Version 2.30.0 (2026-07-22)
 
 This release targets the OpenTelemetry SDK 1.64.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-### 📈 Enhancements
-
-- When `otel.instrumentation.common.v3-preview` is enabled, the Zipkin span exporter is no longer
-  supported and configuring it fails at startup. Zipkin support will be removed in 3.0.
-
 ### 🚫 Deprecations
 
 - Deprecate the `opentelemetry-zipkin-spring-boot-starter` artifact. Use

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for the full list of configuration items. For example:
 ```
 java -javaagent:path/to/opentelemetry-javaagent.jar \
      -Dotel.resource.attributes=service.name=your-service-name \
-     -Dotel.traces.exporter=zipkin \
+     -Dotel.traces.exporter=console \
      -jar myapp.jar
 ```
 

--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -6,7 +6,7 @@ provides.
 - Bundled exporters
   - [OTLP](https://opentelemetry.io/docs/specs/otlp/)
   - Console
-  - Zipkin
+  - Zipkin (deprecated, removed in 3.0)
 - Bundled propagators
   - [W3C TraceContext / Baggage](https://www.w3.org/TR/trace-context/)
   - All Java [trace propagator extensions](https://github.com/open-telemetry/opentelemetry-java/tree/main/extensions/trace-propagators)

--- a/docs/agent-features.md
+++ b/docs/agent-features.md
@@ -6,7 +6,7 @@ provides.
 - Bundled exporters
   - [OTLP](https://opentelemetry.io/docs/specs/otlp/)
   - Console
-  - Zipkin (deprecated, removed in 3.0)
+  - Zipkin (deprecated, will be removed in 3.0)
 - Bundled propagators
   - [W3C TraceContext / Baggage](https://www.w3.org/TR/trace-context/)
   - All Java [trace propagator extensions](https://github.com/open-telemetry/opentelemetry-java/tree/main/extensions/trace-propagators)

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -273,7 +273,7 @@
       "defaultValue": "http://localhost:9411/api/v2/spans",
       "deprecation": {
         "level": "warning",
-        "reason": "The Zipkin exporter is removed in 3.0.",
+        "reason": "The Zipkin exporter will be removed in 3.0.",
         "replacement": "otel.exporter.otlp.traces.endpoint"
       }
     },
@@ -876,7 +876,7 @@
         },
         {
           "value": "zipkin",
-          "description": "Zipkin exporter. Deprecated, removed in 3.0; use \"otlp\" instead."
+          "description": "Zipkin exporter. Deprecated, will be removed in 3.0; use \"otlp\" instead."
         }
       ]
     },

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -270,7 +270,12 @@
       "name": "otel.exporter.zipkin.endpoint",
       "type": "java.lang.String",
       "description": "The Zipkin endpoint to connect to.<br/>Currently only HTTP is supported.",
-      "defaultValue": "http://localhost:9411/api/v2/spans"
+      "defaultValue": "http://localhost:9411/api/v2/spans",
+      "deprecation": {
+        "level": "warning",
+        "reason": "The Zipkin exporter is removed in 3.0.",
+        "replacement": "otel.exporter.otlp.traces.endpoint"
+      }
     },
     {
       "name": "otel.instrumentation.annotations.enabled",
@@ -871,7 +876,7 @@
         },
         {
           "value": "zipkin",
-          "description": "Zipkin exporter."
+          "description": "Zipkin exporter. Deprecated, removed in 3.0; use \"otlp\" instead."
         }
       ]
     },

--- a/instrumentation/spring/starters/zipkin-spring-boot-starter/README.md
+++ b/instrumentation/spring/starters/zipkin-spring-boot-starter/README.md
@@ -1,5 +1,10 @@
 # OpenTelemetry Zipkin Exporter Starter
 
+> **Deprecated:** this starter is deprecated and will be removed in 3.0. Use the
+> [OpenTelemetry Spring Boot Starter](../spring-boot-starter/README.md) with the OTLP exporter
+> instead. When `otel.instrumentation.common.v3-preview` is enabled, configuring
+> `otel.traces.exporter=zipkin` already fails at startup.
+
 The OpenTelemetry Exporter Starter for Java is a starter package that includes packages required to enable tracing using OpenTelemetry. It also provides the dependency and corresponding auto-configuration.
 
 OpenTelemetry Zipkin Exporter Starter is a starter package that includes the opentelemetry-api, opentelemetry-sdk, opentelemetry-extension-annotations, opentelemetry-logging-exporter, opentelemetry-spring-boot-autoconfigurations and spring framework starters required to setup distributed tracing. It also provides the [opentelemetry-exporter-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/v1.64.0/exporters/zipkin) artifact and corresponding exporter auto-configuration.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/JavaagentDistributionAccessCustomizerProvider.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/config/JavaagentDistributionAccessCustomizerProvider.java
@@ -14,15 +14,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.ConfigProvider;
+import io.opentelemetry.instrumentation.config.internal.DeclarativeConfigV3Preview;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AgentDistributionConfig;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.DistributionModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.DistributionPropertyModel;
-import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
-import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalInstrumentationModel;
-import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalLanguageSpecificInstrumentationModel;
-import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalLanguageSpecificInstrumentationPropertyModel;
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -60,31 +57,12 @@ public final class JavaagentDistributionAccessCustomizerProvider
   public void customize(DeclarativeConfigurationCustomizer customizer) {
     customizer.addModelCustomizer(
         model -> {
-          boolean isV3Preview = isV3Preview(model);
+          boolean isV3Preview = DeclarativeConfigV3Preview.isEnabled(model);
           AgentDistributionConfig distributionConfig =
               parseConfig(model.getDistribution(), isV3Preview);
           AgentDistributionConfig.set(distributionConfig);
           return model;
         });
-  }
-
-  // to be removed for 3.0.0
-  private static boolean isV3Preview(OpenTelemetryConfigurationModel model) {
-    ExperimentalInstrumentationModel instrumentationDevelopment =
-        model.getInstrumentationDevelopment();
-    if (instrumentationDevelopment == null) {
-      return false;
-    }
-    ExperimentalLanguageSpecificInstrumentationModel java = instrumentationDevelopment.getJava();
-    if (java == null) {
-      return false;
-    }
-    ExperimentalLanguageSpecificInstrumentationPropertyModel common =
-        java.getAdditionalProperties().get("common");
-    if (common == null) {
-      return false;
-    }
-    return Boolean.TRUE.equals(common.getAdditionalProperties().get("v3_preview"));
   }
 
   private static AgentDistributionConfig parseConfig(

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/config/internal/DeclarativeConfigV3Preview.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/config/internal/DeclarativeConfigV3Preview.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.config.internal;
+
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalInstrumentationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalLanguageSpecificInstrumentationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.internal.ExperimentalLanguageSpecificInstrumentationPropertyModel;
+
+/**
+ * Reads the {@code instrumentation/development.java.common.v3_preview} flag from the declarative
+ * configuration model.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+// to be removed for 3.0.0
+public final class DeclarativeConfigV3Preview {
+
+  /** The property name used to enable the v3 preview when configuring via config properties. */
+  public static final String V3_PREVIEW_PROPERTY = "otel.instrumentation.common.v3-preview";
+
+  public static boolean isEnabled(OpenTelemetryConfigurationModel model) {
+    ExperimentalInstrumentationModel instrumentationDevelopment =
+        model.getInstrumentationDevelopment();
+    if (instrumentationDevelopment == null) {
+      return false;
+    }
+    ExperimentalLanguageSpecificInstrumentationModel java = instrumentationDevelopment.getJava();
+    if (java == null) {
+      return false;
+    }
+    ExperimentalLanguageSpecificInstrumentationPropertyModel common =
+        java.getAdditionalProperties().get("common");
+    if (common == null) {
+      return false;
+    }
+    return Boolean.TRUE.equals(common.getAdditionalProperties().get("v3_preview"));
+  }
+
+  private DeclarativeConfigV3Preview() {}
+}

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemoval.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemoval.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.exporter.internal;
+
+/**
+ * Shared constants for the v3-preview removal of the Zipkin span exporter.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+// to be removed for 3.0.0, when the zipkin exporter dependency itself is dropped
+final class ZipkinExporterRemoval {
+
+  static final String EXPORTER_NAME = "zipkin";
+
+  static final String ERROR_MESSAGE =
+      "The zipkin span exporter is not supported when "
+          + "otel.instrumentation.common.v3-preview is enabled, because zipkin support is removed "
+          + "in 3.0. Use the otlp exporter instead.";
+
+  private ZipkinExporterRemoval() {}
+}

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemoval.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemoval.java
@@ -18,8 +18,8 @@ final class ZipkinExporterRemoval {
 
   static final String ERROR_MESSAGE =
       "The zipkin span exporter is not supported when "
-          + "otel.instrumentation.common.v3-preview is enabled, because zipkin support is removed "
-          + "in 3.0. Use the otlp exporter instead.";
+          + "otel.instrumentation.common.v3-preview is enabled, because zipkin support will be "
+          + "removed in 3.0. Use the otlp exporter instead.";
 
   private ZipkinExporterRemoval() {}
 }

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProvider.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.exporter.internal;
+
+import static java.util.Collections.emptyMap;
+
+import io.opentelemetry.instrumentation.config.internal.DeclarativeConfigV3Preview;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import java.util.Map;
+
+/**
+ * Fails autoconfiguration when the Zipkin span exporter is configured while the v3 preview is
+ * enabled, since Zipkin support is removed in 3.0.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+// to be removed for 3.0.0, when the zipkin exporter dependency itself is dropped
+public class ZipkinExporterRemovalCustomizerProvider
+    implements AutoConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfigurationCustomizer) {
+    autoConfigurationCustomizer.addPropertiesCustomizer(
+        ZipkinExporterRemovalCustomizerProvider::customize);
+  }
+
+  static Map<String, String> customize(ConfigProperties config) {
+    if (!config.getBoolean(DeclarativeConfigV3Preview.V3_PREVIEW_PROPERTY, false)) {
+      return emptyMap();
+    }
+    for (String exporter : config.getList("otel.traces.exporter")) {
+      if (ZipkinExporterRemoval.EXPORTER_NAME.equalsIgnoreCase(exporter.trim())) {
+        throw new ConfigurationException(ZipkinExporterRemoval.ERROR_MESSAGE);
+      }
+    }
+    return emptyMap();
+  }
+
+  @Override
+  public int order() {
+    // make sure it runs AFTER all the user-provided customizers
+    return Integer.MAX_VALUE;
+  }
+}

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProvider.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProvider.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 /**
  * Fails autoconfiguration when the Zipkin span exporter is configured while the v3 preview is
- * enabled, since Zipkin support is removed in 3.0.
+ * enabled, since Zipkin support will be removed in 3.0.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
@@ -38,6 +38,13 @@ public class ZipkinExporterRemovalDeclarativeCustomizerProvider
         });
   }
 
+  @Override
+  public int order() {
+    // make sure it runs AFTER all the user-provided customizers, so that the final model is
+    // validated
+    return Integer.MAX_VALUE;
+  }
+
   static void checkZipkinExporter(OpenTelemetryConfigurationModel model) {
     if (!DeclarativeConfigV3Preview.isEnabled(model)) {
       return;

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.exporter.internal;
+
+import io.opentelemetry.instrumentation.config.internal.DeclarativeConfigV3Preview;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.BatchSpanProcessorModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SimpleSpanProcessorModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanExporterModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanProcessorModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.TracerProviderModel;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Fails declarative configuration when the Zipkin span exporter is configured while the v3 preview
+ * is enabled, since Zipkin support is removed in 3.0.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+// to be removed for 3.0.0, when the zipkin exporter dependency itself is dropped
+public class ZipkinExporterRemovalDeclarativeCustomizerProvider
+    implements DeclarativeConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(DeclarativeConfigurationCustomizer customizer) {
+    customizer.addModelCustomizer(
+        model -> {
+          checkZipkinExporter(model);
+          return model;
+        });
+  }
+
+  static void checkZipkinExporter(OpenTelemetryConfigurationModel model) {
+    if (!DeclarativeConfigV3Preview.isEnabled(model)) {
+      return;
+    }
+    TracerProviderModel tracerProvider = model.getTracerProvider();
+    if (tracerProvider == null) {
+      return;
+    }
+    List<SpanProcessorModel> processors = tracerProvider.getProcessors();
+    if (processors == null) {
+      return;
+    }
+    for (SpanProcessorModel processor : processors) {
+      BatchSpanProcessorModel batch = processor.getBatch();
+      if (batch != null && isZipkin(batch.getExporter())) {
+        throw new ConfigurationException(ZipkinExporterRemoval.ERROR_MESSAGE);
+      }
+      SimpleSpanProcessorModel simple = processor.getSimple();
+      if (simple != null && isZipkin(simple.getExporter())) {
+        throw new ConfigurationException(ZipkinExporterRemoval.ERROR_MESSAGE);
+      }
+    }
+  }
+
+  private static boolean isZipkin(@Nullable SpanExporterModel exporter) {
+    return exporter != null
+        && exporter.getAdditionalProperties().containsKey(ZipkinExporterRemoval.EXPORTER_NAME);
+  }
+}

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProvider.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 /**
  * Fails declarative configuration when the Zipkin span exporter is configured while the v3 preview
- * is enabled, since Zipkin support is removed in 3.0.
+ * is enabled, since Zipkin support will be removed in 3.0.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.

--- a/sdk-autoconfigure-support/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider
+++ b/sdk-autoconfigure-support/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.instrumentation.exporter.internal.ZipkinExporterRemovalDeclarativeCustomizerProvider

--- a/sdk-autoconfigure-support/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/sdk-autoconfigure-support/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizer
+io.opentelemetry.instrumentation.exporter.internal.ZipkinExporterRemovalCustomizerProvider

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProviderTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalCustomizerProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.exporter.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ZipkinExporterRemovalCustomizerProviderTest {
+
+  @Test
+  void registeredViaServiceLoader() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.traces.exporter", "zipkin");
+    properties.put("otel.metrics.exporter", "none");
+    properties.put("otel.logs.exporter", "none");
+    properties.put("otel.instrumentation.common.v3-preview", "true");
+
+    assertThatThrownBy(
+            () ->
+                AutoConfiguredOpenTelemetrySdk.builder()
+                    .addPropertiesSupplier(() -> properties)
+                    .build())
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("zipkin span exporter is not supported");
+  }
+
+  @Test
+  void allowsZipkinWhenV3PreviewDisabled() {
+    assertThatCode(() -> ZipkinExporterRemovalCustomizerProvider.customize(config("zipkin", false)))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void failsOnZipkinWhenV3PreviewEnabled() {
+    assertThatThrownBy(
+            () -> ZipkinExporterRemovalCustomizerProvider.customize(config("zipkin", true)))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("zipkin span exporter is not supported");
+  }
+
+  @Test
+  void failsWhenZipkinIsOneOfSeveralExporters() {
+    assertThatThrownBy(
+            () -> ZipkinExporterRemovalCustomizerProvider.customize(config("otlp, zipkin", true)))
+        .isInstanceOf(ConfigurationException.class);
+  }
+
+  @Test
+  void allowsOtherExportersWhenV3PreviewEnabled() {
+    assertThat(ZipkinExporterRemovalCustomizerProvider.customize(config("otlp", true))).isEmpty();
+  }
+
+  private static ConfigProperties config(String tracesExporter, boolean v3Preview) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("otel.traces.exporter", tracesExporter);
+    properties.put("otel.instrumentation.common.v3-preview", Boolean.toString(v3Preview));
+    return DefaultConfigProperties.createFromMap(properties);
+  }
+}

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProviderTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProviderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.exporter.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.Test;
+
+class ZipkinExporterRemovalDeclarativeCustomizerProviderTest {
+
+  private static final String V3_PREVIEW =
+      "instrumentation/development:\n  java:\n    common:\n      v3_preview: true\n";
+
+  private static final String ZIPKIN_BATCH_PROCESSOR =
+      "tracer_provider:\n  processors:\n    - batch:\n        exporter:\n          zipkin:\n";
+
+  @Test
+  void allowsZipkinWhenV3PreviewDisabled() {
+    assertThatCode(() -> check(ZIPKIN_BATCH_PROCESSOR)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void failsOnZipkinBatchProcessorWhenV3PreviewEnabled() {
+    assertThatThrownBy(() -> check(V3_PREVIEW + ZIPKIN_BATCH_PROCESSOR))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("zipkin span exporter is not supported");
+  }
+
+  @Test
+  void failsOnZipkinSimpleProcessorWhenV3PreviewEnabled() {
+    assertThatThrownBy(
+            () ->
+                check(
+                    V3_PREVIEW
+                        + "tracer_provider:\n  processors:\n    - simple:\n        exporter:\n"
+                        + "          zipkin:\n"))
+        .isInstanceOf(ConfigurationException.class);
+  }
+
+  @Test
+  void allowsOtherExportersWhenV3PreviewEnabled() {
+    assertThatCode(
+            () ->
+                check(
+                    V3_PREVIEW
+                        + "tracer_provider:\n  processors:\n    - batch:\n        exporter:\n"
+                        + "          console:\n"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void allowsMissingTracerProviderWhenV3PreviewEnabled() {
+    assertThatCode(() -> check(V3_PREVIEW)).doesNotThrowAnyException();
+  }
+
+  private static void check(String yaml) {
+    OpenTelemetryConfigurationModel model =
+        DeclarativeConfiguration.parse(
+            new ByteArrayInputStream(("file_format: \"1.1\"\n" + yaml).getBytes(UTF_8)));
+    ZipkinExporterRemovalDeclarativeCustomizerProvider.checkZipkinExporter(model);
+  }
+}

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProviderTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/exporter/internal/ZipkinExporterRemovalDeclarativeCustomizerProviderTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.exporter.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -60,6 +61,12 @@ class ZipkinExporterRemovalDeclarativeCustomizerProviderTest {
   @Test
   void allowsMissingTracerProviderWhenV3PreviewEnabled() {
     assertThatCode(() -> check(V3_PREVIEW)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void runsAfterUserProvidedCustomizers() {
+    assertThat(new ZipkinExporterRemovalDeclarativeCustomizerProvider().order())
+        .isEqualTo(Integer.MAX_VALUE);
   }
 
   private static void check(String yaml) {


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19386#discussion_r3709063268.

Stages the Zipkin removal behind `otel.instrumentation.common.v3-preview` so nothing breaks by default, and deprecates the Zipkin Spring Boot starter.

The zipkin exporter jar is bundled in the agent and published via `opentelemetry-zipkin-spring-boot-starter`, so it can't be un-bundled by a runtime flag. Instead, autoconfiguration now fails at startup when a zipkin span exporter is configured with v3-preview enabled. The check lives in `sdk-autoconfigure-support` (already a runtime dependency of both `javaagent-tooling` and `spring-boot-autoconfigure`) and covers both the config-properties and declarative config paths.

Also deprecates the starter README, `otel.exporter.zipkin.endpoint` in the Spring config metadata, and the `Zipkin` entry in `docs/agent-features.md`.

The Gradle dependency and the starter module itself are left for the 3.0 removal PR.
