### PR TITLE
Key the Micrometer description cache on the emitted instrument name

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -36,9 +36,16 @@ final class Bridging {
     return namingConvention.name(id.getName(), id.getType(), id.getBaseUnit());
   }
 
-  static String description(Meter.Id id) {
+  // Micrometer allows every set of tags to carry its own description, while in OpenTelemetry the
+  // description is one of an instrument's identifying fields. Bridging the descriptions through
+  // unchanged would turn a single Micrometer metric into conflicting OpenTelemetry instruments that
+  // share a name, which the SDK exports as separate metric streams instead of aggregating into one.
+  // So the first description seen for an instrument name wins, which is also what Micrometer's own
+  // PrometheusMeterRegistry does. Callers must pass the name the instrument is actually emitted
+  // under, including any suffix such as ".max", since that is the name a conflict would occur on.
+  static String description(String instrumentName, Meter.Id id) {
     return descriptionsCache.computeIfAbsent(
-        id.getName(),
+        instrumentName,
         n -> {
           String description = id.getDescription();
           return description != null ? description : "";

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -36,7 +36,7 @@ final class OpenTelemetryCounter extends AbstractMeter
     this.otelCounter =
         otelMeter
             .counterBuilder(conventionName)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -66,7 +66,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -74,7 +74,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(id))
+                .setDescription(Bridging.description(name + ".max", id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -37,7 +37,7 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name)
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name + ".count", id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +53,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name + ".sum", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -37,7 +37,7 @@ final class OpenTelemetryGauge<T> extends AbstractMeter
     observableGauge =
         otelMeter
             .gaugeBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -45,7 +45,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name + ".active", id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +53,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name + ".duration", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -37,7 +37,7 @@ final class OpenTelemetryMeter extends AbstractMeter
     for (Measurement measurement : measurements) {
       String name =
           statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
-      String description = Bridging.description(id);
+      String description = Bridging.description(name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -78,7 +78,7 @@ final class OpenTelemetryTimer extends AbstractTimer
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(id))
+            .setDescription(Bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig, baseTimeUnit);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -86,7 +86,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(id))
+                .setDescription(Bridging.description(name + ".max", id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.micrometer.v1_5;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class DescriptionDeduplicationTest {
+
+  @Test
+  void descriptionsAreDeduplicatedOnTheSuffixedInstrumentName() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    AtomicLong count = new AtomicLong(1);
+
+    try (SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+
+      MeterRegistry registry =
+          OpenTelemetryMeterRegistry.builder(
+                  OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build())
+              .build();
+
+      // emits testSuffix.sum as an async double counter with unit s, colliding with the function
+      // counter below
+      FunctionTimer.builder("testSuffix", count, AtomicLong::get, AtomicLong::doubleValue, SECONDS)
+          .description("First description")
+          .register(registry);
+      FunctionCounter.builder("testSuffix.sum", count, AtomicLong::doubleValue)
+          .description("Second description")
+          .baseUnit("s")
+          .register(registry);
+
+      assertThat(reader.collectAllMetrics())
+          .filteredOn(metric -> metric.getName().equals("testSuffix.sum"))
+          .singleElement()
+          .extracting(MetricData::getDescription)
+          .isEqualTo("First description");
+    }
+  }
+}

--- a/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/testing/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/AbstractPrometheusModeTest.java
@@ -373,6 +373,45 @@ public abstract class AbstractPrometheusModeTest {
   }
 
   @Test
+  void testSameNameDifferentTypeKeepsOwnDescription() {
+    // given a counter and a timer that share a Micrometer name, but that the prometheus naming
+    // convention maps onto two different OpenTelemetry instrument names
+    Counter counter =
+        Counter.builder("testPrometheusSharedName")
+            .description("This is a test counter")
+            .tags("type", "counter")
+            .baseUnit("")
+            .register(Metrics.globalRegistry);
+    Timer timer =
+        Timer.builder("testPrometheusSharedName")
+            .description("This is a test timer")
+            .tags("type", "timer")
+            .register(Metrics.globalRegistry);
+
+    // when
+    counter.increment(12);
+    timer.record(1, SECONDS);
+
+    // then each instrument keeps its own description
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName")
+                    .hasDescription("This is a test counter")
+                    .hasDoubleSumSatisfying(sum -> sum.isMonotonic()));
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            metric ->
+                metric
+                    .hasName("testPrometheusSharedName.seconds")
+                    .hasDescription("This is a test timer")
+                    .hasHistogramSatisfying(histogram -> {}));
+  }
+
+  @Test
   void testTimerCustomBucketBoundaryFormatting() {
     // given
     Timer timer =


### PR DESCRIPTION
Stacked on #19463.

The bridge keeps only the first description seen for an instrument, because in OpenTelemetry the description is one of an instrument's identifying fields while Micrometer allows every set of tags to carry its own. Bridging descriptions through unchanged would turn a single Micrometer metric into conflicting OpenTelemetry instruments sharing a name, which the SDK exports as separate metric streams rather than aggregating into one. This is inherent to the two data models ([java#4381](https://github.com/open-telemetry/opentelemetry-java/issues/4381), [java#4510](https://github.com/open-telemetry/opentelemetry-java/issues/4510)) rather than something waiting on an SDK fix, and matches what Micrometer's own `PrometheusMeterRegistry` does.

**The cache was keyed on the wrong name.** #5452 keyed it on the name after the naming convention had been applied, but it came back from #6538 keyed on the raw Micrometer name. Meters sharing a Micrometer name but mapping onto different instrument names therefore incorrectly shared a description. This is reachable in prometheus mode, because `Meter.Id` identity is name plus tags only — a `Counter` `foo` and a `Timer` `foo` both register, and become `foo` and `foo.seconds`.

Callers now pass the name the instrument is actually emitted under, including suffixes such as `.max`. The comment explaining the deduplication — dropped when the class moved back from `opentelemetry-java` in #6538 — is restored and reworded.