### PR TITLE
Add include/exclude selector API

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,17 @@
 Comparing source compatibility of opentelemetry-instrumentation-api-2.31.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.30.0.jar
-No changes.
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.instrumentation.api.config.IncludeExclude  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder builder()
+	+++  NEW METHOD: PUBLIC(+) boolean equals(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getExcluded()
+	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getIncluded()
+	+++  NEW METHOD: PUBLIC(+) int hashCode()
+	+++  NEW METHOD: PUBLIC(+) boolean matches(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExclude build()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setExcluded(java.util.Collection<java.lang.String>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setIncluded(java.util.Collection<java.lang.String>)

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * An immutable selector that matches strings against included and excluded glob patterns.
+ *
+ * <p>Matching is case-sensitive. {@code ?} matches any single character and {@code *} matches any
+ * number of characters, including none. Excluded patterns take precedence over included patterns.
+ * When there are no included patterns, all values that are not excluded match. Callers are
+ * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
+ */
+public final class IncludeExclude {
+
+  private final List<String> included;
+  private final List<String> excluded;
+  private final List<Predicate<String>> includedPredicates;
+  private final List<Predicate<String>> excludedPredicates;
+
+  /** Returns a new builder for an {@link IncludeExclude}. */
+  public static IncludeExcludeBuilder builder() {
+    return new IncludeExcludeBuilder();
+  }
+
+  IncludeExclude(List<String> included, List<String> excluded) {
+    this.included = unmodifiableList(new ArrayList<>(included));
+    this.excluded = unmodifiableList(new ArrayList<>(excluded));
+    this.includedPredicates = createGlobPredicates(included);
+    this.excludedPredicates = createGlobPredicates(excluded);
+  }
+
+  /** Returns the included patterns. */
+  public List<String> getIncluded() {
+    return included;
+  }
+
+  /** Returns the excluded patterns. */
+  public List<String> getExcluded() {
+    return excluded;
+  }
+
+  /** Returns whether {@code value} matches this selector. */
+  public boolean matches(String value) {
+    requireNonNull(value, "value");
+    return (includedPredicates.isEmpty() || matchesAny(includedPredicates, value))
+        && !matchesAny(excludedPredicates, value);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof IncludeExclude)) {
+      return false;
+    }
+    IncludeExclude that = (IncludeExclude) object;
+    return included.equals(that.included) && excluded.equals(that.excluded);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(included, excluded);
+  }
+
+  @Override
+  public String toString() {
+    return "IncludeExclude{included=" + included + ", excluded=" + excluded + '}';
+  }
+
+  private static List<Predicate<String>> createGlobPredicates(List<String> patterns) {
+    if (patterns.isEmpty()) {
+      return emptyList();
+    }
+
+    List<Predicate<String>> predicates = new ArrayList<>(patterns.size());
+    for (String pattern : patterns) {
+      predicates.add(createGlobPredicate(pattern));
+    }
+    return unmodifiableList(predicates);
+  }
+
+  private static Predicate<String> createGlobPredicate(String globPattern) {
+    if (globPattern.indexOf('*') == -1 && globPattern.indexOf('?') == -1) {
+      return globPattern::equals;
+    }
+
+    Pattern pattern = toRegexPattern(globPattern);
+    return value -> pattern.matcher(value).matches();
+  }
+
+  private static Pattern toRegexPattern(String globPattern) {
+    StringBuilder regex = new StringBuilder();
+    int tokenStart = 0;
+    for (int i = 0; i < globPattern.length(); i++) {
+      char character = globPattern.charAt(i);
+      if (character != '*' && character != '?') {
+        continue;
+      }
+
+      if (tokenStart < i) {
+        regex.append(Pattern.quote(globPattern.substring(tokenStart, i)));
+      }
+      regex.append(character == '*' ? ".*" : ".");
+      tokenStart = i + 1;
+    }
+    if (tokenStart < globPattern.length()) {
+      regex.append(Pattern.quote(globPattern.substring(tokenStart)));
+    }
+    return Pattern.compile(regex.toString(), Pattern.DOTALL);
+  }
+
+  private static boolean matchesAny(List<Predicate<String>> predicates, String value) {
+    for (Predicate<String> predicate : predicates) {
+      if (predicate.test(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** A builder for {@link IncludeExclude}. */
+public final class IncludeExcludeBuilder {
+
+  private List<String> included = emptyList();
+  private List<String> excluded = emptyList();
+
+  IncludeExcludeBuilder() {}
+
+  /** Replaces the included patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setIncluded(Collection<String> included) {
+    this.included = copyPatterns(included, "included");
+    return this;
+  }
+
+  /** Replaces the excluded patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setExcluded(Collection<String> excluded) {
+    this.excluded = copyPatterns(excluded, "excluded");
+    return this;
+  }
+
+  /** Returns a new immutable {@link IncludeExclude}. */
+  public IncludeExclude build() {
+    return new IncludeExclude(included, excluded);
+  }
+
+  private static List<String> copyPatterns(Collection<String> patterns, String name) {
+    requireNonNull(patterns, name);
+    List<String> copy = new ArrayList<>(patterns.size());
+    for (String pattern : patterns) {
+      copy.add(requireNonNull(pattern, name + " pattern"));
+    }
+    return copy;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/package-info.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.opentelemetry.instrumentation.api.config;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class IncludeExcludeTest {
+
+  @ParameterizedTest
+  @MethodSource("patterns")
+  void patternMatching(
+      Collection<String> included, Collection<String> excluded, String value, boolean expected) {
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(included).setExcluded(excluded).build();
+
+    assertThat(selector.matches(value)).isEqualTo(expected);
+  }
+
+  @Test
+  void builderReplacesPatterns() {
+    IncludeExclude selector =
+        IncludeExclude.builder()
+            .setIncluded(singletonList("first"))
+            .setIncluded(singletonList("second"))
+            .setExcluded(singletonList("third"))
+            .setExcluded(singletonList("fourth"))
+            .build();
+
+    assertThat(selector.getIncluded()).containsExactly("second");
+    assertThat(selector.getExcluded()).containsExactly("fourth");
+  }
+
+  @Test
+  void selectorIsImmutable() {
+    List<String> included = new ArrayList<>(singletonList("included"));
+    List<String> excluded = new ArrayList<>(singletonList("excluded"));
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(included).setExcluded(excluded).build();
+
+    included.add("later included");
+    excluded.add("later excluded");
+
+    assertThat(selector.getIncluded()).containsExactly("included");
+    assertThat(selector.getExcluded()).containsExactly("excluded");
+    assertThatThrownBy(() -> selector.getIncluded().add("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> selector.getExcluded().add("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void rejectsNullPatterns() {
+    assertThatThrownBy(() -> IncludeExclude.builder().setIncluded(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> IncludeExclude.builder().setExcluded(asList("foo", null)))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  private static Stream<Arguments> patterns() {
+    return Stream.of(
+        argumentSet("empty patterns include all", emptyList(), emptyList(), "foo", true),
+        argumentSet("exact include matches", singletonList("foo"), emptyList(), "foo", true),
+        argumentSet("exact include rejects", singletonList("foo"), emptyList(), "bar", false),
+        argumentSet("matching is case sensitive", singletonList("foo"), emptyList(), "FOO", false),
+        argumentSet(
+            "star matches zero characters", singletonList("foo*"), emptyList(), "foo", true),
+        argumentSet(
+            "star matches many characters", singletonList("foo*"), emptyList(), "foobar", true),
+        argumentSet(
+            "star matches line terminators", singletonList("foo*"), emptyList(), "foo\nbar", true),
+        argumentSet(
+            "question matches one character", singletonList("f?o"), emptyList(), "foo", true),
+        argumentSet(
+            "question matches a line terminator", singletonList("f?o"), emptyList(), "f\no", true),
+        argumentSet(
+            "question rejects zero characters", singletonList("f?o"), emptyList(), "fo", false),
+        argumentSet(
+            "regex characters are literal",
+            singletonList("f()[]$^.{}|*"),
+            emptyList(),
+            "f()[]$^.{}|oo",
+            true),
+        argumentSet(
+            "matching exclude wins", singletonList("*"), singletonList("foo*"), "foobar", false),
+        argumentSet(
+            "exclude-only selector includes nonmatches",
+            emptyList(),
+            singletonList("foo*"),
+            "bar",
+            true),
+        argumentSet("any include can match", asList("foo", "bar"), emptyList(), "bar", true));
+  }
+}


### PR DESCRIPTION
Add a shared stable `IncludeExclude` selector API with immutable include/exclude glob patterns, builder support, focused tests, and the generated API diff. This provides reusable collection-capture filtering without coupling the selector to a specific instrumentation.