### PR TITLE
Fix instrumentation-docs path handling on Windows

### DIFF
--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
@@ -29,18 +30,14 @@ public class DocGeneratorApplication {
 
   public static void main(String[] args) throws IOException {
     // Identify path to repo so we can use absolute paths
-    String baseRepoPath = System.getProperty("basePath");
-    if (baseRepoPath == null) {
-      baseRepoPath = "./";
-    } else {
-      baseRepoPath += "/";
-    }
+    String basePath = System.getProperty("basePath");
+    Path baseRepoPath = Paths.get(basePath == null ? "." : basePath);
 
     FileManager fileManager = new FileManager(baseRepoPath);
     List<InstrumentationModule> modules = new InstrumentationAnalyzer(fileManager).analyze();
 
     try (BufferedWriter writer =
-        Files.newBufferedWriter(Paths.get(baseRepoPath + "docs/instrumentation-list.yaml"))) {
+        Files.newBufferedWriter(baseRepoPath.resolve("docs/instrumentation-list.yaml"))) {
       writer.write("# This file is generated and should not be manually edited.\n");
       writer.write("# The structure and contents are a work in progress and subject to change.\n");
       writer.write(

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -94,8 +94,9 @@ class InstrumentationAnalyzer {
   }
 
   private Set<String> getVersionInformation(InstrumentationModule module) {
+    Path moduleRoot = fileManager.rootDir().resolve(module.getSrcPath());
     List<Path> gradleFiles = fileManager.findBuildGradleFiles(module.getSrcPath());
-    return GradleParser.extractVersions(gradleFiles, module);
+    return GradleParser.extractVersions(moduleRoot, gradleFiles, module);
   }
 
   /**

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -23,6 +23,7 @@ import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
 import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,8 +52,7 @@ class InstrumentationAnalyzer {
    */
   public List<InstrumentationModule> analyze() throws IOException {
     List<InstrumentationPath> paths = fileManager.getInstrumentationPaths();
-    List<InstrumentationModule> modules =
-        ModuleParser.convertToModules(fileManager.rootDir(), paths);
+    List<InstrumentationModule> modules = ModuleParser.convertToModules(paths);
 
     for (InstrumentationModule module : modules) {
       enrichModule(module);
@@ -94,7 +94,7 @@ class InstrumentationAnalyzer {
   }
 
   private Set<String> getVersionInformation(InstrumentationModule module) {
-    List<String> gradleFiles = fileManager.findBuildGradleFiles(module.getSrcPath());
+    List<Path> gradleFiles = fileManager.findBuildGradleFiles(module.getSrcPath());
     return GradleParser.extractVersions(gradleFiles, module);
   }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/auditors/SupportedLibrariesAuditor.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/auditors/SupportedLibrariesAuditor.java
@@ -11,6 +11,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -76,14 +78,9 @@ public class SupportedLibrariesAuditor implements DocumentationAuditor {
    * @return list of library names from the local file
    */
   private static List<String> parseLocalSupportedLibraries() {
-    String baseRepoPath = System.getProperty("basePath");
-    if (baseRepoPath == null) {
-      baseRepoPath = "./";
-    } else {
-      baseRepoPath += "/";
-    }
+    String basePath = System.getProperty("basePath");
+    Path file = Paths.get(basePath == null ? "." : basePath).resolve("docs/supported-libraries.md");
 
-    String file = baseRepoPath + "docs/supported-libraries.md";
     String fileContent = FileManager.readFileToString(file);
 
     if (fileContent == null) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/auditors/SuppressionListAuditor.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/auditors/SuppressionListAuditor.java
@@ -11,6 +11,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -67,14 +69,10 @@ public class SuppressionListAuditor implements DocumentationAuditor {
    * @throws RuntimeException if the file cannot be read
    */
   private static String getInstrumentationListContent() {
-    String baseRepoPath = System.getProperty("basePath");
-    if (baseRepoPath == null) {
-      baseRepoPath = "./";
-    } else {
-      baseRepoPath += "/";
-    }
+    String basePath = System.getProperty("basePath");
+    Path file =
+        Paths.get(basePath == null ? "." : basePath).resolve("docs/instrumentation-list.yaml");
 
-    String file = baseRepoPath + "docs/instrumentation-list.yaml";
     String content = FileManager.readFileToString(file);
     if (content == null) {
       throw new IllegalStateException("Failed to read instrumentation list from: " + file);

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
@@ -15,7 +15,6 @@ import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -40,8 +39,8 @@ public class EmittedMetricsParser {
    * @return contents of aggregated files
    */
   public static Map<String, EmittedMetrics> getMetricsFromFiles(
-      String rootDir, String instrumentationDirectory) {
-    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
+      Path rootDir, String instrumentationDirectory) {
+    Path telemetryDir = rootDir.resolve(instrumentationDirectory).resolve(".telemetry");
 
     Map<String, List<EmittedMetrics.MetricsByScope>> metricsByWhen =
         parseAllMetricFiles(telemetryDir);
@@ -65,7 +64,7 @@ public class EmittedMetricsParser {
             .filter(path -> path.getFileName().toString().startsWith("metrics-"))
             .forEach(
                 path -> {
-                  String content = FileManager.readFileToString(path.toString());
+                  String content = FileManager.readFileToString(path);
                   if (content != null) {
                     String whenKey = normalizeWhenCondition(content);
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParser.java
@@ -41,7 +41,7 @@ public class EmittedMetricsParser {
    */
   public static Map<String, EmittedMetrics> getMetricsFromFiles(
       String rootDir, String instrumentationDirectory) {
-    Path telemetryDir = Paths.get(rootDir + "/" + instrumentationDirectory, ".telemetry");
+    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
 
     Map<String, List<EmittedMetrics.MetricsByScope>> metricsByWhen =
         parseAllMetricFiles(telemetryDir);

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -21,7 +21,6 @@ import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -138,8 +137,8 @@ public class EmittedScopeParser {
    * @return set of all unique scopes found in scope files
    */
   public static Set<EmittedScope.Scope> getScopesFromFiles(
-      String rootDir, String instrumentationDirectory) {
-    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
+      Path rootDir, String instrumentationDirectory) {
+    Path telemetryDir = rootDir.resolve(instrumentationDirectory).resolve(".telemetry");
 
     Set<EmittedScope.Scope> allScopes = new HashSet<>();
 
@@ -149,7 +148,7 @@ public class EmittedScopeParser {
             .filter(path -> path.getFileName().toString().startsWith("scope-"))
             .forEach(
                 path -> {
-                  String content = FileManager.readFileToString(path.toString());
+                  String content = FileManager.readFileToString(path);
                   if (content != null) {
                     EmittedScope parsed;
                     try {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -139,7 +139,7 @@ public class EmittedScopeParser {
    */
   public static Set<EmittedScope.Scope> getScopesFromFiles(
       String rootDir, String instrumentationDirectory) {
-    Path telemetryDir = Paths.get(rootDir + "/" + instrumentationDirectory, ".telemetry");
+    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
 
     Set<EmittedScope.Scope> allScopes = new HashSet<>();
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
@@ -15,7 +15,6 @@ import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,9 +38,9 @@ public class EmittedSpanParser {
    * @return contents of aggregated files
    */
   public static Map<String, EmittedSpans> getSpansByScopeFromFiles(
-      String rootDir, String instrumentationDirectory) throws JsonProcessingException {
+      Path rootDir, String instrumentationDirectory) throws JsonProcessingException {
     Map<String, StringBuilder> spansByScope = new HashMap<>();
-    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
+    Path telemetryDir = rootDir.resolve(instrumentationDirectory).resolve(".telemetry");
 
     if (Files.exists(telemetryDir) && Files.isDirectory(telemetryDir)) {
       try (Stream<Path> files = Files.list(telemetryDir)) {
@@ -49,7 +48,7 @@ public class EmittedSpanParser {
             .filter(path -> path.getFileName().toString().startsWith("spans-"))
             .forEach(
                 path -> {
-                  String content = FileManager.readFileToString(path.toString());
+                  String content = FileManager.readFileToString(path);
                   if (content != null) {
                     String whenKey = normalizeWhenCondition(content);
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedSpanParser.java
@@ -41,7 +41,7 @@ public class EmittedSpanParser {
   public static Map<String, EmittedSpans> getSpansByScopeFromFiles(
       String rootDir, String instrumentationDirectory) throws JsonProcessingException {
     Map<String, StringBuilder> spansByScope = new HashMap<>();
-    Path telemetryDir = Paths.get(rootDir + "/" + instrumentationDirectory, ".telemetry");
+    Path telemetryDir = Paths.get(rootDir).resolve(instrumentationDirectory).resolve(".telemetry");
 
     if (Files.exists(telemetryDir) && Files.isDirectory(telemetryDir)) {
       try (Stream<Path> files = Files.list(telemetryDir)) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
@@ -182,20 +182,21 @@ public class GradleParser {
     return null;
   }
 
-  public static Set<String> extractVersions(List<Path> gradleFiles, InstrumentationModule module) {
+  public static Set<String> extractVersions(
+      Path moduleRoot, List<Path> gradleFiles, InstrumentationModule module) {
     Set<String> allVersions = new HashSet<>();
-    gradleFiles.forEach(file -> processGradleFile(file, allVersions, module));
+    gradleFiles.forEach(file -> processGradleFile(moduleRoot, file, allVersions, module));
     return allVersions;
   }
 
   private static void processGradleFile(
-      Path filePath, Set<String> versions, InstrumentationModule module) {
+      Path moduleRoot, Path filePath, Set<String> versions, InstrumentationModule module) {
     String fileContents = FileManager.readFileToString(filePath);
     if (fileContents == null) {
       return;
     }
 
-    Optional<InstrumentationType> type = determineInstrumentationType(filePath);
+    Optional<InstrumentationType> type = determineInstrumentationType(moduleRoot, filePath);
     if (type.isEmpty()) {
       return;
     }
@@ -216,16 +217,24 @@ public class GradleParser {
     }
   }
 
-  private static Optional<InstrumentationType> determineInstrumentationType(Path filePath) {
-    // matching on path elements rather than substrings keeps this working on Windows, where
-    // Path#toString uses backslashes
-    for (Path element : filePath) {
-      String segment = element.toString();
-      if (segment.equals("javaagent")) {
-        return Optional.of(InstrumentationType.JAVAAGENT);
-      } else if (segment.equals("library")) {
-        return Optional.of(InstrumentationType.LIBRARY);
-      }
+  /**
+   * Determines the instrumentation type from the first segment of the build file's path relative to
+   * the module root. Resolving against the module root rather than scanning the absolute path keeps
+   * an ancestor checkout directory named {@code javaagent} or {@code library} from being mistaken
+   * for the module's own type.
+   */
+  private static Optional<InstrumentationType> determineInstrumentationType(
+      Path moduleRoot, Path filePath) {
+    Path relativePath = moduleRoot.relativize(filePath);
+    if (relativePath.getNameCount() < 2) {
+      return Optional.empty();
+    }
+
+    String type = relativePath.getName(0).toString();
+    if (type.equals("javaagent")) {
+      return Optional.of(InstrumentationType.JAVAAGENT);
+    } else if (type.equals("library")) {
+      return Optional.of(InstrumentationType.LIBRARY);
     }
     return Optional.empty();
   }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.docs.internal.DependencyInfo;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -181,15 +182,14 @@ public class GradleParser {
     return null;
   }
 
-  public static Set<String> extractVersions(
-      List<String> gradleFiles, InstrumentationModule module) {
+  public static Set<String> extractVersions(List<Path> gradleFiles, InstrumentationModule module) {
     Set<String> allVersions = new HashSet<>();
     gradleFiles.forEach(file -> processGradleFile(file, allVersions, module));
     return allVersions;
   }
 
   private static void processGradleFile(
-      String filePath, Set<String> versions, InstrumentationModule module) {
+      Path filePath, Set<String> versions, InstrumentationModule module) {
     String fileContents = FileManager.readFileToString(filePath);
     if (fileContents == null) {
       return;
@@ -216,11 +216,16 @@ public class GradleParser {
     }
   }
 
-  private static Optional<InstrumentationType> determineInstrumentationType(String filePath) {
-    if (filePath.contains("/javaagent/")) {
-      return Optional.of(InstrumentationType.JAVAAGENT);
-    } else if (filePath.contains("/library/")) {
-      return Optional.of(InstrumentationType.LIBRARY);
+  private static Optional<InstrumentationType> determineInstrumentationType(Path filePath) {
+    // matching on path elements rather than substrings keeps this working on Windows, where
+    // Path#toString uses backslashes
+    for (Path element : filePath) {
+      String segment = element.toString();
+      if (segment.equals("javaagent")) {
+        return Optional.of(InstrumentationType.JAVAAGENT);
+      } else if (segment.equals("library")) {
+        return Optional.of(InstrumentationType.LIBRARY);
+      }
     }
     return Optional.empty();
   }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/ModuleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/ModuleParser.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.docs.parsers;
 
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
-import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,17 +18,15 @@ public class ModuleParser {
   /**
    * Converts a list of {@link InstrumentationPath} into a list of {@link InstrumentationModule}.
    *
-   * @param rootPath the root path for sanitization
    * @param paths the list of {@link InstrumentationPath} objects to be converted
    * @return a list of {@link InstrumentationModule} objects
    */
-  public static List<InstrumentationModule> convertToModules(
-      String rootPath, List<InstrumentationPath> paths) {
+  public static List<InstrumentationModule> convertToModules(List<InstrumentationPath> paths) {
     Map<String, InstrumentationModule> moduleMap = new HashMap<>();
 
     for (InstrumentationPath path : paths) {
       String moduleKey = createModuleKey(path);
-      moduleMap.computeIfAbsent(moduleKey, k -> createModule(rootPath, path));
+      moduleMap.computeIfAbsent(moduleKey, k -> createModule(path));
     }
 
     return new ArrayList<>(moduleMap.values());
@@ -39,24 +36,13 @@ public class ModuleParser {
     return String.join(":", path.group(), path.namespace(), path.instrumentationName());
   }
 
-  private static InstrumentationModule createModule(String rootPath, InstrumentationPath path) {
+  private static InstrumentationModule createModule(InstrumentationPath path) {
     return new InstrumentationModule.Builder()
-        .srcPath(sanitizePathName(rootPath, path.srcPath()))
+        .srcPath(path.srcPath())
         .instrumentationName(path.instrumentationName())
         .namespace(path.namespace())
         .group(path.group())
         .build();
-  }
-
-  // visible for testing
-  public static String sanitizePathName(String rootPath, String path) {
-    // both sides are normalized so that the replacements also match on Windows, where the root path
-    // and the instrumentation path may use different separators
-    String normalizedRootPath = FileManager.normalizeSeparators(rootPath);
-    return FileManager.normalizeSeparators(path)
-        .replace(normalizedRootPath, "")
-        .replace("/javaagent", "")
-        .replace("/library", "");
   }
 
   private ModuleParser() {}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/ModuleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/ModuleParser.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.docs.parsers;
 
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import io.opentelemetry.instrumentation.docs.utils.InstrumentationPath;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,7 +50,13 @@ public class ModuleParser {
 
   // visible for testing
   public static String sanitizePathName(String rootPath, String path) {
-    return path.replace(rootPath, "").replace("/javaagent", "").replace("/library", "");
+    // both sides are normalized so that the replacements also match on Windows, where the root path
+    // and the instrumentation path may use different separators
+    String normalizedRootPath = FileManager.normalizeSeparators(rootPath);
+    return FileManager.normalizeSeparators(path)
+        .replace(normalizedRootPath, "")
+        .replace("/javaagent", "")
+        .replace("/library", "");
   }
 
   private ModuleParser() {}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
@@ -28,7 +28,10 @@ public record FileManager(Path rootDir) {
 
     try (Stream<Path> walk = Files.walk(instrumentationRoot)) {
       return walk.filter(Files::isDirectory)
-          .filter(dir -> isValidInstrumentationPath(dir.toString()))
+          // the exclusion rules are written against repository-relative paths, so a checkout
+          // directory that happens to contain something like "build" or "-common-" does not
+          // exclude every module
+          .filter(dir -> isValidInstrumentationPath(rootDir.relativize(dir).toString()))
           .map(this::parseInstrumentationPath)
           .collect(toList());
     }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
@@ -5,56 +5,51 @@
 
 package io.opentelemetry.instrumentation.docs.utils;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
-public record FileManager(String rootDir) {
+public record FileManager(Path rootDir) {
   private static final Logger logger = Logger.getLogger(FileManager.class.getName());
 
   public List<InstrumentationPath> getInstrumentationPaths() throws IOException {
-    Path rootPath = resolveFromRoot("instrumentation");
+    Path instrumentationRoot = rootDir.resolve("instrumentation");
 
-    try (Stream<Path> walk = Files.walk(rootPath)) {
+    try (Stream<Path> walk = Files.walk(instrumentationRoot)) {
       return walk.filter(Files::isDirectory)
           .filter(dir -> isValidInstrumentationPath(dir.toString()))
-          .map(dir -> parseInstrumentationPath(dir.toString()))
+          .map(this::parseInstrumentationPath)
           .collect(toList());
     }
   }
 
-  @Nullable
-  private static InstrumentationPath parseInstrumentationPath(String filePath) {
-    if (filePath == null || filePath.isEmpty()) {
-      return null;
-    }
-
-    String normalized = normalizeSeparators(filePath);
-    String instrumentationSegment = "/instrumentation/";
-    int startIndex = normalized.indexOf(instrumentationSegment) + instrumentationSegment.length();
-    String[] parts = normalized.substring(startIndex).split("/");
-
-    if (parts.length < 2) {
-      return null;
-    }
-
+  private InstrumentationPath parseInstrumentationPath(Path directory) {
     InstrumentationType instrumentationType =
-        InstrumentationType.fromString(parts[parts.length - 1]);
-    String name = parts[parts.length - 2];
+        InstrumentationType.fromString(directory.getFileName().toString());
+
+    // the directory is known to end with a javaagent/library segment nested under
+    // instrumentation/, so it always has a parent
+    Path moduleDirectory = requireNonNull(directory.getParent());
+    String name = moduleDirectory.getFileName().toString();
     String namespace = name.contains("-") ? name.split("-")[0] : name;
 
-    // the normalized path is stored so that downstream string manipulation (e.g. making the path
-    // relative to the repository root) behaves the same on Windows as it does on other platforms
-    return new InstrumentationPath(name, normalized, namespace, namespace, instrumentationType);
+    return new InstrumentationPath(
+        name,
+        toUnixString(rootDir.relativize(moduleDirectory)),
+        namespace,
+        namespace,
+        instrumentationType);
   }
 
   public static boolean isValidInstrumentationPath(String filePath) {
@@ -81,22 +76,30 @@ public record FileManager(String rootDir) {
     return normalized.endsWith("javaagent") || normalized.endsWith("library");
   }
 
-  /** Converts Windows path separators to forward slashes, leaving other platforms untouched. */
-  public static String normalizeSeparators(String filePath) {
+  private static String normalizeSeparators(String filePath) {
     return filePath.replace('\\', '/');
   }
 
-  public List<String> findBuildGradleFiles(String instrumentationDirectory) {
-    Path rootPath = resolveFromRoot(instrumentationDirectory);
+  /**
+   * Renders a relative path using forward slashes on every platform, so that generated
+   * documentation is identical regardless of the operating system it was generated on.
+   */
+  private static String toUnixString(Path relativePath) {
+    return StreamSupport.stream(relativePath.spliterator(), false)
+        .map(Path::toString)
+        .collect(joining("/"));
+  }
 
-    try (Stream<Path> walk = Files.walk(rootPath)) {
+  public List<Path> findBuildGradleFiles(String instrumentationDirectory) {
+    Path modulePath = rootDir.resolve(instrumentationDirectory);
+
+    try (Stream<Path> walk = Files.walk(modulePath)) {
       return walk.filter(Files::isRegularFile)
           .filter(
               path ->
                   path.getFileName().toString().equals("build.gradle.kts")
-                      && !normalizeSeparators(path.toString()).contains("/testing/")
-                      && !isInNestedInstrumentationModule(path, rootPath))
-          .map(path -> normalizeSeparators(path.toString()))
+                      && !containsElement(modulePath.relativize(path), "testing")
+                      && !isInNestedInstrumentationModule(path, modulePath))
           .collect(toList());
     } catch (IOException e) {
       logger.severe("Error traversing directory: " + e.getMessage());
@@ -127,23 +130,28 @@ public record FileManager(String rootDir) {
     return false;
   }
 
+  private static boolean containsElement(Path path, String element) {
+    for (Path segment : path) {
+      if (segment.toString().equals(element)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Nullable
   public String getMetaDataFile(String instrumentationDirectory) {
-    Path metadataFile = resolveFromRoot(instrumentationDirectory).resolve("metadata.yaml");
+    Path metadataFile = rootDir.resolve(instrumentationDirectory).resolve("metadata.yaml");
     if (Files.exists(metadataFile)) {
-      return readFileToString(metadataFile.toString());
+      return readFileToString(metadataFile);
     }
     return null;
   }
 
-  private Path resolveFromRoot(String relativePath) {
-    return Paths.get(rootDir).resolve(relativePath);
-  }
-
   @Nullable
-  public static String readFileToString(String filePath) {
+  public static String readFileToString(Path filePath) {
     try {
-      return Files.readString(Paths.get(filePath));
+      return Files.readString(filePath);
     } catch (IOException e) {
       logger.severe("Error reading file: " + e.getMessage());
       return null;

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/FileManager.java
@@ -22,7 +22,7 @@ public record FileManager(String rootDir) {
   private static final Logger logger = Logger.getLogger(FileManager.class.getName());
 
   public List<InstrumentationPath> getInstrumentationPaths() throws IOException {
-    Path rootPath = Paths.get(rootDir + "instrumentation");
+    Path rootPath = resolveFromRoot("instrumentation");
 
     try (Stream<Path> walk = Files.walk(rootPath)) {
       return walk.filter(Files::isDirectory)
@@ -52,7 +52,9 @@ public record FileManager(String rootDir) {
     String name = parts[parts.length - 2];
     String namespace = name.contains("-") ? name.split("-")[0] : name;
 
-    return new InstrumentationPath(name, filePath, namespace, namespace, instrumentationType);
+    // the normalized path is stored so that downstream string manipulation (e.g. making the path
+    // relative to the repository root) behaves the same on Windows as it does on other platforms
+    return new InstrumentationPath(name, normalized, namespace, namespace, instrumentationType);
   }
 
   public static boolean isValidInstrumentationPath(String filePath) {
@@ -79,12 +81,13 @@ public record FileManager(String rootDir) {
     return normalized.endsWith("javaagent") || normalized.endsWith("library");
   }
 
-  private static String normalizeSeparators(String filePath) {
+  /** Converts Windows path separators to forward slashes, leaving other platforms untouched. */
+  public static String normalizeSeparators(String filePath) {
     return filePath.replace('\\', '/');
   }
 
   public List<String> findBuildGradleFiles(String instrumentationDirectory) {
-    Path rootPath = Paths.get(rootDir + instrumentationDirectory);
+    Path rootPath = resolveFromRoot(instrumentationDirectory);
 
     try (Stream<Path> walk = Files.walk(rootPath)) {
       return walk.filter(Files::isRegularFile)
@@ -93,7 +96,7 @@ public record FileManager(String rootDir) {
                   path.getFileName().toString().equals("build.gradle.kts")
                       && !normalizeSeparators(path.toString()).contains("/testing/")
                       && !isInNestedInstrumentationModule(path, rootPath))
-          .map(Path::toString)
+          .map(path -> normalizeSeparators(path.toString()))
           .collect(toList());
     } catch (IOException e) {
       logger.severe("Error traversing directory: " + e.getMessage());
@@ -126,11 +129,15 @@ public record FileManager(String rootDir) {
 
   @Nullable
   public String getMetaDataFile(String instrumentationDirectory) {
-    String metadataFile = rootDir + instrumentationDirectory + "/metadata.yaml";
-    if (Files.exists(Paths.get(metadataFile))) {
-      return readFileToString(metadataFile);
+    Path metadataFile = resolveFromRoot(instrumentationDirectory).resolve("metadata.yaml");
+    if (Files.exists(metadataFile)) {
+      return readFileToString(metadataFile.toString());
     }
     return null;
+  }
+
+  private Path resolveFromRoot(String relativePath) {
+    return Paths.get(rootDir).resolve(relativePath);
   }
 
   @Nullable

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/InstrumentationPath.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/InstrumentationPath.java
@@ -7,6 +7,11 @@ package io.opentelemetry.instrumentation.docs.utils;
 
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 
+/**
+ * A discovered instrumentation source directory.
+ *
+ * @param srcPath repository-relative module path, using forward slashes on every platform
+ */
 public record InstrumentationPath(
     String instrumentationName,
     String srcPath,

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzerTest.java
@@ -30,24 +30,24 @@ class InstrumentationAnalyzerTest {
         asList(
             new InstrumentationPath(
                 "log4j-appender-2.17",
-                "instrumentation/log4j/log4j-appender-2.17/library",
+                "instrumentation/log4j/log4j-appender-2.17",
                 "log4j",
                 "log4j",
                 InstrumentationType.LIBRARY),
             new InstrumentationPath(
                 "log4j-appender-2.17",
-                "instrumentation/log4j/log4j-appender-2.17/javaagent",
+                "instrumentation/log4j/log4j-appender-2.17",
                 "log4j",
                 "log4j",
                 InstrumentationType.JAVAAGENT),
             new InstrumentationPath(
                 "spring-web",
-                "instrumentation/spring/spring-web/library",
+                "instrumentation/spring/spring-web",
                 "spring",
                 "spring",
                 InstrumentationType.LIBRARY));
 
-    List<InstrumentationModule> modules = ModuleParser.convertToModules("test", paths);
+    List<InstrumentationModule> modules = ModuleParser.convertToModules(paths);
 
     assertThat(modules.size()).isEqualTo(2);
 
@@ -83,18 +83,18 @@ class InstrumentationAnalyzerTest {
         asList(
             new InstrumentationPath(
                 "same-name",
-                "instrumentation/test1/same-name/library",
+                "instrumentation/test1/same-name",
                 "namespace1",
                 "group1",
                 InstrumentationType.LIBRARY),
             new InstrumentationPath(
                 "same-name",
-                "instrumentation/test2/same-name/library",
+                "instrumentation/test2/same-name",
                 "namespace2",
                 "group2",
                 InstrumentationType.LIBRARY));
 
-    List<InstrumentationModule> modules = ModuleParser.convertToModules("test", paths);
+    List<InstrumentationModule> modules = ModuleParser.convertToModules(paths);
 
     // Should create 2 separate modules because they have different group/namespace combinations
     assertThat(modules.size()).isEqualTo(2);
@@ -148,7 +148,7 @@ class InstrumentationAnalyzerTest {
         """);
 
     List<InstrumentationModule> modules =
-        new InstrumentationAnalyzer(new FileManager(tempDir + "/")).analyze();
+        new InstrumentationAnalyzer(new FileManager(tempDir)).analyze();
 
     assertThat(modules).hasSize(1);
     InstrumentationModule module = modules.get(0);

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ModuleConverterTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ModuleConverterTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.docs;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,5 +58,35 @@ class ModuleConverterTest {
 
     sanitized = ModuleParser.sanitizePathName("/root", "/root/other");
     assertThat(sanitized).isEqualTo("/other");
+  }
+
+  @Test
+  void testSanitizePathNameHandlesWindowsSeparators() {
+    // the root path comes from the basePath system property and mixes separators on Windows
+    String sanitized =
+        ModuleParser.sanitizePathName(
+            "C:\\Users\\me\\repo/", "C:\\Users\\me\\repo\\instrumentation\\camel-2.20\\javaagent");
+    assertThat(sanitized).isEqualTo("instrumentation/camel-2.20");
+
+    sanitized =
+        ModuleParser.sanitizePathName(
+            "C:\\Users\\me\\repo/", "C:/Users/me/repo/instrumentation/camel-2.20/library");
+    assertThat(sanitized).isEqualTo("instrumentation/camel-2.20");
+  }
+
+  @Test
+  void testConvertToModulesHandlesWindowsSeparators() {
+    InstrumentationPath path = mock(InstrumentationPath.class);
+    when(path.group()).thenReturn("camel");
+    when(path.namespace()).thenReturn("camel");
+    when(path.instrumentationName()).thenReturn("camel-2.20");
+    when(path.srcPath()).thenReturn("C:/Users/me/repo/instrumentation/camel-2.20/javaagent");
+
+    List<InstrumentationModule> modules =
+        ModuleParser.convertToModules("C:\\Users\\me\\repo/", singletonList(path));
+
+    assertThat(modules)
+        .extracting(InstrumentationModule::getSrcPath)
+        .containsExactly("instrumentation/camel-2.20");
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ModuleConverterTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/ModuleConverterTest.java
@@ -25,65 +25,37 @@ class ModuleConverterTest {
     when(path1.group()).thenReturn("g1");
     when(path1.namespace()).thenReturn("n1");
     when(path1.instrumentationName()).thenReturn("i1");
-    when(path1.srcPath()).thenReturn("/root/javaagent/foo");
+    when(path1.srcPath()).thenReturn("instrumentation/foo");
 
     InstrumentationPath path2 = mock(InstrumentationPath.class);
     when(path2.group()).thenReturn("g1");
     when(path2.namespace()).thenReturn("n1");
     when(path2.instrumentationName()).thenReturn("i1");
-    when(path2.srcPath()).thenReturn("/root/library/bar");
+    when(path2.srcPath()).thenReturn("instrumentation/foo");
 
     InstrumentationPath path3 = mock(InstrumentationPath.class);
     when(path3.group()).thenReturn("g2");
     when(path3.namespace()).thenReturn("n2");
     when(path3.instrumentationName()).thenReturn("i2");
-    when(path3.srcPath()).thenReturn("/root/javaagent/baz");
+    when(path3.srcPath()).thenReturn("instrumentation/bar");
 
     List<InstrumentationModule> modules =
-        ModuleParser.convertToModules("/root", asList(path1, path2, path3));
+        ModuleParser.convertToModules(asList(path1, path2, path3));
 
-    assertThat(modules.size()).isEqualTo(2);
     assertThat(modules)
         .extracting(InstrumentationModule::getGroup)
         .containsExactlyInAnyOrder("g1", "g2");
   }
 
   @Test
-  void testSanitizePathNameRemovesRootAndKnownFolders() throws Exception {
-    String sanitized = ModuleParser.sanitizePathName("/root", "/root/javaagent/foo/bar");
-    assertThat(sanitized).isEqualTo("/foo/bar");
-
-    sanitized = ModuleParser.sanitizePathName("/root", "/root/library/baz");
-    assertThat(sanitized).isEqualTo("/baz");
-
-    sanitized = ModuleParser.sanitizePathName("/root", "/root/other");
-    assertThat(sanitized).isEqualTo("/other");
-  }
-
-  @Test
-  void testSanitizePathNameHandlesWindowsSeparators() {
-    // the root path comes from the basePath system property and mixes separators on Windows
-    String sanitized =
-        ModuleParser.sanitizePathName(
-            "C:\\Users\\me\\repo/", "C:\\Users\\me\\repo\\instrumentation\\camel-2.20\\javaagent");
-    assertThat(sanitized).isEqualTo("instrumentation/camel-2.20");
-
-    sanitized =
-        ModuleParser.sanitizePathName(
-            "C:\\Users\\me\\repo/", "C:/Users/me/repo/instrumentation/camel-2.20/library");
-    assertThat(sanitized).isEqualTo("instrumentation/camel-2.20");
-  }
-
-  @Test
-  void testConvertToModulesHandlesWindowsSeparators() {
+  void testConvertToModulesKeepsSrcPath() {
     InstrumentationPath path = mock(InstrumentationPath.class);
     when(path.group()).thenReturn("camel");
     when(path.namespace()).thenReturn("camel");
     when(path.instrumentationName()).thenReturn("camel-2.20");
-    when(path.srcPath()).thenReturn("C:/Users/me/repo/instrumentation/camel-2.20/javaagent");
+    when(path.srcPath()).thenReturn("instrumentation/camel-2.20");
 
-    List<InstrumentationModule> modules =
-        ModuleParser.convertToModules("C:\\Users\\me\\repo/", singletonList(path));
+    List<InstrumentationModule> modules = ModuleParser.convertToModules(singletonList(path));
 
     assertThat(modules)
         .extracting(InstrumentationModule::getSrcPath)

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedMetricsParserTest.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.docs.utils.FileManager;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,16 +96,13 @@ class EmittedMetricsParserTest {
 
     try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
       fileManagerMock
-          .when(
-              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml")))
           .thenReturn(file1Content);
       fileManagerMock
-          .when(
-              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml")))
           .thenReturn(file2Content);
 
-      Map<String, EmittedMetrics> result =
-          EmittedMetricsParser.getMetricsFromFiles(tempDir.toString(), "");
+      Map<String, EmittedMetrics> result = EmittedMetricsParser.getMetricsFromFiles(tempDir, "");
 
       EmittedMetrics.MetricsByScope metrics =
           result.get("default").getMetricsByScope().stream()
@@ -156,16 +154,13 @@ class EmittedMetricsParserTest {
 
     try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
       fileManagerMock
-          .when(
-              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("metrics-1.yaml")))
           .thenReturn(withState);
       fileManagerMock
-          .when(
-              () -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("metrics-2.yaml")))
           .thenReturn(withoutState);
 
-      Map<String, EmittedMetrics> result =
-          EmittedMetricsParser.getMetricsFromFiles(tempDir.toString(), "");
+      Map<String, EmittedMetrics> result = EmittedMetricsParser.getMetricsFromFiles(tempDir, "");
 
       EmittedMetrics.MetricsByScope metrics =
           result.get("Java17").getMetricsByScope().stream()
@@ -186,7 +181,7 @@ class EmittedMetricsParserTest {
   @Test
   void getMetricsFromFilesHandlesNonexistentDirectory() throws JsonProcessingException {
     Map<String, EmittedMetrics> result =
-        EmittedMetricsParser.getMetricsFromFiles("/nonexistent", "path");
+        EmittedMetricsParser.getMetricsFromFiles(Paths.get("/nonexistent"), "path");
     assertThat(result).isEmpty();
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -74,7 +74,7 @@ class EmittedScopeParserTest {
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
     Set<EmittedScope.Scope> scopes =
-        EmittedScopeParser.getScopesFromFiles(tempDir.toString(), "test-instrumentation");
+        EmittedScopeParser.getScopesFromFiles(tempDir, "test-instrumentation");
 
     assertThat(scopes).hasSize(2);
     assertThat(scopes)
@@ -112,7 +112,7 @@ class EmittedScopeParserTest {
     Files.writeString(telemetryDir.resolve("scope-file2.yaml"), scopeContent2);
 
     Set<EmittedScope.Scope> scopes =
-        EmittedScopeParser.getScopesFromFiles(tempDir.toString(), "test-instrumentation");
+        EmittedScopeParser.getScopesFromFiles(tempDir, "test-instrumentation");
 
     // duplicates should be removed
     assertThat(scopes).hasSize(2);
@@ -133,7 +133,7 @@ class EmittedScopeParserTest {
 
     // Parse should return empty set
     Set<EmittedScope.Scope> scopes =
-        EmittedScopeParser.getScopesFromFiles(tempDir.toString(), "test-instrumentation");
+        EmittedScopeParser.getScopesFromFiles(tempDir, "test-instrumentation");
 
     assertThat(scopes).isEmpty();
   }
@@ -154,7 +154,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
 
@@ -181,7 +181,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-test.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("spring-web-6.0").srcPath("test-instrumentation").build();
 
@@ -194,7 +194,7 @@ class EmittedScopeParserTest {
 
   @Test
   void testGetScopeNoTelemetryDirectory(@TempDir Path tempDir) {
-    FileManager fileManager = new FileManager(tempDir.toString() + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
 
@@ -222,7 +222,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
 
@@ -250,7 +250,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("oshi-5.0").srcPath("test-instrumentation").build();
 
@@ -281,7 +281,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("reactor-netty-0.9")
             .srcPath("test-instrumentation")
@@ -311,7 +311,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
 
@@ -344,7 +344,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-multi.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("hibernate-6.0").srcPath("test-instrumentation").build();
 
@@ -374,7 +374,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-with-attrs.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("jdbc").srcPath("test-instrumentation").build();
 
@@ -409,7 +409,7 @@ class EmittedScopeParserTest {
 
     Files.writeString(telemetryDir.resolve("scope-mixed-attrs.yaml"), scopeContent);
 
-    FileManager fileManager = new FileManager(tempDir + "/");
+    FileManager fileManager = new FileManager(tempDir);
     InstrumentationModule module =
         new InstrumentationModule.Builder("test-lib").srcPath("test-instrumentation").build();
 
@@ -454,7 +454,7 @@ class EmittedScopeParserTest {
     Files.writeString(telemetryDir.resolve("scope-2.yaml"), scopeContent2);
 
     Set<EmittedScope.Scope> scopes =
-        EmittedScopeParser.getScopesFromFiles(tempDir.toString(), "test-instrumentation");
+        EmittedScopeParser.getScopesFromFiles(tempDir, "test-instrumentation");
 
     assertThat(scopes).hasSize(1);
   }
@@ -489,7 +489,7 @@ class EmittedScopeParserTest {
     Files.writeString(telemetryDir.resolve("scope-2.yaml"), scopeContent2);
 
     Set<EmittedScope.Scope> scopes =
-        EmittedScopeParser.getScopesFromFiles(tempDir.toString(), "test-instrumentation");
+        EmittedScopeParser.getScopesFromFiles(tempDir, "test-instrumentation");
 
     assertThat(scopes).hasSize(2);
   }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/SpanParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/SpanParserTest.java
@@ -77,17 +77,16 @@ class SpanParserTest {
 
     try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
       fileManagerMock
-          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-1.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-1.yaml")))
           .thenReturn(file1Content);
       fileManagerMock
-          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-2.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-2.yaml")))
           .thenReturn(file2Content);
       fileManagerMock
-          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-3.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-3.yaml")))
           .thenReturn(file2Content);
 
-      Map<String, EmittedSpans> result =
-          EmittedSpanParser.getSpansByScopeFromFiles(tempDir.toString(), "");
+      Map<String, EmittedSpans> result = EmittedSpanParser.getSpansByScopeFromFiles(tempDir, "");
 
       EmittedSpans spans = result.get("default");
       assertThat(spans.getSpansByScope()).hasSize(2);
@@ -240,11 +239,11 @@ class SpanParserTest {
 
     try (MockedStatic<FileManager> fileManagerMock = mockStatic(FileManager.class)) {
       fileManagerMock
-          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-1.yaml").toString()))
+          .when(() -> FileManager.readFileToString(telemetryDir.resolve("spans-1.yaml")))
           .thenReturn(file1Content);
 
       Map<String, EmittedSpans> fileContents =
-          EmittedSpanParser.getSpansByScopeFromFiles(tempDir.toString(), "");
+          EmittedSpanParser.getSpansByScopeFromFiles(tempDir, "");
 
       EmittedSpans emittedSpans = fileContents.get("default");
 

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
@@ -33,7 +33,26 @@ class FileManagerTest {
         Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation/javaagent"));
     List<InstrumentationPath> paths = fileManager.getInstrumentationPaths();
     assertThat(paths).hasSize(1);
-    assertThat(paths.get(0).srcPath()).isEqualTo(validDir.toString());
+    // paths always use forward slashes, even on Windows, so that they can be made relative to the
+    // repository root via string manipulation
+    assertThat(paths.get(0).srcPath())
+        .isEqualTo(validDir.toString().replace('\\', '/'))
+        .doesNotContain("\\");
+  }
+
+  @Test
+  void testGetMetaDataFileWithMixedSeparatorRootDir() throws IOException {
+    // on Windows tempDir uses backslashes while the module path uses forward slashes
+    Path moduleDir = Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation"));
+    Files.writeString(moduleDir.resolve("metadata.yaml"), "description: test\n");
+
+    assertThat(fileManager.getMetaDataFile("instrumentation/my-instrumentation"))
+        .isEqualTo("description: test\n");
+  }
+
+  @Test
+  void testGetMetaDataFileReturnsNullWhenMissing() {
+    assertThat(fileManager.getMetaDataFile("instrumentation/my-instrumentation")).isNull();
   }
 
   @Test
@@ -72,14 +91,19 @@ class FileManagerTest {
     List<String> gradleFiles =
         fileManager.findBuildGradleFiles("instrumentation/runtime-telemetry");
 
-    assertThat(gradleFiles).hasSize(2);
+    // paths always use forward slashes, even on Windows, so that downstream consumers can match on
+    // "/javaagent/" and "/library/" segments
     assertThat(gradleFiles)
         .containsExactlyInAnyOrder(
-            javaagent.resolve("build.gradle.kts").toString(),
-            library.resolve("build.gradle.kts").toString());
+            normalized(javaagent.resolve("build.gradle.kts")),
+            normalized(library.resolve("build.gradle.kts")));
     assertThat(gradleFiles)
         .doesNotContain(
-            nestedJava17.resolve("build.gradle.kts").toString(),
-            nestedJava8.resolve("build.gradle.kts").toString());
+            normalized(nestedJava17.resolve("build.gradle.kts")),
+            normalized(nestedJava8.resolve("build.gradle.kts")));
+  }
+
+  private static String normalized(Path path) {
+    return path.toString().replace('\\', '/');
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
@@ -7,9 +7,11 @@ package io.opentelemetry.instrumentation.docs.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,20 +26,30 @@ class FileManagerTest {
 
   @BeforeEach
   void setUp() {
-    fileManager = new FileManager(tempDir.toString() + "/");
+    fileManager = new FileManager(tempDir);
   }
 
   @Test
   void testGetInstrumentationPaths() throws IOException {
-    Path validDir =
-        Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation/javaagent"));
+    Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation/javaagent"));
     List<InstrumentationPath> paths = fileManager.getInstrumentationPaths();
     assertThat(paths).hasSize(1);
-    // paths always use forward slashes, even on Windows, so that they can be made relative to the
-    // repository root via string manipulation
-    assertThat(paths.get(0).srcPath())
-        .isEqualTo(validDir.toString().replace('\\', '/'))
-        .doesNotContain("\\");
+    assertThat(paths.get(0).instrumentationName()).isEqualTo("my-instrumentation");
+    assertThat(paths.get(0).type()).isEqualTo(InstrumentationType.JAVAAGENT);
+    // src paths are relative to the repository root and always use forward slashes, even on Windows
+    assertThat(paths.get(0).srcPath()).isEqualTo("instrumentation/my-instrumentation");
+  }
+
+  @Test
+  void testGetInstrumentationPathsWithTrailingSeparatorRootDir() throws IOException {
+    Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation/library"));
+    // a root dir with a trailing separator, as produced by appending "/" to the basePath property
+    FileManager trailingSeparator = new FileManager(Paths.get(tempDir + "/"));
+
+    List<InstrumentationPath> paths = trailingSeparator.getInstrumentationPaths();
+
+    assertThat(paths).hasSize(1);
+    assertThat(paths.get(0).srcPath()).isEqualTo("instrumentation/my-instrumentation");
   }
 
   @Test
@@ -88,22 +100,13 @@ class FileManagerTest {
     Files.createFile(nestedJava17.resolve("build.gradle.kts"));
     Files.createFile(nestedJava8.resolve("build.gradle.kts"));
 
-    List<String> gradleFiles =
-        fileManager.findBuildGradleFiles("instrumentation/runtime-telemetry");
+    List<Path> gradleFiles = fileManager.findBuildGradleFiles("instrumentation/runtime-telemetry");
 
-    // paths always use forward slashes, even on Windows, so that downstream consumers can match on
-    // "/javaagent/" and "/library/" segments
     assertThat(gradleFiles)
         .containsExactlyInAnyOrder(
-            normalized(javaagent.resolve("build.gradle.kts")),
-            normalized(library.resolve("build.gradle.kts")));
+            javaagent.resolve("build.gradle.kts"), library.resolve("build.gradle.kts"));
     assertThat(gradleFiles)
         .doesNotContain(
-            normalized(nestedJava17.resolve("build.gradle.kts")),
-            normalized(nestedJava8.resolve("build.gradle.kts")));
-  }
-
-  private static String normalized(Path path) {
-    return path.toString().replace('\\', '/');
+            nestedJava17.resolve("build.gradle.kts"), nestedJava8.resolve("build.gradle.kts"));
   }
 }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/FileManagerTest.java
@@ -53,6 +53,18 @@ class FileManagerTest {
   }
 
   @Test
+  void testGetInstrumentationPathsWithExcludedWordInRootDir() throws IOException {
+    // the checkout directory contains "build", which the exclusion rules match on
+    Path rootDir = tempDir.resolve("build/repo");
+    Files.createDirectories(rootDir.resolve("instrumentation/my-instrumentation/javaagent"));
+
+    List<InstrumentationPath> paths = new FileManager(rootDir).getInstrumentationPaths();
+
+    assertThat(paths).hasSize(1);
+    assertThat(paths.get(0).srcPath()).isEqualTo("instrumentation/my-instrumentation");
+  }
+
+  @Test
   void testGetMetaDataFileWithMixedSeparatorRootDir() throws IOException {
     // on Windows tempDir uses backslashes while the module path uses forward slashes
     Path moduleDir = Files.createDirectories(tempDir.resolve("instrumentation/my-instrumentation"));


### PR DESCRIPTION
`:instrumentation-docs:runAnalysis` fails on Windows with `java.nio.file.InvalidPathException`, so `docs/instrumentation-list.yaml` can't be regenerated there. The generator builds paths by string concatenation and by stripping prefixes with `replace()`, which only works when every separator is already a forward slash — true on Linux, not on Windows. A second, silent symptom of the same problem: substring matching on `"/javaagent/"` never matched, dropping `has_javaagent`, `has_standalone_library`, `javaagent_target_versions`, and `minimum_java_version` from every module.

Fixed by using `java.nio.file.Path` instead of string manipulation.

`runAnalysis` now succeeds on Windows and produces output identical to the committed file.