### PR TITLE
Redact credentials from url.full in camel-2.20

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesExtractor.java
@@ -16,7 +16,7 @@ import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import io.opentelemetry.instrumentation.api.semconv.network.internal.InternalNetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.internal.InternalServerAttributesExtractor;
-import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlQuerySanitizer;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlSanitizer;
 import java.util.Set;
 import java.util.function.ToIntFunction;
 import javax.annotation.Nullable;
@@ -76,8 +76,8 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
 
     internalServerExtractor.onStart(attributes, request);
 
-    String fullUrl = stripSensitiveData(getter.getUrlFull(request));
-    attributes.put(URL_FULL, fullUrl);
+    attributes.put(
+        URL_FULL, UrlSanitizer.sanitizeUrl(getter.getUrlFull(request), sensitiveQueryParameters));
 
     int resendCount = resendCountIncrementer.applyAsInt(parentContext);
     if (resendCount > 0) {
@@ -104,55 +104,5 @@ public final class HttpClientAttributesExtractor<REQUEST, RESPONSE>
   @Override
   public SpanKey internalGetSpanKey() {
     return SpanKey.HTTP_CLIENT;
-  }
-
-  @Nullable
-  private String stripSensitiveData(@Nullable String url) {
-    if (url == null || url.isEmpty()) {
-      return url;
-    }
-
-    url = redactUserInfo(url);
-    url = UrlQuerySanitizer.redactUrl(url, sensitiveQueryParameters);
-
-    return url;
-  }
-
-  private static String redactUserInfo(String url) {
-    int schemeEndIndex = url.indexOf(':');
-
-    if (schemeEndIndex == -1) {
-      // not a valid url
-      return url;
-    }
-
-    int len = url.length();
-    if (len <= schemeEndIndex + 2
-        || url.charAt(schemeEndIndex + 1) != '/'
-        || url.charAt(schemeEndIndex + 2) != '/') {
-      // has no authority component
-      return url;
-    }
-
-    // look for the end of the authority component:
-    //   '/', '?', '#' ==> start of path
-    int index;
-    int atIndex = -1;
-    for (index = schemeEndIndex + 3; index < len; index++) {
-      char c = url.charAt(index);
-
-      if (c == '@') {
-        atIndex = index;
-      }
-
-      if (c == '/' || c == '?' || c == '#') {
-        break;
-      }
-    }
-
-    if (atIndex == -1 || atIndex == len - 1) {
-      return url;
-    }
-    return url.substring(0, schemeEndIndex + 3) + "REDACTED:REDACTED" + url.substring(atIndex);
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.semconv.url.internal;
+
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class UrlSanitizer {
+
+  private static final String REDACTED = "REDACTED";
+
+  private UrlSanitizer() {}
+
+  /**
+   * Removes the credentials that the semantic conventions require to be absent from {@code
+   * url.full}: the {@code userinfo} component of the authority, and the values of any query
+   * parameter named in {@code sensitiveQueryParameters}.
+   */
+  @Nullable
+  public static String sanitizeUrl(@Nullable String url, Set<String> sensitiveQueryParameters) {
+    if (url == null || url.isEmpty()) {
+      return url;
+    }
+
+    url = redactUserInfo(url);
+    url = UrlQuerySanitizer.redactUrl(url, sensitiveQueryParameters);
+
+    return url;
+  }
+
+  private static String redactUserInfo(String url) {
+    int schemeEndIndex = url.indexOf(':');
+
+    if (schemeEndIndex == -1) {
+      // not a valid url
+      return url;
+    }
+
+    int len = url.length();
+    if (len <= schemeEndIndex + 2
+        || url.charAt(schemeEndIndex + 1) != '/'
+        || url.charAt(schemeEndIndex + 2) != '/') {
+      // has no authority component
+      return url;
+    }
+
+    // look for the end of the authority component:
+    //   '/', '?', '#' ==> start of path
+    int index;
+    int atIndex = -1;
+    for (index = schemeEndIndex + 3; index < len; index++) {
+      char c = url.charAt(index);
+
+      if (c == '@') {
+        atIndex = index;
+      }
+
+      if (c == '/' || c == '?' || c == '#') {
+        break;
+      }
+    }
+
+    if (atIndex == -1 || atIndex == len - 1) {
+      return url;
+    }
+    return url.substring(0, schemeEndIndex + 3)
+        + REDACTED
+        + ":"
+        + REDACTED
+        + url.substring(atIndex);
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizer.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizer.java
@@ -12,11 +12,9 @@ import javax.annotation.Nullable;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-public final class UrlSanitizer {
+public class UrlSanitizer {
 
   private static final String REDACTED = "REDACTED";
-
-  private UrlSanitizer() {}
 
   /**
    * Removes the credentials that the semantic conventions require to be absent from {@code
@@ -76,4 +74,6 @@ public final class UrlSanitizer {
         + REDACTED
         + url.substring(atIndex);
   }
+
+  private UrlSanitizer() {}
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesExtractorTest.java
@@ -40,7 +40,6 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpClientAttributesExtractorTest {
@@ -200,36 +199,10 @@ class HttpClientAttributesExtractorTest {
             entry(NETWORK_PEER_PORT, 456L));
   }
 
-  @ParameterizedTest
-  @CsvSource({
-    "https://user1:secret@github.com, https://REDACTED:REDACTED@github.com",
-    "https://user1:secret@github.com/path/, https://REDACTED:REDACTED@github.com/path/",
-    "https://user1:secret@github.com#test.html, https://REDACTED:REDACTED@github.com#test.html",
-    "https://user1:secret@github.com?foo=b@r, https://REDACTED:REDACTED@github.com?foo=b@r",
-    "https://user1:secret@github.com/p@th?foo=b@r, https://REDACTED:REDACTED@github.com/p@th?foo=b@r",
-    "https://github.com/p@th?foo=b@r, https://github.com/p@th?foo=b@r",
-    "https://github.com#t@st.html, https://github.com#t@st.html",
-    "user1:secret@github.com, user1:secret@github.com",
-    "https://github.com@, https://github.com@",
-    "https://service.com?paramA=valA&paramB=valB, https://service.com?paramA=valA&paramB=valB",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED",
-    "https://service.com?Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, https://service.com?Signature=REDACTED",
-    "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?sig=REDACTED",
-    "https://service.com?X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Goog-Signature=REDACTED",
-    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, https://service.com?AWSAccessKeyId=REDACTED&paramA=valA",
-    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7#ref, https://service.com?AWSAccessKeyId=REDACTED#ref",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, https://service.com?AWSAccessKeyId=REDACTED&aa&bb",
-    "https://service.com?aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?aa&bb&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&&, https://service.com?AWSAccessKeyId=REDACTED&&",
-    "https://service.com?&&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?&&AWSAccessKeyId=REDACTED",
-    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, https://service.com?AWSAccessKeyId=REDACTED&a&b#fragment"
-  })
-  void shouldRedactUserInfoAndQueryParameters(String url, String expectedResult) {
+  @Test
+  void shouldApplyUrlSanitizer() {
     Map<String, String> request = new HashMap<>();
-    request.put("urlFull", url);
+    request.put("urlFull", "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0");
 
     AttributesExtractor<Map<String, String>, Map<String, String>> extractor =
         HttpClientAttributesExtractor.create(new TestHttpClientAttributesGetter());
@@ -237,7 +210,8 @@ class HttpClientAttributesExtractorTest {
     AttributesBuilder attributes = Attributes.builder();
     extractor.onStart(attributes, Context.root(), request);
 
-    assertThat(attributes.build()).containsOnly(entry(URL_FULL, expectedResult));
+    assertThat(attributes.build())
+        .containsOnly(entry(URL_FULL, "https://service.com?sig=REDACTED"));
   }
 
   @ParameterizedTest

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/url/internal/UrlSanitizerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.semconv.url.internal;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.internal.HttpConstants;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class UrlSanitizerTest {
+
+  private static final Set<String> TEST_SENSITIVE_PARAMS =
+      new HashSet<>(asList("secret", "apiKey", "token"));
+
+  private static final String URL_WITH_USER_INFO = "https://user:pass@example.com?secret=val";
+
+  @ParameterizedTest
+  @CsvSource({
+    "https://user1:secret@github.com, https://REDACTED:REDACTED@github.com",
+    "https://user1:secret@github.com/path/, https://REDACTED:REDACTED@github.com/path/",
+    "https://user1:secret@github.com#test.html, https://REDACTED:REDACTED@github.com#test.html",
+    "https://user1:secret@github.com?foo=b@r, https://REDACTED:REDACTED@github.com?foo=b@r",
+    "https://user1:secret@github.com/p@th?foo=b@r, https://REDACTED:REDACTED@github.com/p@th?foo=b@r",
+    "https://github.com/p@th?foo=b@r, https://github.com/p@th?foo=b@r",
+    "https://github.com#t@st.html, https://github.com#t@st.html",
+    "user1:secret@github.com, user1:secret@github.com",
+    "https://github.com@, https://github.com@",
+    "https://service.com?paramA=valA&paramB=valB, https://service.com?paramA=valA&paramB=valB",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED",
+    "https://service.com?Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0%3A377, https://service.com?Signature=REDACTED",
+    "https://service.com?sig=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?sig=REDACTED",
+    "https://service.com?X-Goog-Signature=39Up9jzHkxhuIhFE9594DJxe7w6cIRCg0V6ICGS0, https://service.com?X-Goog-Signature=REDACTED",
+    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7&paramB=valB, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED&paramB=valB",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&paramA=valA, https://service.com?AWSAccessKeyId=REDACTED&paramA=valA",
+    "https://service.com?paramA=valA&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?paramA=valA&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&AWSAccessKeyId=ZGIAIOSFODNN7, https://service.com?AWSAccessKeyId=REDACTED&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7#ref, https://service.com?AWSAccessKeyId=REDACTED#ref",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&aa&bb, https://service.com?AWSAccessKeyId=REDACTED&aa&bb",
+    "https://service.com?aa&bb&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?aa&bb&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&&, https://service.com?AWSAccessKeyId=REDACTED&&",
+    "https://service.com?&&AWSAccessKeyId=AKIAIOSFODNN7, https://service.com?&&AWSAccessKeyId=REDACTED",
+    "https://service.com?AWSAccessKeyId=AKIAIOSFODNN7&a&b#fragment, https://service.com?AWSAccessKeyId=REDACTED&a&b#fragment"
+  })
+  void shouldRedactUserInfoAndQueryParameters(String url, String expectedResult) {
+    assertThat(UrlSanitizer.sanitizeUrl(url, HttpConstants.SENSITIVE_QUERY_PARAMETERS))
+        .isEqualTo(expectedResult);
+  }
+
+  @Test
+  void shouldReturnNullForNullInput() {
+    assertThat(UrlSanitizer.sanitizeUrl(null, TEST_SENSITIVE_PARAMS)).isNull();
+  }
+
+  @Test
+  void shouldReturnEmptyForEmptyInput() {
+    assertThat(UrlSanitizer.sanitizeUrl("", TEST_SENSITIVE_PARAMS)).isEmpty();
+  }
+
+  @Test
+  void shouldRedactUserInfoWhenNoSensitiveQueryParametersConfigured() {
+    // query redaction early-returns on an empty parameter set, but the semantic conventions
+    // require url.full to never carry credentials, so userinfo redaction is unconditional
+    assertThat(UrlSanitizer.sanitizeUrl(URL_WITH_USER_INFO, emptySet()))
+        .isEqualTo("https://REDACTED:REDACTED@example.com?secret=val");
+  }
+
+  @Test
+  void shouldRedactBothUserInfoAndQueryParameters() {
+    assertThat(UrlSanitizer.sanitizeUrl(URL_WITH_USER_INFO, TEST_SENSITIVE_PARAMS))
+        .isEqualTo("https://REDACTED:REDACTED@example.com?secret=REDACTED");
+  }
+
+  @Test
+  void shouldReturnOriginalWhenNoScheme() {
+    assertThat(UrlSanitizer.sanitizeUrl("example.com/path", TEST_SENSITIVE_PARAMS))
+        .isEqualTo("example.com/path");
+  }
+
+  @Test
+  void shouldReturnOriginalWhenNoAuthority() {
+    assertThat(UrlSanitizer.sanitizeUrl("mailto:someone@example.com", TEST_SENSITIVE_PARAMS))
+        .isEqualTo("mailto:someone@example.com");
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
@@ -33,6 +33,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
+import io.opentelemetry.instrumentation.api.semconv.url.internal.UrlSanitizer;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelDirection;
 import java.net.MalformedURLException;
@@ -48,6 +49,8 @@ class HttpSpanDecorator extends BaseSpanDecorator {
   private static final String GET_METHOD = "GET";
   private static final Set<String> knownMethods =
       AgentCommonConfig.get().getKnownHttpRequestMethods();
+  private static final Set<String> sensitiveQueryParameters =
+      AgentCommonConfig.get().getSensitiveQueryParameters();
 
   protected String getProtocol() {
     return "http";
@@ -98,7 +101,9 @@ class HttpSpanDecorator extends BaseSpanDecorator {
       CamelDirection camelDirection) {
     super.pre(attributes, exchange, endpoint, camelDirection);
 
-    attributes.put(URL_FULL, getHttpUrl(exchange, endpoint));
+    attributes.put(
+        URL_FULL,
+        UrlSanitizer.sanitizeUrl(getHttpUrl(exchange, endpoint), sensitiveQueryParameters));
 
     String method = getHttpMethod(exchange, endpoint);
     if (method == null || knownMethods.contains(method)) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
@@ -17,6 +17,9 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import java.net.URI;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -76,5 +79,34 @@ class SingleServiceCamelTest extends AbstractHttpServerUsingTest<ConfigurableApp
                                 stringKey("camel.uri"),
                                 experimental(
                                     requestUrl.toString().replace("localhost", "0.0.0.0"))))));
+  }
+
+  @Test
+  void sensitiveQueryParametersAreRedacted() throws Exception {
+    CamelContext clientContext = new DefaultCamelContext();
+    clientContext.addRoutes(
+        new RouteBuilder() {
+          @Override
+          public void configure() {
+            from("direct:input").to("http://localhost:" + port + "/camelService?sig=secret");
+          }
+        });
+    clientContext.start();
+    try {
+      clientContext.createProducerTemplate().sendBody("direct:input", "testContent");
+
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("input").hasKind(SpanKind.INTERNAL),
+                  span ->
+                      span.hasName("GET")
+                          .hasKind(SpanKind.CLIENT)
+                          .hasAttribute(
+                              URL_FULL, "http://localhost:" + port + "/camelService?sig=REDACTED"),
+                  span -> span.hasName("GET /camelService").hasKind(SpanKind.SERVER)));
+    } finally {
+      clientContext.stop();
+    }
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
@@ -109,4 +109,35 @@ class SingleServiceCamelTest extends AbstractHttpServerUsingTest<ConfigurableApp
       clientContext.stop();
     }
   }
+
+  @Test
+  void userInfoIsRedacted() throws Exception {
+    CamelContext clientContext = new DefaultCamelContext();
+    clientContext.addRoutes(
+        new RouteBuilder() {
+          @Override
+          public void configure() {
+            from("direct:userInfoInput")
+                .to("http://user:secret@localhost:" + port + "/camelService");
+          }
+        });
+    clientContext.start();
+    try {
+      clientContext.createProducerTemplate().sendBody("direct:userInfoInput", "testContent");
+
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName("userInfoInput").hasKind(SpanKind.INTERNAL),
+                  span ->
+                      span.hasName("POST")
+                          .hasKind(SpanKind.CLIENT)
+                          .hasAttribute(
+                              URL_FULL,
+                              "http://REDACTED:REDACTED@localhost:" + port + "/camelService"),
+                  span -> span.hasName("POST /camelService").hasKind(SpanKind.SERVER)));
+    } finally {
+      clientContext.stop();
+    }
+  }
 }


### PR DESCRIPTION
The camel instrumentation sets `url.full` by calling `attributes.put(URL_FULL, ...)` directly, bypassing the redaction that `HttpClientAttributesExtractor` normally applies. Credentials the semantic conventions require to be absent from `url.full` were recorded verbatim: the `userinfo` component of the authority (a MUST NOT, and redacted unconditionally everywhere else in this repo) and the values of the configured sensitive query parameters. This is reachable through the endpoint-URI fallback in `getHttpUrl`, so a producer endpoint such as `.to("http://user:secret@host/path?sig=...")` lands in span attributes as-is.

The redaction logic lived as private methods on `HttpClientAttributesExtractor`, so this moves it into a new internal `UrlSanitizer` that both call sites share. `HttpClientAttributesExtractor` behavior is unchanged, and its existing userinfo and query parameter tests continue to cover the moved code.

This is one of three direct `url.full` call sites; aws-lambda and elasticsearch-rest-common are #19424, and the stale default parameter list is #19422. This one is worth merging first: it is the highest severity of the three, and it introduces `UrlSanitizer`, so landing it first lets #19424 rebase and adopt the same helper before merging.

Part of #19419
