### PR TITLE
Add AWS SigV4 sensitive query parameters

### DIFF
--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -1130,7 +1130,7 @@ definitions:
       description: List of URL query parameter names whose values are redacted in
         URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
       type: list
-      default: AWSAccessKeyId,Signature,sig,X-Goog-Signature
+      default: X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature
   metrics:
     db.client.connection.count-2e6ba9b7:
       name: db.client.connection.count

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -1130,7 +1130,7 @@ definitions:
       description: List of URL query parameter names whose values are redacted in
         URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
       type: list
-      default: X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature
+      default: AWSAccessKeyId,Signature,X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature
   metrics:
     db.client.connection.count-2e6ba9b7:
       name: db.client.connection.count

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpConstants.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpConstants.java
@@ -26,7 +26,13 @@ public final class HttpConstants {
 
   public static final Set<String> SENSITIVE_QUERY_PARAMETERS =
       unmodifiableSet(
-          new HashSet<>(asList("AWSAccessKeyId", "Signature", "sig", "X-Goog-Signature")));
+          new HashSet<>(
+              asList(
+                  "X-Amz-Signature",
+                  "X-Amz-Credential",
+                  "X-Amz-Security-Token",
+                  "sig",
+                  "X-Goog-Signature")));
 
   public static final String _OTHER = "_OTHER";
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpConstants.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpConstants.java
@@ -28,6 +28,8 @@ public final class HttpConstants {
       unmodifiableSet(
           new HashSet<>(
               asList(
+                  "AWSAccessKeyId",
+                  "Signature",
                   "X-Amz-Signature",
                   "X-Amz-Credential",
                   "X-Amz-Security-Token",

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerAttributesExtractorTest.java
@@ -554,21 +554,23 @@ class HttpServerAttributesExtractorTest {
   @ParameterizedTest
   @CsvSource({
     "paramA=valA&paramB=valB, paramA=valA&paramB=valB",
+    "AWSAccessKeyId=AKIAIOSFODNN7, AWSAccessKeyId=REDACTED",
+    "Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, Signature=REDACTED",
     "X-Amz-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, X-Amz-Signature=REDACTED",
     "X-Amz-Credential=AKIAIOSFODNN7%2F20260101%2Fus-east-1%2Fs3%2Faws4_request, X-Amz-Credential=REDACTED",
     "X-Amz-Security-Token=FwoGZXIvYXdzEBYaDG, X-Amz-Security-Token=REDACTED",
     "sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, sig=REDACTED",
     "X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, X-Goog-Signature=REDACTED",
-    "paramA=valA&X-Amz-Signature=AKIAIOSFODNN7&paramB=valB, paramA=valA&X-Amz-Signature=REDACTED&paramB=valB",
-    "X-Amz-Signature=AKIAIOSFODNN7&paramA=valA, X-Amz-Signature=REDACTED&paramA=valA",
-    "paramA=valA&X-Amz-Signature=AKIAIOSFODNN7, paramA=valA&X-Amz-Signature=REDACTED",
-    "X-Amz-Signature=AKIAIOSFODNN7&X-Amz-Signature=ZGIAIOSFODNN7, X-Amz-Signature=REDACTED&X-Amz-Signature=REDACTED",
-    "X-Amz-Signature=AKIAIOSFODNN7#ref, X-Amz-Signature=REDACTED#ref",
-    "X-Amz-Signature=AKIAIOSFODNN7&aa&bb, X-Amz-Signature=REDACTED&aa&bb",
-    "aa&bb&X-Amz-Signature=AKIAIOSFODNN7, aa&bb&X-Amz-Signature=REDACTED",
-    "X-Amz-Signature=AKIAIOSFODNN7&&, X-Amz-Signature=REDACTED&&",
-    "&&X-Amz-Signature=AKIAIOSFODNN7, &&X-Amz-Signature=REDACTED",
-    "X-Amz-Signature=AKIAIOSFODNN7&a&b#fragment, X-Amz-Signature=REDACTED&a&b#fragment"
+    "paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
+    "AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, AWSAccessKeyId=REDACTED&paramA=valA",
+    "paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, paramA=valA&AWSAccessKeyId=REDACTED",
+    "AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
+    "AWSAccessKeyId=AKIAIOSFODNN7#ref, AWSAccessKeyId=REDACTED#ref",
+    "AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, AWSAccessKeyId=REDACTED&aa&bb",
+    "aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, aa&bb&AWSAccessKeyId=REDACTED",
+    "AWSAccessKeyId=AKIAIOSFODNN7&&, AWSAccessKeyId=REDACTED&&",
+    "&&AWSAccessKeyId=AKIAIOSFODNN7, &&AWSAccessKeyId=REDACTED",
+    "AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, AWSAccessKeyId=REDACTED&a&b#fragment"
   })
   void shouldRedactQueryParameters(String urlQuery, String expectedQuery) {
     Map<String, String> request = new HashMap<>();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpServerAttributesExtractorTest.java
@@ -554,20 +554,21 @@ class HttpServerAttributesExtractorTest {
   @ParameterizedTest
   @CsvSource({
     "paramA=valA&paramB=valB, paramA=valA&paramB=valB",
-    "AWSAccessKeyId=AKIAIOSFODNN7, AWSAccessKeyId=REDACTED",
-    "Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, Signature=REDACTED",
+    "X-Amz-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, X-Amz-Signature=REDACTED",
+    "X-Amz-Credential=AKIAIOSFODNN7%2F20260101%2Fus-east-1%2Fs3%2Faws4_request, X-Amz-Credential=REDACTED",
+    "X-Amz-Security-Token=FwoGZXIvYXdzEBYaDG, X-Amz-Security-Token=REDACTED",
     "sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, sig=REDACTED",
     "X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, X-Goog-Signature=REDACTED",
-    "paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
-    "AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, AWSAccessKeyId=REDACTED&paramA=valA",
-    "paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, paramA=valA&AWSAccessKeyId=REDACTED",
-    "AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
-    "AWSAccessKeyId=AKIAIOSFODNN7#ref, AWSAccessKeyId=REDACTED#ref",
-    "AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, AWSAccessKeyId=REDACTED&aa&bb",
-    "aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, aa&bb&AWSAccessKeyId=REDACTED",
-    "AWSAccessKeyId=AKIAIOSFODNN7&&, AWSAccessKeyId=REDACTED&&",
-    "&&AWSAccessKeyId=AKIAIOSFODNN7, &&AWSAccessKeyId=REDACTED",
-    "AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, AWSAccessKeyId=REDACTED&a&b#fragment"
+    "paramA=valA&X-Amz-Signature=AKIAIOSFODNN7&paramB=valB, paramA=valA&X-Amz-Signature=REDACTED&paramB=valB",
+    "X-Amz-Signature=AKIAIOSFODNN7&paramA=valA, X-Amz-Signature=REDACTED&paramA=valA",
+    "paramA=valA&X-Amz-Signature=AKIAIOSFODNN7, paramA=valA&X-Amz-Signature=REDACTED",
+    "X-Amz-Signature=AKIAIOSFODNN7&X-Amz-Signature=ZGIAIOSFODNN7, X-Amz-Signature=REDACTED&X-Amz-Signature=REDACTED",
+    "X-Amz-Signature=AKIAIOSFODNN7#ref, X-Amz-Signature=REDACTED#ref",
+    "X-Amz-Signature=AKIAIOSFODNN7&aa&bb, X-Amz-Signature=REDACTED&aa&bb",
+    "aa&bb&X-Amz-Signature=AKIAIOSFODNN7, aa&bb&X-Amz-Signature=REDACTED",
+    "X-Amz-Signature=AKIAIOSFODNN7&&, X-Amz-Signature=REDACTED&&",
+    "&&X-Amz-Signature=AKIAIOSFODNN7, &&X-Amz-Signature=REDACTED",
+    "X-Amz-Signature=AKIAIOSFODNN7&a&b#fragment, X-Amz-Signature=REDACTED&a&b#fragment"
   })
   void shouldRedactQueryParameters(String urlQuery, String expectedQuery) {
     Map<String, String> request = new HashMap<>();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
@@ -35,20 +35,21 @@ class UrlSanitizerTest {
     "user1:secret@github.com, user1:secret@github.com",
     "https://github.com@, https://github.com@",
     "https://service.com?paramA=valA&paramB=valB, https://service.com?paramA=valA&paramB=valB",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED",
-    "https://service.com?Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, https://service.com?Signature=REDACTED",
+    "https://service.com?X-Amz-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Amz-Signature=REDACTED",
+    "https://service.com?X-Amz-Credential=AKIAIOSFODNN7%2F20260101%2Fus-east-1%2Fs3%2Faws4_request, https://service.com?X-Amz-Credential=REDACTED",
+    "https://service.com?X-Amz-Security-Token=FwoGZXIvYXdzEBYaDG, https://service.com?X-Amz-Security-Token=REDACTED",
     "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?sig=REDACTED",
     "https://service.com?X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Goog-Signature=REDACTED",
-    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, https://service.com?AWSAccessKeyId=REDACTED&paramA=valA",
-    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7#ref, https://service.com?AWSAccessKeyId=REDACTED#ref",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, https://service.com?AWSAccessKeyId=REDACTED&aa&bb",
-    "https://service.com?aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?aa&bb&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&&, https://service.com?AWSAccessKeyId=REDACTED&&",
-    "https://service.com?&&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?&&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, https://service.com?AWSAccessKeyId=REDACTED&a&b#fragment"
+    "https://service.com?paramA=valA&X-Amz-Signature=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&X-Amz-Signature=REDACTED&paramB=valB",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&paramA=valA, https://service.com?X-Amz-Signature=REDACTED&paramA=valA",
+    "https://service.com?paramA=valA&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?paramA=valA&X-Amz-Signature=REDACTED",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&X-Amz-Signature=ZGIAIOSFODNN7, https://service.com?X-Amz-Signature=REDACTED&X-Amz-Signature=REDACTED",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7#ref, https://service.com?X-Amz-Signature=REDACTED#ref",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&aa&bb, https://service.com?X-Amz-Signature=REDACTED&aa&bb",
+    "https://service.com?aa&bb&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?aa&bb&X-Amz-Signature=REDACTED",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&&, https://service.com?X-Amz-Signature=REDACTED&&",
+    "https://service.com?&&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?&&X-Amz-Signature=REDACTED",
+    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&a&b#fragment, https://service.com?X-Amz-Signature=REDACTED&a&b#fragment"
   })
   void shouldRedactUserInfoAndQueryParameters(String url, String expectedResult) {
     assertThat(UrlSanitizer.sanitizeUrl(url, HttpConstants.SENSITIVE_QUERY_PARAMETERS))

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
@@ -35,21 +35,23 @@ class UrlSanitizerTest {
     "user1:secret@github.com, user1:secret@github.com",
     "https://github.com@, https://github.com@",
     "https://service.com?paramA=valA&paramB=valB, https://service.com?paramA=valA&paramB=valB",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED",
+    "https://service.com?Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, https://service.com?Signature=REDACTED",
     "https://service.com?X-Amz-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Amz-Signature=REDACTED",
     "https://service.com?X-Amz-Credential=AKIAIOSFODNN7%2F20260101%2Fus-east-1%2Fs3%2Faws4_request, https://service.com?X-Amz-Credential=REDACTED",
     "https://service.com?X-Amz-Security-Token=FwoGZXIvYXdzEBYaDG, https://service.com?X-Amz-Security-Token=REDACTED",
     "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?sig=REDACTED",
     "https://service.com?X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Goog-Signature=REDACTED",
-    "https://service.com?paramA=valA&X-Amz-Signature=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&X-Amz-Signature=REDACTED&paramB=valB",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&paramA=valA, https://service.com?X-Amz-Signature=REDACTED&paramA=valA",
-    "https://service.com?paramA=valA&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?paramA=valA&X-Amz-Signature=REDACTED",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&X-Amz-Signature=ZGIAIOSFODNN7, https://service.com?X-Amz-Signature=REDACTED&X-Amz-Signature=REDACTED",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7#ref, https://service.com?X-Amz-Signature=REDACTED#ref",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&aa&bb, https://service.com?X-Amz-Signature=REDACTED&aa&bb",
-    "https://service.com?aa&bb&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?aa&bb&X-Amz-Signature=REDACTED",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&&, https://service.com?X-Amz-Signature=REDACTED&&",
-    "https://service.com?&&X-Amz-Signature=AKIAIOSFODNN7, https://service.com?&&X-Amz-Signature=REDACTED",
-    "https://service.com?X-Amz-Signature=AKIAIOSFODNN7&a&b#fragment, https://service.com?X-Amz-Signature=REDACTED&a&b#fragment"
+    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, https://service.com?AWSAccessKeyId=REDACTED&paramA=valA",
+    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7#ref, https://service.com?AWSAccessKeyId=REDACTED#ref",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, https://service.com?AWSAccessKeyId=REDACTED&aa&bb",
+    "https://service.com?aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?aa&bb&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&&, https://service.com?AWSAccessKeyId=REDACTED&&",
+    "https://service.com?&&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?&&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, https://service.com?AWSAccessKeyId=REDACTED&a&b#fragment"
   })
   void shouldRedactUserInfoAndQueryParameters(String url, String expectedResult) {
     assertThat(UrlSanitizer.sanitizeUrl(url, HttpConstants.SENSITIVE_QUERY_PARAMETERS))

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -94,7 +94,7 @@ configurations:
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: "List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans."
     type: list
-    default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+    default: "X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
 
   common.db.query-sanitization.enabled:
     name: otel.instrumentation.common.db.query-sanitization.enabled

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -94,7 +94,7 @@ configurations:
     declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: "List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans."
     type: list
-    default: "X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
+    default: "AWSAccessKeyId,Signature,X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
 
   common.db.query-sanitization.enabled:
     name: otel.instrumentation.common.db.query-sanitization.enabled

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -572,7 +572,7 @@
       "name": "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters",
       "type": "java.util.List<java.lang.String>",
       "description": "List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.",
-      "defaultValue": "AWSAccessKeyId,Signature,sig,X-Goog-Signature"
+      "defaultValue": "X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
     },
     {
       "name": "otel.instrumentation.spring-web.enabled",

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -572,7 +572,7 @@
       "name": "otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters",
       "type": "java.util.List<java.lang.String>",
       "description": "List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.",
-      "defaultValue": "X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
+      "defaultValue": "AWSAccessKeyId,Signature,X-Amz-Signature,X-Amz-Credential,X-Amz-Security-Token,sig,X-Goog-Signature"
     },
     {
       "name": "otel.instrumentation.spring-web.enabled",


### PR DESCRIPTION
Adds `X-Amz-Signature`, `X-Amz-Credential`, and `X-Amz-Security-Token` to the default sensitive query parameter list.

See https://github.com/open-telemetry/semantic-conventions/pull/3779 and https://github.com/open-telemetry/semantic-conventions/pull/3989