### PR TITLE
Fix Micrometer custom meter naming in v3 preview

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -51,12 +51,14 @@ final class Bridging {
   }
 
   static String statisticInstrumentName(
-      Meter.Id id, Statistic statistic, NamingConvention namingConvention) {
-    String prefix = id.getName() + ".";
+      Meter.Id id, Statistic statistic, NamingConvention namingConvention, boolean v3Preview) {
     // use "total_time" instead of "total" to avoid clashing with Statistic.TOTAL
     String statisticStr =
         statistic == Statistic.TOTAL_TIME ? "total_time" : statistic.getTagValueRepresentation();
-    return namingConvention.name(prefix + statisticStr, id.getType(), id.getBaseUnit());
+    if (v3Preview) {
+      return name(id, namingConvention) + "." + statisticStr;
+    }
+    return namingConvention.name(id.getName() + "." + statisticStr, id.getType(), id.getBaseUnit());
   }
 
   private Bridging() {}

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -28,13 +28,15 @@ final class OpenTelemetryMeter extends AbstractMeter
       Id id,
       NamingConvention namingConvention,
       Iterable<Measurement> measurements,
+      boolean v3Preview,
       io.opentelemetry.api.metrics.Meter otelMeter) {
     super(id);
     Attributes attributes = tagsAsAttributes(id, namingConvention);
 
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
-      String name = statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
+      String name =
+          statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
       String description = Bridging.description(id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -52,6 +52,7 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
   private final TimeUnit baseTimeUnit;
   private final DistributionStatisticConfigModifier distributionStatisticConfigModifier;
   private final boolean emitMaxGauge;
+  private final boolean v3Preview;
   private final io.opentelemetry.api.metrics.Meter otelMeter;
 
   OpenTelemetryMeterRegistry(
@@ -59,12 +60,13 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
       TimeUnit baseTimeUnit,
       NamingConvention namingConvention,
       DistributionStatisticConfigModifier distributionStatisticConfigModifier,
-      boolean emitMaxGauge,
+      boolean v3Preview,
       io.opentelemetry.api.metrics.Meter otelMeter) {
     super(clock);
     this.baseTimeUnit = baseTimeUnit;
     this.distributionStatisticConfigModifier = distributionStatisticConfigModifier;
-    this.emitMaxGauge = emitMaxGauge;
+    this.emitMaxGauge = !v3Preview;
+    this.v3Preview = v3Preview;
     this.otelMeter = otelMeter;
 
     this.config()
@@ -142,7 +144,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
 
   @Override
   protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
-    return new OpenTelemetryMeter(id, config().namingConvention(), measurements, otelMeter);
+    return new OpenTelemetryMeter(
+        id, config().namingConvention(), measurements, v3Preview, otelMeter);
   }
 
   @Override

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
@@ -119,7 +119,7 @@ public final class OpenTelemetryMeterRegistryBuilder {
         baseTimeUnit,
         namingConvention,
         modifier,
-        !SemconvStability.v3Preview(openTelemetry),
+        SemconvStability.v3Preview(openTelemetry),
         meterBuilder.build());
   }
 }

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.micrometer.v1_5.AbstractCounterTe
 import static io.opentelemetry.instrumentation.micrometer.v1_5.MaxGaugeAssertions.assertMaxGauge;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -19,8 +20,12 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Timer;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -279,6 +284,42 @@ public abstract class AbstractPrometheusModeTest {
                                         .hasValue(0)
                                         .hasAttributesSatisfyingExactly(
                                             equalTo(stringKey("tag"), "value")))));
+  }
+
+  @Test
+  void testMeter() {
+    // given
+    Measurement measurement = new Measurement(() -> 12.0, Statistic.COUNT);
+    String expectedName =
+        SemconvStability.v3Preview()
+            ? "testPrometheusMeter.bytes.count"
+            : "testPrometheusMeter.count.bytes";
+
+    // when
+    Meter.builder("testPrometheusMeter", Meter.Type.COUNTER, singletonList(measurement))
+        .description("This is a test meter")
+        .baseUnit("bytes")
+        .tag("tag", "value")
+        .register(Metrics.globalRegistry);
+
+    // then
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName(expectedName)
+                    .hasDescription("This is a test meter")
+                    .hasUnit("bytes")
+                    .hasDoubleSumSatisfying(
+                        sum ->
+                            sum.isMonotonic()
+                                .hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(12)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(stringKey("tag"), "value")))));
   }
 
   @Test


### PR DESCRIPTION
Align custom `Meter` statistic names with the bridge's other Micrometer instruments by applying the naming convention before appending the statistic suffix. #5328 originally introduced suffix-then-convention ordering for every statistic-producing instrument, but #5338 migrated all of them except custom `Meter`; this completes that missed migration while gating the changed names on `otel.instrumentation.common.v3-preview` so default behavior remains unchanged.

The resulting ordering matches upstream Micrometer, whose `PrometheusNamingConvention` appends the base unit to the family name and lets the call site append the aggregation suffix afterward, and matches the OpenTelemetry Prometheus compatibility spec: "The unit suffix comes before any type-specific suffixes."