### PR TITLE
Fix propagation issues in tail-delegated WithSpan methods

### DIFF
--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/build.gradle.kts
@@ -27,6 +27,7 @@ muzzle {
 dependencies {
   compileOnly("io.opentelemetry:opentelemetry-extension-kotlin")
   compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+  compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0")
   compileOnly(project(":opentelemetry-instrumentation-annotations-shaded-for-instrumenting", configuration = "shadow"))
 
   implementation("org.ow2.asm:asm-tree")
@@ -55,6 +56,10 @@ kotlin {
 }
 
 tasks {
+  named("byteBuddyKotlin") {
+    enabled = false
+  }
+
   val testV3Preview = register<Test>("testV3Preview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationHelper.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationHelper.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import kotlin.coroutines.Continuation;
 import kotlin.coroutines.CoroutineContext;
 import kotlin.coroutines.intrinsics.IntrinsicsKt;
+import kotlin.coroutines.jvm.internal.CoroutineStackFrame;
 import kotlinx.coroutines.ThreadContextElement;
 import org.jetbrains.annotations.NotNull;
 
@@ -190,7 +191,7 @@ public class AnnotationInstrumentationHelper {
     // TODO: arrays and List not supported see AttributeBindingFactoryTest
   }
 
-  public static final class ContextContinuation<T> implements Continuation<T> {
+  public static final class ContextContinuation<T> implements Continuation<T>, CoroutineStackFrame {
     private final Continuation<T> delegate;
     private final CoroutineContext coroutineContext;
     private final ThreadContextElement<Scope> delegateContextElement;
@@ -213,6 +214,18 @@ public class AnnotationInstrumentationHelper {
     @Override
     public CoroutineContext getContext() {
       return coroutineContext;
+    }
+
+    @Nullable
+    @Override
+    public CoroutineStackFrame getCallerFrame() {
+      return delegate instanceof CoroutineStackFrame ? (CoroutineStackFrame) delegate : null;
+    }
+
+    @Nullable
+    @Override
+    public StackTraceElement getStackTraceElement() {
+      return null;
     }
 
     @Override

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationHelper.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationHelper.java
@@ -11,10 +11,14 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.extension.kotlin.ContextExtensionsKt;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import javax.annotation.Nullable;
 import kotlin.coroutines.Continuation;
+import kotlin.coroutines.CoroutineContext;
 import kotlin.coroutines.intrinsics.IntrinsicsKt;
+import kotlinx.coroutines.ThreadContextElement;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Instrumentation helper that is called through bytecode instrumentation. When using invokedynamic
@@ -61,6 +65,15 @@ public class AnnotationInstrumentationHelper {
     } else {
       return continuation != null ? CONTEXT_FIELD.get(continuation) : null;
     }
+  }
+
+  public static Context currentContext() {
+    return Context.current();
+  }
+
+  public static <T> Continuation<T> wrapContinuation(
+      Continuation<T> continuation, Context context, Context parentContext, Object request) {
+    return new ContextContinuation<>(continuation, context, parentContext, request);
   }
 
   @Nullable
@@ -175,6 +188,45 @@ public class AnnotationInstrumentationHelper {
       Span.current().setAttribute(name, (Long) value);
     }
     // TODO: arrays and List not supported see AttributeBindingFactoryTest
+  }
+
+  public static final class ContextContinuation<T> implements Continuation<T> {
+    private final Continuation<T> delegate;
+    private final CoroutineContext coroutineContext;
+    private final ThreadContextElement<Scope> delegateContextElement;
+    private final Context spanContext;
+    private final Object request;
+
+    @SuppressWarnings("unchecked") // asContextElement returns CoroutineContext to Java
+    ContextContinuation(
+        Continuation<T> delegate, Context spanContext, Context parentContext, Object request) {
+      this.delegate = delegate;
+      this.coroutineContext =
+          delegate.getContext().plus(ContextExtensionsKt.asContextElement(spanContext));
+      this.delegateContextElement =
+          (ThreadContextElement<Scope>) ContextExtensionsKt.asContextElement(parentContext);
+      this.spanContext = spanContext;
+      this.request = request;
+    }
+
+    @NotNull
+    @Override
+    public CoroutineContext getContext() {
+      return coroutineContext;
+    }
+
+    @Override
+    public void resumeWith(@NotNull Object result) {
+      Throwable error = KotlinResultUtilKt.exceptionOrNull(result);
+      instrumenter().end(spanContext, (MethodRequest) request, null, error);
+
+      Scope scope = delegateContextElement.updateThreadContext(delegate.getContext());
+      try {
+        delegate.resumeWith(result);
+      } finally {
+        delegateContextElement.restoreThreadContext(delegate.getContext(), scope);
+      }
+    }
   }
 
   public static void init() {}

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
@@ -39,6 +40,11 @@ public class AnnotationInstrumentationModule extends InstrumentationModule {
   }
 
   @Override
+  public boolean isHelperClass(String className) {
+    return className.startsWith("io.opentelemetry.extension.kotlin.");
+  }
+
+  @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassesNamed(
         // added in 1.0.0
@@ -55,8 +61,10 @@ public class AnnotationInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<String> exposedClassNames() {
-    // AnnotationInstrumentationHelper is called directly in the instrumented bytecode.
-    return singletonList(
-        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper");
+    // These are called (in-)directly in the instrumented bytecode.
+    return asList(
+        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper",
+        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper$ContextContinuation",
+        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.KotlinResultUtilKt");
   }
 }

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/AnnotationInstrumentationModule.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
@@ -61,10 +60,8 @@ public class AnnotationInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<String> exposedClassNames() {
-    // These are called (in-)directly in the instrumented bytecode.
-    return asList(
-        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper",
-        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper$ContextContinuation",
-        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.KotlinResultUtilKt");
+    // AnnotationInstrumentationHelper is called directly in the instrumented bytecode.
+    return singletonList(
+        "io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations.AnnotationInstrumentationHelper");
   }
 }

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/WithSpanInstrumentation.java
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/WithSpanInstrumentation.java
@@ -213,12 +213,17 @@ class WithSpanInstrumentation implements TypeInstrumentation {
               source.desc,
               source.signature,
               source.exceptions.toArray(new String[0]));
+      // Argument size includes an implicit this; the final Continuation occupies one slot.
+      int continuationArgumentLocal =
+          (Type.getArgumentsAndReturnSizes(source.desc) >> 2)
+              - ((source.access & Opcodes.ACC_STATIC) == 0 ? 1 : 2);
       GeneratorAdapter generatorAdapter =
           new GeneratorAdapter(
               AsmApi.VERSION, methodNode, source.access, source.name, source.desc) {
             int requestLocal;
             int ourContinuationLocal;
             int contextLocal;
+            int parentContextLocal;
             int scopeLocal;
             int lastLocal;
 
@@ -235,6 +240,7 @@ class WithSpanInstrumentation implements TypeInstrumentation {
               requestLocal = newLocal(Type.getType(Object.class));
               ourContinuationLocal = newLocal(Type.getType(Continuation.class));
               contextLocal = newLocal(Type.getType(Context.class));
+              parentContextLocal = newLocal(Type.getType(Context.class));
               scopeLocal = newLocal(Type.getType(Scope.class));
               // set lastLocal to the last local we added
               lastLocal = scopeLocal;
@@ -348,6 +354,9 @@ class WithSpanInstrumentation implements TypeInstrumentation {
                   temp.visitInsn(Opcodes.ACONST_NULL);
                   temp.visitInsn(Opcodes.DUP);
                   temp.visitVarInsn(Opcodes.ASTORE, ourContinuationLocal);
+                  visitInvokeHelperMethod(
+                      temp, "currentContext", "()" + Type.getDescriptor(Context.class));
+                  temp.visitVarInsn(Opcodes.ASTORE, parentContextLocal);
                 }
                 temp.visitLdcInsn(Type.getObjectType(className));
                 temp.visitLdcInsn(methodName);
@@ -382,6 +391,22 @@ class WithSpanInstrumentation implements TypeInstrumentation {
                         + ")"
                         + Type.getDescriptor(Scope.class));
                 temp.visitVarInsn(Opcodes.ASTORE, scopeLocal);
+                if (!hasBlockingOperation) {
+                  temp.visitVarInsn(Opcodes.ALOAD, continuationArgumentLocal);
+                  temp.visitVarInsn(Opcodes.ALOAD, contextLocal);
+                  temp.visitVarInsn(Opcodes.ALOAD, parentContextLocal);
+                  temp.visitVarInsn(Opcodes.ALOAD, requestLocal);
+                  visitInvokeHelperMethod(
+                      temp,
+                      "wrapContinuation",
+                      "(Lkotlin/coroutines/Continuation;"
+                          + Type.getDescriptor(Context.class)
+                          + Type.getDescriptor(Context.class)
+                          + "Ljava/lang/Object;)Lkotlin/coroutines/Continuation;");
+                  temp.visitInsn(Opcodes.DUP);
+                  temp.visitVarInsn(Opcodes.ASTORE, continuationArgumentLocal);
+                  temp.visitVarInsn(Opcodes.ASTORE, ourContinuationLocal);
+                }
                 // @SpanAttribute handling
                 for (Parameter parameter : annotatedParameters) {
                   // label on stack, make a copy
@@ -424,6 +449,8 @@ class WithSpanInstrumentation implements TypeInstrumentation {
                 temp.visitInsn(Opcodes.ACONST_NULL);
                 temp.visitVarInsn(Opcodes.ASTORE, contextLocal);
                 temp.visitInsn(Opcodes.ACONST_NULL);
+                temp.visitVarInsn(Opcodes.ASTORE, parentContextLocal);
+                temp.visitInsn(Opcodes.ACONST_NULL);
                 temp.visitVarInsn(Opcodes.ASTORE, scopeLocal);
 
                 methodNode.instructions.insertBefore(
@@ -442,6 +469,7 @@ class WithSpanInstrumentation implements TypeInstrumentation {
                 locals[requestLocal] = Type.getInternalName(Object.class);
                 locals[ourContinuationLocal] = Type.getInternalName(Continuation.class);
                 locals[contextLocal] = Type.getInternalName(Context.class);
+                locals[parentContextLocal] = Type.getInternalName(Context.class);
                 locals[scopeLocal] = Type.getInternalName(Scope.class);
 
                 temp.visitFrame(

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/KotlinResultUtil.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/main/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/instrumentationannotations/KotlinResultUtil.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.instrumentationannotations
+
+@JvmName("exceptionOrNull")
+fun resultExceptionOrNull(result: Result<*>): Throwable? = result.exceptionOrNull()

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
@@ -57,6 +57,8 @@ import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.stream.Stream
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.jvm.internal.CoroutineStackFrame
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExperimentalCoroutinesApi
@@ -494,6 +496,35 @@ class KotlinCoroutinesInstrumentationTest {
   @WithSpan("leaf")
   private suspend fun annotatedLeaf() {
     delay(10)
+  }
+
+  @Test
+  fun `WithSpan preserves coroutine stack frames`() {
+    Assumptions.assumeFalse(v3Preview())
+
+    runBlocking {
+      stackFrameCaller()
+    }
+  }
+
+  private suspend fun stackFrameCaller() {
+    annotatedStackFrame()
+    yield()
+  }
+
+  @WithSpan("stack-frame")
+  private suspend fun annotatedStackFrame() {
+    inspectStackFrame()
+  }
+
+  private suspend fun inspectStackFrame() {
+    suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+      assertThat(continuation).isInstanceOf(CoroutineStackFrame::class.java)
+      val frame = continuation as CoroutineStackFrame
+      assertThat(frame.callerFrame).isNotNull()
+      assertThat(frame.getStackTraceElement()).isNull()
+      Unit
+    }
   }
 
   @Test

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
@@ -558,7 +558,7 @@ class KotlinCoroutinesInstrumentationTest {
     unannotatedFailure(exception)
   }
 
-  private suspend fun unannotatedFailure(exception: RuntimeException): Nothing {
+  private suspend fun unannotatedFailure(exception: RuntimeException) {
     delay(10)
     throw exception
   }

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
@@ -438,6 +438,63 @@ class KotlinCoroutinesInstrumentationTest {
     delay(10)
   }
 
+  // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/12837
+  @Test
+  fun `WithSpan restores effective context after unannotated suspension`() {
+    Assumptions.assumeFalse(v3Preview())
+
+    val rootSpan = tracer.spanBuilder("root").startSpan()
+    runBlocking(Context.root().asContextElement()) {
+      withContext(TestContextElement(rootSpan.storeInContext(Context.root()))) {
+        annotatedIntermediate()
+        tracer.spanBuilder("after").startSpan().end()
+      }
+    }
+    rootSpan.end()
+
+    testing.waitAndAssertTraces(
+      { trace ->
+        trace.hasSpansSatisfyingExactly(
+          {
+            it.hasName("root")
+              .hasNoParent()
+          },
+          {
+            it.hasName("intermediate")
+              .hasParent(trace.getSpan(0))
+          },
+          {
+            it.hasName("leaf")
+              .hasParent(trace.getSpan(1))
+          },
+          {
+            it.hasName("leaf")
+              .hasParent(trace.getSpan(1))
+          },
+          {
+            it.hasName("after")
+              .hasParent(trace.getSpan(0))
+          },
+        )
+      },
+    )
+  }
+
+  @WithSpan("intermediate")
+  private suspend fun annotatedIntermediate() {
+    unannotatedIntermediate()
+  }
+
+  private suspend fun unannotatedIntermediate() {
+    annotatedLeaf()
+    annotatedLeaf()
+  }
+
+  @WithSpan("leaf")
+  private suspend fun annotatedLeaf() {
+    delay(10)
+  }
+
   // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9312
   @Test
   fun `test class with default constructor argument`() {

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-1.0/javaagent/src/test/kotlin/io/opentelemetry/javaagent/instrumentation/kotlinxcoroutines/v1_0/KotlinCoroutinesInstrumentationTest.kt
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityU
 import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.assertj.TraceAssert
+import io.opentelemetry.sdk.trace.data.StatusData
 import io.vertx.core.Vertx
 import io.vertx.kotlin.coroutines.dispatcher
 import kotlinx.coroutines.CompletableDeferred
@@ -493,6 +494,42 @@ class KotlinCoroutinesInstrumentationTest {
   @WithSpan("leaf")
   private suspend fun annotatedLeaf() {
     delay(10)
+  }
+
+  @Test
+  fun `WithSpan ends span on failed completion`() {
+    Assumptions.assumeFalse(v3Preview())
+
+    val exception = IllegalStateException("expected")
+    val result = runCatching {
+      runBlocking {
+        annotatedFailure(exception)
+      }
+    }
+
+    assertThat(result.exceptionOrNull()).isSameAs(exception)
+    testing.waitAndAssertTraces(
+      { trace ->
+        trace.hasSpansSatisfyingExactly(
+          {
+            it.hasName("failing")
+              .hasNoParent()
+              .hasStatus(StatusData.error())
+              .hasException(exception)
+          },
+        )
+      },
+    )
+  }
+
+  @WithSpan("failing")
+  private suspend fun annotatedFailure(exception: RuntimeException) {
+    unannotatedFailure(exception)
+  }
+
+  private suspend fun unannotatedFailure(exception: RuntimeException): Nothing {
+    delay(10)
+    throw exception
   }
 
   // regression test for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9312


### PR DESCRIPTION
A tail-delegated WithSpan coroutine used to not propagate its span when callee suspend functions actually suspended.

To fix this, this commit introduces a new custom Continuation class, which basically ensures that resumeWith properly restores the thread context for all callees. This essentially uses the native Kotlin context propagation machinery (via ContextElement) to let the Kotlin compiler take care of passing this down. The advantage of this approach is the limitation of instrumentation to suspend WithSpan methods only.

An alternative implementation might've stored the context in the parent's continuation and instrumented resumeWith to walk the continuation "backwards"/up the coroutine stack. However, this would've caused every coroutine resumption to take the performance penalty of walking the coroutine depth.

Fixes #12837.

<!--
CHANGELOG.md is generated from merged pull requests. Do not add an entry unless this PR introduces
a deprecation or breaking change.
-->
