### PR TITLE
Document structured selector naming

### DIFF
--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -128,30 +128,6 @@ capture_mdc_attributes:
 This configuration rule does not govern Java method names. Existing and future Java `setCapture*`
 APIs follow Java API naming conventions and are unchanged by this guidance.
 
-#### Migration impact
-
-This rule is migration-capable, not permanently non-retroactive. A future migration PR may add a
-preferred noun-based name, deprecate an existing `capture_*` selector, and eventually remove the old
-name within the applicable stability policy:
-
-- **Five experimental list selectors:** messaging `capture_headers`, servlet
-  `capture_request_parameters`, and the Logback, Log4j, and JBoss LogManager MDC capture selectors
-  may migrate to noun-based structured parents. During the deprecation window, each old scalar list
-  becomes an alias for the new selector's `included` list, while `included` and `excluded` are
-  exposed as flat leaves. The migration PR must define precedence and defaults explicitly, emit
-  deprecation warnings, and update metadata, generated documentation, user documentation, and
-  tests.
-- **Six stable list selectors:** the four HTTP request/response header selectors and two gRPC
-  metadata selectors may receive preferred aliases and deprecations now, but both old and new forms
-  must continue working throughout 2.x. Stable old names may be removed only in 3.0. The HTTP
-  declarative names are standardized across languages, so changing or aliasing them also requires
-  upstream coordination. This guidance intentionally does not choose final replacement spellings.
-- **Twenty-two unaffected capture booleans:** four stable and eighteen experimental action booleans
-  keep their `capture_*` names. The deprecated runtime `capture_gc_cause` property is not a naming
-  precedent.
-
-The repository inventory is 33 active capture-named metadata properties: 22 booleans and 11 lists.
-
 ## Structured Config (YAML-Only)
 
 Some configurations require structured data only expressible in YAML:

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -134,9 +134,7 @@ the intended end state. Retain `setCapture*` for action booleans, such as
 ### Structured Selector Defaults
 
 What a selector means when it is absent depends on whether the setting it controls is
-none-by-default or all-by-default. Both baselines use the same shape and matching rules, and the
-declarative schema requires at least one entry in `included` and `excluded`, so a selector with no
-patterns is not a shape that configuration is expected to take.
+none-by-default or all-by-default. Both baselines use the same shape and matching rules.
 
 For a none-by-default setting, the selector doubles as the on switch. An absent selector selects
 nothing, and an exclude-only selector selects everything except the excluded values. Document
@@ -153,13 +151,15 @@ mdc_attributes:
   included: ["*"]
 ```
 
-Treat an empty selector, one with no patterns in either list, the same as an absent selector rather
-than as select-all. This keeps an empty selector a no-op and matches flat configuration, where empty
-property values cannot be distinguished from unset ones.
-
 For an all-by-default setting, the selector filters telemetry that is already emitted. An absent
 selector keeps everything, an omitted `included` list keeps everything not excluded, and
 exclude-only is the natural shape.
+
+An empty selector, one with no patterns in either list, carries no configuration, so treat it the
+same as an absent selector: a none-by-default setting still selects nothing, and an all-by-default
+setting still keeps everything. This keeps an empty selector a no-op and matches flat configuration,
+where empty property values cannot be distinguished from unset ones. `IncludeExclude#isEmpty()`
+identifies that case.
 
 ## Structured Config (YAML-Only)
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -153,6 +153,9 @@ mdc_attributes:
   included: ["*"]
 ```
 
+Treat a selector with no patterns in either list as absent rather than as select-all, so invalid
+configuration fails safe instead of capturing everything.
+
 For an all-by-default setting, the selector filters telemetry that is already emitted. An absent
 selector keeps everything, an omitted `included` list keeps everything not excluded, and
 exclude-only is the natural shape.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -125,8 +125,11 @@ capture_mdc_attributes:
   excluded: [password]
 ```
 
-This configuration rule does not govern Java method names. Existing and future Java `setCapture*`
-APIs follow Java API naming conventions and are unchanged by this guidance.
+Java methods that configure a structured selector are also named after the selected resource,
+without `Capture` or `Captured`, for example `setMdcAttributes(IncludeExclude)`. Use one selector
+value instead of paired include/exclude setters, with the shared `IncludeExclude` selector type as
+the intended end state. Retain `setCapture*` for action booleans, such as
+`setCaptureQuery(boolean)`.
 
 ## Structured Config (YAML-Only)
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -131,6 +131,32 @@ value instead of paired include/exclude setters, with the shared `IncludeExclude
 the intended end state. Retain `setCapture*` for action booleans, such as
 `setCaptureQuery(boolean)`.
 
+### Structured Selector Defaults
+
+What a selector means when it is absent depends on whether the setting it controls is
+none-by-default or all-by-default. Both baselines use the same shape and matching rules, and the
+declarative schema requires at least one entry in `included` and `excluded`, so an explicitly empty
+list is never valid configuration.
+
+For a none-by-default setting, the selector doubles as the on switch. An absent selector selects
+nothing, and an exclude-only selector selects everything except the excluded values. Document
+select-all as `included: ["*"]`, or `included=*` in flat configuration, because flat configuration
+cannot express a present selector that omits its included patterns:
+
+```yaml
+# select everything except one value
+mdc_attributes:
+  excluded: [password]
+
+# select everything
+mdc_attributes:
+  included: ["*"]
+```
+
+For an all-by-default setting, the selector filters telemetry that is already emitted. An absent
+selector keeps everything, an omitted `included` list keeps everything not excluded, and
+exclude-only is the natural shape.
+
 ## Structured Config (YAML-Only)
 
 Some configurations require structured data only expressible in YAML:

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -100,6 +100,58 @@ if (value == null) {
 | Boolean toggle      | `.enabled` suffix                                                  | `enabled` leaf key                                                |
 | Env var form        | dots/hyphens → ALL_CAPS underscores                                | N/A                                                               |
 
+### Structured Selector Names
+
+A structured selector object with `included` and/or `excluded` lists is named after the resource
+being selected, for example `mdc_attributes`, `headers`, or `request_parameters`. This follows the
+OpenTelemetry Configuration
+[`IncludeExclude`](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/common.yaml)
+shape and its noun-based uses such as `attribute_keys` and `resource_constant_labels`.
+
+Do not give a new structured selector parent a `capture_*` name. A path such as
+`capture_mdc_attributes.excluded` is contradictory: the parent describes a selection, while the
+leaf excludes values from that selection. Retain `capture_*` for action booleans that collect or
+emit data that would otherwise be absent, such as `capture_query` and
+`capture_message_content`.
+
+```yaml
+# Preferred
+mdc_attributes:
+  included: [trace_id, request_id]
+  excluded: [password]
+
+# Avoid
+capture_mdc_attributes:
+  excluded: [password]
+```
+
+This configuration rule does not govern Java method names. Existing and future Java `setCapture*`
+APIs follow Java API naming conventions and are unchanged by this guidance.
+
+#### Migration impact
+
+This rule is migration-capable, not permanently non-retroactive. A future migration PR may add a
+preferred noun-based name, deprecate an existing `capture_*` selector, and eventually remove the old
+name within the applicable stability policy:
+
+- **Five experimental list selectors:** messaging `capture_headers`, servlet
+  `capture_request_parameters`, and the Logback, Log4j, and JBoss LogManager MDC capture selectors
+  may migrate to noun-based structured parents. During the deprecation window, each old scalar list
+  becomes an alias for the new selector's `included` list, while `included` and `excluded` are
+  exposed as flat leaves. The migration PR must define precedence and defaults explicitly, emit
+  deprecation warnings, and update metadata, generated documentation, user documentation, and
+  tests.
+- **Six stable list selectors:** the four HTTP request/response header selectors and two gRPC
+  metadata selectors may receive preferred aliases and deprecations now, but both old and new forms
+  must continue working throughout 2.x. Stable old names may be removed only in 3.0. The HTTP
+  declarative names are standardized across languages, so changing or aliasing them also requires
+  upstream coordination. This guidance intentionally does not choose final replacement spellings.
+- **Twenty-two unaffected capture booleans:** four stable and eighteen experimental action booleans
+  keep their `capture_*` names. The deprecated runtime `capture_gc_cause` property is not a naming
+  precedent.
+
+The repository inventory is 33 active capture-named metadata properties: 22 booleans and 11 lists.
+
 ## Structured Config (YAML-Only)
 
 Some configurations require structured data only expressible in YAML:

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -135,8 +135,8 @@ the intended end state. Retain `setCapture*` for action booleans, such as
 
 What a selector means when it is absent depends on whether the setting it controls is
 none-by-default or all-by-default. Both baselines use the same shape and matching rules, and the
-declarative schema requires at least one entry in `included` and `excluded`, so an explicitly empty
-list is never valid configuration.
+declarative schema requires at least one entry in `included` and `excluded`, so a selector with no
+patterns is not a shape that configuration is expected to take.
 
 For a none-by-default setting, the selector doubles as the on switch. An absent selector selects
 nothing, and an exclude-only selector selects everything except the excluded values. Document
@@ -153,8 +153,9 @@ mdc_attributes:
   included: ["*"]
 ```
 
-Treat a selector with no patterns in either list as absent rather than as select-all, so invalid
-configuration fails safe instead of capturing everything.
+Treat an empty selector, one with no patterns in either list, the same as an absent selector rather
+than as select-all. This keeps an empty selector a no-op and matches flat configuration, where empty
+property values cannot be distinguished from unset ones.
 
 For an all-by-default setting, the selector filters telemetry that is already emitted. An absent
 selector keeps everything, an omitted `included` list keeps everything not excluded, and


### PR DESCRIPTION
Document the durable conventions for structured `included`/`excluded` selectors across configuration and Java APIs.

Name selectors after the selected resource, represent them with the shared `IncludeExclude` type, and reserve `capture_*`/`setCapture*` for action booleans.

Also document what an absent selector means, which depends on whether the setting selects nothing or everything by default. For a none-by-default setting the selector doubles as the on switch, so select-all is spelled `included: ["*"]` rather than an omitted list, which flat configuration cannot express. For an all-by-default setting an absent selector keeps everything and exclude-only is the natural shape.

Migration of existing configuration and Java APIs is tracked in [#19444](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19444).
