### PR TITLE
Scope the Micrometer description cache to each registry

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/Bridging.java
@@ -16,7 +16,12 @@ import java.util.concurrent.ConcurrentMap;
 
 final class Bridging {
 
-  private static final ConcurrentMap<String, String> descriptionsCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, String> descriptionsCache = new ConcurrentHashMap<>();
+  private final boolean v3Preview;
+
+  Bridging(boolean v3Preview) {
+    this.v3Preview = v3Preview;
+  }
 
   static Attributes tagsAsAttributes(Meter.Id id, NamingConvention namingConvention) {
     Iterable<Tag> tags = id.getTagsAsIterable();
@@ -43,7 +48,7 @@ final class Bridging {
   // So the first description seen for an instrument name wins, which is also what Micrometer's own
   // PrometheusMeterRegistry does. Callers must pass the name the instrument is actually emitted
   // under, including any suffix such as ".max", since that is the name a conflict would occur on.
-  static String description(String instrumentName, Meter.Id id) {
+  String description(String instrumentName, Meter.Id id) {
     return descriptionsCache.computeIfAbsent(
         instrumentName,
         n -> {
@@ -57,8 +62,8 @@ final class Bridging {
     return baseUnit == null ? "" : baseUnit;
   }
 
-  static String statisticInstrumentName(
-      Meter.Id id, Statistic statistic, NamingConvention namingConvention, boolean v3Preview) {
+  String statisticInstrumentName(
+      Meter.Id id, Statistic statistic, NamingConvention namingConvention) {
     // use "total_time" instead of "total" to avoid clashing with Statistic.TOTAL
     String statisticStr =
         statistic == Statistic.TOTAL_TIME ? "total_time" : statistic.getTagValueRepresentation();
@@ -67,6 +72,4 @@ final class Bridging {
     }
     return namingConvention.name(id.getName() + "." + statisticStr, id.getType(), id.getBaseUnit());
   }
-
-  private Bridging() {}
 }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryCounter.java
@@ -28,7 +28,8 @@ final class OpenTelemetryCounter extends AbstractMeter
 
   private volatile boolean removed = false;
 
-  OpenTelemetryCounter(Id id, NamingConvention namingConvention, Meter otelMeter) {
+  OpenTelemetryCounter(
+      Id id, NamingConvention namingConvention, Meter otelMeter, Bridging bridging) {
     super(id);
 
     this.attributes = tagsAsAttributes(id, namingConvention);
@@ -36,7 +37,7 @@ final class OpenTelemetryCounter extends AbstractMeter
     this.otelCounter =
         otelMeter
             .counterBuilder(conventionName)
-            .setDescription(Bridging.description(conventionName, id))
+            .setDescription(bridging.description(conventionName, id))
             .setUnit(baseUnit(id))
             .ofDoubles()
             .build();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryDistributionSummary.java
@@ -50,7 +50,8 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
       DistributionStatisticConfigModifier modifier,
       double scale,
       boolean emitMaxGauge,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id, clock, modifier.modify(distributionStatisticConfig), scale, false);
 
     if (isUsingMicrometerHistograms()) {
@@ -66,7 +67,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -74,7 +75,7 @@ final class OpenTelemetryDistributionSummary extends AbstractDistributionSummary
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(name + ".max", id))
+                .setDescription(bridging.description(name + ".max", id))
                 .setUnit(baseUnit(id))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, TimeWindowMax::poll, attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionCounter.java
@@ -29,7 +29,8 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
       NamingConvention namingConvention,
       T obj,
       ToDoubleFunction<T> countFunction,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
 
     String name = name(id, namingConvention);
@@ -37,7 +38,7 @@ final class OpenTelemetryFunctionCounter<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name)
             .ofDoubles()
-            .setDescription(Bridging.description(name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryFunctionTimer.java
@@ -35,7 +35,8 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
       ToDoubleFunction<T> totalTimeFunction,
       TimeUnit totalTimeFunctionUnit,
       TimeUnit baseTimeUnit,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
     this.baseTimeUnit = baseTimeUnit;
 
@@ -45,7 +46,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
     this.observableCount =
         otelMeter
             .counterBuilder(name + ".count")
-            .setDescription(Bridging.description(name + ".count", id))
+            .setDescription(bridging.description(name + ".count", id))
             .setUnit("{invocation}")
             .buildWithCallback(new LongMeasurementRecorder<>(obj, countFunction, attributes));
 
@@ -53,7 +54,7 @@ final class OpenTelemetryFunctionTimer<T> extends AbstractMeter
         otelMeter
             .counterBuilder(name + ".sum")
             .ofDoubles()
-            .setDescription(Bridging.description(name + ".sum", id))
+            .setDescription(bridging.description(name + ".sum", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryGauge.java
@@ -30,14 +30,15 @@ final class OpenTelemetryGauge<T> extends AbstractMeter
       NamingConvention namingConvention,
       @Nullable T obj,
       ToDoubleFunction<T> objMetric,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id);
 
     String name = name(id, namingConvention);
     observableGauge =
         otelMeter
             .gaugeBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(baseUnit(id))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryLongTaskTimer.java
@@ -34,7 +34,8 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
       Clock clock,
       TimeUnit baseTimeUnit,
       DistributionStatisticConfig distributionStatisticConfig,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(id, clock, baseTimeUnit, distributionStatisticConfig, false);
 
     this.distributionStatisticConfig = distributionStatisticConfig;
@@ -45,7 +46,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
     this.observableActiveTasks =
         otelMeter
             .upDownCounterBuilder(name + ".active")
-            .setDescription(Bridging.description(name + ".active", id))
+            .setDescription(bridging.description(name + ".active", id))
             .setUnit("{tasks}")
             .buildWithCallback(
                 new LongMeasurementRecorder<>(this, DefaultLongTaskTimer::activeTasks, attributes));
@@ -53,7 +54,7 @@ final class OpenTelemetryLongTaskTimer extends DefaultLongTaskTimer
         otelMeter
             .upDownCounterBuilder(name + ".duration")
             .ofDoubles()
-            .setDescription(Bridging.description(name + ".duration", id))
+            .setDescription(bridging.description(name + ".duration", id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
             .buildWithCallback(
                 new DoubleMeasurementRecorder<>(

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.baseUnit;
-import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.statisticInstrumentName;
 import static io.opentelemetry.instrumentation.micrometer.v1_5.Bridging.tagsAsAttributes;
 import static java.util.Collections.emptyList;
 
@@ -28,16 +27,16 @@ final class OpenTelemetryMeter extends AbstractMeter
       Id id,
       NamingConvention namingConvention,
       Iterable<Measurement> measurements,
-      boolean v3Preview,
-      io.opentelemetry.api.metrics.Meter otelMeter) {
+      io.opentelemetry.api.metrics.Meter otelMeter,
+      Bridging bridging) {
     super(id);
     Attributes attributes = tagsAsAttributes(id, namingConvention);
 
     List<AutoCloseable> observableInstruments = new ArrayList<>();
     for (Measurement measurement : measurements) {
       String name =
-          statisticInstrumentName(id, measurement.getStatistic(), namingConvention, v3Preview);
-      String description = Bridging.description(name, id);
+          bridging.statisticInstrumentName(id, measurement.getStatistic(), namingConvention);
+      String description = bridging.description(name, id);
       String baseUnit = baseUnit(id);
       DoubleMeasurementRecorder<Measurement> callback =
           new DoubleMeasurementRecorder<>(measurement, Measurement::getValue, attributes);

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -49,10 +49,10 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
     return new OpenTelemetryMeterRegistryBuilder(openTelemetry);
   }
 
+  private final Bridging bridging;
   private final TimeUnit baseTimeUnit;
   private final DistributionStatisticConfigModifier distributionStatisticConfigModifier;
   private final boolean emitMaxGauge;
-  private final boolean v3Preview;
   private final io.opentelemetry.api.metrics.Meter otelMeter;
 
   OpenTelemetryMeterRegistry(
@@ -63,10 +63,10 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
       boolean v3Preview,
       io.opentelemetry.api.metrics.Meter otelMeter) {
     super(clock);
+    this.bridging = new Bridging(v3Preview);
     this.baseTimeUnit = baseTimeUnit;
     this.distributionStatisticConfigModifier = distributionStatisticConfigModifier;
     this.emitMaxGauge = !v3Preview;
-    this.v3Preview = v3Preview;
     this.otelMeter = otelMeter;
 
     this.config()
@@ -76,12 +76,13 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
 
   @Override
   protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
-    return new OpenTelemetryGauge<>(id, config().namingConvention(), obj, valueFunction, otelMeter);
+    return new OpenTelemetryGauge<>(
+        id, config().namingConvention(), obj, valueFunction, otelMeter, bridging);
   }
 
   @Override
   protected Counter newCounter(Meter.Id id) {
-    return new OpenTelemetryCounter(id, config().namingConvention(), otelMeter);
+    return new OpenTelemetryCounter(id, config().namingConvention(), otelMeter, bridging);
   }
 
   @Override
@@ -94,7 +95,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             clock,
             getBaseTimeUnit(),
             distributionStatisticConfig,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (timer.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(timer, this);
     }
@@ -116,7 +118,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             pauseDetector,
             getBaseTimeUnit(),
             emitMaxGauge,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (timer.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(timer, this);
     }
@@ -135,7 +138,8 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
             distributionStatisticConfigModifier,
             scale,
             emitMaxGauge,
-            otelMeter);
+            otelMeter,
+            bridging);
     if (distributionSummary.isUsingMicrometerHistograms()) {
       HistogramGauges.registerWithCommonFormat(distributionSummary, this);
     }
@@ -145,7 +149,7 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
   @Override
   protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
     return new OpenTelemetryMeter(
-        id, config().namingConvention(), measurements, v3Preview, otelMeter);
+        id, config().namingConvention(), measurements, otelMeter, bridging);
   }
 
   @Override
@@ -163,14 +167,15 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
         totalTimeFunction,
         totalTimeFunctionUnit,
         getBaseTimeUnit(),
-        otelMeter);
+        otelMeter,
+        bridging);
   }
 
   @Override
   protected <T> FunctionCounter newFunctionCounter(
       Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
     return new OpenTelemetryFunctionCounter<>(
-        id, config().namingConvention(), obj, countFunction, otelMeter);
+        id, config().namingConvention(), obj, countFunction, otelMeter, bridging);
   }
 
   @Override

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryTimer.java
@@ -55,7 +55,8 @@ final class OpenTelemetryTimer extends AbstractTimer
       PauseDetector pauseDetector,
       TimeUnit baseTimeUnit,
       boolean emitMaxGauge,
-      Meter otelMeter) {
+      Meter otelMeter,
+      Bridging bridging) {
     super(
         id,
         clock,
@@ -78,7 +79,7 @@ final class OpenTelemetryTimer extends AbstractTimer
     DoubleHistogramBuilder otelHistogramBuilder =
         otelMeter
             .histogramBuilder(name)
-            .setDescription(Bridging.description(name, id))
+            .setDescription(bridging.description(name, id))
             .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit));
     setExplicitBucketsIfConfigured(otelHistogramBuilder, distributionStatisticConfig, baseTimeUnit);
     this.otelHistogram = otelHistogramBuilder.build();
@@ -86,7 +87,7 @@ final class OpenTelemetryTimer extends AbstractTimer
         emitMaxGauge
             ? otelMeter
                 .gaugeBuilder(name + ".max")
-                .setDescription(Bridging.description(name + ".max", id))
+                .setDescription(bridging.description(name + ".max", id))
                 .setUnit(TimeUnitHelper.getUnitString(baseTimeUnit))
                 .buildWithCallback(
                     new DoubleMeasurementRecorder<>(max, m -> m.poll(baseTimeUnit), attributes))

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/DescriptionDeduplicationTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.micrometer.v1_5;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,6 +20,33 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
 class DescriptionDeduplicationTest {
+
+  @Test
+  void descriptionsAreNotSharedAcrossRegistries() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+
+    try (SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build()) {
+      OpenTelemetrySdk openTelemetry =
+          OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
+
+      MeterRegistry firstRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).build();
+      MeterRegistry secondRegistry = OpenTelemetryMeterRegistry.builder(openTelemetry).build();
+
+      Counter.builder("testCounter")
+          .description("First description")
+          .register(firstRegistry)
+          .increment();
+      Counter.builder("testCounter")
+          .description("Second description")
+          .register(secondRegistry)
+          .increment();
+
+      assertThat(reader.collectAllMetrics())
+          .extracting(MetricData::getDescription)
+          .containsExactlyInAnyOrder("First description", "Second description");
+    }
+  }
 
   @Test
   void descriptionsAreDeduplicatedOnTheSuffixedInstrumentName() {


### PR DESCRIPTION
Stacked on #19466.

**The description cache was static**, so descriptions were deduplicated across every registry in the process, and entries were never released. It is now scoped to each `OpenTelemetryMeterRegistry`, so entries become collectable with the registry and description selection does not depend on whether a `MeterProvider` reuses `Meter` instances. Multiple registries intentionally make independent description choices.

Making `Bridging` a per-registry instance also lets the `v3Preview` flag added in #19463 become a field rather than being threaded through `statisticInstrumentName` as a parameter.

One thing I'm deliberately not changing: within a single registry the cache is still unbounded, so an application generating meter names dynamically grows it. Restoring #5452's `Cache.bounded(1024)` doesn't seem worth it. `MetricStorageRegistry` has no removal API at all — closing an async instrument only unregisters its callback — so the SDK already retains a heavier entry per distinct name for the life of the provider, and capping the bridge's cache wouldn't cap overall growth. A bound also reintroduces eviction, where an evicted name re-seeds from whichever description arrives next and silently produces the split metric streams the cache exists to prevent.