### PR TITLE
Use shared OSSF Scorecard workflow

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,44 +8,15 @@ on:
     - cron: "43 6 * * 5" # weekly at 06:43 (UTC) on Friday
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
     permissions:
-      # Needed for Code scanning upload
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable
-      # uploads of run results in SARIF format to the repository Actions tab.
-      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
-        with:
-          sarif_file: results.sarif
+      contents: read # for actions/checkout
+      id-token: write # for Scorecard to publish results
+      security-events: write # for the SARIF upload to code scanning
+    uses: open-telemetry/shared-workflows/.github/workflows/scorecard.yml@f13d0cb656d7244ca8c1638b6996dbaef1083bdd # v0.6.0
 
   workflow-notification:
     permissions:


### PR DESCRIPTION
<!--
CHANGELOG.md is generated from merged pull requests. Do not add an entry unless this PR introduces
a deprecation or breaking change.
-->
Replace the inline OSSF Scorecard job with the reusable workflow from `open-telemetry/shared-workflows`, pinned to the v0.6.0 commit. This preserves the full public Scorecard result, badge, SARIF artifact, existing Friday schedule, and failure-notification job while limiting code scanning uploads to `BinaryArtifactsID`, `DangerousWorkflowID`, `PinnedDependenciesID`, and `TokenPermissionsID`. Tracks open-telemetry/sig-security#311 and implements the repository migration described in open-telemetry/sig-security#309.