### PR TITLE
Bump weaver to v0.25.1 to fix flaky jmx-metrics registry validation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,9 +9,6 @@
   ignorePaths: [
     // instrumentation modules intentionally pin old library versions in order to test the oldest
     // supported version, so renovate must not update their build files
-    //
-    // this is scoped to build files (instead of all of instrumentation/) so that renovate can still
-    // see test container image pins, see the weaver custom manager below
     'instrumentation/**/*.gradle.kts',
   ],
   packageRules: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -466,7 +466,6 @@
       ],
     },
     {
-      // weaver image used by the jmx-metrics registry validation tests
       customType: 'regex',
       datasourceTemplate: 'docker',
       managerFilePatterns: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,12 @@
     ':semanticCommits',
   ],
   ignorePaths: [
-    'instrumentation/**',
+    // instrumentation modules intentionally pin old library versions in order to test the oldest
+    // supported version, so renovate must not update their build files
+    //
+    // this is scoped to build files (instead of all of instrumentation/) so that renovate can still
+    // see test container image pins, see the weaver custom manager below
+    'instrumentation/**/*.gradle.kts',
   ],
   packageRules: [
 
@@ -461,6 +466,17 @@
       ],
       matchStrings: [
         'npx (?<depName>[^@]+)@(?<currentValue>[^\\s]+)',
+      ],
+    },
+    {
+      // weaver image used by the jmx-metrics registry validation tests
+      customType: 'regex',
+      datasourceTemplate: 'docker',
+      managerFilePatterns: [
+        'instrumentation/jmx-metrics/**/WeaverContainer.java',
+      ],
+      matchStrings: [
+        '"(?<depName>otel/weaver):(?<currentValue>[^"]+)"',
       ],
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -469,7 +469,7 @@
       customType: 'regex',
       datasourceTemplate: 'docker',
       managerFilePatterns: [
-        'instrumentation/jmx-metrics/**/WeaverContainer.java',
+        '**/*.java',
       ],
       matchStrings: [
         '"(?<depName>otel/weaver):(?<currentValue>[^"]+)"',

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WeaverContainer.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/WeaverContainer.java
@@ -43,7 +43,7 @@ class WeaverContainer extends GenericContainer<WeaverContainer> {
   @Nullable private JsonNode result = null;
 
   WeaverContainer(Path registryRoot, String... registryFiles) {
-    super("otel/weaver:v0.24.2");
+    super("otel/weaver:v0.25.1");
 
     super.withExposedPorts(OTLP_PORT, ADMIN_PORT);
     super.waitingFor(Wait.forListeningPorts(OTLP_PORT, ADMIN_PORT));

--- a/instrumentation/jmx-metrics/model/camel.yaml
+++ b/instrumentation/jmx-metrics/model/camel.yaml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.24.2/schemas/semconv.schema.json
-
 groups:
   - id: attributes.camel
     type: attribute_group

--- a/instrumentation/jmx-metrics/model/jvm.yaml
+++ b/instrumentation/jmx-metrics/model/jvm.yaml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.24.2/schemas/semconv.schema.json
-
 imports:
   metrics:
     - jvm.*

--- a/instrumentation/jmx-metrics/model/manifest.yaml
+++ b/instrumentation/jmx-metrics/model/manifest.yaml
@@ -4,3 +4,4 @@ schema_url: https://github.com/open-telemetry/opentelemetry-java-instrumentation
 dependencies:
   - name: otel
     registry_path: https://github.com/open-telemetry/semantic-conventions@v1.43.0[model]
+    schema_url: https://opentelemetry.io/schemas/1.43.0

--- a/instrumentation/jmx-metrics/model/tomcat.yaml
+++ b/instrumentation/jmx-metrics/model/tomcat.yaml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/open-telemetry/weaver/v0.24.2/schemas/semconv.schema.json
-
 groups:
   - id: attributes.tomcat
     type: attribute_group


### PR DESCRIPTION
Fixes the intermittent jmx-metrics registry validation failures:

```
java.util.concurrent.CompletionException: com.linecorp.armeria.client.ClosedSessionException
    at io.opentelemetry.instrumentation.jmx.rules.WeaverContainer.stop(WeaverContainer.java:87)
```

This was a shutdown race in weaver, fixed by open-telemetry/weaver#1632. Note that v0.25.0 has to
be skipped, since it introduced open-telemetry/weaver#1644, which was fixed by #1645 in v0.25.1.

v0.25.1 also requires `schema_url` on manifest dependencies (open-telemetry/weaver#1651), so that
is added to `manifest.yaml`, matching the semantic-conventions version already pinned by
`registry_path`.

Renovate wasn't seeing the weaver image at all, because `ignorePaths` covered all of
`instrumentation/**`. That entry is there so renovate doesn't bump the intentionally old library
versions that instrumentation modules pin, and those are declared in the build files, so it's now
scoped to `instrumentation/**/*.gradle.kts`, with a custom manager for the weaver image tag.

Also dropping the `yaml-language-server` `$schema` comments, since they only drive editor
validation and would otherwise be one more weaver version to keep in sync.
