### PR TITLE
Improve Vibur DBCP pool name stability

### DIFF
--- a/instrumentation/vibur-dbcp-11.0/javaagent/build.gradle.kts
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
   library("org.vibur:vibur-dbcp:11.0")
 
   implementation(project(":instrumentation:vibur-dbcp-11.0:library"))
+  implementation(project(":instrumentation:jdbc:javaagent-common"))
+  bootstrap(project(":instrumentation:jdbc:bootstrap"))
 
   testImplementation(project(":instrumentation:vibur-dbcp-11.0:testing"))
 }

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburConfigInstrumentation.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburConfigInstrumentation.java
@@ -5,12 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
 
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -26,15 +27,17 @@ final class ViburConfigInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        isConstructor().and(takesArguments(0)), getClass().getName() + "$ConstructorAdvice");
+        isPublic().and(named("setName")).and(takesArguments(String.class)),
+        getClass().getName() + "$SetNameAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class ConstructorAdvice {
+  public static class SetNameAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-    public static void onExit(@Advice.This ViburConfig config) {
-      ViburSingletons.captureDefaultName(config);
+    public static void onExit(
+        @Advice.This ViburConfig config, @Advice.Argument(0) @Nullable String name) {
+      ViburSingletons.markDataSourceNameConfigured(config, name);
     }
   }
 }

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburConfigInstrumentation.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburConfigInstrumentation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.vibur.dbcp.ViburConfig;
+
+final class ViburConfigInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.vibur.dbcp.ViburConfig");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArguments(0)), getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This ViburConfig config) {
+      ViburSingletons.captureDefaultName(config);
+    }
+  }
+}

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpDataSourceInstrumentation.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpDataSourceInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.Properties;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -26,9 +27,24 @@ final class ViburDbcpDataSourceInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
+        named("configureFromProperties").and(takesArguments(Properties.class)),
+        getClass().getName() + "$ConfigureFromPropertiesAdvice");
+    transformer.applyAdviceToMethod(
         named("start").and(takesArguments(0)), getClass().getName() + "$StartAdvice");
     transformer.applyAdviceToMethod(
         named("close").and(takesArguments(0)), getClass().getName() + "$CloseAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConfigureFromPropertiesAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This ViburDBCPDataSource dataSource, @Advice.Argument(0) Properties properties) {
+      if (properties.containsKey("name")) {
+        ViburSingletons.markDataSourceNameConfigured(dataSource, properties.getProperty("name"));
+      }
+    }
   }
 
   @SuppressWarnings("unused")

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpDataSourceInstrumentation.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpDataSourceInstrumentation.java
@@ -36,7 +36,11 @@ final class ViburDbcpDataSourceInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.This ViburDBCPDataSource dataSource) {
-      telemetry().registerMetrics(dataSource);
+      String poolName = dataSource.getName();
+      if (!ViburSingletons.isDataSourceNameConfigured(dataSource)) {
+        poolName = ViburSingletons.getDataSourceName(dataSource);
+      }
+      telemetry().registerMetrics(dataSource, poolName);
     }
   }
 

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpInstrumentationModule.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburDbcpInstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -30,6 +30,6 @@ public class ViburDbcpInstrumentationModule extends InstrumentationModule {
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ViburDbcpDataSourceInstrumentation());
+    return asList(new ViburConfigInstrumentation(), new ViburDbcpDataSourceInstrumentation());
   }
 }

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
@@ -11,14 +11,15 @@ import io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionPoolNameUtil
 import io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser;
 import io.opentelemetry.instrumentation.viburdbcp.v11_0.ViburTelemetry;
 import io.opentelemetry.javaagent.bootstrap.jdbc.DbInfo;
+import javax.annotation.Nullable;
 import org.vibur.dbcp.ViburConfig;
 import org.vibur.dbcp.ViburDBCPDataSource;
 
 public class ViburSingletons {
 
   private static final String DEFAULT_DATA_SOURCE_NAME = "vibur-dbcp";
-  private static final VirtualField<ViburConfig, String> defaultNameField =
-      VirtualField.find(ViburConfig.class, String.class);
+  private static final VirtualField<ViburConfig, Boolean> configuredNameField =
+      VirtualField.find(ViburConfig.class, Boolean.class);
 
   private static final ViburTelemetry telemetry = ViburTelemetry.create(GlobalOpenTelemetry.get());
 
@@ -26,13 +27,14 @@ public class ViburSingletons {
     return telemetry;
   }
 
-  public static void captureDefaultName(ViburConfig config) {
-    defaultNameField.set(config, config.getName());
+  public static void markDataSourceNameConfigured(ViburConfig config, @Nullable String name) {
+    if (name != null && !name.trim().isEmpty()) {
+      configuredNameField.set(config, true);
+    }
   }
 
   public static boolean isDataSourceNameConfigured(ViburConfig config) {
-    String defaultName = defaultNameField.get(config);
-    return defaultName == null || !defaultName.equals(config.getName());
+    return Boolean.TRUE.equals(configuredNameField.get(config));
   }
 
   public static String getDataSourceName(ViburDBCPDataSource dataSource) {

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
@@ -6,14 +6,39 @@
 package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionPoolNameUtil;
+import io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser;
 import io.opentelemetry.instrumentation.viburdbcp.v11_0.ViburTelemetry;
+import io.opentelemetry.javaagent.bootstrap.jdbc.DbInfo;
+import org.vibur.dbcp.ViburConfig;
+import org.vibur.dbcp.ViburDBCPDataSource;
 
 public class ViburSingletons {
+
+  private static final String DEFAULT_DATA_SOURCE_NAME = "vibur-dbcp";
+  private static final VirtualField<ViburConfig, String> defaultNameField =
+      VirtualField.find(ViburConfig.class, String.class);
 
   private static final ViburTelemetry telemetry = ViburTelemetry.create(GlobalOpenTelemetry.get());
 
   public static ViburTelemetry telemetry() {
     return telemetry;
+  }
+
+  public static void captureDefaultName(ViburConfig config) {
+    defaultNameField.set(config, config.getName());
+  }
+
+  public static boolean isDataSourceNameConfigured(ViburConfig config) {
+    String defaultName = defaultNameField.get(config);
+    return defaultName == null || !defaultName.equals(config.getName());
+  }
+
+  public static String getDataSourceName(ViburDBCPDataSource dataSource) {
+    DbInfo dbInfo =
+        JdbcConnectionUrlParser.parse(dataSource.getJdbcUrl(), dataSource.getDriverProperties());
+    return JdbcConnectionPoolNameUtil.poolName(dbInfo, DEFAULT_DATA_SOURCE_NAME);
   }
 
   private ViburSingletons() {}

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburSingletons.java
@@ -18,7 +18,7 @@ import org.vibur.dbcp.ViburDBCPDataSource;
 public class ViburSingletons {
 
   private static final String DEFAULT_DATA_SOURCE_NAME = "vibur-dbcp";
-  private static final VirtualField<ViburConfig, Boolean> configuredNameField =
+  private static final VirtualField<ViburConfig, Boolean> CONFIGURED_NAME_FIELD =
       VirtualField.find(ViburConfig.class, Boolean.class);
 
   private static final ViburTelemetry telemetry = ViburTelemetry.create(GlobalOpenTelemetry.get());
@@ -28,13 +28,14 @@ public class ViburSingletons {
   }
 
   public static void markDataSourceNameConfigured(ViburConfig config, @Nullable String name) {
+    // Vibur rejects invalid names and does not support renaming, so this state is monotonic.
     if (name != null && !name.trim().isEmpty()) {
-      configuredNameField.set(config, true);
+      CONFIGURED_NAME_FIELD.set(config, true);
     }
   }
 
   public static boolean isDataSourceNameConfigured(ViburConfig config) {
-    return Boolean.TRUE.equals(configuredNameField.get(config));
+    return Boolean.TRUE.equals(CONFIGURED_NAME_FIELD.get(config));
   }
 
   public static String getDataSourceName(ViburDBCPDataSource dataSource) {

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
@@ -93,6 +93,16 @@ class ViburInstrumentationTest extends AbstractViburInstrumentationTest {
   }
 
   @Test
+  void shouldKeepConfiguredNameAfterRejectedInvalidRename() throws SQLException {
+    ViburDBCPDataSource dataSource = newDataSource();
+    dataSource.setName("configured");
+
+    dataSource.setName("");
+
+    assertPoolName(dataSource, "configured");
+  }
+
+  @Test
   void shouldUseNameConfiguredThroughPropertiesWhenItMatchesGeneratedName() throws SQLException {
     ViburDBCPDataSource previousDataSource = new ViburDBCPDataSource();
     String previousName = previousDataSource.getName();

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
@@ -5,10 +5,21 @@
 
 package io.opentelemetry.javaagent.instrumentation.viburdbcp.v11_0;
 
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.when;
+
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.viburdbcp.AbstractViburInstrumentationTest;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.vibur.dbcp.ViburDBCPDataSource;
 
 class ViburInstrumentationTest extends AbstractViburInstrumentationTest {
@@ -26,4 +37,65 @@ class ViburInstrumentationTest extends AbstractViburInstrumentationTest {
 
   @Override
   protected void shutdown(ViburDBCPDataSource viburDataSource) {}
+
+  @ParameterizedTest
+  @MethodSource("defaultPoolNameArguments")
+  void shouldUseDerivedPoolName(
+      String jdbcUrl, Properties driverProperties, String expectedPoolName) throws SQLException {
+    ViburDBCPDataSource dataSource = newDataSource();
+    if (jdbcUrl != null) {
+      dataSource.setJdbcUrl(jdbcUrl);
+    }
+    if (driverProperties != null) {
+      dataSource.setDriverProperties(driverProperties);
+    }
+
+    assertPoolName(dataSource, expectedPoolName);
+  }
+
+  private static Stream<Arguments> defaultPoolNameArguments() {
+    Properties driverProperties = new Properties();
+    driverProperties.setProperty("serverName", "properties.example");
+    driverProperties.setProperty("portNumber", "5433");
+    driverProperties.setProperty("databaseName", "inventory");
+
+    return Stream.of(
+        argumentSet(
+            "JDBC URL", "jdbc:postgresql://db.example:5432/orders", null, "db.example:5432/orders"),
+        argumentSet(
+            "driver properties",
+            "jdbc:postgresql:ignored",
+            driverProperties,
+            "properties.example:5433/inventory"),
+        argumentSet("database namespace", "jdbc:h2:mem:orders", null, "orders"),
+        argumentSet("fallback", null, null, "vibur-dbcp"));
+  }
+
+  @Test
+  void shouldUseNameConfiguredThroughProperties() throws SQLException {
+    Properties properties = new Properties();
+    properties.setProperty("name", "propertiesPool");
+
+    ViburDBCPDataSource dataSource = new ViburDBCPDataSource(properties);
+    dataSource.setExternalDataSource(dataSourceMock);
+
+    assertPoolName(dataSource, "propertiesPool");
+  }
+
+  private ViburDBCPDataSource newDataSource() {
+    ViburDBCPDataSource dataSource = new ViburDBCPDataSource();
+    dataSource.setExternalDataSource(dataSourceMock);
+    return dataSource;
+  }
+
+  private void assertPoolName(ViburDBCPDataSource dataSource, String expectedPoolName)
+      throws SQLException {
+    when(dataSourceMock.getConnection()).thenReturn(connectionMock);
+    dataSource.start();
+    try (Connection unused = dataSource.getConnection()) {
+      assertConnectionPoolEmitsMetrics(expectedPoolName);
+    } finally {
+      dataSource.close();
+    }
+  }
 }

--- a/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/viburdbcp/v11_0/ViburInstrumentationTest.java
@@ -82,6 +82,39 @@ class ViburInstrumentationTest extends AbstractViburInstrumentationTest {
     assertPoolName(dataSource, "propertiesPool");
   }
 
+  @Test
+  void shouldUseNameConfiguredThroughSetterWhenItMatchesGeneratedName() throws SQLException {
+    ViburDBCPDataSource dataSource = newDataSource();
+    String poolName = dataSource.getName();
+
+    dataSource.setName(poolName);
+
+    assertPoolName(dataSource, poolName);
+  }
+
+  @Test
+  void shouldUseNameConfiguredThroughPropertiesWhenItMatchesGeneratedName() throws SQLException {
+    ViburDBCPDataSource previousDataSource = new ViburDBCPDataSource();
+    String previousName = previousDataSource.getName();
+    String poolName = "p" + (Integer.parseInt(previousName.substring(1)) + 1);
+
+    Properties properties = new Properties();
+    properties.setProperty("name", poolName);
+
+    ViburDBCPDataSource dataSource = new ViburDBCPDataSource(properties);
+    dataSource.setExternalDataSource(dataSourceMock);
+
+    assertPoolName(dataSource, poolName);
+  }
+
+  @Test
+  void shouldUseFallbackPoolNameAfterInvalidName() throws SQLException {
+    ViburDBCPDataSource dataSource = newDataSource();
+    dataSource.setName("");
+
+    assertPoolName(dataSource, "vibur-dbcp");
+  }
+
   private ViburDBCPDataSource newDataSource() {
     ViburDBCPDataSource dataSource = new ViburDBCPDataSource();
     dataSource.setExternalDataSource(dataSourceMock);

--- a/instrumentation/vibur-dbcp-11.0/library/README.md
+++ b/instrumentation/vibur-dbcp-11.0/library/README.md
@@ -44,3 +44,14 @@ void destroy(ViburDBCPDataSource viburDataSource) {
   viburTelemetry.unregisterMetrics(viburDataSource);
 }
 ```
+
+The single-argument `registerMetrics` method uses the data source name provided by Vibur DBCP. To
+use an explicit pool name instead:
+
+```java
+void configureWithExplicitName(
+    OpenTelemetry openTelemetry, ViburDBCPDataSource viburDataSource) {
+  ViburTelemetry telemetry = ViburTelemetry.create(openTelemetry);
+  telemetry.registerMetrics(viburDataSource, "orders-pool");
+}
+```

--- a/instrumentation/vibur-dbcp-11.0/library/src/main/java/io/opentelemetry/instrumentation/viburdbcp/v11_0/ConnectionPoolMetrics.java
+++ b/instrumentation/vibur-dbcp-11.0/library/src/main/java/io/opentelemetry/instrumentation/viburdbcp/v11_0/ConnectionPoolMetrics.java
@@ -24,14 +24,19 @@ final class ConnectionPoolMetrics {
       new ConcurrentHashMap<>();
 
   static void registerMetrics(OpenTelemetry openTelemetry, ViburDBCPDataSource dataSource) {
+    registerMetrics(openTelemetry, dataSource, dataSource.getName());
+  }
+
+  static void registerMetrics(
+      OpenTelemetry openTelemetry, ViburDBCPDataSource dataSource, String poolName) {
     dataSourceMetrics.computeIfAbsent(
-        dataSource, (unused) -> createMeters(openTelemetry, dataSource));
+        dataSource, (unused) -> createMeters(openTelemetry, dataSource, poolName));
   }
 
   private static BatchCallback createMeters(
-      OpenTelemetry openTelemetry, ViburDBCPDataSource dataSource) {
+      OpenTelemetry openTelemetry, ViburDBCPDataSource dataSource, String poolName) {
     DbConnectionPoolMetrics metrics =
-        DbConnectionPoolMetrics.create(openTelemetry, INSTRUMENTATION_NAME, dataSource.getName());
+        DbConnectionPoolMetrics.create(openTelemetry, INSTRUMENTATION_NAME, poolName);
 
     ObservableLongMeasurement connections = metrics.connections();
     ObservableLongMeasurement maxConnections = metrics.maxConnections();

--- a/instrumentation/vibur-dbcp-11.0/library/src/main/java/io/opentelemetry/instrumentation/viburdbcp/v11_0/ViburTelemetry.java
+++ b/instrumentation/vibur-dbcp-11.0/library/src/main/java/io/opentelemetry/instrumentation/viburdbcp/v11_0/ViburTelemetry.java
@@ -26,6 +26,11 @@ public final class ViburTelemetry {
     ConnectionPoolMetrics.registerMetrics(openTelemetry, dataSource);
   }
 
+  /** Start collecting metrics for given data source using the given pool name. */
+  public void registerMetrics(ViburDBCPDataSource dataSource, String poolName) {
+    ConnectionPoolMetrics.registerMetrics(openTelemetry, dataSource, poolName);
+  }
+
   /** Stop collecting metrics for given data source. */
   public void unregisterMetrics(ViburDBCPDataSource dataSource) {
     ConnectionPoolMetrics.unregisterMetrics(dataSource);

--- a/instrumentation/vibur-dbcp-11.0/metadata.yaml
+++ b/instrumentation/vibur-dbcp-11.0/metadata.yaml
@@ -1,6 +1,9 @@
 display_name: Vibur DBCP
 description: >
-  This instrumentation enables database connection pool metrics for Vibur DBCP data sources.
+  This instrumentation enables database connection pool metrics for Vibur DBCP data sources. When
+  no pool name is explicitly configured, the JDBC URL and connection properties are used to derive
+  `server.address[:server.port][/db.namespace]`. If no server address or database namespace is
+  available, `vibur-dbcp` is used.
 library_link: https://www.vibur.org/
 semantic_conventions:
   - DATABASE_POOL_METRICS

--- a/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
+++ b/instrumentation/vibur-dbcp-11.0/testing/src/main/java/io/opentelemetry/instrumentation/viburdbcp/AbstractViburInstrumentationTest.java
@@ -24,8 +24,8 @@ import org.vibur.dbcp.ViburDBCPDataSource;
 public abstract class AbstractViburInstrumentationTest {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.vibur-dbcp-11.0";
 
-  @Mock private DataSource dataSourceMock;
-  @Mock private Connection connectionMock;
+  @Mock protected DataSource dataSourceMock;
+  @Mock protected Connection connectionMock;
 
   protected abstract InstrumentationExtension testing();
 
@@ -48,15 +48,7 @@ public abstract class AbstractViburInstrumentationTest {
     Connection viburConnection = viburDataSource.getConnection();
 
     // then
-    DbConnectionPoolMetricsAssertions.create(testing(), INSTRUMENTATION_NAME, "testPool")
-        .disableMinIdleConnections()
-        .disableMaxIdleConnections()
-        .disablePendingRequests()
-        .disableConnectionTimeouts()
-        .disableCreateTime()
-        .disableWaitTime()
-        .disableUseTime()
-        .assertConnectionPoolEmitsMetrics();
+    assertConnectionPoolEmitsMetrics("testPool");
 
     // when
     viburConnection.close();
@@ -79,5 +71,17 @@ public abstract class AbstractViburInstrumentationTest {
             INSTRUMENTATION_NAME,
             emitStableDatabaseSemconv() ? "db.client.connection.max" : "db.client.connections.max",
             AbstractIterableAssert::isEmpty);
+  }
+
+  protected void assertConnectionPoolEmitsMetrics(String poolName) {
+    DbConnectionPoolMetricsAssertions.create(testing(), INSTRUMENTATION_NAME, poolName)
+        .disableMinIdleConnections()
+        .disableMaxIdleConnections()
+        .disablePendingRequests()
+        .disableConnectionTimeouts()
+        .disableCreateTime()
+        .disableWaitTime()
+        .disableUseTime()
+        .assertConnectionPoolEmitsMetrics();
   }
 }


### PR DESCRIPTION
## Summary

Vibur DBCP generates pool names such as `p1`, `p2`, and so on. These names depend on data source creation order and are therefore unstable across application restarts.

This change:

- Preserves explicitly configured names from `setName()` or `Properties`.
- Derives the metric pool name from `serverAddress[:port][/dbNamespace]` when the generated Vibur name is still in use.
- Uses `vibur-dbcp` when no database information is available.
- Leaves `ViburDBCPDataSource#getName()` unchanged.
- Adds a compatible `ViburTelemetry#registerMetrics(dataSource, poolName)` overload.
