### PR TITLE
Rename remaining setCaptured* to setCapture* for a single convention

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -44,10 +44,20 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setCapturedHeaders(
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setCaptureHeaders(
       Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setCapturedHeaders(
+      Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -41,7 +41,7 @@ public class TracingRequestHandler extends RequestHandler2 {
                   .getBoolean("experimental_span_attributes/development", false))
           .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .build()
           .createRequestHandler();
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
@@ -46,7 +46,7 @@ public final class TracingRequestHandler extends RequestHandler2 {
                     SystemProperty.getBoolean(
                         "otel.instrumentation.messaging.experimental.receive-telemetry.enabled",
                         false)))
-        .setCapturedHeaders(
+        .setCaptureHeaders(
             messaging.getScalarList(
                 "capture_headers/development",
                 String.class,

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
@@ -32,9 +32,18 @@ public final class AwsSdkTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public AwsSdkTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -98,7 +98,7 @@ public final class AwsSdkInstrumenterFactory {
   private <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> messagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/SqsTracingTest.java
@@ -28,7 +28,7 @@ class SqsTracingTest extends AbstractSqsTracingTest {
         AwsSdkTelemetry.builder(testing().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
             .setMessagingReceiveTelemetryEnabled(true)
-            .setCapturedHeaders(singletonList("Test-Message-Header"))
+            .setCaptureHeaders(singletonList("Test-Message-Header"))
             .build()
             .createRequestHandler());
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
@@ -36,9 +36,18 @@ public final class AwsSdkTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public AwsSdkTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -127,7 +127,7 @@ public final class AwsSdkInstrumenterFactory {
   private <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> messagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, MessageOperation operation) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkTelemetryFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkTelemetryFactory.java
@@ -42,7 +42,7 @@ public final class AwsSdkTelemetryFactory {
         DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "aws_sdk");
 
     return AwsSdkTelemetry.builder(openTelemetry)
-        .setCapturedHeaders(
+        .setCaptureHeaders(
             messaging.getScalarList(
                 "capture_headers/development",
                 String.class,

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/Aws2SqsTracingTest.java
@@ -33,7 +33,7 @@ abstract class Aws2SqsTracingTest extends AbstractAws2SqsTracingTest {
         AwsSdkTelemetry.builder(getTesting().getOpenTelemetry())
             .setCaptureExperimentalSpanAttributes(true)
             .setMessagingReceiveTelemetryEnabled(true)
-            .setCapturedHeaders(singletonList("Test-Message-Header"));
+            .setCaptureHeaders(singletonList("Test-Message-Header"));
 
     configure(telemetryBuilder);
     telemetry = telemetryBuilder.build();

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -61,8 +61,8 @@ public class GrpcSingletons {
         GrpcTelemetry.builder(GlobalOpenTelemetry.get())
             .setEmitMessageEvents(emitMessageEvents)
             .setCaptureExperimentalSpanAttributes(experimentalSpanAttributes)
-            .setCapturedClientRequestMetadata(clientRequestMetadata)
-            .setCapturedServerRequestMetadata(serverRequestMetadata)
+            .setCaptureClientRequestMetadata(clientRequestMetadata)
+            .setCaptureServerRequestMetadata(serverRequestMetadata)
             .build();
 
     clientInterceptor = telemetry.createClientInterceptor();

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -139,18 +139,38 @@ public final class GrpcTelemetryBuilder {
 
   /** Sets which metadata request values should be captured as span attributes on client spans. */
   @CanIgnoreReturnValue
-  public GrpcTelemetryBuilder setCapturedClientRequestMetadata(
+  public GrpcTelemetryBuilder setCaptureClientRequestMetadata(
       List<String> capturedClientRequestMetadata) {
     this.capturedClientRequestMetadata = capturedClientRequestMetadata;
     return this;
   }
 
+  /**
+   * @deprecated Use {@link #setCaptureClientRequestMetadata(List)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public GrpcTelemetryBuilder setCapturedClientRequestMetadata(
+      List<String> capturedClientRequestMetadata) {
+    return setCaptureClientRequestMetadata(capturedClientRequestMetadata);
+  }
+
   /** Sets which metadata request values should be captured as span attributes on server spans. */
   @CanIgnoreReturnValue
-  public GrpcTelemetryBuilder setCapturedServerRequestMetadata(
+  public GrpcTelemetryBuilder setCaptureServerRequestMetadata(
       List<String> capturedServerRequestMetadata) {
     this.capturedServerRequestMetadata = capturedServerRequestMetadata;
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureServerRequestMetadata(List)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public GrpcTelemetryBuilder setCapturedServerRequestMetadata(
+      List<String> capturedServerRequestMetadata) {
+    return setCaptureServerRequestMetadata(capturedServerRequestMetadata);
   }
 
   /** Returns a new {@link GrpcTelemetry} with the settings of this {@link GrpcTelemetryBuilder}. */

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -42,7 +42,7 @@ class GrpcTest extends AbstractGrpcTest {
   protected ServerBuilder<?> configureServer(ServerBuilder<?> server) {
     return server.intercept(
         GrpcTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedServerRequestMetadata(singletonList(SERVER_REQUEST_METADATA_KEY))
+            .setCaptureServerRequestMetadata(singletonList(SERVER_REQUEST_METADATA_KEY))
             .build()
             .createServerInterceptor());
   }
@@ -51,7 +51,7 @@ class GrpcTest extends AbstractGrpcTest {
   protected ManagedChannelBuilder<?> configureClient(ManagedChannelBuilder<?> client) {
     return client.intercept(
         GrpcTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedClientRequestMetadata(singletonList(CLIENT_REQUEST_METADATA_KEY))
+            .setCaptureClientRequestMetadata(singletonList(CLIENT_REQUEST_METADATA_KEY))
             .build()
             .createClientInterceptor());
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
@@ -21,7 +21,7 @@ public class JmsSingletons {
   static {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
 

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
@@ -21,7 +21,7 @@ public class JmsSingletons {
   static {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(
                 ExperimentalConfig.get().messagingReceiveInstrumentationEnabled());
 

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -37,7 +37,7 @@ public class JmsInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public JmsInstrumenterFactory setCapturedHeaders(Collection<String> capturedHeaders) {
+  public JmsInstrumenterFactory setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
   }
@@ -108,7 +108,7 @@ public class JmsInstrumenterFactory {
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(
       MessageOperation operation) {
     return MessagingAttributesExtractor.builder(new JmsMessageAttributesGetter(), operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -30,7 +30,7 @@ public class KafkaSingletons {
   static {
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setCaptureExperimentalSpanAttributes(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                     .getBoolean("experimental_span_attributes/development", false))

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -66,9 +66,18 @@ public final class KafkaTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public KafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public KafkaTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public KafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**
@@ -112,7 +121,7 @@ public final class KafkaTelemetryBuilder {
   public KafkaTelemetry build() {
     KafkaInstrumenterFactory instrumenterFactory =
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
-            .setCapturedHeaders(capturedHeaders)
+            .setCaptureHeaders(capturedHeaders)
             .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
             .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled);
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractWrapperTest.java
@@ -37,7 +37,7 @@ abstract class AbstractWrapperTest extends KafkaClientBaseTest {
   void testWrappers(boolean testHeaders, boolean testExperimental) throws InterruptedException {
     KafkaTelemetryBuilder telemetryBuilder =
         KafkaTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedHeaders(singletonList("Test-Message-Header"))
+            .setCaptureHeaders(singletonList("Test-Message-Header"))
             .setCaptureExperimentalSpanAttributes(testExperimental);
     configure(telemetryBuilder);
     KafkaTelemetry telemetry = telemetryBuilder.build();

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsTest.java
@@ -12,7 +12,7 @@ class InterceptorsTest extends AbstractInterceptorsTest {
   private static final KafkaTelemetry kafkaTelemetry =
       KafkaTelemetry.builder(testing.getOpenTelemetry())
           .setMessagingReceiveTelemetryEnabled(true)
-          .setCapturedHeaders(singletonList("Test-Message-Header"))
+          .setCaptureHeaders(singletonList("Test-Message-Header"))
           .build();
 
   @Override

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsWithExperimentalAttributesTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsWithExperimentalAttributesTest.java
@@ -12,7 +12,7 @@ class InterceptorsWithExperimentalAttributesTest extends AbstractInterceptorsTes
   private static final KafkaTelemetry kafkaTelemetry =
       KafkaTelemetry.builder(testing.getOpenTelemetry())
           .setMessagingReceiveTelemetryEnabled(true)
-          .setCapturedHeaders(singletonList("Test-Message-Header"))
+          .setCaptureHeaders(singletonList("Test-Message-Header"))
           .setCaptureExperimentalSpanAttributes(true)
           .build();
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -52,9 +52,18 @@ public final class KafkaInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public KafkaInstrumenterFactory setCapturedHeaders(Collection<String> capturedHeaders) {
+  public KafkaInstrumenterFactory setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public KafkaInstrumenterFactory setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   @CanIgnoreReturnValue
@@ -183,7 +192,7 @@ public final class KafkaInstrumenterFactory {
           MessageOperation operation,
           List<String> capturedHeaders) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 }

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSingletons.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSingletons.java
@@ -18,7 +18,7 @@ public class KafkaStreamsSingletons {
 
   private static final Instrumenter<KafkaProcessRequest, Void> instrumenter =
       new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                   .getBoolean("experimental_span_attributes/development", false))

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
@@ -30,9 +30,18 @@ public final class NatsTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public NatsTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public NatsTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public NatsTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /** Returns a new {@link NatsTelemetry} with the settings of this {@link NatsTelemetryBuilder}. */

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -34,7 +34,7 @@ public final class NatsInstrumenterFactory {
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(
                         new NatsRequestMessagingAttributesGetter(), MessageOperation.PUBLISH)
-                    .setCapturedHeaders(capturedHeaders)
+                    .setCaptureHeaders(capturedHeaders)
                     .build());
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new NatsRequestTextMapSetter());
@@ -51,7 +51,7 @@ public final class NatsInstrumenterFactory {
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(
                         new NatsRequestMessagingAttributesGetter(), MessageOperation.PROCESS)
-                    .setCapturedHeaders(capturedHeaders)
+                    .setCaptureHeaders(capturedHeaders)
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);
 

--- a/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsDispatcherTest.java
@@ -26,7 +26,7 @@ class NatsDispatcherTest extends AbstractNatsDispatcherTest {
   void wrapConnection() {
     connection =
         NatsTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedHeaders(singletonList("Test-Message-Header"))
+            .setCaptureHeaders(singletonList("Test-Message-Header"))
             .build()
             .wrap(connection);
   }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -160,7 +160,7 @@ public class PulsarSingletons {
   private static <T> AttributesExtractor<T, Void> createMessagingAttributesExtractor(
       MessagingAttributesGetter<T, Void> getter, MessageOperation operation) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
@@ -121,7 +121,7 @@ public class RabbitSingletons {
   private static <T, V> AttributesExtractor<T, V> buildMessagingAttributesExtractor(
       MessagingAttributesGetter<T, V> getter, @Nullable MessageOperation operation) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+        .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
         .build();
   }
 

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaSingletons.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaSingletons.java
@@ -18,7 +18,7 @@ final class ReactorKafkaSingletons {
 
   private static final Instrumenter<KafkaProcessRequest, Void> processInstrumenter =
       new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                   .getBoolean("experimental_span_attributes/development", false))

--- a/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqSingletons.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqSingletons.java
@@ -17,7 +17,7 @@ public class RocketMqSingletons {
   @SuppressWarnings("deprecation") // call to deprecated method will be removed in the future
   private static final RocketMqTelemetry telemetry =
       RocketMqTelemetry.builder(GlobalOpenTelemetry.get())
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(
                       GlobalOpenTelemetry.get(), "rocketmq_client")

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -118,7 +118,7 @@ class RocketMqInstrumenterFactory {
       MessageOperation operation,
       List<String> capturedHeaders) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
@@ -43,9 +43,18 @@ public final class RocketMqTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public RocketMqTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public RocketMqTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public RocketMqTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqClientTest.java
@@ -30,7 +30,7 @@ class RocketMqClientTest extends AbstractRocketMqClientTest {
         .getDefaultMQProducerImpl()
         .registerSendMessageHook(
             RocketMqTelemetry.builder(testing.getOpenTelemetry())
-                .setCapturedHeaders(singletonList("Test-Message-Header"))
+                .setCaptureHeaders(singletonList("Test-Message-Header"))
                 .setCaptureExperimentalSpanAttributes(true)
                 .build()
                 .createSendMessageHook());
@@ -42,7 +42,7 @@ class RocketMqClientTest extends AbstractRocketMqClientTest {
         .getDefaultMQPushConsumerImpl()
         .registerConsumeMessageHook(
             RocketMqTelemetry.builder(testing.getOpenTelemetry())
-                .setCapturedHeaders(singletonList("Test-Message-Header"))
+                .setCaptureHeaders(singletonList("Test-Message-Header"))
                 .setCaptureExperimentalSpanAttributes(true)
                 .build()
                 .createConsumeMessageHook());

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -117,7 +117,7 @@ final class RocketMqInstrumenterFactory {
       MessageOperation operation,
       List<String> capturedHeaders) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
@@ -48,7 +48,7 @@ public class KafkaInstrumentationAutoConfiguration {
                 .get("messaging")
                 .get("receive_telemetry/development")
                 .getBoolean("enabled", false))
-        .setCapturedHeaders(
+        .setCaptureHeaders(
             commonConfig
                 .get("messaging")
                 .getScalarList("capture_headers/development", String.class, emptyList()))

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationSingletons.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationSingletons.java
@@ -23,7 +23,7 @@ public class SpringIntegrationSingletons {
 
   private static final ChannelInterceptor interceptor =
       SpringIntegrationTelemetry.builder(GlobalOpenTelemetry.get())
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setProducerSpanEnabled(
               DeclarativeConfigUtil.getInstrumentationConfig(
                       GlobalOpenTelemetry.get(), "spring_integration")

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -55,9 +55,18 @@ public final class SpringIntegrationTelemetryBuilder {
    * @param capturedHeaders A list of messaging header names.
    */
   @CanIgnoreReturnValue
-  public SpringIntegrationTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public SpringIntegrationTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public SpringIntegrationTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   /**
@@ -124,7 +133,7 @@ public final class SpringIntegrationTelemetryBuilder {
       MessageOperation operation,
       List<String> capturedHeaders) {
     return MessagingAttributesExtractor.builder(getter, operation)
-        .setCapturedHeaders(capturedHeaders)
+        .setCaptureHeaders(capturedHeaders)
         .build();
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/GlobalInterceptorSpringConfig.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/GlobalInterceptorSpringConfig.java
@@ -21,7 +21,7 @@ class GlobalInterceptorSpringConfig {
   @Bean
   ChannelInterceptor otelInterceptor() {
     return SpringIntegrationTelemetry.builder(GlobalOpenTelemetry.get())
-        .setCapturedHeaders(singletonList("Test-Message-Header"))
+        .setCaptureHeaders(singletonList("Test-Message-Header"))
         .build()
         .createChannelInterceptor();
   }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
@@ -22,7 +22,7 @@ public class SpringJmsSingletons {
   static {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
     listenerInstrumenter = factory.createConsumerProcessInstrumenter(true);

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
@@ -22,7 +22,7 @@ public class SpringJmsSingletons {
   static {
     JmsInstrumenterFactory factory =
         new JmsInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
     listenerInstrumenter = factory.createConsumerProcessInstrumenter(true);

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
@@ -19,7 +19,7 @@ public class SpringKafkaSingletons {
 
   private static final SpringKafkaTelemetry telemetry =
       SpringKafkaTelemetry.builder(GlobalOpenTelemetry.get())
-          .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                   .getBoolean("experimental_span_attributes/development", false))
@@ -31,7 +31,7 @@ public class SpringKafkaSingletons {
   static {
     KafkaInstrumenterFactory factory =
         new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setCaptureExperimentalSpanAttributes(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                     .getBoolean("experimental_span_attributes/development", false))

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
@@ -30,9 +30,18 @@ public final class SpringKafkaTelemetryBuilder {
   }
 
   @CanIgnoreReturnValue
-  public SpringKafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+  public SpringKafkaTelemetryBuilder setCaptureHeaders(Collection<String> capturedHeaders) {
     this.capturedHeaders = new ArrayList<>(capturedHeaders);
     return this;
+  }
+
+  /**
+   * @deprecated Use {@link #setCaptureHeaders(Collection)} instead.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  public SpringKafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
+    return setCaptureHeaders(capturedHeaders);
   }
 
   @CanIgnoreReturnValue
@@ -62,7 +71,7 @@ public final class SpringKafkaTelemetryBuilder {
   public SpringKafkaTelemetry build() {
     KafkaInstrumenterFactory factory =
         new KafkaInstrumenterFactory(openTelemetry, INSTRUMENTATION_NAME)
-            .setCapturedHeaders(capturedHeaders)
+            .setCaptureHeaders(capturedHeaders)
             .setCaptureExperimentalSpanAttributes(captureExperimentalSpanAttributes)
             .setMessagingReceiveTelemetryEnabled(messagingReceiveInstrumentationEnabled)
             .setErrorCauseExtractor(new SpringKafkaErrorCauseExtractor());

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
@@ -37,7 +37,7 @@ public class SpringPulsarSingletons {
                 MessagingSpanNameExtractor.create(getter, operation))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(getter, operation)
-                    .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+                    .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);
     if (messagingReceiveInstrumentationEnabled) {

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
@@ -33,7 +33,7 @@ public class SpringRabbitSingletons {
                 MessagingSpanNameExtractor.create(getter, operation))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(getter, operation)
-                    .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+                    .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build());
     setMessagingProcessExceptionEventExtractor(builder);
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafkaclient/v3_6/VertxKafkaSingletons.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafkaclient/v3_6/VertxKafkaSingletons.java
@@ -23,7 +23,7 @@ public class VertxKafkaSingletons {
   static {
     KafkaInstrumenterFactory factory =
         new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME)
-            .setCapturedHeaders(ExperimentalConfig.get().getMessagingHeaders())
+            .setCaptureHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setCaptureExperimentalSpanAttributes(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                     .getBoolean("experimental_span_attributes/development", false))


### PR DESCRIPTION
Related to #17069, follows #17154

Applies the `setCapture*` naming convention from #17069 to the last `setCaptured*` holdouts: messaging `setCapturedHeaders` and gRPC `setCapturedClientRequestMetadata` / `setCapturedServerRequestMetadata`. After this there are no `setCaptured*` methods left apart from the deprecated overloads.

See #17154 for the reasoning on why `setCapture*` is the right form.

Published builders keep the old names as deprecated overloads. Javaagent modules are not published, so those are renamed outright.
