### PR TITLE
Use consumable configurations for JMX test artifacts

### DIFF
--- a/instrumentation/jmx-metrics/library/build.gradle.kts
+++ b/instrumentation/jmx-metrics/library/build.gradle.kts
@@ -3,8 +3,33 @@ plugins {
   id("otel.library-instrumentation")
 }
 
+val baseAgent = configurations.create("baseAgent") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+val jmxAgent = configurations.create("jmxAgent") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+val testWebApp = configurations.create("testWebApp") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+val camelTestApp = configurations.create("camelTestApp") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
 dependencies {
   implementation("org.snakeyaml:snakeyaml-engine")
+
+  baseAgent(project(":javaagent", configuration = "baseJar"))
+  jmxAgent(project(":instrumentation:jmx-metrics:javaagent", configuration = "shadow"))
+  testWebApp(project(":instrumentation:jmx-metrics:testing-apps:testing-webapp", configuration = "testWebApp"))
+  camelTestApp(project(":instrumentation:jmx-metrics:testing-apps:camel-testing-app", configuration = "camelTestApp"))
 
   testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
   testImplementation("org.testcontainers:testcontainers")
@@ -26,44 +51,33 @@ tasks {
     // the base agent only contains the agent machinery and the internal instrumentations that it
     // requires, the JMX instrumentation is added on top of it. Using the full agent would capture
     // telemetry from the target systems that is unrelated to JMX metrics.
-    val baseAgentTask = project(":javaagent").tasks.named<Jar>("baseJavaagentJar")
-    val jmxAgentTask = project(":instrumentation:jmx-metrics:javaagent").tasks.named<Jar>("shadowJar")
-    val testAppTask = project(":instrumentation:jmx-metrics:testing-apps:testing-webapp").tasks.named<War>("war")
-    val camelTestAppTask = project(":instrumentation:jmx-metrics:testing-apps:camel-testing-app").tasks.named<Jar>("camelTestAppJar")
-
-    dependsOn(baseAgentTask)
-    dependsOn(jmxAgentTask)
-    dependsOn(testAppTask)
-    dependsOn(camelTestAppTask)
-
-    val agentJar = baseAgentTask.flatMap { it.archiveFile }
-    val jmxInstrumentationJar = jmxAgentTask.flatMap { it.archiveFile }
-    val testAppWar = testAppTask.flatMap { it.archiveFile }
-    val camelTestAppJar = camelTestAppTask.flatMap { it.archiveFile }
-
-    inputs.file(agentJar)
+    inputs.files(baseAgent)
       .withPropertyName("javaagent")
       .withNormalizer(ClasspathNormalizer::class)
-    inputs.file(jmxInstrumentationJar)
+    inputs.files(jmxAgent)
       .withPropertyName("jmxInstrumentation")
       .withNormalizer(ClasspathNormalizer::class)
-    inputs.file(testAppWar)
+    inputs.files(testWebApp)
       .withPropertyName("testWebApp")
       .withNormalizer(ClasspathNormalizer::class)
-    inputs.file(camelTestAppJar)
+    inputs.files(camelTestApp)
       .withPropertyName("camelTestApp")
       .withNormalizer(ClasspathNormalizer::class)
 
+    val agentJarPath = baseAgent.elements.map { it.single().asFile.absolutePath }
+    val jmxInstrumentationJarPath = jmxAgent.elements.map { it.single().asFile.absolutePath }
+    val testAppWarPath = testWebApp.elements.map { it.single().asFile.absolutePath }
+    val camelTestAppJarPath = camelTestApp.elements.map { it.single().asFile.absolutePath }
     val registryDir = layout.projectDirectory.dir("../model").asFile.absolutePath
     inputs.dir(registryDir).withPathSensitivity(PathSensitivity.RELATIVE)
 
     jvmArgumentProviders += CommandLineArgumentProvider {
       listOf(
-        "-Dio.opentelemetry.javaagent.path=${agentJar.get().asFile.absolutePath}",
-        "-Dio.opentelemetry.javaagent.jmx.path=${jmxInstrumentationJar.get().asFile.absolutePath}",
-        "-Dio.opentelemetry.testapp.path=${testAppWar.get().asFile.absolutePath}",
+        "-Dio.opentelemetry.javaagent.path=${agentJarPath.get()}",
+        "-Dio.opentelemetry.javaagent.jmx.path=${jmxInstrumentationJarPath.get()}",
+        "-Dio.opentelemetry.testapp.path=${testAppWarPath.get()}",
         "-Dio.opentelemetry.registry.path=$registryDir",
-        "-Dio.opentelemetry.cameltestapp.path=${camelTestAppJar.get().asFile.absolutePath}",
+        "-Dio.opentelemetry.cameltestapp.path=${camelTestAppJarPath.get()}",
       )
     }
   }

--- a/instrumentation/jmx-metrics/testing-apps/camel-testing-app/build.gradle.kts
+++ b/instrumentation/jmx-metrics/testing-apps/camel-testing-app/build.gradle.kts
@@ -35,3 +35,12 @@ tasks {
     exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
   }
 }
+
+configurations.create("camelTestApp") {
+  isCanBeConsumed = true
+  isCanBeResolved = false
+}
+
+artifacts {
+  add("camelTestApp", tasks.named("camelTestAppJar"))
+}

--- a/instrumentation/jmx-metrics/testing-apps/testing-webapp/build.gradle.kts
+++ b/instrumentation/jmx-metrics/testing-apps/testing-webapp/build.gradle.kts
@@ -11,3 +11,12 @@ dependencies {
   compileOnly("jakarta.servlet:jakarta.servlet-api:5.0.0")
   compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 }
+
+configurations.create("testWebApp") {
+  isCanBeConsumed = true
+  isCanBeResolved = false
+}
+
+artifacts {
+  add("testWebApp", tasks.named("war"))
+}


### PR DESCRIPTION
Replace cross-project task access in the JMX Metrics library tests with consumable configurations for the base agent, JMX extension, web app, and Camel app. This carries producer task dependencies through artifact resolution and removes coupling to producer task names and types, following up on https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19431#discussion_r3735613476.