### PR TITLE
Redact sensitive query parameters from url.full for aws-lambda and elasticsearch

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSingletons.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSingletons.java
@@ -22,7 +22,8 @@ public class AwsLambdaSingletons {
       AwsLambdaEventsInstrumenterFactory.createInstrumenter(
           GlobalOpenTelemetry.get(),
           INSTRUMENTATION_NAME,
-          AgentCommonConfig.get().getKnownHttpRequestMethods());
+          AgentCommonConfig.get().getKnownHttpRequestMethods(),
+          AgentCommonConfig.get().getSensitiveQueryParameters());
   private static final Instrumenter<SQSEvent, Void> messageInstrumenter =
       AwsLambdaSqsInstrumenterFactory.forEvent(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME);
   public static final Duration FLUSH_TIMEOUT =

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/TracingRequestWrapperBase.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/TracingRequestWrapperBase.java
@@ -50,7 +50,10 @@ abstract class TracingRequestWrapperBase<I, O> extends TracingRequestHandler<I, 
         openTelemetrySdk,
         WrapperConfiguration.flushTimeout(),
         AwsLambdaEventsInstrumenterFactory.createInstrumenter(
-            openTelemetrySdk, INSTRUMENTATION_NAME, HttpConstants.KNOWN_METHODS));
+            openTelemetrySdk,
+            INSTRUMENTATION_NAME,
+            HttpConstants.KNOWN_METHODS,
+            HttpConstants.SENSITIVE_QUERY_PARAMETERS));
     this.wrappedLambda = wrappedLambda;
     this.targetMethod = wrappedLambda.getRequestTargetMethod();
     this.parameterMapper = parameterMapper;

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
@@ -21,6 +21,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlQuerySanitizer;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -37,9 +38,12 @@ final class ApiGatewayProxyAttributesExtractor
   private static final String HTTP = "http";
 
   private final Set<String> knownMethods;
+  private final Set<String> sensitiveQueryParameters;
 
-  ApiGatewayProxyAttributesExtractor(Set<String> knownMethods) {
+  ApiGatewayProxyAttributesExtractor(
+      Set<String> knownMethods, Set<String> sensitiveQueryParameters) {
     this.knownMethods = knownMethods;
+    this.sensitiveQueryParameters = sensitiveQueryParameters;
   }
 
   @Override
@@ -64,12 +68,14 @@ final class ApiGatewayProxyAttributesExtractor
     String userAgent = headers.get("user-agent");
     attributes.put(USER_AGENT_ORIGINAL, userAgent);
 
-    attributes.put(URL_FULL, getHttpUrl(request, headers));
+    attributes.put(URL_FULL, getHttpUrl(request, headers, sensitiveQueryParameters));
   }
 
   @Nullable
   private static String getHttpUrl(
-      APIGatewayProxyRequestEvent request, Map<String, String> headers) {
+      APIGatewayProxyRequestEvent request,
+      Map<String, String> headers,
+      Set<String> sensitiveQueryParameters) {
     StringBuilder str = new StringBuilder();
 
     String scheme = headers.get("x-forwarded-proto");
@@ -97,7 +103,9 @@ final class ApiGatewayProxyAttributesExtractor
     } catch (UnsupportedEncodingException ignored) {
       // Ignore
     }
-    return str.length() == 0 ? null : str.toString();
+    return str.length() == 0
+        ? null
+        : UrlQuerySanitizer.redactUrl(str.toString(), sensitiveQueryParameters);
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractor.java
@@ -21,7 +21,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlQuerySanitizer;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlSanitizer;
 import io.opentelemetry.instrumentation.awslambdacore.v1_0.AwsLambdaRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -105,7 +105,7 @@ final class ApiGatewayProxyAttributesExtractor
     }
     return str.length() == 0
         ? null
-        : UrlQuerySanitizer.redactUrl(str.toString(), sensitiveQueryParameters);
+        : UrlSanitizer.sanitizeUrl(str.toString(), sensitiveQueryParameters);
   }
 
   @Override

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaEventsInstrumenterFactory.java
@@ -24,12 +24,16 @@ import java.util.Set;
 public final class AwsLambdaEventsInstrumenterFactory {
 
   public static AwsLambdaFunctionInstrumenter createInstrumenter(
-      OpenTelemetry openTelemetry, String instrumentationName, Set<String> knownMethods) {
+      OpenTelemetry openTelemetry,
+      String instrumentationName,
+      Set<String> knownMethods,
+      Set<String> sensitiveQueryParameters) {
     InstrumenterBuilder<AwsLambdaRequest, Object> builder =
         Instrumenter.<AwsLambdaRequest, Object>builder(
                 openTelemetry, instrumentationName, AwsLambdaEventsInstrumenterFactory::spanName)
             .addAttributesExtractor(new AwsLambdaFunctionAttributesExtractor())
-            .addAttributesExtractor(new ApiGatewayProxyAttributesExtractor(knownMethods));
+            .addAttributesExtractor(
+                new ApiGatewayProxyAttributesExtractor(knownMethods, sensitiveQueryParameters));
     setFaasInvocationExceptionEventExtractor(builder);
 
     return new AwsLambdaFunctionInstrumenter(

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractorTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
+
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.internal.HttpConstants;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ApiGatewayProxyAttributesExtractorTest {
+
+  @Test
+  void redactsSensitiveQueryParameters() {
+    assertThat(urlFull(HttpConstants.SENSITIVE_QUERY_PARAMETERS))
+        .isEqualTo("https://localhost:123/hello?q=value&Signature=REDACTED&sig=REDACTED");
+  }
+
+  @Test
+  void redactsConfiguredQueryParameters() {
+    assertThat(urlFull(singleton("q")))
+        .isEqualTo("https://localhost:123/hello?q=REDACTED&Signature=secret&sig=secret");
+  }
+
+  private static String urlFull(Set<String> sensitiveQueryParameters) {
+    ApiGatewayProxyAttributesExtractor extractor =
+        new ApiGatewayProxyAttributesExtractor(
+            HttpConstants.KNOWN_METHODS, sensitiveQueryParameters);
+
+    Map<String, String> query = new LinkedHashMap<>();
+    query.put("q", "value");
+    query.put("Signature", "secret");
+    query.put("sig", "secret");
+
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put("Host", "localhost:123");
+    headers.put("X-Forwarded-Proto", "https");
+
+    APIGatewayProxyRequestEvent request =
+        new APIGatewayProxyRequestEvent()
+            .withHttpMethod("GET")
+            .withPath("/hello")
+            .withQueryStringParameters(query)
+            .withHeaders(headers);
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onRequest(attributes, request);
+    return attributes.build().get(URL_FULL);
+  }
+}

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractorTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/ApiGatewayProxyAttributesExtractorTest.java
@@ -23,13 +23,13 @@ class ApiGatewayProxyAttributesExtractorTest {
   @Test
   void redactsSensitiveQueryParameters() {
     assertThat(urlFull(HttpConstants.SENSITIVE_QUERY_PARAMETERS))
-        .isEqualTo("https://localhost:123/hello?q=value&Signature=REDACTED&sig=REDACTED");
+        .isEqualTo("https://localhost:123/hello?q=value&sig=REDACTED");
   }
 
   @Test
   void redactsConfiguredQueryParameters() {
     assertThat(urlFull(singleton("q")))
-        .isEqualTo("https://localhost:123/hello?q=REDACTED&Signature=secret&sig=secret");
+        .isEqualTo("https://localhost:123/hello?q=REDACTED&sig=secret");
   }
 
   private static String urlFull(Set<String> sensitiveQueryParameters) {
@@ -39,7 +39,6 @@ class ApiGatewayProxyAttributesExtractorTest {
 
     Map<String, String> query = new LinkedHashMap<>();
     query.put("q", "value");
-    query.put("Signature", "secret");
     query.put("sig", "secret");
 
     Map<String, String> headers = new LinkedHashMap<>();

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7TelemetryBuilder.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7TelemetryBuilder.java
@@ -95,6 +95,7 @@ public final class ElasticsearchRest7TelemetryBuilder {
             attributesExtractors,
             spanNameExtractorCustomizer,
             knownMethods,
+            HttpConstants.SENSITIVE_QUERY_PARAMETERS,
             false);
 
     return new ElasticsearchRest7Telemetry(instrumenter);

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchRestJavaagentInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchRestJavaagentInstrumenterFactory.java
@@ -30,6 +30,7 @@ public class ElasticsearchRestJavaagentInstrumenterFactory {
         emptyList(),
         Function.identity(),
         AgentCommonConfig.get().getKnownHttpRequestMethods(),
+        AgentCommonConfig.get().getSensitiveQueryParameters(),
         CAPTURE_SEARCH_QUERY);
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/build.gradle.kts
@@ -7,4 +7,6 @@ dependencies {
   compileOnly("com.google.auto.value:auto-value-annotations")
 
   annotationProcessor("com.google.auto.value:auto-value")
+
+  testImplementation("org.elasticsearch.client:rest:5.0.0")
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractor.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlQuerySanitizer;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -35,9 +36,12 @@ final class ElasticsearchClientAttributeExtractor
   private static final Cache<String, AttributeKey<String>> pathPartKeysCache = Cache.bounded(64);
 
   private final Set<String> knownMethods;
+  private final Set<String> sensitiveQueryParameters;
 
-  ElasticsearchClientAttributeExtractor(Set<String> knownMethods) {
+  ElasticsearchClientAttributeExtractor(
+      Set<String> knownMethods, Set<String> sensitiveQueryParameters) {
     this.knownMethods = new HashSet<>(knownMethods);
+    this.sensitiveQueryParameters = new HashSet<>(sensitiveQueryParameters);
   }
 
   private static void setServerAttributes(AttributesBuilder attributes, Response response) {
@@ -48,12 +52,12 @@ final class ElasticsearchClientAttributeExtractor
     }
   }
 
-  private static void setUrlAttribute(AttributesBuilder attributes, Response response) {
+  private void setUrlAttribute(AttributesBuilder attributes, Response response) {
     String uri = response.getRequestLine().getUri();
     uri = uri.startsWith("/") ? uri : "/" + uri;
     String fullUrl = response.getHost().toURI() + uri;
 
-    attributes.put(URL_FULL, fullUrl);
+    attributes.put(URL_FULL, UrlQuerySanitizer.redactUrl(fullUrl, sensitiveQueryParameters));
   }
 
   private static void setPathPartsAttributes(

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractor.java
@@ -17,7 +17,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
-import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlQuerySanitizer;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlSanitizer;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -57,7 +57,7 @@ final class ElasticsearchClientAttributeExtractor
     uri = uri.startsWith("/") ? uri : "/" + uri;
     String fullUrl = response.getHost().toURI() + uri;
 
-    attributes.put(URL_FULL, UrlQuerySanitizer.redactUrl(fullUrl, sensitiveQueryParameters));
+    attributes.put(URL_FULL, UrlSanitizer.sanitizeUrl(fullUrl, sensitiveQueryParameters));
   }
 
   private static void setPathPartsAttributes(

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchRestInstrumenterFactory.java
@@ -35,11 +35,12 @@ public final class ElasticsearchRestInstrumenterFactory {
               ? extends SpanNameExtractor<? super ElasticsearchRestRequest>>
           spanNameExtractorTransformer,
       Set<String> knownMethods,
+      Set<String> sensitiveQueryParameters,
       boolean captureSearchQuery) {
     ElasticsearchDbAttributesGetter dbClientAttributesGetter =
         new ElasticsearchDbAttributesGetter(captureSearchQuery);
     ElasticsearchClientAttributeExtractor esClientAttributesExtractor =
-        new ElasticsearchClientAttributeExtractor(knownMethods);
+        new ElasticsearchClientAttributeExtractor(knownMethods, sensitiveQueryParameters);
     SpanNameExtractor<? super ElasticsearchRestRequest> spanNameExtractor =
         spanNameExtractorTransformer.apply(
             new ElasticsearchSpanNameExtractor(dbClientAttributesGetter));

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractorTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractorTest.java
@@ -27,13 +27,13 @@ class ElasticsearchClientAttributeExtractorTest {
   @Test
   void redactsSensitiveQueryParameters() {
     assertThat(urlFull(HttpConstants.SENSITIVE_QUERY_PARAMETERS))
-        .isEqualTo("http://localhost:9200/_search?q=value&Signature=REDACTED&sig=REDACTED");
+        .isEqualTo("http://localhost:9200/_search?q=value&sig=REDACTED");
   }
 
   @Test
   void redactsConfiguredQueryParameters() {
     assertThat(urlFull(singleton("q")))
-        .isEqualTo("http://localhost:9200/_search?q=REDACTED&Signature=secret&sig=secret");
+        .isEqualTo("http://localhost:9200/_search?q=REDACTED&sig=secret");
   }
 
   private static String urlFull(Set<String> sensitiveQueryParameters) {
@@ -45,8 +45,7 @@ class ElasticsearchClientAttributeExtractorTest {
     when(response.getHost()).thenReturn(new HttpHost("localhost", 9200, "http"));
     when(response.getRequestLine())
         .thenReturn(
-            new BasicRequestLine(
-                "GET", "/_search?q=value&Signature=secret&sig=secret", HttpVersion.HTTP_1_1));
+            new BasicRequestLine("GET", "/_search?q=value&sig=secret", HttpVersion.HTTP_1_1));
 
     AttributesBuilder attributes = Attributes.builder();
     extractor.onEnd(

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractorTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/common/v5_0/internal/ElasticsearchClientAttributeExtractorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.elasticsearch.rest.common.v5_0.internal;
+
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.internal.HttpConstants;
+import java.util.Set;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpVersion;
+import org.apache.http.message.BasicRequestLine;
+import org.elasticsearch.client.Response;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchClientAttributeExtractorTest {
+
+  @Test
+  void redactsSensitiveQueryParameters() {
+    assertThat(urlFull(HttpConstants.SENSITIVE_QUERY_PARAMETERS))
+        .isEqualTo("http://localhost:9200/_search?q=value&Signature=REDACTED&sig=REDACTED");
+  }
+
+  @Test
+  void redactsConfiguredQueryParameters() {
+    assertThat(urlFull(singleton("q")))
+        .isEqualTo("http://localhost:9200/_search?q=REDACTED&Signature=secret&sig=secret");
+  }
+
+  private static String urlFull(Set<String> sensitiveQueryParameters) {
+    ElasticsearchClientAttributeExtractor extractor =
+        new ElasticsearchClientAttributeExtractor(
+            HttpConstants.KNOWN_METHODS, sensitiveQueryParameters);
+
+    Response response = mock(Response.class);
+    when(response.getHost()).thenReturn(new HttpHost("localhost", 9200, "http"));
+    when(response.getRequestLine())
+        .thenReturn(
+            new BasicRequestLine(
+                "GET", "/_search?q=value&Signature=secret&sig=secret", HttpVersion.HTTP_1_1));
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onEnd(
+        attributes,
+        Context.root(),
+        ElasticsearchRestRequest.create("GET", "/_search"),
+        response,
+        null);
+    return attributes.build().get(URL_FULL);
+  }
+}


### PR DESCRIPTION
URL redaction lives inside the HTTP semconv attribute extractors rather than at the `url.full` attribute key itself, so instrumentations that call `attributes.put(URL_FULL, ...)` directly silently opt out.

This applies the shared `UrlSanitizer.sanitizeUrl` at the two remaining direct call sites, threading a configurable `sensitiveQueryParameters` set through the instrumenter factories the same way `knownMethods` already is.

Neither instrumentation can structurally carry userinfo in the URL, but using `UrlSanitizer.sanitizeUrl` rather than `UrlQuerySanitizer.redactUrl` keeps all four `url.full` producers on one line and keeps userinfo redaction unconditional even when the configured parameter set is empty.

Follows #19425, which covered camel-2.20 and introduced the shared helper.

Part of #19419