### PR TITLE
Document the Micrometer bridge mapping, and fix description deduplication

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -41,7 +41,7 @@ MeterRegistry meterRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).
 
 `<name>` below is the Micrometer meter name after the registry's
 [naming convention](https://docs.micrometer.io/micrometer/reference/concepts/naming.html) has been
-applied. The default naming convention passes the name through unchanged; see
+applied. The default convention passes the name through unchanged; see
 [Prometheus mode](#prometheus-mode) for the exception.
 
 | Micrometer instrument | OpenTelemetry instrument(s)                                            | Name(s)                            | Unit                           |
@@ -55,73 +55,35 @@ applied. The default naming convention passes the name through unchanged; see
 | `FunctionTimer`       | asynchronous long counter, asynchronous double counter                 | `<name>.count`, `<name>.sum`       | `{invocation}`, base time unit |
 | `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<name>.<statistic>`               | base unit                      |
 
-The suffixes above are appended after the naming convention has been applied, except for a custom
-`Meter`, where the convention is applied to the already-suffixed name.
+Notes:
 
-Tags become attributes and the meter description becomes the instrument description; see [Names,
-tags, and descriptions](#names-tags-and-descriptions). Instruments configured with percentiles or
-service level objectives can emit additional gauges; see [Histograms](#histograms).
-
-For a custom `Meter`, each measurement's `Statistic` determines the instrument type: `COUNT`,
-`TOTAL`, and `TOTAL_TIME` become asynchronous double counters, `ACTIVE_TASKS` becomes an
-asynchronous double up-down counter, and `DURATION`, `MAX`, `VALUE`, and `UNKNOWN` become
-asynchronous double gauges. The suffix is the statistic's Micrometer tag value, so `ACTIVE_TASKS`
-produces `<name>.active`, not `<name>.active_tasks`.
-
-### Units
-
-The Micrometer base unit is used verbatim as the OpenTelemetry instrument unit, and meters
-registered without one have an empty unit. Base units are not translated to
-[UCUM](https://ucum.org/), which OpenTelemetry semantic conventions use, so the base unit `bytes`
-produces the unit `bytes` rather than `By`.
-
-Timing instruments use the registry's base time unit, which is seconds by default and can be changed
-with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`. It is reported as `ns`, `us`,
-`ms`, `s`, `min`, `h`, or `d`.
-
-### Histograms
-
-Only Micrometer's service level objectives become the OpenTelemetry histogram's explicit bucket
-boundaries advice. `publishPercentileHistogram()`, `minimumExpectedValue`, and
-`maximumExpectedValue` do **not** contribute boundaries, so a `Timer` or `DistributionSummary`
-without service level objectives leaves bucket selection to the OpenTelemetry SDK.
-
-Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all. Enabling
-`io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled`,
-which is experimental and may change at any time, additionally emits Micrometer's own gauges:
-`<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le` attribute.
-
-The decaying `<name>.max` gauge emitted alongside the `Timer` and `DistributionSummary` histograms
-is deprecated and will be removed in 3.0, since OpenTelemetry histograms already carry a max. It is
-no longer emitted when `otel.instrumentation.common.v3-preview` is enabled.
-
-### Names, tags, and descriptions
-
-Metrics are emitted under the instrumentation scope `io.opentelemetry.micrometer-1.5`.
-
-Tag keys and values are passed through the registry's naming convention before becoming attribute
-keys and values.
-
-Meter descriptions are deduplicated by the emitted OpenTelemetry instrument name, because in
-OpenTelemetry the description is one of an instrument's identifying fields: the first description
-registered for a name is reused by every instrument that later shares it, and a `null` description
-becomes an empty description.
+- Micrometer tags become OpenTelemetry attributes. Meter names and tag keys both pass through the
+  registry's naming convention, and metrics are emitted under the instrumentation scope
+  `io.opentelemetry.micrometer-1.5`.
+- Base units are used verbatim rather than translated to [UCUM](https://ucum.org/), so a base unit
+  of `bytes` stays `bytes` rather than becoming `By`. The base time unit defaults to seconds and can
+  be changed with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`.
+- Only Micrometer's service level objectives become explicit bucket boundaries advice;
+  `publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do not.
+  Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all, but percentiles
+  and service level objectives can additionally be emitted as `<name>.percentile` and
+  `<name>.histogram` gauges by enabling the experimental
+  `Experimental#setMicrometerHistogramGaugesEnabled`.
+- Descriptions are deduplicated by instrument name, because in OpenTelemetry the description is one
+  of an instrument's identifying fields. The first description registered for a name wins.
+- The `<name>.max` gauge is deprecated and will be removed in 3.0. It is no longer emitted when
+  `otel.instrumentation.common.v3-preview` is enabled.
+- For a custom `Meter`, each measurement's `Statistic` determines the instrument type, and the name
+  suffix is the statistic's Micrometer tag value.
 
 ### Prometheus mode
 
 Prometheus mode approximates the naming behavior of Micrometer's `PrometheusMeterRegistry`, for
 users exporting with the Prometheus exporter. It forces the base time unit to seconds and appends
-the unit to the instrument name, keying off the Micrometer meter type: `Timer`, `FunctionTimer`, and
-`LongTaskTimer` get `.seconds`, while `Counter`, `FunctionCounter`, `DistributionSummary`, and
-`Gauge` get their base unit when they have a non-empty one. Only custom `Meter` instruments are
-unchanged.
-
-Any suffix from the table above is appended afterwards, so `my.timer` (a `Timer`) becomes
-`my.timer.seconds`, `my.summary` (a `DistributionSummary` with the base unit `bytes`) becomes
-`my.summary.bytes`, and `my.function` (a `FunctionTimer`) becomes `my.function.seconds.count` and
-`my.function.seconds.sum`. Encoding the unit in the metric name is contrary to the OpenTelemetry
-naming rules, so this mode is disabled by default and should only be enabled for Prometheus
-compatibility.
+the unit to the instrument name, so a `Timer` named `my.timer` becomes `my.timer.seconds` and a
+`DistributionSummary` named `my.summary` with the base unit `bytes` becomes `my.summary.bytes`.
+Encoding the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is
+disabled by default and should only be enabled for Prometheus compatibility.
 
 ```java
 MeterRegistry meterRegistry =
@@ -131,16 +93,9 @@ MeterRegistry meterRegistry =
 ### Reading measurements is mostly not supported
 
 The bridge forwards measurements to OpenTelemetry rather than keeping them readable through the
-Micrometer API, and it logs a warning the first time an unsupported read is attempted.
-
-`Meter#measure()` returns an empty list for every bridged instrument. `Counter#count()`,
-`FunctionCounter#count()`, `Gauge#value()`, `FunctionTimer#count()`, `FunctionTimer#totalTime()`,
-and `FunctionTimer#mean()` return `Double.NaN`.
-`Timer` and `DistributionSummary` only track `count()` and `totalTime()` / `totalAmount()` locally
-when the meter is configured with percentiles or service level objectives *and* gauge-based
-Micrometer histograms are enabled; otherwise `count()` returns `0` and the totals return
-`Double.NaN`. Their `max()` is always tracked. `LongTaskTimer` is the one instrument whose reads
-mostly work, because it only overrides `measure()`.
+Micrometer API. Most read methods, such as `Counter#count()` and `Gauge#value()`, return
+`Double.NaN`, and `Meter#measure()` returns an empty list. A warning is logged the first time an
+unsupported read is attempted. `LongTaskTimer` is the one instrument whose reads mostly work.
 
 Code that reads values back from the registry, such as a Micrometer-based health check or test
 assertion, should read from the OpenTelemetry SDK instead.

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -66,8 +66,7 @@ For a custom `Meter`, each measurement's `Statistic` determines the instrument t
 `TOTAL`, and `TOTAL_TIME` become asynchronous double counters, `ACTIVE_TASKS` becomes an
 asynchronous double up-down counter, and `DURATION`, `MAX`, `VALUE`, and `UNKNOWN` become
 asynchronous double gauges. The suffix is the statistic's Micrometer tag value, so `ACTIVE_TASKS`
-produces `<name>.active`, not `<name>.active_tasks`. The exception is `TOTAL_TIME`, which uses
-`total_time` rather than its tag value `total`, to avoid clashing with `TOTAL`.
+produces `<name>.active`, not `<name>.active_tasks`.
 
 ### Units
 
@@ -83,26 +82,18 @@ with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`. It is report
 ### Histograms
 
 Only Micrometer's service level objectives become the OpenTelemetry histogram's explicit bucket
-boundaries advice, converted from nanoseconds to the base time unit for a `Timer`.
-`publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do **not**
-contribute boundaries, so a `Timer` or `DistributionSummary` without service level objectives
-produces no boundaries advice, leaving bucket selection to the OpenTelemetry SDK.
+boundaries advice. `publishPercentileHistogram()`, `minimumExpectedValue`, and
+`maximumExpectedValue` do **not** contribute boundaries, so a `Timer` or `DistributionSummary`
+without service level objectives leaves bucket selection to the OpenTelemetry SDK.
 
 Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all. Enabling
 `io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled`,
 which is experimental and may change at any time, additionally emits Micrometer's own gauges:
-`<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le` attribute. Percentile
-gauges inherit the source meter's base unit, which for a `Timer` is empty even though the values are
-in the base time unit; bucket count gauges have no unit.
-
-`LongTaskTimer` is the exception: it is not bridged to an OpenTelemetry histogram, so it always
-emits those gauges when percentiles or service level objectives are configured on it, regardless of
-the experimental setting.
+`<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le` attribute.
 
 The decaying `<name>.max` gauge emitted alongside the `Timer` and `DistributionSummary` histograms
-is deprecated and will be removed in 3.0: OpenTelemetry histograms already carry a max, and the
-`<name>` / `<name>.max` pair violates the OpenTelemetry metric naming rules. It is no longer emitted
-when `otel.instrumentation.common.v3-preview` is enabled.
+is deprecated and will be removed in 3.0, since OpenTelemetry histograms already carry a max. It is
+no longer emitted when `otel.instrumentation.common.v3-preview` is enabled.
 
 ### Names, tags, and descriptions
 
@@ -111,22 +102,10 @@ Metrics are emitted under the instrumentation scope `io.opentelemetry.micrometer
 Tag keys and values are passed through the registry's naming convention before becoming attribute
 keys and values.
 
-Meter descriptions are deduplicated by the emitted OpenTelemetry instrument name: the first
-description registered for a name is reused by every instrument that later shares it, and a `null`
-description becomes an empty description.
-
-This reconciles a data model difference: in Micrometer each set of tags is a separate meter with its
-own description, while in OpenTelemetry the description is one of an instrument's identifying
-fields. Passing descriptions through unchanged would turn one Micrometer metric into several
-conflicting instruments sharing a name, which the SDK exports as separate metric streams instead of
-aggregating them, along with duplicate registration warnings. Micrometer's own
-`PrometheusMeterRegistry` resolves this the same way, by keeping one description per metric.
-
-Deduplication is scoped to the OpenTelemetry `MeterProvider` rather than to the Micrometer registry,
-so the winning description depends on registration order, and registries sharing a `MeterProvider`
-share descriptions. Because the key is the emitted name, meters that share a Micrometer name but map
-onto different instrument names each keep their own description — for example a `Counter` and a
-`Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and `foo.seconds`.
+Meter descriptions are deduplicated by the emitted OpenTelemetry instrument name, because in
+OpenTelemetry the description is one of an instrument's identifying fields: the first description
+registered for a name is reused by every instrument that later shares it, and a `null` description
+becomes an empty description.
 
 ### Prometheus mode
 
@@ -140,10 +119,9 @@ unchanged.
 Any suffix from the table above is appended afterwards, so `my.timer` (a `Timer`) becomes
 `my.timer.seconds`, `my.summary` (a `DistributionSummary` with the base unit `bytes`) becomes
 `my.summary.bytes`, and `my.function` (a `FunctionTimer`) becomes `my.function.seconds.count` and
-`my.function.seconds.sum`. These are the OpenTelemetry instrument names; the Prometheus exporter
-still replaces `.` with `_` and appends `_total` to counters, so the final series names differ.
-Encoding the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is
-disabled by default and should only be enabled for Prometheus compatibility.
+`my.function.seconds.sum`. Encoding the unit in the metric name is contrary to the OpenTelemetry
+naming rules, so this mode is disabled by default and should only be enabled for Prometheus
+compatibility.
 
 ```java
 MeterRegistry meterRegistry =
@@ -161,10 +139,8 @@ and `FunctionTimer#mean()` return `Double.NaN`.
 `Timer` and `DistributionSummary` only track `count()` and `totalTime()` / `totalAmount()` locally
 when the meter is configured with percentiles or service level objectives *and* gauge-based
 Micrometer histograms are enabled; otherwise `count()` returns `0` and the totals return
-`Double.NaN`. Their `max()` is always tracked, but it is a decaying max over the configured
-distribution statistic expiry window rather than the all-time max. `LongTaskTimer` is the one
-instrument whose reads mostly work, because it extends Micrometer's `DefaultLongTaskTimer` and only
-overrides `measure()`.
+`Double.NaN`. Their `max()` is always tracked. `LongTaskTimer` is the one instrument whose reads
+mostly work, because it only overrides `measure()`.
 
 Code that reads values back from the registry, such as a Micrometer-based health check or test
 assertion, should read from the OpenTelemetry SDK instead.

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -142,12 +142,15 @@ applied, meters that share a Micrometer name but map onto different instrument n
 
 Prometheus mode approximates the naming behavior of Micrometer's `PrometheusMeterRegistry` and is
 intended for users exporting with the Prometheus exporter. It forces the base time unit to seconds
-and appends the unit to the instrument name: `Timer` and `LongTaskTimer` names get `.seconds`, while
-`Counter`, `DistributionSummary`, and `Gauge` names get their base unit appended when they have a
-non-empty one. Other meter types are left unchanged.
+and appends the unit to the instrument name. The naming convention keys off the Micrometer meter
+type, so `Timer`, `FunctionTimer`, and `LongTaskTimer` names get `.seconds`, while `Counter`,
+`FunctionCounter`, `DistributionSummary`, and `Gauge` names get their base unit appended when they
+have a non-empty one. Only custom `Meter` instruments are left unchanged.
 
-So a `Timer` named `my.timer` produces the OpenTelemetry instrument `my.timer.seconds`, and a
-`DistributionSummary` named `my.summary` with the base unit `bytes` produces `my.summary.bytes`.
+Any suffix from the table above is appended afterwards, so a `Timer` named `my.timer` produces the
+OpenTelemetry instrument `my.timer.seconds`, a `DistributionSummary` named `my.summary` with the
+base unit `bytes` produces `my.summary.bytes`, and a `FunctionTimer` named `my.function` produces
+`my.function.seconds.count` and `my.function.seconds.sum`.
 These are the OpenTelemetry instrument names; replacing `.` with `_` and appending `_total` to
 counters is left to the Prometheus exporter, so the final Prometheus series names differ. Encoding
 the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is disabled

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -69,8 +69,9 @@ Notes:
   service level objectives can additionally be emitted as `<name>.percentile` and
   `<name>.histogram` gauges by enabling the experimental
   `Experimental#setMicrometerHistogramGaugesEnabled`.
-- Descriptions are deduplicated by instrument name, because in OpenTelemetry the description is one
-  of an instrument's identifying fields. The first description registered for a name wins.
+- Descriptions are deduplicated by instrument name within each registry, because in OpenTelemetry
+  the description is one of an instrument's identifying fields. The first description registered
+  for a name in that registry wins.
 - The `<name>.max` gauge is deprecated and will be removed in 3.0. It is no longer emitted when
   `otel.instrumentation.common.v3-preview` is enabled.
 - For a custom `Meter`, each measurement's `Statistic` determines the instrument type, and the name

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -36,3 +36,142 @@ The instrumentation library provides an implementation of `MeterRegistry` to bri
 ```java
 MeterRegistry meterRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).build();
 ```
+
+## How Micrometer instruments are mapped to OpenTelemetry
+
+`<name>` below is the Micrometer meter name after the registry's
+[naming convention](https://docs.micrometer.io/micrometer/reference/concepts/naming.html) has been
+applied. The default naming convention passes the name through unchanged; see
+[Prometheus mode](#prometheus-mode) for the exception.
+
+| Micrometer instrument | OpenTelemetry instrument(s)                                            | Name(s)                            | Unit                           |
+| --------------------- | ---------------------------------------------------------------------- | ---------------------------------- | ------------------------------ |
+| `Counter`             | synchronous double counter                                             | `<name>`                           | base unit                      |
+| `Gauge`               | asynchronous double gauge                                              | `<name>`                           | base unit                      |
+| `Timer`               | synchronous double histogram, plus an asynchronous double gauge        | `<name>`, `<name>.max`             | base time unit                 |
+| `DistributionSummary` | synchronous double histogram, plus an asynchronous double gauge        | `<name>`, `<name>.max`             | base unit                      |
+| `LongTaskTimer`       | asynchronous long up-down counter, asynchronous double up-down counter | `<name>.active`, `<name>.duration` | `{tasks}`, base time unit      |
+| `FunctionCounter`     | asynchronous double counter                                            | `<name>`                           | base unit                      |
+| `FunctionTimer`       | asynchronous long counter, asynchronous double counter                 | `<name>.count`, `<name>.sum`       | `{invocation}`, base time unit |
+| `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<name>.<statistic>`               | base unit                      |
+
+Except for custom `Meter` instruments, the suffixes above are appended after the naming convention
+has been applied. For a custom `Meter` the naming convention is applied to the suffixed name.
+
+Instruments configured with percentiles or service level objectives can emit additional gauges; see
+[Histograms](#histograms).
+
+Micrometer tags are mapped to OpenTelemetry attributes, and the Micrometer meter description is
+mapped to the OpenTelemetry instrument description. See [Names, tags, and
+descriptions](#names-tags-and-descriptions) for details.
+
+For a custom `Meter`, the OpenTelemetry instrument type is derived from each measurement's
+`Statistic`: `COUNT`, `TOTAL`, and `TOTAL_TIME` become asynchronous double counters, `ACTIVE_TASKS`
+becomes an asynchronous double up-down counter, and `DURATION`, `MAX`, `VALUE`, and `UNKNOWN` become
+asynchronous double gauges. The name suffix is the statistic's Micrometer tag value representation,
+so `ACTIVE_TASKS` produces `<name>.active`, not `<name>.active_tasks`. `TOTAL_TIME` is the one
+exception: it uses `total_time` rather than its tag value representation `total`, to avoid clashing
+with `TOTAL`.
+
+### Units
+
+The Micrometer base unit is used verbatim as the OpenTelemetry instrument unit, and instruments
+registered without a base unit have an empty unit. Micrometer base units are not translated to
+[UCUM](https://ucum.org/), which is what OpenTelemetry semantic conventions use, so a Micrometer
+meter with the base unit `bytes` produces an OpenTelemetry instrument with the unit `bytes` rather
+than `By`.
+
+Timing instruments use the registry's base time unit, which is seconds by default and can be changed
+with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`. It is reported as `ns`, `us`,
+`ms`, `s`, `min`, `h`, or `d`.
+
+### Histograms
+
+Only Micrometer's service level objectives are mapped to the OpenTelemetry histogram's explicit
+bucket boundaries advice, and for a `Timer` they are converted from nanoseconds to the base time
+unit. `publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do **not**
+contribute bucket boundaries, so a `Timer` or `DistributionSummary` configured without service level
+objectives produces a histogram with no boundaries advice, leaving bucket selection to the
+OpenTelemetry SDK.
+
+Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all. Percentiles and
+service level objectives can additionally be emitted as gauges by enabling
+`io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled`,
+which is experimental and may change at any time. These are Micrometer's own generated gauges, so
+they are named `<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le`
+attribute. Percentile gauges inherit the source meter's base unit, which for a `Timer` is empty even
+though the values are expressed in the base time unit, and bucket count gauges have no unit.
+
+`LongTaskTimer` is the exception to the setting above: it is not bridged to an OpenTelemetry
+histogram, and it always emits the `<name>.percentile` and `<name>.histogram` gauges when
+percentiles or service level objectives are configured on it, regardless of whether the experimental
+setting is enabled.
+
+The decaying `<name>.max` gauge emitted alongside the `Timer` and `DistributionSummary` histograms
+is deprecated and will be removed in 3.0. OpenTelemetry histograms already carry a max, and the
+`<name>` / `<name>.max` pair violates the OpenTelemetry metric naming rules. It is no longer emitted
+when `otel.instrumentation.common.v3-preview` is enabled.
+
+### Names, tags, and descriptions
+
+Metrics are emitted under the instrumentation scope `io.opentelemetry.micrometer-1.5`.
+
+Tag keys and values are passed through the registry's naming convention before becoming attribute
+keys and values.
+
+Meter descriptions are deduplicated by the emitted OpenTelemetry instrument name: the first
+description registered for a given name is reused for every instrument that later shares that name,
+and a `null` description is mapped to an empty description.
+
+This reconciles a difference between the two data models. In Micrometer, each set of tags is a
+separate meter and may carry its own description, whereas in OpenTelemetry the description is one of
+an instrument's identifying fields. Bridging the descriptions through unchanged would therefore turn
+a single Micrometer metric into several conflicting OpenTelemetry instruments that share a name, so
+the SDK would emit duplicate registration warnings and export the tag sets as separate metric
+streams instead of aggregating them into one. Micrometer's own `PrometheusMeterRegistry` resolves
+this the same way, by keeping one description per metric.
+
+The deduplication is process-wide rather than per-registry, so the description that wins depends on
+registration order. Because the key is the name after the naming convention has been applied, meters
+that share a Micrometer name but map onto different instrument names — for example a `Counter` and a
+`Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and `foo.seconds` —
+each keep their own description.
+
+### Prometheus mode
+
+Prometheus mode approximates the naming behavior of Micrometer's `PrometheusMeterRegistry` and is
+intended for users exporting with the Prometheus exporter. It forces the base time unit to seconds
+and appends the unit to the instrument name: `Timer` and `LongTaskTimer` names get `.seconds`, while
+`Counter`, `DistributionSummary`, and `Gauge` names get their base unit appended when they have a
+non-empty one. Other meter types are left unchanged.
+
+So a `Timer` named `my.timer` produces the OpenTelemetry instrument `my.timer.seconds`, and a
+`DistributionSummary` named `my.summary` with the base unit `bytes` produces `my.summary.bytes`.
+These are the OpenTelemetry instrument names; replacing `.` with `_` and appending `_total` to
+counters is left to the Prometheus exporter, so the final Prometheus series names differ. Encoding
+the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is disabled
+by default and should only be enabled for Prometheus compatibility.
+
+```java
+MeterRegistry meterRegistry =
+    OpenTelemetryMeterRegistry.builder(openTelemetry).setPrometheusMode(true).build();
+```
+
+### Reading measurements is mostly not supported
+
+The bridge forwards measurements to OpenTelemetry rather than keeping them readable through the
+Micrometer API, and it logs a warning the first time an unsupported read is attempted.
+
+`Meter#measure()` returns an empty list for every bridged instrument. `Counter#count()`,
+`FunctionCounter#count()`, `Gauge#value()`, `FunctionTimer#count()`, `FunctionTimer#totalTime()`,
+and `FunctionTimer#mean()` return `Double.NaN`.
+`Timer` and `DistributionSummary` only track `count()` and `totalTime()` / `totalAmount()` locally
+when the meter is configured with percentiles or service level objectives *and* gauge-based
+Micrometer histograms are enabled; otherwise `count()` returns `0` and the totals return
+`Double.NaN`. Their `max()` is always tracked, but it is a decaying max over the configured
+distribution statistic expiry window rather than the all-time max. `LongTaskTimer` is the one
+instrument whose reads mostly work, because it extends Micrometer's `DefaultLongTaskTimer` and only
+overrides `measure()`.
+
+Code that reads values back from the registry, such as a Micrometer-based health check or test
+assertion, should read from the OpenTelemetry SDK instead.

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -89,13 +89,3 @@ disabled by default and should only be enabled for Prometheus compatibility.
 MeterRegistry meterRegistry =
     OpenTelemetryMeterRegistry.builder(openTelemetry).setPrometheusMode(true).build();
 ```
-
-### Reading measurements is mostly not supported
-
-The bridge forwards measurements to OpenTelemetry rather than keeping them readable through the
-Micrometer API. Most read methods, such as `Counter#count()` and `Gauge#value()`, return
-`Double.NaN`, and `Meter#measure()` returns an empty list. A warning is logged the first time an
-unsupported read is attempted. `LongTaskTimer` is the one instrument whose reads mostly work.
-
-Code that reads values back from the registry, such as a Micrometer-based health check or test
-assertion, should read from the OpenTelemetry SDK instead.

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -131,11 +131,12 @@ the SDK would emit duplicate registration warnings and export the tag sets as se
 streams instead of aggregating them into one. Micrometer's own `PrometheusMeterRegistry` resolves
 this the same way, by keeping one description per metric.
 
-The deduplication is process-wide rather than per-registry, so the description that wins depends on
-registration order. Because the key is the name after the naming convention has been applied, meters
-that share a Micrometer name but map onto different instrument names — for example a `Counter` and a
-`Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and `foo.seconds` —
-each keep their own description.
+The deduplication is scoped to the OpenTelemetry `MeterProvider` rather than to the Micrometer
+registry, so the description that wins depends on registration order, and registries sharing a
+`MeterProvider` share descriptions. Because the key is the name after the naming convention has been
+applied, meters that share a Micrometer name but map onto different instrument names — for example a
+`Counter` and a `Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and
+`foo.seconds` — each keep their own description.
 
 ### Prometheus mode
 

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -53,7 +53,7 @@ applied. The default convention passes the name through unchanged; see
 | `LongTaskTimer`       | asynchronous long up-down counter, asynchronous double up-down counter | `<name>.active`, `<name>.duration` | `{tasks}`, base time unit      |
 | `FunctionCounter`     | asynchronous double counter                                            | `<name>`                           | base unit                      |
 | `FunctionTimer`       | asynchronous long counter, asynchronous double counter                 | `<name>.count`, `<name>.sum`       | `{invocation}`, base time unit |
-| `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<raw name>.<statistic>`           | base unit                      |
+| `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<name>.<statistic>`               | base unit                      |
 
 Notes:
 
@@ -76,10 +76,11 @@ Notes:
   `otel.instrumentation.common.v3-preview` is enabled.
 - For a custom `Meter`, each measurement's `Statistic` determines the instrument type, and the name
   suffix is the statistic's Micrometer tag value, except for `TOTAL_TIME`, which uses `total_time`
-  so that it does not clash with `TOTAL`. The naming convention is applied to the combined
-  `<raw name>.<statistic>`, where `<raw name>` is the Micrometer meter name before the convention,
-  so a custom `Meter` of type `COUNTER` named `my.meter` with the base unit `bytes` is emitted as
-  `my.meter.count.bytes` in [Prometheus mode](#prometheus-mode).
+  so that it does not clash with `TOTAL`. Before `otel.instrumentation.common.v3-preview` is
+  enabled, the naming convention is applied to the combined name and suffix instead of to the name
+  alone, so in [Prometheus mode](#prometheus-mode) a custom `Meter` of type `COUNTER` named
+  `my.meter` with the base unit `bytes` is emitted as `my.meter.count.bytes` rather than
+  `my.meter.bytes.count`.
 
 ### Prometheus mode
 

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -75,7 +75,8 @@ Notes:
 - The `<name>.max` gauge is deprecated and will be removed in 3.0. It is no longer emitted when
   `otel.instrumentation.common.v3-preview` is enabled.
 - For a custom `Meter`, each measurement's `Statistic` determines the instrument type, and the name
-  suffix is the statistic's Micrometer tag value. The naming convention is applied to the combined
+  suffix is the statistic's Micrometer tag value, except for `TOTAL_TIME`, which uses `total_time`
+  so that it does not clash with `TOTAL`. The naming convention is applied to the combined
   `<raw name>.<statistic>`, where `<raw name>` is the Micrometer meter name before the convention,
   so a custom `Meter` of type `COUNTER` named `my.meter` with the base unit `bytes` is emitted as
   `my.meter.count.bytes` in [Prometheus mode](#prometheus-mode).

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -55,31 +55,26 @@ applied. The default naming convention passes the name through unchanged; see
 | `FunctionTimer`       | asynchronous long counter, asynchronous double counter                 | `<name>.count`, `<name>.sum`       | `{invocation}`, base time unit |
 | `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<name>.<statistic>`               | base unit                      |
 
-Except for custom `Meter` instruments, the suffixes above are appended after the naming convention
-has been applied. For a custom `Meter` the naming convention is applied to the suffixed name.
+The suffixes above are appended after the naming convention has been applied, except for a custom
+`Meter`, where the convention is applied to the already-suffixed name.
 
-Instruments configured with percentiles or service level objectives can emit additional gauges; see
-[Histograms](#histograms).
+Tags become attributes and the meter description becomes the instrument description; see [Names,
+tags, and descriptions](#names-tags-and-descriptions). Instruments configured with percentiles or
+service level objectives can emit additional gauges; see [Histograms](#histograms).
 
-Micrometer tags are mapped to OpenTelemetry attributes, and the Micrometer meter description is
-mapped to the OpenTelemetry instrument description. See [Names, tags, and
-descriptions](#names-tags-and-descriptions) for details.
-
-For a custom `Meter`, the OpenTelemetry instrument type is derived from each measurement's
-`Statistic`: `COUNT`, `TOTAL`, and `TOTAL_TIME` become asynchronous double counters, `ACTIVE_TASKS`
-becomes an asynchronous double up-down counter, and `DURATION`, `MAX`, `VALUE`, and `UNKNOWN` become
-asynchronous double gauges. The name suffix is the statistic's Micrometer tag value representation,
-so `ACTIVE_TASKS` produces `<name>.active`, not `<name>.active_tasks`. `TOTAL_TIME` is the one
-exception: it uses `total_time` rather than its tag value representation `total`, to avoid clashing
-with `TOTAL`.
+For a custom `Meter`, each measurement's `Statistic` determines the instrument type: `COUNT`,
+`TOTAL`, and `TOTAL_TIME` become asynchronous double counters, `ACTIVE_TASKS` becomes an
+asynchronous double up-down counter, and `DURATION`, `MAX`, `VALUE`, and `UNKNOWN` become
+asynchronous double gauges. The suffix is the statistic's Micrometer tag value, so `ACTIVE_TASKS`
+produces `<name>.active`, not `<name>.active_tasks`. The exception is `TOTAL_TIME`, which uses
+`total_time` rather than its tag value `total`, to avoid clashing with `TOTAL`.
 
 ### Units
 
-The Micrometer base unit is used verbatim as the OpenTelemetry instrument unit, and instruments
-registered without a base unit have an empty unit. Micrometer base units are not translated to
-[UCUM](https://ucum.org/), which is what OpenTelemetry semantic conventions use, so a Micrometer
-meter with the base unit `bytes` produces an OpenTelemetry instrument with the unit `bytes` rather
-than `By`.
+The Micrometer base unit is used verbatim as the OpenTelemetry instrument unit, and meters
+registered without one have an empty unit. Base units are not translated to
+[UCUM](https://ucum.org/), which OpenTelemetry semantic conventions use, so the base unit `bytes`
+produces the unit `bytes` rather than `By`.
 
 Timing instruments use the registry's base time unit, which is seconds by default and can be changed
 with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`. It is reported as `ns`, `us`,
@@ -87,28 +82,25 @@ with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`. It is report
 
 ### Histograms
 
-Only Micrometer's service level objectives are mapped to the OpenTelemetry histogram's explicit
-bucket boundaries advice, and for a `Timer` they are converted from nanoseconds to the base time
-unit. `publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do **not**
-contribute bucket boundaries, so a `Timer` or `DistributionSummary` configured without service level
-objectives produces a histogram with no boundaries advice, leaving bucket selection to the
-OpenTelemetry SDK.
+Only Micrometer's service level objectives become the OpenTelemetry histogram's explicit bucket
+boundaries advice, converted from nanoseconds to the base time unit for a `Timer`.
+`publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do **not**
+contribute boundaries, so a `Timer` or `DistributionSummary` without service level objectives
+produces no boundaries advice, leaving bucket selection to the OpenTelemetry SDK.
 
-Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all. Percentiles and
-service level objectives can additionally be emitted as gauges by enabling
+Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all. Enabling
 `io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled`,
-which is experimental and may change at any time. These are Micrometer's own generated gauges, so
-they are named `<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le`
-attribute. Percentile gauges inherit the source meter's base unit, which for a `Timer` is empty even
-though the values are expressed in the base time unit, and bucket count gauges have no unit.
+which is experimental and may change at any time, additionally emits Micrometer's own gauges:
+`<name>.percentile` with a `phi` attribute and `<name>.histogram` with an `le` attribute. Percentile
+gauges inherit the source meter's base unit, which for a `Timer` is empty even though the values are
+in the base time unit; bucket count gauges have no unit.
 
-`LongTaskTimer` is the exception to the setting above: it is not bridged to an OpenTelemetry
-histogram, and it always emits the `<name>.percentile` and `<name>.histogram` gauges when
-percentiles or service level objectives are configured on it, regardless of whether the experimental
-setting is enabled.
+`LongTaskTimer` is the exception: it is not bridged to an OpenTelemetry histogram, so it always
+emits those gauges when percentiles or service level objectives are configured on it, regardless of
+the experimental setting.
 
 The decaying `<name>.max` gauge emitted alongside the `Timer` and `DistributionSummary` histograms
-is deprecated and will be removed in 3.0. OpenTelemetry histograms already carry a max, and the
+is deprecated and will be removed in 3.0: OpenTelemetry histograms already carry a max, and the
 `<name>` / `<name>.max` pair violates the OpenTelemetry metric naming rules. It is no longer emitted
 when `otel.instrumentation.common.v3-preview` is enabled.
 
@@ -120,41 +112,38 @@ Tag keys and values are passed through the registry's naming convention before b
 keys and values.
 
 Meter descriptions are deduplicated by the emitted OpenTelemetry instrument name: the first
-description registered for a given name is reused for every instrument that later shares that name,
-and a `null` description is mapped to an empty description.
+description registered for a name is reused by every instrument that later shares it, and a `null`
+description becomes an empty description.
 
-This reconciles a difference between the two data models. In Micrometer, each set of tags is a
-separate meter and may carry its own description, whereas in OpenTelemetry the description is one of
-an instrument's identifying fields. Bridging the descriptions through unchanged would therefore turn
-a single Micrometer metric into several conflicting OpenTelemetry instruments that share a name, so
-the SDK would emit duplicate registration warnings and export the tag sets as separate metric
-streams instead of aggregating them into one. Micrometer's own `PrometheusMeterRegistry` resolves
-this the same way, by keeping one description per metric.
+This reconciles a data model difference: in Micrometer each set of tags is a separate meter with its
+own description, while in OpenTelemetry the description is one of an instrument's identifying
+fields. Passing descriptions through unchanged would turn one Micrometer metric into several
+conflicting instruments sharing a name, which the SDK exports as separate metric streams instead of
+aggregating them, along with duplicate registration warnings. Micrometer's own
+`PrometheusMeterRegistry` resolves this the same way, by keeping one description per metric.
 
-The deduplication is scoped to the OpenTelemetry `MeterProvider` rather than to the Micrometer
-registry, so the description that wins depends on registration order, and registries sharing a
-`MeterProvider` share descriptions. Because the key is the name after the naming convention has been
-applied, meters that share a Micrometer name but map onto different instrument names — for example a
-`Counter` and a `Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and
-`foo.seconds` — each keep their own description.
+Deduplication is scoped to the OpenTelemetry `MeterProvider` rather than to the Micrometer registry,
+so the winning description depends on registration order, and registries sharing a `MeterProvider`
+share descriptions. Because the key is the emitted name, meters that share a Micrometer name but map
+onto different instrument names each keep their own description — for example a `Counter` and a
+`Timer` named `foo` in [prometheus mode](#prometheus-mode), which become `foo` and `foo.seconds`.
 
 ### Prometheus mode
 
-Prometheus mode approximates the naming behavior of Micrometer's `PrometheusMeterRegistry` and is
-intended for users exporting with the Prometheus exporter. It forces the base time unit to seconds
-and appends the unit to the instrument name. The naming convention keys off the Micrometer meter
-type, so `Timer`, `FunctionTimer`, and `LongTaskTimer` names get `.seconds`, while `Counter`,
-`FunctionCounter`, `DistributionSummary`, and `Gauge` names get their base unit appended when they
-have a non-empty one. Only custom `Meter` instruments are left unchanged.
+Prometheus mode approximates the naming behavior of Micrometer's `PrometheusMeterRegistry`, for
+users exporting with the Prometheus exporter. It forces the base time unit to seconds and appends
+the unit to the instrument name, keying off the Micrometer meter type: `Timer`, `FunctionTimer`, and
+`LongTaskTimer` get `.seconds`, while `Counter`, `FunctionCounter`, `DistributionSummary`, and
+`Gauge` get their base unit when they have a non-empty one. Only custom `Meter` instruments are
+unchanged.
 
-Any suffix from the table above is appended afterwards, so a `Timer` named `my.timer` produces the
-OpenTelemetry instrument `my.timer.seconds`, a `DistributionSummary` named `my.summary` with the
-base unit `bytes` produces `my.summary.bytes`, and a `FunctionTimer` named `my.function` produces
-`my.function.seconds.count` and `my.function.seconds.sum`.
-These are the OpenTelemetry instrument names; replacing `.` with `_` and appending `_total` to
-counters is left to the Prometheus exporter, so the final Prometheus series names differ. Encoding
-the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is disabled
-by default and should only be enabled for Prometheus compatibility.
+Any suffix from the table above is appended afterwards, so `my.timer` (a `Timer`) becomes
+`my.timer.seconds`, `my.summary` (a `DistributionSummary` with the base unit `bytes`) becomes
+`my.summary.bytes`, and `my.function` (a `FunctionTimer`) becomes `my.function.seconds.count` and
+`my.function.seconds.sum`. These are the OpenTelemetry instrument names; the Prometheus exporter
+still replaces `.` with `_` and appends `_total` to counters, so the final series names differ.
+Encoding the unit in the metric name is contrary to the OpenTelemetry naming rules, so this mode is
+disabled by default and should only be enabled for Prometheus compatibility.
 
 ```java
 MeterRegistry meterRegistry =

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -53,7 +53,7 @@ applied. The default convention passes the name through unchanged; see
 | `LongTaskTimer`       | asynchronous long up-down counter, asynchronous double up-down counter | `<name>.active`, `<name>.duration` | `{tasks}`, base time unit      |
 | `FunctionCounter`     | asynchronous double counter                                            | `<name>`                           | base unit                      |
 | `FunctionTimer`       | asynchronous long counter, asynchronous double counter                 | `<name>.count`, `<name>.sum`       | `{invocation}`, base time unit |
-| `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<name>.<statistic>`               | base unit                      |
+| `Meter` (custom)      | one instrument per `Measurement`, see below                            | `<raw name>.<statistic>`           | base unit                      |
 
 Notes:
 
@@ -75,7 +75,10 @@ Notes:
 - The `<name>.max` gauge is deprecated and will be removed in 3.0. It is no longer emitted when
   `otel.instrumentation.common.v3-preview` is enabled.
 - For a custom `Meter`, each measurement's `Statistic` determines the instrument type, and the name
-  suffix is the statistic's Micrometer tag value.
+  suffix is the statistic's Micrometer tag value. The naming convention is applied to the combined
+  `<raw name>.<statistic>`, where `<raw name>` is the Micrometer meter name before the convention,
+  so a custom `Meter` of type `COUNTER` named `my.meter` with the base unit `bytes` is emitted as
+  `my.meter.count.bytes` in [Prometheus mode](#prometheus-mode).
 
 ### Prometheus mode
 

--- a/instrumentation/micrometer/micrometer-1.5/library/README.md
+++ b/instrumentation/micrometer/micrometer-1.5/library/README.md
@@ -65,8 +65,8 @@ Notes:
   be changed with `OpenTelemetryMeterRegistryBuilder.setBaseTimeUnit(TimeUnit)`.
 - Only Micrometer's service level objectives become explicit bucket boundaries advice;
   `publishPercentileHistogram()`, `minimumExpectedValue`, and `maximumExpectedValue` do not.
-  Micrometer percentiles cannot be represented as an OpenTelemetry histogram at all, but percentiles
-  and service level objectives can additionally be emitted as `<name>.percentile` and
+  Micrometer percentiles cannot be represented as an OpenTelemetry histogram, but percentiles and
+  service level objectives can additionally be emitted as `<name>.percentile` and
   `<name>.histogram` gauges by enabling the experimental
   `Experimental#setMicrometerHistogramGaugesEnabled`.
 - Descriptions are deduplicated by instrument name, because in OpenTelemetry the description is one

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -46,14 +46,14 @@ final class Bridging {
   // unchanged would turn a single Micrometer metric into conflicting OpenTelemetry instruments that
   // share a name, which the SDK exports as separate metric streams instead of aggregating into one.
   // So the first description seen for an instrument name wins, which is also what Micrometer's own
-  // PrometheusMeterRegistry does. Note this is keyed on the name after the naming convention has
-  // been applied, since that is the name the conflict would occur on.
+  // PrometheusMeterRegistry does. Callers must pass the name the instrument is actually emitted
+  // under, including any suffix such as ".max", since that is the name a conflict would occur on.
   static String description(
-      io.opentelemetry.api.metrics.Meter otelMeter, String conventionName, Meter.Id id) {
+      io.opentelemetry.api.metrics.Meter otelMeter, String instrumentName, Meter.Id id) {
     return descriptionCaches
         .computeIfAbsent(otelMeter, meter -> new ConcurrentHashMap<>())
         .computeIfAbsent(
-            conventionName,
+            instrumentName,
             n -> {
               String description = id.getDescription();
               return description != null ? description : "";

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -36,9 +36,16 @@ final class Bridging {
     return namingConvention.name(id.getName(), id.getType(), id.getBaseUnit());
   }
 
-  static String description(Meter.Id id) {
+  // Micrometer allows every set of tags to carry its own description, while in OpenTelemetry the
+  // description is one of an instrument's identifying fields. Bridging the descriptions through
+  // unchanged would turn a single Micrometer metric into conflicting OpenTelemetry instruments that
+  // share a name, which the SDK exports as separate metric streams instead of aggregating into one.
+  // So the first description seen for an instrument name wins, which is also what Micrometer's own
+  // PrometheusMeterRegistry does. Note this is keyed on the name after the naming convention has
+  // been applied, since that is the name the conflict would occur on.
+  static String description(String conventionName, Meter.Id id) {
     return descriptionsCache.computeIfAbsent(
-        id.getName(),
+        conventionName,
         n -> {
           String description = id.getDescription();
           return description != null ? description : "";

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -11,12 +11,17 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 final class Bridging {
 
-  private static final ConcurrentMap<String, String> descriptionsCache = new ConcurrentHashMap<>();
+  // Scoped to the OpenTelemetry Meter, since that is where a description conflict would occur, and
+  // so that entries become collectable together with the meter provider. Registries sharing a meter
+  // provider deliberately share a cache.
+  private static final Cache<io.opentelemetry.api.metrics.Meter, ConcurrentMap<String, String>>
+      descriptionCaches = Cache.weak();
 
   static Attributes tagsAsAttributes(Meter.Id id, NamingConvention namingConvention) {
     Iterable<Tag> tags = id.getTagsAsIterable();
@@ -43,13 +48,16 @@ final class Bridging {
   // So the first description seen for an instrument name wins, which is also what Micrometer's own
   // PrometheusMeterRegistry does. Note this is keyed on the name after the naming convention has
   // been applied, since that is the name the conflict would occur on.
-  static String description(String conventionName, Meter.Id id) {
-    return descriptionsCache.computeIfAbsent(
-        conventionName,
-        n -> {
-          String description = id.getDescription();
-          return description != null ? description : "";
-        });
+  static String description(
+      io.opentelemetry.api.metrics.Meter otelMeter, String conventionName, Meter.Id id) {
+    return descriptionCaches
+        .computeIfAbsent(otelMeter, meter -> new ConcurrentHashMap<>())
+        .computeIfAbsent(
+            conventionName,
+            n -> {
+              String description = id.getDescription();
+              return description != null ? description : "";
+            });
   }
 
   static String baseUnit(Meter.Id id) {

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -11,17 +11,17 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 final class Bridging {
 
-  // Scoped to the OpenTelemetry Meter, since that is where a description conflict would occur, and
-  // so that entries become collectable together with the meter provider. Registries sharing a meter
-  // provider deliberately share a cache.
-  private static final Cache<io.opentelemetry.api.metrics.Meter, ConcurrentMap<String, String>>
-      descriptionCaches = Cache.weak();
+  private final ConcurrentMap<String, String> descriptionsCache = new ConcurrentHashMap<>();
+  private final boolean v3Preview;
+
+  Bridging(boolean v3Preview) {
+    this.v3Preview = v3Preview;
+  }
 
   static Attributes tagsAsAttributes(Meter.Id id, NamingConvention namingConvention) {
     Iterable<Tag> tags = id.getTagsAsIterable();
@@ -48,16 +48,13 @@ final class Bridging {
   // So the first description seen for an instrument name wins, which is also what Micrometer's own
   // PrometheusMeterRegistry does. Callers must pass the name the instrument is actually emitted
   // under, including any suffix such as ".max", since that is the name a conflict would occur on.
-  static String description(
-      io.opentelemetry.api.metrics.Meter otelMeter, String instrumentName, Meter.Id id) {
-    return descriptionCaches
-        .computeIfAbsent(otelMeter, meter -> new ConcurrentHashMap<>())
-        .computeIfAbsent(
-            instrumentName,
-            n -> {
-              String description = id.getDescription();
-              return description != null ? description : "";
-            });
+  String description(String instrumentName, Meter.Id id) {
+    return descriptionsCache.computeIfAbsent(
+        instrumentName,
+        n -> {
+          String description = id.getDescription();
+          return description != null ? description : "";
+        });
   }
 
   static String baseUnit(Meter.Id id) {
@@ -65,8 +62,8 @@ final class Bridging {
     return baseUnit == null ? "" : baseUnit;
   }
 
-  static String statisticInstrumentName(
-      Meter.Id id, Statistic statistic, NamingConvention namingConvention, boolean v3Preview) {
+  String statisticInstrumentName(
+      Meter.Id id, Statistic statistic, NamingConvention namingConvention) {
     // use "total_time" instead of "total" to avoid clashing with Statistic.TOTAL
     String statisticStr =
         statistic == Statistic.TOTAL_TIME ? "total_time" : statistic.getTagValueRepresentation();
@@ -75,6 +72,4 @@ final class Bridging {
     }
     return namingConvention.name(id.getName() + "." + statisticStr, id.getType(), id.getBaseUnit());
   }
-
-  private Bridging() {}
 }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -36,7 +36,7 @@ final class OpenTelemetryCounter extends AbstractMeter
     this.otelCounter =
         otelMeter
             .counterBuilder(conventionName)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -28,7 +28,8 @@ final class OpenTelemetryCounter extends AbstractMeter
 
   private volatile boolean removed = false;
 
-  OpenTelemetryCounter(Id id, NamingConvention namingConvention, Meter otelMeter) {
+  OpenTelemetryCounter(
+      Id id, NamingConvention namingConvention, Meter otelMeter, Bridging bridging) {
     super(id);
 
     this.attributes = tagsAsAttributes(id, namingConvention);
@@ -36,7 +37,7 @@ final class OpenTelemetryCounter extends AbstractMeter
     this.otelCounter =
         otelMeter
             .counterBuilder(conventionName)
-            .setDescription(Bridging.description(otelMeter, conventionName, id))
+            .setDescription(bridging.description(conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -36,7 +36,7 @@ final class OpenTelemetryCounter extends AbstractMeter
     this.otelCounter =
         otelMeter
             .counterBuilder(conventionName)
-            .setDescription(Bridging.description(conventionName, id))
+            .setDescription(Bridging.description(otelMeter, conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -74,7 +74,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(otelMeter, name, id))
+                .setDescription(Bridging.description(otelMeter, name + ".max", id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -66,7 +66,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -74,7 +74,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(id))
+                .setDescription(Bridging.description(name, id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -50,7 +50,8 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
       DistributionStatisticConfigModifier modifier,
       double scale,
       boolean emitMaxGauge,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id, clock, modifier.modify(distributionStatisticConfig), scale, false);
 
     if (isUsingMicrometerHistograms()) {
@@ -66,7 +67,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -74,7 +75,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(otelMeter, name + ".max", id))
+                .setDescription(bridging.description(name + ".max", id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -66,7 +66,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(baseUnit(id));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -74,7 +74,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(name, id))
+                .setDescription(Bridging.description(otelMeter, name, id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -37,7 +37,7 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name)
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -37,7 +37,7 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name)
             .ofDoubles()
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -29,7 +29,8 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
       NamingConvention namingConvention,
       T obj,
       ToDoubleFunction<T> countFunction,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
 
     String name = name(id, namingConvention);
@@ -37,7 +38,7 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name)
             .ofDoubles()
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(Bridging.description(otelMeter, name + ".count", id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +53,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(Bridging.description(otelMeter, name + ".sum", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +53,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -35,7 +35,8 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
       ToDoubleFunction<T> totalTimeFunction,
       TimeUnit totalTimeFunctionUnit,
       TimeUnit baseTimeUnit,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
     this.baseTimeUnit = baseTimeUnit;
 
@@ -45,7 +46,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(otelMeter, name + ".count", id))
+            .setDescription(bridging.description(name + ".count", id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +54,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(otelMeter, name + ".sum", id))
+            .setDescription(bridging.description(name + ".sum", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +53,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -37,7 +37,7 @@ final class OpenTelemetryGauge<T> extends AbstractMeter
     observableGauge =
         otelMeter
             .gaugeBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -37,7 +37,7 @@ final class OpenTelemetryGauge<T> extends AbstractMeter
     observableGauge =
         otelMeter
             .gaugeBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -30,14 +30,15 @@ final class OpenTelemetryGauge<T> extends AbstractMeter
       NamingConvention namingConvention,
       @Nullable T obj,
       ToDoubleFunction<T> objMetric,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
 
     String name = name(id, namingConvention);
     observableGauge =
         otelMeter
             .gaugeBuilder(name)
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(Bridging.description(otelMeter, name + ".active", id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +53,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(Bridging.description(otelMeter, name + ".duration", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +53,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -34,7 +34,8 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
       Clock clock,
       TimeUnit baseTimeUnit,
       DistributionStatisticConfig distributionStatisticConfig,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id, clock, baseTimeUnit, distributionStatisticConfig, false);
 
     this.distributionStatisticConfig = distributionStatisticConfig;
@@ -45,7 +46,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(otelMeter, name + ".active", id))
+            .setDescription(bridging.description(name + ".active", id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +54,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(otelMeter, name + ".duration", id))
+            .setDescription(bridging.description(name + ".duration", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +53,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -37,7 +37,7 @@ final class OpenTelemetryMeter extends AbstractMeter
     for (Measurement measurement : measurements) {
       String name =
           statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
-      String description = Bridging.description(id);
+      String description = Bridging.description(name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -35,7 +35,7 @@ final class OpenTelemetryMeter extends AbstractMeter
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
       String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
-      String description = Bridging.description(name, id);
+      String description = Bridging.description(otelMeter, name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -35,9 +35,8 @@ final class OpenTelemetryMeter extends AbstractMeter
 
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
-      String name =
-          statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
-      String description = Bridging.description(name, id);
+      String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
+      String description = Bridging.description(otelMeter, name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.baseUnit;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.statisticInstrumentName;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 import static java.util.Collections.emptyList;
 
@@ -28,15 +27,16 @@ final class OpenTelemetryMeter extends AbstractMeter
       Id id,
       NamingConvention namingConvention,
       Iterable<Measurement> measurements,
-      boolean v3Preview,
-      io.opentelemetry.api.metrics.Meter otelMeter) {
+      io.opentelemetry.api.metrics.Meter otelMeter,
+      Bridging bridging) {
     super(id);
     Attributes attributes = tagsAsAttributes(id, namingConvention);
 
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
-      String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
-      String description = Bridging.description(otelMeter, name, id);
+      String name =
+          bridging.statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
+      String description = bridging.description(name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -35,7 +35,7 @@ final class OpenTelemetryMeter extends AbstractMeter
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
       String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
-      String description = Bridging.description(id);
+      String description = Bridging.description(name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -49,10 +49,10 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
     return new OpenTelemetryMeterRegistryBuilder(openTelemetry);
   }
 
+  private final Bridging bridging;
   private final TimeUnit baseTimeUnit;
   private final DistributionStatisticConfigModifier distributionStatisticConfigModifier;
   private final boolean emitMaxGauge;
-  private final boolean v3Preview;
   private final io.opentelemetry.api.metrics.Meter otelMeter;
 
   OpenTelemetryMeterRegistry(
@@ -63,10 +63,10 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
       boolean v3Preview,
       io.opentelemetry.api.metrics.Meter otelMeter) {
     super(clock);
+    this.bridging = new Bridging(v3Preview);
     this.baseTimeUnit = baseTimeUnit;
     this.distributionStatisticConfigModifier = distributionStatisticConfigModifier;
     this.emitMaxGauge = !v3Preview;
-    this.v3Preview = v3Preview;
     this.otelMeter = otelMeter;
 
     this.config()
@@ -76,12 +76,13 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
 
   @Override
   protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
-    return new OpenTelemetryGauge<>(id, config().namingConvention(), obj, valueFunction, otelMeter);
+    return new OpenTelemetryGauge<>(
+        id, config().namingConvention(), obj, valueFunction, otelMeter, bridging);
   }
 
   @Override
   protected Counter newCounter(Meter.Id id) {
-    return new OpenTelemetryCounter(id, config().namingConvention(), otelMeter);
+    return new OpenTelemetryCounter(id, config().namingConvention(), otelMeter, bridging);
   }
 
   @Override
@@ -94,7 +95,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             clock,
             getBaseTimeUnit(),
             distributionStatisticConfig,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (timer.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(timer, this);
     }
@@ -116,7 +118,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             pauseDetector,
             getBaseTimeUnit(),
             emitMaxGauge,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (timer.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(timer, this);
     }
@@ -135,7 +138,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             distributionStatisticConfigModifier,
             scale,
             emitMaxGauge,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (distributionSummary.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(distributionSummary, this);
     }
@@ -145,7 +149,7 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
   @Override
   protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
     return new OpenTelemetryMeter(
-        id, config().namingConvention(), measurements, v3Preview, otelMeter);
+        id, config().namingConvention(), measurements, otelMeter, bridging);
   }
 
   @Override
@@ -163,14 +167,15 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
         totalTimeFunction,
         totalTimeFunctionUnit,
         getBaseTimeUnit(),
-        otelMeter);
+        otelMeter,
+        bridging);
   }
 
   @Override
   protected <T> FunctionCounter newFunctionCounter(
       Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
     return new OpenTelemetryFunctionCounter<>(
-        id, config().namingConvention(), obj, countFunction, otelMeter);
+        id, config().namingConvention(), obj, countFunction, otelMeter, bridging);
   }
 
   @Override

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -78,7 +78,7 @@ final class OpenTelemetryTimer extends AbstractTimer
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(Bridging.description(otelMeter, name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig, baseTimeUnit);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -86,7 +86,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(name, id))
+                .setDescription(Bridging.description(otelMeter, name, id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -78,7 +78,7 @@ final class OpenTelemetryTimer extends AbstractTimer
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig, baseTimeUnit);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -86,7 +86,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(id))
+                .setDescription(Bridging.description(name, id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -55,7 +55,8 @@ final class OpenTelemetryTimer extends AbstractTimer
       PauseDetector pauseDetector,
       TimeUnit baseTimeUnit,
       boolean emitMaxGauge,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(
         id,
         clock,
@@ -78,7 +79,7 @@ final class OpenTelemetryTimer extends AbstractTimer
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(otelMeter, name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig, baseTimeUnit);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -86,7 +87,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(otelMeter, name + ".max", id))
+                .setDescription(bridging.description(name + ".max", id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -86,7 +86,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(otelMeter, name, id))
+                .setDescription(Bridging.description(otelMeter, name + ".max", id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
@@ -5,14 +5,18 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 class DescriptionDeduplicationTest {
@@ -53,6 +57,37 @@ class DescriptionDeduplicationTest {
           .singleElement()
           .extracting(MetricData::getDescription)
           .isEqualTo("Second description");
+    }
+  }
+
+  @Test
+  void descriptionsAreDeduplicatedOnTheSuffixedInstrumentName() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    AtomicLong count = new AtomicLong(1);
+
+    try (SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+
+      MeterRegistry registry =
+          OpenTelemetryMeterRegistry.builder(
+                  OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build())
+              .build();
+
+      // emits testSuffix.sum as an async double counter with unit s, colliding with the function
+      // counter below
+      FunctionTimer.builder("testSuffix", count, AtomicLong::get, AtomicLong::doubleValue, SECONDS)
+          .description("First description")
+          .register(registry);
+      FunctionCounter.builder("testSuffix.sum", count, AtomicLong::doubleValue)
+          .description("Second description")
+          .baseUnit("s")
+          .register(registry);
+
+      assertThat(reader.collectAllMetrics())
+          .filteredOn(metric -> metric.getName().equals("testSuffix.sum"))
+          .singleElement()
+          .extracting(MetricData::getDescription)
+          .isEqualTo("First description");
     }
   }
 }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.micrometer.v1_5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+
+class DescriptionDeduplicationTest {
+
+  @Test
+  void descriptionsAreNotSharedAcrossMeterProviders() {
+    InMemoryMetricReader firstReader = InMemoryMetricReader.create();
+    InMemoryMetricReader secondReader = InMemoryMetricReader.create();
+
+    try (SdkMeterProvider firstMeterProvider =
+            SdkMeterProvider.builder().registerMetricReader(firstReader).build();
+        SdkMeterProvider secondMeterProvider =
+            SdkMeterProvider.builder().registerMetricReader(secondReader).build()) {
+
+      MeterRegistry firstRegistry =
+          OpenTelemetryMeterRegistry.builder(
+                  OpenTelemetrySdk.builder().setMeterProvider(firstMeterProvider).build())
+              .build();
+      MeterRegistry secondRegistry =
+          OpenTelemetryMeterRegistry.builder(
+                  OpenTelemetrySdk.builder().setMeterProvider(secondMeterProvider).build())
+              .build();
+
+      Counter.builder("testCounter")
+          .description("First description")
+          .register(firstRegistry)
+          .increment();
+      Counter.builder("testCounter")
+          .description("Second description")
+          .register(secondRegistry)
+          .increment();
+
+      assertThat(firstReader.collectAllMetrics())
+          .singleElement()
+          .extracting(MetricData::getDescription)
+          .isEqualTo("First description");
+      assertThat(secondReader.collectAllMetrics())
+          .singleElement()
+          .extracting(MetricData::getDescription)
+          .isEqualTo("Second description");
+    }
+  }
+}

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
@@ -22,23 +22,16 @@ import org.junit.jupiter.api.Test;
 class DescriptionDeduplicationTest {
 
   @Test
-  void descriptionsAreNotSharedAcrossMeterProviders() {
-    InMemoryMetricReader firstReader = InMemoryMetricReader.create();
-    InMemoryMetricReader secondReader = InMemoryMetricReader.create();
+  void descriptionsAreNotSharedAcrossRegistries() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
 
-    try (SdkMeterProvider firstMeterProvider =
-            SdkMeterProvider.builder().registerMetricReader(firstReader).build();
-        SdkMeterProvider secondMeterProvider =
-            SdkMeterProvider.builder().registerMetricReader(secondReader).build()) {
+    try (SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+      OpenTelemetrySdk openTelemetry =
+          OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
 
-      MeterRegistry firstRegistry =
-          OpenTelemetryMeterRegistry.builder(
-                  OpenTelemetrySdk.builder().setMeterProvider(firstMeterProvider).build())
-              .build();
-      MeterRegistry secondRegistry =
-          OpenTelemetryMeterRegistry.builder(
-                  OpenTelemetrySdk.builder().setMeterProvider(secondMeterProvider).build())
-              .build();
+      MeterRegistry firstRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).build();
+      MeterRegistry secondRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).build();
 
       Counter.builder("testCounter")
           .description("First description")
@@ -49,14 +42,9 @@ class DescriptionDeduplicationTest {
           .register(secondRegistry)
           .increment();
 
-      assertThat(firstReader.collectAllMetrics())
-          .singleElement()
+      assertThat(reader.collectAllMetrics())
           .extracting(MetricData::getDescription)
-          .isEqualTo("First description");
-      assertThat(secondReader.collectAllMetrics())
-          .singleElement()
-          .extracting(MetricData::getDescription)
-          .isEqualTo("Second description");
+          .containsExactlyInAnyOrder("First description", "Second description");
     }
   }
 

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
@@ -373,6 +373,45 @@ public abstract class AbstractPrometheusModeTest {
   }
 
   @Test
+  void testSameNameDifferentTypeKeepsOwnDescription() {
+    // given a counter and a timer that share a Micrometer name, but that the prometheus naming
+    // convention maps onto two different OpenTelemetry instrument names
+    Counter counter =
+        Counter.builder("testPrometheusSharedName")
+            .description("This is a test counter")
+            .tags("type", "counter")
+            .baseUnit("")
+            .register(Metrics.globalRegistry);
+    Timer timer =
+        Timer.builder("testPrometheusSharedName")
+            .description("This is a test timer")
+            .tags("type", "timer")
+            .register(Metrics.globalRegistry);
+
+    // when
+    counter.increment(12);
+    timer.record(1, SECONDS);
+
+    // then each instrument keeps its own description
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName")
+                    .hasDescription("This is a test counter")
+                    .hasDoubleSumSatisfying(sum -> sum.isMonotonic()));
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName.seconds")
+                    .hasDescription("This is a test timer")
+                    .hasHistogramSatisfying(histogram -> {}));
+  }
+
+  @Test
   void testTimerCustomBucketBoundaryFormatting() {
     // given
     Timer timer =

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
@@ -332,6 +332,45 @@ public abstract class AbstractPrometheusModeTest {
   }
 
   @Test
+  void testSameNameDifferentTypeKeepsOwnDescription() {
+    // given a counter and a timer that share a Micrometer name, but that the prometheus naming
+    // convention maps onto two different OpenTelemetry instrument names
+    Counter counter =
+        Counter.builder("testPrometheusSharedName")
+            .description("This is a test counter")
+            .tags("type", "counter")
+            .baseUnit("")
+            .register(Metrics.globalRegistry);
+    Timer timer =
+        Timer.builder("testPrometheusSharedName")
+            .description("This is a test timer")
+            .tags("type", "timer")
+            .register(Metrics.globalRegistry);
+
+    // when
+    counter.increment(12);
+    timer.record(1, SECONDS);
+
+    // then each instrument keeps its own description
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName")
+                    .hasDescription("This is a test counter")
+                    .hasDoubleSumSatisfying(sum -> sum.isMonotonic()));
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName.seconds")
+                    .hasDescription("This is a test timer")
+                    .hasHistogramSatisfying(histogram -> {}));
+  }
+
+  @Test
   void testTimerCustomBucketBoundaryFormatting() {
     // given
     Timer timer =


### PR DESCRIPTION
Groundwork for #13867.

Stacked on #19463, which fixes the custom `Meter` statistic naming behind `otel.instrumentation.common.v3-preview`. The README section here documents both orderings, and `Bridging` becoming a per-registry instance lets that PR's `v3Preview` parameter collapse into a field.

Adds a README section describing how each Micrometer instrument is mapped onto OpenTelemetry instruments, covering names, units, histograms, prometheus mode, and which reads are unsupported.

Writing it surfaced two problems with the description cache, both fixed here.

Some background first. Micrometer allows every set of tags to carry its own description, while in OpenTelemetry the description is one of an instrument's identifying fields. Bridging descriptions through unchanged would turn a single Micrometer metric into conflicting OpenTelemetry instruments sharing a name, which the SDK exports as separate metric streams rather than aggregating into one. So within each registry the bridge keeps only the first description seen for a name, matching what Micrometer's own `PrometheusMeterRegistry` does. This is inherent to the two data models ([java#4381](https://github.com/open-telemetry/opentelemetry-java/issues/4381), [java#4510](https://github.com/open-telemetry/opentelemetry-java/issues/4510)) rather than something waiting on an SDK fix, and the comment explaining it — dropped when the class moved back from `opentelemetry-java` in #6538 — is restored and reworded.

**The cache was keyed on the wrong name.** #5452 keyed it on the name after the naming convention had been applied, but it came back from #6538 keyed on the raw Micrometer name. Meters sharing a Micrometer name but mapping onto different instrument names therefore incorrectly shared a description. This is reachable in prometheus mode, because `Meter.Id` identity is name plus tags only — a `Counter` `foo` and a `Timer` `foo` both register, and become `foo` and `foo.seconds`.

**The cache was static**, so descriptions were deduplicated across every registry in the process, and entries were never released. It is now scoped to each `OpenTelemetryMeterRegistry`, so entries become collectable with the registry and description selection does not depend on whether a `MeterProvider` reuses `Meter` instances. Multiple registries intentionally make independent description choices.

Both fixes are covered by tests that I confirmed fail without them.

One thing I'm deliberately not changing: within a single registry the cache is still unbounded, so an application generating meter names dynamically grows it. Restoring #5452's `Cache.bounded(1024)` doesn't seem worth it. `MetricStorageRegistry` has no removal API at all — closing an async instrument only unregisters its callback — so the SDK already retains a heavier entry per distinct name for the life of the provider, and capping the bridge's cache wouldn't cap overall growth. A bound also reintroduces eviction, where an evicted name re-seeds from whichever description arrives next and silently produces the split metric streams the cache exists to prevent.
