### PR TITLE
Use slimmed down agent in jmx-metrics container tests

### DIFF
--- a/instrumentation/jmx-metrics/library/build.gradle.kts
+++ b/instrumentation/jmx-metrics/library/build.gradle.kts
@@ -23,20 +23,29 @@ tasks {
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
 
-    val shadowTask = project(":javaagent").tasks.named<Jar>("shadowJar")
+    // the base agent only contains the agent machinery and the internal instrumentations that it
+    // requires, the JMX instrumentation is added on top of it. Using the full agent would capture
+    // telemetry from the target systems that is unrelated to JMX metrics.
+    val baseAgentTask = project(":javaagent").tasks.named<Jar>("baseJavaagentJar")
+    val jmxAgentTask = project(":instrumentation:jmx-metrics:javaagent").tasks.named<Jar>("shadowJar")
     val testAppTask = project(":instrumentation:jmx-metrics:testing-apps:testing-webapp").tasks.named<War>("war")
     val camelTestAppTask = project(":instrumentation:jmx-metrics:testing-apps:camel-testing-app").tasks.named<Jar>("camelTestAppJar")
 
-    dependsOn(shadowTask)
+    dependsOn(baseAgentTask)
+    dependsOn(jmxAgentTask)
     dependsOn(testAppTask)
     dependsOn(camelTestAppTask)
 
-    val agentJar = shadowTask.flatMap { it.archiveFile }
+    val agentJar = baseAgentTask.flatMap { it.archiveFile }
+    val jmxInstrumentationJar = jmxAgentTask.flatMap { it.archiveFile }
     val testAppWar = testAppTask.flatMap { it.archiveFile }
     val camelTestAppJar = camelTestAppTask.flatMap { it.archiveFile }
 
     inputs.file(agentJar)
       .withPropertyName("javaagent")
+      .withNormalizer(ClasspathNormalizer::class)
+    inputs.file(jmxInstrumentationJar)
+      .withPropertyName("jmxInstrumentation")
       .withNormalizer(ClasspathNormalizer::class)
     inputs.file(testAppWar)
       .withPropertyName("testWebApp")
@@ -51,6 +60,7 @@ tasks {
     jvmArgumentProviders += CommandLineArgumentProvider {
       listOf(
         "-Dio.opentelemetry.javaagent.path=${agentJar.get().asFile.absolutePath}",
+        "-Dio.opentelemetry.javaagent.jmx.path=${jmxInstrumentationJar.get().asFile.absolutePath}",
         "-Dio.opentelemetry.testapp.path=${testAppWar.get().asFile.absolutePath}",
         "-Dio.opentelemetry.registry.path=$registryDir",
         "-Dio.opentelemetry.cameltestapp.path=${camelTestAppJar.get().asFile.absolutePath}",

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/TargetSystemTest.java
@@ -65,11 +65,13 @@ class TargetSystemTest {
   private static final Logger targetSystemLogger = LoggerFactory.getLogger("targetSystem");
 
   private static final String AGENT_PATH = "/opentelemetry-instrumentation-javaagent.jar";
+  private static final String JMX_INSTRUMENTATION_PATH = "/opentelemetry-jmx-instrumentation.jar";
 
   private static final Network network = Network.newNetwork();
 
   private static OtlpGrpcServer otlpServer;
   private static Path agentPath;
+  private static Path jmxInstrumentationPath;
   private static Path testWebAppPath;
 
   private static String otlpEndpoint;
@@ -88,6 +90,8 @@ class TargetSystemTest {
     otlpEndpoint = "http://host.testcontainers.internal:" + otlpServer.httpPort();
 
     TargetSystemTest.agentPath = getArtifactPath("io.opentelemetry.javaagent.path");
+    TargetSystemTest.jmxInstrumentationPath =
+        getArtifactPath("io.opentelemetry.javaagent.jmx.path");
     TargetSystemTest.testWebAppPath = getArtifactPath("io.opentelemetry.testapp.path");
   }
 
@@ -191,8 +195,8 @@ class TargetSystemTest {
     config.put("otel.exporter.otlp.protocol", "grpc");
     // short export interval for testing
     config.put("otel.metric.export.interval", "5s");
-    // disable runtime telemetry metrics
-    config.put("otel.instrumentation.runtime-telemetry.enabled", "false");
+    // the agent only provides the machinery, the JMX instrumentation is added on top of it
+    config.put("otel.javaagent.experimental.initializer.jar", JMX_INSTRUMENTATION_PATH);
     // set yaml config files to test
     config.put(
         "otel.jmx.config",
@@ -234,6 +238,12 @@ class TargetSystemTest {
   protected static void copyAgentToTarget(GenericContainer<?> target) {
     logger.info("copying java agent {} to container {}", agentPath, AGENT_PATH);
     target.withCopyFileToContainer(MountableFile.forHostPath(agentPath), AGENT_PATH);
+    logger.info(
+        "copying jmx instrumentation {} to container {}",
+        jmxInstrumentationPath,
+        JMX_INSTRUMENTATION_PATH);
+    target.withCopyFileToContainer(
+        MountableFile.forHostPath(jmxInstrumentationPath), JMX_INSTRUMENTATION_PATH);
   }
 
   protected static void copyYamlFilesToTarget(GenericContainer<?> target, List<String> yamlFiles) {

--- a/instrumentation/jmx-metrics/library/src/test/resources/hadoop2-env.sh
+++ b/instrumentation/jmx-metrics/library/src/test/resources/hadoop2-env.sh
@@ -98,7 +98,8 @@ export HADOOP_IDENT_STRING=$USER
 export JAVA_AGENT_OPTS="-javaagent:/opentelemetry-instrumentation-javaagent.jar"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.logs.exporter=none -Dotel.traces.exporter=none -Dotel.metrics.exporter=otlp"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.exporter.otlp.endpoint=<<ENDPOINT_PLACEHOLDER>> -Dotel.exporter.otlp.protocol=grpc"
-export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.metric.export.interval=5s -Dotel.instrumentation.runtime-telemetry.enabled=false"
+export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.metric.export.interval=5s"
+export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.javaagent.experimental.initializer.jar=/opentelemetry-jmx-instrumentation.jar"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.jmx.config=/hadoop.yaml"
 
 export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS $JAVA_AGENT_OPTS"

--- a/instrumentation/jmx-metrics/library/src/test/resources/hadoop3-env.sh
+++ b/instrumentation/jmx-metrics/library/src/test/resources/hadoop3-env.sh
@@ -430,7 +430,8 @@ export YARN_NODEMANAGER_USER=hdfs
 export JAVA_AGENT_OPTS="-javaagent:/opentelemetry-instrumentation-javaagent.jar"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.logs.exporter=none -Dotel.traces.exporter=none -Dotel.metrics.exporter=otlp"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.exporter.otlp.endpoint=<<ENDPOINT_PLACEHOLDER>> -Dotel.exporter.otlp.protocol=grpc"
-export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.metric.export.interval=5s -Dotel.instrumentation.runtime-telemetry.enabled=false"
+export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.metric.export.interval=5s"
+export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.javaagent.experimental.initializer.jar=/opentelemetry-jmx-instrumentation.jar"
 export JAVA_AGENT_OPTS="$JAVA_AGENT_OPTS -Dotel.jmx.config=/hadoop.yaml"
 
 export HDFS_NAMENODE_OPTS="$HDFS_NAMENODE_OPTS $JAVA_AGENT_OPTS"


### PR DESCRIPTION
The jmx-metrics container tests were running the target systems with the full javaagent, which instruments the target system itself and produces telemetry unrelated to JMX metrics. The weaver live-check reports those metrics as registry violations, e.g. `http.server.request.duration` and `http.client.request.duration` for target systems that serve or make HTTP requests.

This switches the tests to the base agent jar (agent machinery plus the internal instrumentations it requires) and adds the JMX instrumentation on top of it via `otel.javaagent.experimental.initializer.jar`, which is the same pattern the javaagent instrumentation module tests use.

This also drops `otel.instrumentation.runtime-telemetry.enabled=false`, which is no longer needed since runtime telemetry is not part of the base agent.

This unblocks #19374.