### PR TITLE
Add include/exclude selector API

### DIFF
--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -100,6 +100,67 @@ if (value == null) {
 | Boolean toggle      | `.enabled` suffix                                                  | `enabled` leaf key                                                |
 | Env var form        | dots/hyphens → ALL_CAPS underscores                                | N/A                                                               |
 
+### Structured Selector Names
+
+A structured selector object with `included` and/or `excluded` lists is named after the resource
+being selected, for example `mdc_attributes`, `headers`, or `request_parameters`. This follows the
+OpenTelemetry Configuration
+[`IncludeExclude`](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/common.yaml)
+shape and its noun-based uses such as `attribute_keys` and `resource_constant_labels`.
+
+Do not give a new structured selector parent a `capture_*` name. A path such as
+`capture_mdc_attributes.excluded` is contradictory: the parent describes a selection, while the
+leaf excludes values from that selection. Retain `capture_*` for action booleans that collect or
+emit data that would otherwise be absent, such as `capture_query` and
+`capture_message_content`.
+
+```yaml
+# Preferred
+mdc_attributes:
+  included: [trace_id, request_id]
+  excluded: [password]
+
+# Avoid
+capture_mdc_attributes:
+  excluded: [password]
+```
+
+Java methods that configure a structured selector are also named after the selected resource,
+without `Capture` or `Captured`, for example `setMdcAttributes(IncludeExclude)`. Use one selector
+value instead of paired include/exclude setters, with the shared `IncludeExclude` selector type as
+the intended end state. Retain `setCapture*` for action booleans, such as
+`setCaptureQuery(boolean)`.
+
+### Structured Selector Defaults
+
+What a selector means when it is absent depends on whether the setting it controls is
+none-by-default or all-by-default. Both baselines use the same shape and matching rules.
+
+For a none-by-default setting, the selector doubles as the on switch. An absent selector selects
+nothing, and an exclude-only selector selects everything except the excluded values. Document
+select-all as `included: ["*"]`, or `included=*` in flat configuration, because flat configuration
+cannot express a present selector that omits its included patterns:
+
+```yaml
+# select everything except one value
+mdc_attributes:
+  excluded: [password]
+
+# select everything
+mdc_attributes:
+  included: ["*"]
+```
+
+For an all-by-default setting, the selector filters telemetry that is already emitted. An absent
+selector keeps everything, an omitted `included` list keeps everything not excluded, and
+exclude-only is the natural shape.
+
+An empty selector, one with no patterns in either list, carries no configuration, so treat it the
+same as an absent selector: a none-by-default setting still selects nothing, and an all-by-default
+setting still keeps everything. This keeps an empty selector a no-op and matches flat configuration,
+where empty property values cannot be distinguished from unset ones. `IncludeExclude#isEmpty()`
+identifies that case.
+
 ## Structured Config (YAML-Only)
 
 Some configurations require structured data only expressible in YAML:

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -156,10 +156,9 @@ selector keeps everything, an omitted `included` list keeps everything not exclu
 exclude-only is the natural shape.
 
 An empty selector, one with no patterns in either list, carries no configuration, so treat it the
-same as an absent selector: a none-by-default setting still selects nothing, and an all-by-default
-setting still keeps everything. This keeps an empty selector a no-op and matches flat configuration,
-where empty property values cannot be distinguished from unset ones. `IncludeExclude#isEmpty()`
-identifies that case.
+same as an absent selector and fall back to the setting's own default. This keeps an empty selector
+a no-op and matches flat configuration, where empty property values cannot be distinguished from
+unset ones. `IncludeExclude#isEmpty()` identifies that case.
 
 ## Structured Config (YAML-Only)
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -160,6 +160,21 @@ same as an absent selector and fall back to the setting's own default. This keep
 a no-op and matches flat configuration, where empty property values cannot be distinguished from
 unset ones. `IncludeExclude#isEmpty()` identifies that case.
 
+### Documenting Structured Selectors
+
+Describe the relationship between the two lists as precedence, not as order of application.
+"Exclusions are applied after inclusions" reads as a sequence and leaves it ambiguous whether a
+later rule can re-add a value that an earlier rule removed. State the outcome instead, using the
+same sentence everywhere:
+
+```text
+Excluded patterns take precedence over included patterns.
+```
+
+Document the matching rules on every surface a user reads: the property table, the metadata
+description, and the javadoc of the Java setter. Cover pattern syntax, case sensitivity, precedence,
+and what an absent selector means, because a reader on IDE hover does not see the README.
+
 ## Structured Config (YAML-Only)
 
 Some configurations require structured data only expressible in YAML:

--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -7,6 +7,7 @@ Comparing source compatibility of opentelemetry-instrumentation-api-2.31.0-SNAPS
 	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getExcluded()
 	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getIncluded()
 	+++  NEW METHOD: PUBLIC(+) int hashCode()
+	+++  NEW METHOD: PUBLIC(+) boolean isEmpty()
 	+++  NEW METHOD: PUBLIC(+) boolean matches(java.lang.String)
 	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder  (not serializable)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,17 @@
 Comparing source compatibility of opentelemetry-instrumentation-api-2.31.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.30.0.jar
-No changes.
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.instrumentation.api.config.IncludeExclude  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder builder()
+	+++  NEW METHOD: PUBLIC(+) boolean equals(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getExcluded()
+	+++  NEW METHOD: PUBLIC(+) java.util.List<java.lang.String> getIncluded()
+	+++  NEW METHOD: PUBLIC(+) int hashCode()
+	+++  NEW METHOD: PUBLIC(+) boolean matches(java.lang.String)
+	+++  NEW METHOD: PUBLIC(+) java.lang.String toString()
++++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder  (not serializable)
+	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
+	+++  NEW SUPERCLASS: java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExclude build()
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setExcluded(java.util.Collection<java.lang.String>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setIncluded(java.util.Collection<java.lang.String>)

--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -15,4 +15,6 @@ Comparing source compatibility of opentelemetry-instrumentation-api-2.31.0-SNAPS
 	+++  NEW SUPERCLASS: java.lang.Object
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExclude build()
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setExcluded(java.util.Collection<java.lang.String>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setExcluded(java.lang.String[])
 	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setIncluded(java.util.Collection<java.lang.String>)
+	+++  NEW METHOD: PUBLIC(+) io.opentelemetry.instrumentation.api.config.IncludeExcludeBuilder setIncluded(java.lang.String[])

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -22,9 +22,10 @@ import java.util.function.Predicate;
  * When there are no included patterns, all values that are not excluded match. Callers are
  * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
  *
- * <p>There is no selector that matches nothing: an empty selector, one with no patterns in either
- * list, matches every value. Settings that select nothing until they are configured should treat an
- * empty selector the same as an absent one.
+ * <p>An empty selector, one with no included and no excluded patterns, carries no configuration.
+ * Settings should treat an empty selector the same as an absent one: a setting that selects nothing
+ * until it is configured still selects nothing, and a setting that selects everything until it is
+ * configured still selects everything.
  */
 public final class IncludeExclude {
 
@@ -53,6 +54,16 @@ public final class IncludeExclude {
   /** Returns the excluded patterns. */
   public List<String> getExcluded() {
     return excluded;
+  }
+
+  /**
+   * Returns whether this selector has no included and no excluded patterns.
+   *
+   * <p>An empty selector carries no configuration, so settings should treat it the same as an
+   * absent selector.
+   */
+  public boolean isEmpty() {
+    return included.isEmpty() && excluded.isEmpty();
   }
 
   /** Returns whether {@code value} matches this selector. */

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -22,10 +22,9 @@ import java.util.function.Predicate;
  * When there are no included patterns, all values that are not excluded match. Callers are
  * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
  *
- * <p>An empty selector, one with no included and no excluded patterns, carries no configuration.
- * Settings should treat an empty selector the same as an absent one: a setting that selects nothing
- * until it is configured still selects nothing, and a setting that selects everything until it is
- * configured still selects everything.
+ * <p>An empty selector, one with no included and no excluded patterns, carries no configuration. A
+ * setting that uses one should behave as if no selector were configured and fall back to its own
+ * default.
  */
 public final class IncludeExclude {
 
@@ -59,8 +58,8 @@ public final class IncludeExclude {
   /**
    * Returns whether this selector has no included and no excluded patterns.
    *
-   * <p>An empty selector carries no configuration, so settings should treat it the same as an
-   * absent selector.
+   * <p>An empty selector carries no configuration, so a setting that uses one should fall back to
+   * its own default, as if no selector were configured.
    */
   public boolean isEmpty() {
     return included.isEmpty() && excluded.isEmpty();

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -22,9 +22,9 @@ import java.util.function.Predicate;
  * When there are no included patterns, all values that are not excluded match. Callers are
  * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
  *
- * <p>There is no selector that matches nothing: a selector with no patterns at all matches every
- * value. Settings that select nothing until they are configured should represent that as an absent
- * selector rather than as a selector without patterns.
+ * <p>There is no selector that matches nothing: an empty selector, one with no patterns in either
+ * list, matches every value. Settings that select nothing until they are configured should treat an
+ * empty selector the same as an absent one.
  */
 public final class IncludeExclude {
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -65,7 +65,15 @@ public final class IncludeExclude {
     return included.isEmpty() && excluded.isEmpty();
   }
 
-  /** Returns whether {@code value} matches this selector. */
+  /**
+   * Returns whether {@code value} matches this selector.
+   *
+   * <p>Excluded patterns take precedence over included patterns: an excluded value never matches,
+   * even when an included pattern also matches it. When there are no included patterns, every value
+   * that is not excluded matches, so an {@linkplain #isEmpty() empty} selector matches every value.
+   * A caller that treats an empty selector as no configuration should check {@link #isEmpty()}
+   * rather than call this method.
+   */
   public boolean matches(String value) {
     requireNonNull(value, "value");
     return (includedPredicates.isEmpty() || matchesAny(includedPredicates, value))

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -124,8 +124,7 @@ public final class IncludeExclude {
     // regex backtracking on a non-match. Possessive quantifiers change glob semantics because '*'
     // may need to give characters back to match a later token (for example, glob "*a" must match
     // "ba"). Each retry below consumes one value code point, bounding the work by the product of
-    // the
-    // pattern and value lengths.
+    // the pattern and value lengths.
     while (valueIndex < value.length()) {
       if (patternIndex < pattern.length()) {
         int patternCodePoint = pattern.codePointAt(patternIndex);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -21,6 +21,10 @@ import java.util.function.Predicate;
  * number of characters, including none. Excluded patterns take precedence over included patterns.
  * When there are no included patterns, all values that are not excluded match. Callers are
  * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
+ *
+ * <p>There is no selector that matches nothing: a selector with no patterns at all matches every
+ * value. Settings that select nothing until they are configured should represent that as an absent
+ * selector rather than as a selector without patterns.
  */
 public final class IncludeExclude {
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExclude.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * An immutable selector that matches strings against included and excluded glob patterns.
+ *
+ * <p>Matching is case-sensitive. {@code ?} matches any single character and {@code *} matches any
+ * number of characters, including none. Excluded patterns take precedence over included patterns.
+ * When there are no included patterns, all values that are not excluded match. Callers are
+ * responsible for normalizing values and patterns when a domain requires case-insensitive matching.
+ */
+public final class IncludeExclude {
+
+  private final List<String> included;
+  private final List<String> excluded;
+  private final List<Predicate<String>> includedPredicates;
+  private final List<Predicate<String>> excludedPredicates;
+
+  /** Returns a new builder for an {@link IncludeExclude}. */
+  public static IncludeExcludeBuilder builder() {
+    return new IncludeExcludeBuilder();
+  }
+
+  IncludeExclude(List<String> included, List<String> excluded) {
+    this.included = unmodifiableList(new ArrayList<>(included));
+    this.excluded = unmodifiableList(new ArrayList<>(excluded));
+    this.includedPredicates = createGlobPredicates(included);
+    this.excludedPredicates = createGlobPredicates(excluded);
+  }
+
+  /** Returns the included patterns. */
+  public List<String> getIncluded() {
+    return included;
+  }
+
+  /** Returns the excluded patterns. */
+  public List<String> getExcluded() {
+    return excluded;
+  }
+
+  /** Returns whether {@code value} matches this selector. */
+  public boolean matches(String value) {
+    requireNonNull(value, "value");
+    return (includedPredicates.isEmpty() || matchesAny(includedPredicates, value))
+        && !matchesAny(excludedPredicates, value);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (!(object instanceof IncludeExclude)) {
+      return false;
+    }
+    IncludeExclude that = (IncludeExclude) object;
+    return included.equals(that.included) && excluded.equals(that.excluded);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(included, excluded);
+  }
+
+  @Override
+  public String toString() {
+    return "IncludeExclude{included=" + included + ", excluded=" + excluded + '}';
+  }
+
+  private static List<Predicate<String>> createGlobPredicates(List<String> patterns) {
+    if (patterns.isEmpty()) {
+      return emptyList();
+    }
+
+    List<Predicate<String>> predicates = new ArrayList<>(patterns.size());
+    for (String pattern : patterns) {
+      predicates.add(createGlobPredicate(pattern));
+    }
+    return unmodifiableList(predicates);
+  }
+
+  private static Predicate<String> createGlobPredicate(String globPattern) {
+    if (globPattern.indexOf('*') == -1 && globPattern.indexOf('?') == -1) {
+      return globPattern::equals;
+    }
+
+    return value -> globMatches(globPattern, value);
+  }
+
+  private static boolean globMatches(String pattern, String value) {
+    int patternIndex = 0;
+    int valueIndex = 0;
+    int patternIndexAfterStar = -1;
+    int valueIndexAfterStar = -1;
+
+    // Do not translate globs to regular expressions: repeated '*' segments can cause excessive
+    // regex backtracking on a non-match. Possessive quantifiers change glob semantics because '*'
+    // may need to give characters back to match a later token (for example, glob "*a" must match
+    // "ba"). Each retry below consumes one value code point, bounding the work by the product of
+    // the
+    // pattern and value lengths.
+    while (valueIndex < value.length()) {
+      if (patternIndex < pattern.length()) {
+        int patternCodePoint = pattern.codePointAt(patternIndex);
+        if (patternCodePoint == '*') {
+          patternIndex += Character.charCount(patternCodePoint);
+          patternIndexAfterStar = patternIndex;
+          valueIndexAfterStar = valueIndex;
+          continue;
+        }
+
+        int valueCodePoint = value.codePointAt(valueIndex);
+        if (patternCodePoint == '?' || patternCodePoint == valueCodePoint) {
+          patternIndex += Character.charCount(patternCodePoint);
+          valueIndex += Character.charCount(valueCodePoint);
+          continue;
+        }
+      }
+
+      if (patternIndexAfterStar == -1) {
+        return false;
+      }
+
+      int valueCodePoint = value.codePointAt(valueIndexAfterStar);
+      valueIndexAfterStar += Character.charCount(valueCodePoint);
+      valueIndex = valueIndexAfterStar;
+      patternIndex = patternIndexAfterStar;
+    }
+
+    while (patternIndex < pattern.length() && pattern.codePointAt(patternIndex) == '*') {
+      patternIndex++;
+    }
+    return patternIndex == pattern.length();
+  }
+
+  private static boolean matchesAny(List<Predicate<String>> predicates, String value) {
+    for (Predicate<String> predicate : predicates) {
+      if (predicate.test(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** A builder for {@link IncludeExclude}. */
+public final class IncludeExcludeBuilder {
+
+  private List<String> included = emptyList();
+  private List<String> excluded = emptyList();
+
+  IncludeExcludeBuilder() {}
+
+  /** Replaces the included patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setIncluded(Collection<String> included) {
+    this.included = copyPatterns(included, "included");
+    return this;
+  }
+
+  /** Replaces the excluded patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setExcluded(Collection<String> excluded) {
+    this.excluded = copyPatterns(excluded, "excluded");
+    return this;
+  }
+
+  /** Returns a new immutable {@link IncludeExclude}. */
+  public IncludeExclude build() {
+    return new IncludeExclude(included, excluded);
+  }
+
+  private static List<String> copyPatterns(Collection<String> patterns, String name) {
+    requireNonNull(patterns, name);
+    List<String> copy = new ArrayList<>(patterns.size());
+    for (String pattern : patterns) {
+      copy.add(requireNonNull(pattern, name + " pattern"));
+    }
+    return copy;
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeBuilder.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.config;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
@@ -28,11 +29,23 @@ public final class IncludeExcludeBuilder {
     return this;
   }
 
+  /** Replaces the included patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setIncluded(String... included) {
+    return setIncluded(asList(included));
+  }
+
   /** Replaces the excluded patterns. */
   @CanIgnoreReturnValue
   public IncludeExcludeBuilder setExcluded(Collection<String> excluded) {
     this.excluded = copyPatterns(excluded, "excluded");
     return this;
+  }
+
+  /** Replaces the excluded patterns. */
+  @CanIgnoreReturnValue
+  public IncludeExcludeBuilder setExcluded(String... excluded) {
+    return setExcluded(asList(excluded));
   }
 
   /** Returns a new immutable {@link IncludeExclude}. */

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/package-info.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/config/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package io.opentelemetry.instrumentation.api.config;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
@@ -49,6 +49,15 @@ class IncludeExcludeTest {
   }
 
   @Test
+  void selectorIsEmptyOnlyWithoutPatterns() {
+    assertThat(IncludeExclude.builder().build().isEmpty()).isTrue();
+    assertThat(IncludeExclude.builder().setIncluded(singletonList("included")).build().isEmpty())
+        .isFalse();
+    assertThat(IncludeExclude.builder().setExcluded(singletonList("excluded")).build().isEmpty())
+        .isFalse();
+  }
+
+  @Test
   void selectorIsImmutable() {
     List<String> included = new ArrayList<>(singletonList("included"));
     List<String> excluded = new ArrayList<>(singletonList("excluded"));

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.config;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.nCopies;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class IncludeExcludeTest {
+
+  @ParameterizedTest
+  @MethodSource("patterns")
+  void patternMatching(
+      Collection<String> included, Collection<String> excluded, String value, boolean expected) {
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(included).setExcluded(excluded).build();
+
+    assertThat(selector.matches(value)).isEqualTo(expected);
+  }
+
+  @Test
+  void builderReplacesPatterns() {
+    IncludeExclude selector =
+        IncludeExclude.builder()
+            .setIncluded(singletonList("first"))
+            .setIncluded(singletonList("second"))
+            .setExcluded(singletonList("third"))
+            .setExcluded(singletonList("fourth"))
+            .build();
+
+    assertThat(selector.getIncluded()).containsExactly("second");
+    assertThat(selector.getExcluded()).containsExactly("fourth");
+  }
+
+  @Test
+  void selectorIsImmutable() {
+    List<String> included = new ArrayList<>(singletonList("included"));
+    List<String> excluded = new ArrayList<>(singletonList("excluded"));
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(included).setExcluded(excluded).build();
+
+    included.add("later included");
+    excluded.add("later excluded");
+
+    assertThat(selector.getIncluded()).containsExactly("included");
+    assertThat(selector.getExcluded()).containsExactly("excluded");
+    assertThatThrownBy(() -> selector.getIncluded().add("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> selector.getExcluded().add("other"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void rejectsNullPatterns() {
+    assertThatThrownBy(() -> IncludeExclude.builder().setIncluded(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> IncludeExclude.builder().setExcluded(asList("foo", null)))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void multiStarNonMatchHasBoundedRuntime() {
+    String value = String.join("", nCopies(1_000, "a"));
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(singletonList("*a*a*a*a*a*a*a*a*a*a*b")).build();
+
+    assertThat(selector.matches(value)).isFalse();
+  }
+
+  @Test
+  void matchesAllSmallPatterns() {
+    List<String> mismatches = new ArrayList<>();
+    List<String> values = allStrings("ab", 5);
+    for (String pattern : allStrings("ab*?", 5)) {
+      IncludeExclude selector =
+          IncludeExclude.builder().setIncluded(singletonList(pattern)).build();
+      for (String value : values) {
+        boolean expected = referenceAsciiGlobMatches(pattern, value);
+        boolean actual = selector.matches(value);
+        if (actual != expected) {
+          mismatches.add(
+              "pattern="
+                  + pattern
+                  + ", value="
+                  + value
+                  + ", expected="
+                  + expected
+                  + ", actual="
+                  + actual);
+        }
+      }
+    }
+
+    assertThat(mismatches).isEmpty();
+  }
+
+  private static Stream<Arguments> patterns() {
+    return Stream.of(
+        argumentSet("empty patterns include all", emptyList(), emptyList(), "foo", true),
+        argumentSet("exact include matches", singletonList("foo"), emptyList(), "foo", true),
+        argumentSet("exact include rejects", singletonList("foo"), emptyList(), "bar", false),
+        argumentSet("matching is case sensitive", singletonList("foo"), emptyList(), "FOO", false),
+        argumentSet("star matches empty value", singletonList("*"), emptyList(), "", true),
+        argumentSet(
+            "star matches zero characters", singletonList("foo*"), emptyList(), "foo", true),
+        argumentSet(
+            "star matches many characters", singletonList("foo*"), emptyList(), "foobar", true),
+        argumentSet(
+            "star backtracks to match suffix",
+            singletonList("f*bar"),
+            emptyList(),
+            "foobazbar",
+            true),
+        argumentSet(
+            "multiple stars backtrack", singletonList("*ab*cd"), emptyList(), "xxabyycd", true),
+        argumentSet("consecutive stars match", singletonList("f**o"), emptyList(), "foo", true),
+        argumentSet(
+            "trailing stars match empty", singletonList("foo***"), emptyList(), "foo", true),
+        argumentSet(
+            "wildcards require whole value", singletonList("foo*"), emptyList(), "xfoobar", false),
+        argumentSet(
+            "star cannot make missing suffix",
+            singletonList("foo*bar"),
+            emptyList(),
+            "foobaz",
+            false),
+        argumentSet(
+            "star matches line terminators", singletonList("foo*"), emptyList(), "foo\nbar", true),
+        argumentSet(
+            "star matches unicode characters",
+            singletonList("f*o"),
+            emptyList(),
+            "f" + new String(Character.toChars(0x1F600)) + "o",
+            true),
+        argumentSet(
+            "question matches one character", singletonList("f?o"), emptyList(), "foo", true),
+        argumentSet(
+            "question matches a line terminator", singletonList("f?o"), emptyList(), "f\no", true),
+        argumentSet(
+            "question matches one unicode character",
+            singletonList("f?o"),
+            emptyList(),
+            "f" + new String(Character.toChars(0x1F600)) + "o",
+            true),
+        argumentSet(
+            "question rejects zero characters", singletonList("f?o"), emptyList(), "fo", false),
+        argumentSet(
+            "regex characters are literal",
+            singletonList("f()[]$^.{}|*"),
+            emptyList(),
+            "f()[]$^.{}|oo",
+            true),
+        argumentSet(
+            "matching exclude wins", singletonList("*"), singletonList("foo*"), "foobar", false),
+        argumentSet(
+            "exclude-only selector includes nonmatches",
+            emptyList(),
+            singletonList("foo*"),
+            "bar",
+            true),
+        argumentSet("any include can match", asList("foo", "bar"), emptyList(), "bar", true));
+  }
+
+  private static List<String> allStrings(String alphabet, int maxLength) {
+    List<String> strings = new ArrayList<>();
+    addStrings(strings, alphabet, maxLength, "");
+    return strings;
+  }
+
+  private static void addStrings(
+      List<String> strings, String alphabet, int maxLength, String prefix) {
+    strings.add(prefix);
+    if (prefix.length() == maxLength) {
+      return;
+    }
+    for (int i = 0; i < alphabet.length(); i++) {
+      addStrings(strings, alphabet, maxLength, prefix + alphabet.charAt(i));
+    }
+  }
+
+  private static boolean referenceAsciiGlobMatches(String pattern, String value) {
+    boolean[][] matches = new boolean[pattern.length() + 1][value.length() + 1];
+    matches[0][0] = true;
+    for (int patternIndex = 1; patternIndex <= pattern.length(); patternIndex++) {
+      char patternChar = pattern.charAt(patternIndex - 1);
+      if (patternChar == '*') {
+        matches[patternIndex][0] = matches[patternIndex - 1][0];
+      }
+      for (int valueIndex = 1; valueIndex <= value.length(); valueIndex++) {
+        if (patternChar == '*') {
+          matches[patternIndex][valueIndex] =
+              matches[patternIndex - 1][valueIndex] || matches[patternIndex][valueIndex - 1];
+        } else if (patternChar == '?' || patternChar == value.charAt(valueIndex - 1)) {
+          matches[patternIndex][valueIndex] = matches[patternIndex - 1][valueIndex - 1];
+        }
+      }
+    }
+    return matches[pattern.length()][value.length()];
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/config/IncludeExcludeTest.java
@@ -39,13 +39,13 @@ class IncludeExcludeTest {
     IncludeExclude selector =
         IncludeExclude.builder()
             .setIncluded(singletonList("first"))
-            .setIncluded(singletonList("second"))
-            .setExcluded(singletonList("third"))
+            .setIncluded("second", "third")
             .setExcluded(singletonList("fourth"))
+            .setExcluded("fifth", "sixth")
             .build();
 
-    assertThat(selector.getIncluded()).containsExactly("second");
-    assertThat(selector.getExcluded()).containsExactly("fourth");
+    assertThat(selector.getIncluded()).containsExactly("second", "third");
+    assertThat(selector.getExcluded()).containsExactly("fifth", "sixth");
   }
 
   @Test
@@ -77,9 +77,13 @@ class IncludeExcludeTest {
 
   @Test
   void rejectsNullPatterns() {
-    assertThatThrownBy(() -> IncludeExclude.builder().setIncluded(null))
+    assertThatThrownBy(() -> IncludeExclude.builder().setIncluded((Collection<String>) null))
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> IncludeExclude.builder().setExcluded(asList("foo", null)))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> IncludeExclude.builder().setIncluded((String[]) null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> IncludeExclude.builder().setExcluded("foo", null))
         .isInstanceOf(NullPointerException.class);
   }
 


### PR DESCRIPTION
Adds `IncludeExclude` and `IncludeExcludeBuilder` to `instrumentation-api`, an immutable selector that matches a string against include and exclude glob patterns, so instrumentations can share one filtering API instead of each defining its own.

```java
IncludeExclude headers =
    IncludeExclude.builder()
        .setIncluded(asList("x-request-*", "content-type"))
        .setExcluded(singletonList("x-request-token"))
        .build();

headers.matches("x-request-id"); // true
headers.matches("x-request-token"); // false
```

Matching is case-sensitive, `?` matches any single character, and `*` matches any number of characters including none. Excluded patterns take precedence over included patterns, so an excluded value never matches even when an included pattern also matches it. A selector with no included patterns matches every value that is not excluded.

`isEmpty()` reports whether a selector has no patterns in either list. Such a selector carries no configuration, so a setting that uses one should behave as if no selector were configured and fall back to its own default. Note that an empty selector still matches every value, so a caller that treats empty as unconfigured must check `isEmpty()` rather than rely on `matches`.

This keeps an empty selector a no-op and matches flat configuration, where an empty property value cannot be distinguished from an unset one.

This also documents the naming, default, and documentation conventions for structured selectors in `.github/agents/knowledge/config-property-stability.md`, so the guidance lives alongside the type that encodes it. A selector is named after the resource being selected rather than with a `capture_*` prefix, which stays reserved for action booleans such as `capture_query`. The two lists are always described as precedence rather than as order of application, since "exclusions are applied after inclusions" reads as a sequence and leaves it ambiguous whether a later rule can re-add a value an earlier rule removed.

This adds the API only; no instrumentation uses it yet.