### PR TITLE
Document deprecation removal timing and v3 preview configuration conventions

### DIFF
--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -123,7 +123,9 @@ names, so both `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
 Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
 key is silently ignored. Otherwise, if the legacy key is explicitly set, a one-time WARNING is
-logged pointing at the new key.
+logged pointing at the new key. This is specific to instrumentation-name aliases: unlike ordinary
+replacement-property fallback, the warning is based on explicit legacy-key presence and can occur
+even when the current name determines the effective enablement.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
 needed — one string literal is the entire change.

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -122,10 +122,12 @@ The framework (`DeprecatedInstrumentationNames.expand`) splits the marker and re
 names, so both `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
 Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
-key is silently ignored. Otherwise, if the legacy key is explicitly set, a one-time WARNING is
-logged pointing at the new key. This is specific to instrumentation-name aliases: unlike ordinary
-replacement-property fallback, the warning is based on explicit legacy-key presence and can occur
-even when the current name determines the effective enablement.
+key is silently ignored. This mirrors 3.0, which will no longer know about the legacy name and
+therefore cannot read it or emit a deprecation warning for it. Users still receive that warning in
+the preceding minor releases when they run without v3 preview and explicitly configure the legacy
+key. This is specific to instrumentation-name aliases: unlike ordinary replacement-property
+fallback, the warning is based on explicit legacy-key presence and can occur even when the current
+name determines the effective enablement.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
 needed — one string literal is the entire change.

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -192,13 +192,10 @@ static {
 
 ### CHANGELOG
 
-The rename is **not** a breaking change or a deprecation in the current release: by default
-the old config keys and scope names continue to work unchanged, and the new names are only
-visible under `otel.instrumentation.common.v3-preview` — a preview flag that users are not
-generally encouraged to enable. Do not add a `⚠️ Breaking changes to non-stable APIs` or
-`🚫 Deprecations` entry for this kind of rename. If mentioned at all, it belongs in whatever
-section tracks v3-preview changes. The breaking change will be recorded when v3-preview
-becomes the default in 3.0.
+An instrumentation-name alias rename is a configuration-property rename and belongs under
+`🚫 Deprecations`, even though the legacy key continues to work outside v3 preview. Do not classify
+it under `⚠️ Breaking changes to non-stable APIs` while the compatibility alias remains. The
+breaking removal will be recorded when v3-preview behavior becomes the default in 3.0.
 
 ## What to Flag in Review
 

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -108,18 +108,19 @@ The names passed to the `InstrumentationModule` constructor drive the
 `otel.instrumentation.<name>.enabled` config keys — any of them, not just the first. A rename
 silently breaks users who have the old key in their config.
 
-Keep the pre-rename name by passing it inline alongside the current name using the
-{@code "<current>|deprecated:<old>"} marker recognized by the `InstrumentationModule`
-constructor:
+Keep the pre-rename name by passing the `"<current>|deprecated:<old>"` marker through
+`expandDeprecatedNames`:
 
 ```java
 public CxfInstrumentationModule() {
-  super("cxf", "jaxws-2.0-cxf-3.0|deprecated:jaxws-cxf-3.0", "jaxws");
+  super(
+      "cxf",
+      expandDeprecatedNames("jaxws-2.0-cxf-3.0|deprecated:jaxws-cxf-3.0", "jaxws"));
 }
 ```
 
-The framework (`DeprecatedInstrumentationNames.expand`) splits the marker and registers both
-names, so both `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
+The helper splits the marker and registers both names, so both
+`otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
 Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
 key is silently ignored, matching 3.0 where it will no longer be recognized. Normal minor releases

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -3,7 +3,7 @@
 ## Quick Reference
 
 - Use when: reviewing public API removals/renames, `@Deprecated` usage, stable-vs-alpha compatibility, or any module rename that touches user-facing config keys or emitted telemetry identity
-- Review focus: deprecate-then-remove timing driven by the publishing artifact's stability,
+- Review focus: deprecate-then-remove timing (driven by the publishing artifact's stability),
   delegation direction, required Javadoc/CHANGELOG coverage, v3-preview gating for config keys and
   scope names
 
@@ -44,16 +44,13 @@ The CHANGELOG uses distinct headings to distinguish:
 ### Determining whether a symbol is stable
 
 Removal timing follows the stability of the **artifact that publishes the symbol**, not how public
-the class looks. A module is stable only when its own `gradle.properties` sets `otel.stable=true`;
-equivalently, its published version has no `-alpha` suffix. Check the module directory before
-deciding on a removal timeline — do not rely on a memorized list of stable artifacts, which goes
-out of date.
+the class looks. A module is stable only when its own `gradle.properties` sets `otel.stable=true`,
+equivalently when its published version has no `-alpha` suffix. Check the module directory rather
+than a memorized list of stable artifacts, which goes out of date.
 
-Classes that look like supported public API are frequently alpha. `*TelemetryBuilder` and
+Classes that look like supported public API are frequently alpha: `*TelemetryBuilder` and
 `internal.Experimental` classes in `instrumentation/**/library` modules, and everything in
-`instrumentation-api-incubator`, are published only from `-alpha` artifacts. A deprecation there
-follows the alpha cycle even when the class is the documented entry point for library
-instrumentation.
+`instrumentation-api-incubator`, are published only from `-alpha` artifacts.
 
 ### Javaagent modules are not a public API
 
@@ -78,14 +75,14 @@ Deprecations in stable modules accumulate over multiple releases and are only **
 next major version** (3.0). Many items carry `// to be removed in 3.0` or `@deprecated ... Will
 be removed in 3.0` comments to make this explicit.
 
-### 3.0 milestone work is a separate thing
+### 3.0 milestone work is separate
 
 Some deprecations are scheduled for 3.0 because 3.0 is where a *behavior* changes, not because the
-symbol is stable. Leave these alone: old-semconv support and the `SemconvStability` clusters,
-`@Override`s of interface methods that are themselves scheduled for 3.0, anything gated on
-`otel.instrumentation.common.v3-preview`, `|deprecated:<old>` instrumentation-name aliases, the
-Zipkin exporter removal, and the flat `ConfigProperties` bridge. They correctly say 3.0 even in
-alpha modules.
+symbol is stable. These correctly say 3.0 even in alpha modules, so leave them alone: old-semconv
+support and the `SemconvStability` clusters, `@Override`s of interface methods that are themselves
+scheduled for 3.0, anything gated on `otel.instrumentation.common.v3-preview`,
+`|deprecated:<old>` instrumentation-name aliases, the Zipkin exporter removal, and the flat
+`ConfigProperties` bridge.
 
 ## Correct `@Deprecated` Usage
 
@@ -103,15 +100,13 @@ Rules:
 
 - Use plain `@Deprecated` — do **not** use `forRemoval=true` or `since="..."` (must stay Java 8 compatible).
 - Always include a `@deprecated` Javadoc tag that names the replacement and states the removal timeline.
-- An inline comment stating the timeline is strongly encouraged. Use
-  `// may be removed in the next minor release` for alpha symbols and `// to be removed in 3.0`
-  for stable ones. Use the same sentence in `metadata.yaml` descriptions, README config tables, and
-  any runtime warning, so one deprecation reads consistently everywhere.
-- Do **not** repeat the removal timeline in the CHANGELOG bullet. A deprecation bullet says what is
-  deprecated and what replaces it; the timeline lives in the Javadoc, the annotation comment, the
-  runtime warning, `metadata.yaml`, and the README, which is where a user actually encounters it.
-  Repeating it in the CHANGELOG adds another copy to keep in sync, and alpha and stable surfaces
-  deprecated by the same PR often differ.
+- An inline comment stating the timeline is strongly encouraged: `// may be removed in the next
+  minor release` for alpha symbols, `// to be removed in 3.0` for stable ones. Reuse the same
+  sentence in `metadata.yaml` descriptions, README config tables, and any runtime warning, so one
+  deprecation reads consistently everywhere.
+- Do **not** repeat the removal timeline in the CHANGELOG bullet — it says what is deprecated and
+  what replaces it. The timeline lives where a user actually encounters it, and alpha and stable
+  surfaces deprecated by the same PR often differ.
 - The **deprecated method must delegate to its replacement**, not the other way around. This ensures
   anyone overriding the deprecated method still gets called.
 - Add the `deprecation` label to the PR — this drives the automated `🚫 Deprecations` CHANGELOG entry.
@@ -156,11 +151,10 @@ public CxfInstrumentationModule() {
 The helper splits the marker and registers both names, so both
 `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
-Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
-key is silently ignored, matching 3.0 where it will no longer be recognized. Normal minor releases
-preceding 3.0 still warn outside preview mode. Unlike ordinary replacement-property fallback, alias
-warnings are based on explicit legacy-key presence and can occur even when the current name
-determines the effective enablement.
+Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and its key
+silently ignored, matching 3.0; releases before then still warn outside preview mode. Unlike
+ordinary replacement-property fallback, the alias warning is driven by explicit legacy-key presence,
+so it fires even when the current name determines the effective enablement.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
 needed — the marker string plus the statically imported `expandDeprecatedNames` call is the
@@ -243,13 +237,10 @@ default in 3.0.
 
 - **`to be removed in 3.0` on an alpha-only symbol**: check the publishing module's
   `gradle.properties`. If it is not `otel.stable=true`, the deprecation should say
-  `may be removed in the next minor release` instead, unless it is 3.0 milestone work
-  (v3-preview-gated behavior, old semconv, instrumentation-name aliases).
+  `may be removed in the next minor release` — unless it is 3.0 milestone work.
 
-- **Removal timing in a CHANGELOG deprecation bullet**: a `🚫 Deprecations` bullet should say what
-  is deprecated and what replaces it, not when it will be removed. Ask for the timing sentence to be
-  dropped; it belongs in the Javadoc, annotation comment, runtime warning, `metadata.yaml`, and
-  README.
+- **Removal timing in a CHANGELOG deprecation bullet**: ask for the timing sentence to be dropped;
+  it belongs in the Javadoc, annotation comment, runtime warning, `metadata.yaml`, and README.
 
 - **`@Deprecated` without Javadoc**: annotation present but no `@deprecated` Javadoc, or the
   Javadoc doesn't name the replacement — ask for both.

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -122,12 +122,10 @@ The framework (`DeprecatedInstrumentationNames.expand`) splits the marker and re
 names, so both `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
 Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
-key is silently ignored. This mirrors 3.0, which will no longer know about the legacy name and
-therefore cannot read it or emit a deprecation warning for it. Users still receive that warning in
-the preceding minor releases when they run without v3 preview and explicitly configure the legacy
-key. This is specific to instrumentation-name aliases: unlike ordinary replacement-property
-fallback, the warning is based on explicit legacy-key presence and can occur even when the current
-name determines the effective enablement.
+key is silently ignored, matching 3.0 where it will no longer be recognized. Normal minor releases
+preceding 3.0 still warn outside preview mode. Unlike ordinary replacement-property fallback, alias
+warnings are based on explicit legacy-key presence and can occur even when the current name
+determines the effective enablement.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
 needed — one string literal is the entire change.
@@ -194,10 +192,9 @@ static {
 
 ### CHANGELOG
 
-An instrumentation-name alias rename is a configuration-property rename and belongs under
-`🚫 Deprecations`, even though the legacy key continues to work outside v3 preview. Do not classify
-it under `⚠️ Breaking changes to non-stable APIs` while the compatibility alias remains. The
-breaking removal will be recorded when v3-preview behavior becomes the default in 3.0.
+An instrumentation-name alias rename belongs under `🚫 Deprecations`, not breaking changes, while
+the compatibility alias remains. Record the breaking removal when v3-preview behavior becomes the
+default in 3.0.
 
 ## What to Flag in Review
 

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -86,6 +86,8 @@ scheduled for 3.0, anything gated on `otel.instrumentation.common.v3-preview`,
 
 ## Correct `@Deprecated` Usage
 
+For a symbol published from an alpha artifact:
+
 ```java
 /**
  * @deprecated Use {@link #newMethod()} instead. May be removed in the next minor release.

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -121,8 +121,9 @@ public CxfInstrumentationModule() {
 The framework (`DeprecatedInstrumentationNames.expand`) splits the marker and registers both
 names, so both `otel.instrumentation.jaxws-2.0-cxf-3.0.enabled` and
 `otel.instrumentation.jaxws-cxf-3.0.enabled` keep working (flat properties and YAML alike).
-Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped; if the
-legacy key is explicitly set, a one-time WARNING is logged pointing at the new key.
+Under `otel.instrumentation.common.v3-preview=true` the deprecated name is dropped and the legacy
+key is silently ignored. Otherwise, if the legacy key is explicitly set, a one-time WARNING is
+logged pointing at the new key.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
 needed — one string literal is the entire change.

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -129,7 +129,8 @@ warnings are based on explicit legacy-key presence and can occur even when the c
 determines the effective enablement.
 
 No per-module `AgentCommonConfig` branching, `isV3Preview()` checks, or bespoke logging are
-needed — one string literal is the entire change.
+needed — the marker string plus the statically imported `expandDeprecatedNames` call is the
+entire change.
 
 ### 2. Emitted instrumentation scope name (`INSTRUMENTATION_NAME` in `*Singletons`)
 

--- a/.github/agents/knowledge/api-deprecation-policy.md
+++ b/.github/agents/knowledge/api-deprecation-policy.md
@@ -3,7 +3,9 @@
 ## Quick Reference
 
 - Use when: reviewing public API removals/renames, `@Deprecated` usage, stable-vs-alpha compatibility, or any module rename that touches user-facing config keys or emitted telemetry identity
-- Review focus: deprecate-then-remove timing, delegation direction, required Javadoc/CHANGELOG coverage, v3-preview gating for config keys and scope names
+- Review focus: deprecate-then-remove timing driven by the publishing artifact's stability,
+  delegation direction, required Javadoc/CHANGELOG coverage, v3-preview gating for config keys and
+  scope names
 
 ## What Counts as "Public API"
 
@@ -39,6 +41,20 @@ The CHANGELOG uses distinct headings to distinguish:
 - `⚠️ Breaking changes to non-stable APIs` — alpha/non-stable modules (routine)
 - `⚠️ Breaking Changes` — stable module changes (rare, requires strong justification)
 
+### Determining whether a symbol is stable
+
+Removal timing follows the stability of the **artifact that publishes the symbol**, not how public
+the class looks. A module is stable only when its own `gradle.properties` sets `otel.stable=true`;
+equivalently, its published version has no `-alpha` suffix. Check the module directory before
+deciding on a removal timeline — do not rely on a memorized list of stable artifacts, which goes
+out of date.
+
+Classes that look like supported public API are frequently alpha. `*TelemetryBuilder` and
+`internal.Experimental` classes in `instrumentation/**/library` modules, and everything in
+`instrumentation-api-incubator`, are published only from `-alpha` artifacts. A deprecation there
+follows the alpha cycle even when the class is the documented entry point for library
+instrumentation.
+
 ### Javaagent modules are not a public API
 
 Javaagent modules (Gradle path ends with `:javaagent`, including shared `-common` javaagent
@@ -53,7 +69,8 @@ cycle described below applies only to non-stable modules whose artifacts are pub
 ### Alpha (non-stable) modules
 
 Deprecations in alpha modules are introduced in one monthly release and removed in a subsequent
-one. The gap is typically **one release** (approximately one month).
+one. The gap is typically **one release** (approximately one month). Do not schedule an alpha-only
+deprecation for 3.0 — it does not have to wait for a major version.
 
 ### Stable modules
 
@@ -61,13 +78,22 @@ Deprecations in stable modules accumulate over multiple releases and are only **
 next major version** (3.0). Many items carry `// to be removed in 3.0` or `@deprecated ... Will
 be removed in 3.0` comments to make this explicit.
 
+### 3.0 milestone work is a separate thing
+
+Some deprecations are scheduled for 3.0 because 3.0 is where a *behavior* changes, not because the
+symbol is stable. Leave these alone: old-semconv support and the `SemconvStability` clusters,
+`@Override`s of interface methods that are themselves scheduled for 3.0, anything gated on
+`otel.instrumentation.common.v3-preview`, `|deprecated:<old>` instrumentation-name aliases, the
+Zipkin exporter removal, and the flat `ConfigProperties` bridge. They correctly say 3.0 even in
+alpha modules.
+
 ## Correct `@Deprecated` Usage
 
 ```java
 /**
- * @deprecated Use {@link #newMethod()} instead. Will be removed in a future release.
+ * @deprecated Use {@link #newMethod()} instead. May be removed in the next minor release.
  */
-@Deprecated // will be removed in X.Y
+@Deprecated // may be removed in the next minor release
 public ReturnType oldMethod() {
   return newMethod();  // delegate to the replacement
 }
@@ -77,7 +103,15 @@ Rules:
 
 - Use plain `@Deprecated` — do **not** use `forRemoval=true` or `since="..."` (must stay Java 8 compatible).
 - Always include a `@deprecated` Javadoc tag that names the replacement and states the removal timeline.
-- An inline comment (`// will be removed in X.Y` or `// to be removed in 3.0`) is strongly encouraged.
+- An inline comment stating the timeline is strongly encouraged. Use
+  `// may be removed in the next minor release` for alpha symbols and `// to be removed in 3.0`
+  for stable ones. Use the same sentence in `metadata.yaml` descriptions, README config tables, and
+  any runtime warning, so one deprecation reads consistently everywhere.
+- Do **not** repeat the removal timeline in the CHANGELOG bullet. A deprecation bullet says what is
+  deprecated and what replaces it; the timeline lives in the Javadoc, the annotation comment, the
+  runtime warning, `metadata.yaml`, and the README, which is where a user actually encounters it.
+  Repeating it in the CHANGELOG adds another copy to keep in sync, and alpha and stable surfaces
+  deprecated by the same PR often differ.
 - The **deprecated method must delegate to its replacement**, not the other way around. This ensures
   anyone overriding the deprecated method still gets called.
 - Add the `deprecation` label to the PR — this drives the automated `🚫 Deprecations` CHANGELOG entry.
@@ -206,6 +240,16 @@ default in 3.0.
 
 - **Removal of a deprecated item from a stable module before 3.0**: deprecated items in stable
   modules must not be removed in a minor release — they stay until the next major version.
+
+- **`to be removed in 3.0` on an alpha-only symbol**: check the publishing module's
+  `gradle.properties`. If it is not `otel.stable=true`, the deprecation should say
+  `may be removed in the next minor release` instead, unless it is 3.0 milestone work
+  (v3-preview-gated behavior, old semconv, instrumentation-name aliases).
+
+- **Removal timing in a CHANGELOG deprecation bullet**: a `🚫 Deprecations` bullet should say what
+  is deprecated and what replaces it, not when it will be removed. Ask for the timing sentence to be
+  dropped; it belongs in the Javadoc, annotation comment, runtime warning, `metadata.yaml`, and
+  README.
 
 - **`@Deprecated` without Javadoc**: annotation present but no `@deprecated` Javadoc, or the
   Javadoc doesn't name the replacement — ask for both.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -78,6 +78,90 @@ must be communicated through:
    Note: the code reads via the declarative config API (YAML key), but the warning cites the
    flat property name for user clarity.
 
+### Deprecated Properties Under Common v3 Preview
+
+Configuration names are user-facing API; also see
+[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). When a deprecated property
+will be removed in 3.0, use this order:
+
+1. Read the replacement first.
+2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.
+3. Warn only when returning/applying that deprecated value.
+4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value. The
+   user explicitly opted into 3.0 behavior, so warning about a value that is not applied is noise.
+
+Keep the deprecated read itself inside the `!v3Preview` branch, rather than reading it eagerly and
+discarding it later:
+
+```java
+Boolean value = config.getBoolean("new_key");
+if (value != null) {
+  return value;
+}
+if (!v3Preview) {
+  Boolean deprecatedValue = config.getBoolean("old_key");
+  if (deprecatedValue != null) {
+    warnOnce();
+    return deprecatedValue;
+  }
+}
+return defaultValue;
+```
+
+Canonical implementations:
+
+- `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java`
+- `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java`
+- `instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java`
+- `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
+- `javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/DeprecatedInstrumentationNames.java`
+
+### Warning Text
+
+Use the flat `otel.instrumentation.*` property name in warnings even when code reads the equivalent
+declarative/YAML key. The dominant templates are:
+
+```text
+The <old-flat-property> setting and the equivalent declarative configuration property are
+deprecated and will be removed in 3.0. Use <new-flat-property> or equivalent declarative
+configuration instead.
+```
+
+```text
+The '<old-flat-property>' system property is deprecated and will be removed in 3.0. Use
+'<new-flat-property>' instead.
+```
+
+For an instrumentation-name alias, the concise form is:
+
+```text
+otel.instrumentation.<old>.enabled is deprecated; use
+otel.instrumentation.<new>.enabled instead.
+```
+
+Only cite a declarative path directly when the old key never had a flat-property equivalent, as in
+`DbConfig`.
+
+### Warning Deduplication
+
+- Use a static `ConcurrentHashMap.newKeySet()` keyed by deprecated property when a helper handles
+  multiple properties or can warn once per key. See `DbConfig`, `CommonConfig`, and
+  `ContextDataKeys`.
+- Use an `AtomicBoolean` for one deprecated property evaluated on a repeatable path. The same
+  one-warning concurrency pattern is used by
+  `instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java`.
+- Omit explicit deduplication only when initialization guarantees one evaluation, as in
+  `GraphqlSingletons` and `DeprecatedInstrumentationNames`.
+
+### CHANGELOG Categorization
+
+The property deprecation belongs under `🚫 Deprecations`. Ignoring that deprecated property under
+v3 preview is a separate behavior improvement and belongs under `📈 Enhancements`; do not combine
+the preview behavior into the deprecation bullet. The
+[#18934 enhancement entry](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18934)
+in `CHANGELOG.md` is the precedent: it separately records that v3 preview ignores previously
+deprecated JDBC/database sanitization names.
+
 ## Migration Support Pattern (Optional)
 
 During the deprecation window, code may read both old and new names:
@@ -143,3 +227,14 @@ These have no flat-property fallback, so tests must cover declarative config mod
   (`getBoolean(name, default)`, etc.) for graceful degradation when YAML is unavailable.
 - **Wrong config scope**: `getInstrumentationConfig(ot, name)` → `java → <name>`;
   `getGeneralInstrumentationConfig(ot)` → `general`. HTTP header capture lives under `general`.
+
+**Deprecated properties under v3 preview:**
+
+- **Deprecated value read before or outside the `!v3Preview` guard**: keep the read inside the
+  compatibility branch so 3.0 behavior does not observe the legacy setting.
+- **Warning emitted for a value ignored under v3 preview**: warn only when the deprecated value is
+  actually applied; v3-preview users should get silent 3.0 behavior.
+- **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
+  properties or an `AtomicBoolean` for a single property.
+- **v3-preview behavior folded into the deprecation CHANGELOG bullet**: keep the deprecation under
+  `🚫 Deprecations` and add a separate `📈 Enhancements` bullet for ignoring it under v3 preview.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -121,6 +121,10 @@ if (!v3Preview) {
 return defaultValue;
 ```
 
+The nullable overloads above are intentional: migration code must distinguish an absent replacement
+from an explicitly configured value before applying the default. Use the defaulted overload for
+ordinary reads, after any migration probes have completed.
+
 ### Warning Text
 
 Use the flat `otel.instrumentation.*` property name in warnings even when code reads the equivalent
@@ -150,7 +154,7 @@ Only cite a declarative path directly when the old key never had a flat-property
 
 - Use a static `ConcurrentHashMap.newKeySet()` keyed by deprecated property when a helper handles
   multiple properties or can warn once per key.
-- Use an `AtomicBoolean` for one deprecated property evaluated on a repeatable path.
+- Use a static `AtomicBoolean` for one deprecated property evaluated on a repeatable path.
 - Omit explicit deduplication only when initialization guarantees one evaluation.
 
 ### CHANGELOG Categorization
@@ -223,8 +227,10 @@ These have no flat-property fallback, so tests must cover declarative config mod
 
 **Declarative config correctness:**
 
-- **Missing default values in declarative config reads**: always provide defaults
-  (`getBoolean(name, default)`, etc.) for graceful degradation when YAML is unavailable.
+- **Missing default values in declarative config reads**: provide defaults
+  (`getBoolean(name, default)`, etc.) for graceful degradation when YAML is unavailable. Migration
+  probes are the exception: use the nullable overload to detect absence, then apply the default after
+  checking replacement and deprecated names.
 - **Wrong config scope**: `getInstrumentationConfig(ot, name)` → `java → <name>`;
   `getGeneralInstrumentationConfig(ot)` → `general`. HTTP header capture lives under `general`.
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -113,7 +113,8 @@ Canonical implementations:
 - `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java`
 - `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java`
 - `instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java`
-- `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
+- `Configuration.getQuerySanitizationEnabled` in
+  `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
 - `javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/DeprecatedInstrumentationNames.java`
 
 ### Warning Text

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -160,9 +160,11 @@ generator assigns one section per pull request and always classifies configurati
 as deprecations, so the generated deprecation bullet may also mention that v3 preview ignores the
 legacy property. Do not request a separate hand-written or generated enhancement entry.
 
-## Migration Support Pattern (Optional)
+## Migration Support Without Major-Preview Removal (Optional)
 
-During the deprecation window, code may read both old and new names:
+For a deprecated property that is not being removed by the active major-version preview, code may
+read both old and new names. Do not use this unconditional fallback for properties being removed by
+the preview; use the guarded pattern above instead.
 
 ```java
 // Using the declarative config API

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -49,6 +49,13 @@ Defined in [VERSIONING.md](../../../VERSIONING.md):
 
 `otel.javaagent.testing.*` — always allowed to break, regardless of marker.
 
+A property name is a stable surface even when the code reading it is alpha. Users configure the
+javaagent, which is published as a stable artifact, so its user-facing names outlive the alpha
+classes behind them. A deprecated *property name* and a deprecated *Java method* introduced by the
+same PR therefore often have different removal timelines. Reflect that in the `metadata.yaml`
+description, README config table, and runtime warning for each, rather than in the CHANGELOG, which
+does not carry removal timing.
+
 Examples (flat ↔ YAML):
 
 - `otel.instrumentation.http.client.capture-request-headers` ↔ `request_captured_headers` — **stable**
@@ -72,8 +79,8 @@ must be communicated through:
 ### Deprecated Properties Under Common v3 Preview
 
 Configuration names are user-facing API; also see
-[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). For ordinary properties whose
-deprecated names will be removed in 3.0, use this order:
+[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). This section applies only to
+**stable** property names — those whose deprecated spelling must survive until 3.0. Use this order:
 
 1. Read the replacement first.
 2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.
@@ -82,6 +89,18 @@ deprecated names will be removed in 3.0, use this order:
    Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the deprecated property,
    so it will not read, apply, or warn about it. Normal preceding minor releases still warn outside
    preview mode.
+
+**An `experimental`-marked property does not get this treatment.** It can be removed in the next
+minor release, so there is nothing for preview mode to reproduce. Read the replacement first, fall
+back to the deprecated name unconditionally, and warn once — no `v3Preview` parameter, no gate, and
+no `v3-preview` test variant.
+
+The gRPC and servlet request-capture deprecations make the contrast concrete:
+
+| Deprecated property                                                | Marker           | Treatment                                  |
+| ------------------------------------------------------------------ | ---------------- | ------------------------------------------ |
+| `otel.instrumentation.grpc.capture-metadata.client.request`          | none → stable    | v3-preview gated, removed in 3.0           |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor  |
 
 Replacement-first lookup also supports warning-free upgrades with centralized configuration:
 operators can publish both names while old versions use the deprecated property and new versions
@@ -117,9 +136,10 @@ The nullable reads are intentional: migration code must detect absence before ap
 
 ## Migration Support Without Major-Preview Removal (Optional)
 
-For a deprecated property that is not being removed by the active major-version preview, code may
-read both old and new names. Do not use this unconditional fallback for properties being removed by
-the preview; use the guarded pattern above instead.
+For a deprecated property that is not being removed by the active major-version preview — including
+every `experimental`-marked name — code may read both old and new names. Do not use this
+unconditional fallback for stable properties being removed by the preview; use the guarded pattern
+above instead.
 
 ```java
 // Using the declarative config API
@@ -193,6 +213,9 @@ These have no flat-property fallback, so tests must cover declarative config mod
 
 **Deprecated properties under v3 preview:**
 
+- **`experimental`-marked property gated on v3 preview**: the gate only exists to reproduce 3.0
+  behavior for names that must survive until 3.0. An experimental name can simply be removed in the
+  next minor release, so it needs the warning and nothing else.
 - **Deprecated value read or warned about under v3 preview**: preview must neither observe nor warn
   about a setting that 3.0 will not recognize.
 - **Warning emitted when the replacement already determines an ordinary property value**: do not

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -30,23 +30,23 @@ declarative API.
 
 ### Two User-Facing Surfaces
 
-| Surface       | Unstable marker                              | Stable marker                         |
-| ------------- | -------------------------------------------- | ------------------------------------- |
-| Flat property | word `experimental` or `preview` in the name | neither `experimental` nor `preview`  |
-| YAML key      | `/development` suffix or word `preview`      | no suffix and no `preview` in the key |
+| Surface       | Unstable marker                                           | Stable marker                         |
+| ------------- | --------------------------------------------------------- | ------------------------------------- |
+| Flat property | word `experimental` or `preview` in the name              | neither `experimental` nor `preview`  |
+| YAML key      | `/development` suffix or word `experimental` or `preview` | no suffix and neither word in the key |
 
 The bridge translates underscores ↔ hyphens and `/development` ↔ the `experimental.` prefix;
-`preview` remains part of the name. `SPECIAL_MAPPINGS` handles legacy renames that don't follow the
-mechanical rule.
+`experimental` and `preview` can also remain part of a name. `SPECIAL_MAPPINGS` handles legacy
+renames that don't follow the mechanical rule.
 
 ## The Two Tiers of Stability
 
 Defined in [VERSIONING.md](../../../VERSIONING.md):
 
-| Tier         | Flat property pattern                                                | YAML key pattern                      | Breaking changes allowed?                     |
-| ------------ | -------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------- |
-| **Stable**   | No `experimental` or `preview`, not under `otel.javaagent.testing.*` | No `/development` suffix or `preview` | ❌ Deprecate in minor, **remove only in 3.0** |
-| **Unstable** | Contains `experimental` or `preview` anywhere                        | Has `/development` or `preview`       | ✅ Deprecate in one release, remove in next   |
+| Tier         | Flat property pattern                                                | YAML key pattern                                 | Breaking changes allowed?                     |
+| ------------ | -------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| **Stable**   | No `experimental` or `preview`, not under `otel.javaagent.testing.*` | No `/development`, `experimental`, or `preview`  | ❌ Deprecate in minor, **remove only in 3.0** |
+| **Unstable** | Contains `experimental` or `preview` anywhere                        | Has `/development`, `experimental`, or `preview` | ✅ Deprecate in one release, remove in next   |
 
 `otel.javaagent.testing.*` — always allowed to break, regardless of marker.
 
@@ -134,7 +134,7 @@ property fallback.
 | --------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
 | Prefix          | `otel.instrumentation.<module>.` or `otel.instrumentation.common.` | Under `instrumentation/development → java → <module>` or `common` |
 | Word separator  | hyphens (kebab-case)                                               | underscores (snake_case)                                          |
-| Unstable marker | `experimental` or `preview` in name                                | `/development` suffix or `preview` in name                        |
+| Unstable marker | `experimental` or `preview` in name                                | `/development` suffix or `experimental` or `preview` in name      |
 | Boolean toggle  | `.enabled` suffix                                                  | `enabled` leaf key                                                |
 | Env var form    | dots/hyphens → ALL_CAPS underscores                                | N/A                                                               |
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -97,10 +97,10 @@ no `v3-preview` test variant.
 
 The gRPC and servlet request-capture deprecations make the contrast concrete:
 
-| Deprecated property                                                | Marker           | Treatment                                  |
-| ------------------------------------------------------------------ | ---------------- | ------------------------------------------ |
-| `otel.instrumentation.grpc.capture-metadata.client.request`          | none → stable    | v3-preview gated, removed in 3.0           |
-| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor  |
+| Deprecated property                                                    | Marker         | Treatment                                 |
+| ---------------------------------------------------------------------- | -------------- | ----------------------------------------- |
+| `otel.instrumentation.grpc.capture-metadata.client.request`            | none → stable  | v3-preview gated, removed in 3.0          |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor |
 
 Replacement-first lookup also supports warning-free upgrades with centralized configuration:
 operators can publish both names while old versions use the deprecated property and new versions

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -115,7 +115,12 @@ Canonical implementations:
 - `instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java`
 - `Configuration.getQuerySanitizationEnabled` in
   `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
-- `javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/DeprecatedInstrumentationNames.java`
+
+Instrumentation-name aliases are a special case rather than a canonical property fallback. When
+v3 preview is disabled, `DeprecatedInstrumentationNames` registers the current alias before the
+deprecated alias and warns whenever the deprecated alias is explicitly configured, even if the
+current alias takes precedence. Under v3 preview, it drops the deprecated alias and silently ignores
+the corresponding legacy key.
 
 ### Warning Text
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -62,7 +62,8 @@ must be communicated through:
 
 1. A `🚫 Deprecations` CHANGELOG entry naming the old and new property.
 2. A comment in code near where the old property is read.
-3. **A `WARN`-level log message at startup** if the deprecated property is detected.
+3. **A `WARN`-level log message at startup** if the deprecated property is detected and applied.
+   Instrumentation enablement name aliases are the exception described below.
    The warning message should reference the **flat system property name**
    (`otel.instrumentation.…`) since that is what most users configure today:
 
@@ -174,7 +175,13 @@ the preview; use the guarded pattern above instead.
 // Using the declarative config API
 Boolean value = config.getBoolean("new_property_name");
 if (value == null) {
-  value = config.getBoolean("old_property_name");
+  Boolean deprecatedValue = config.getBoolean("old_property_name");
+  if (deprecatedValue != null) {
+    warnOnce();
+    value = deprecatedValue;
+  } else {
+    value = defaultValue;
+  }
 }
 ```
 
@@ -244,6 +251,6 @@ These have no flat-property fallback, so tests must cover declarative config mod
   warn merely because shared configuration carries both names during a mixed-version rollout. This
   does not apply to instrumentation enablement name aliases.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
-  properties or an `AtomicBoolean` for a single property.
+  properties or a static `AtomicBoolean` for a single property.
 - **Configuration-property rename classified outside deprecations**: generated release notes assign
   the pull request to `🚫 Deprecations`, including any v3-preview behavior described by its bullet.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -90,6 +90,13 @@ will be removed in 3.0, use this order:
 4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value. The
    user explicitly opted into 3.0 behavior, so warning about a value that is not applied is noise.
 
+Replacement-first lookup also supports warning-free rolling upgrades when many deployments share
+centralized configuration. Operators can temporarily publish both names: old versions use the
+deprecated property and ignore the replacement they do not recognize, while new versions use the
+replacement and do not warn about the redundant deprecated property. After every deployment has
+upgraded, operators can remove the deprecated property. A warning therefore identifies a deployment
+that still depends on the deprecated value, not one merely carrying it for compatibility.
+
 Keep the deprecated read itself inside the `!v3Preview` branch, rather than reading it eagerly and
 discarding it later:
 
@@ -107,21 +114,6 @@ if (!v3Preview) {
 }
 return defaultValue;
 ```
-
-Canonical implementations:
-
-- `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/DbConfig.java`
-- `instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/CommonConfig.java`
-- `instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/log4j/contextdata/v2_17/internal/ContextDataKeys.java`
-- `Configuration.getQuerySanitizationEnabled` in
-  `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
-
-Instrumentation-name aliases are a special case because their `.enabled` settings are resolved as
-one ordered list of equivalent instrumentation names, not as a single replacement property read
-followed by a deprecated fallback. When v3 preview is disabled, `DeprecatedInstrumentationNames`
-registers the current alias before the deprecated alias and warns whenever the deprecated alias is
-explicitly configured, even if the current alias takes precedence. Under v3 preview, it drops the
-deprecated alias and silently ignores the corresponding legacy key.
 
 ### Warning Text
 
@@ -146,19 +138,14 @@ otel.instrumentation.<old>.enabled is deprecated; use
 otel.instrumentation.<new>.enabled instead.
 ```
 
-Only cite a declarative path directly when the old key never had a flat-property equivalent, as in
-`DbConfig`.
+Only cite a declarative path directly when the old key never had a flat-property equivalent.
 
 ### Warning Deduplication
 
 - Use a static `ConcurrentHashMap.newKeySet()` keyed by deprecated property when a helper handles
-  multiple properties or can warn once per key. See `DbConfig`, `CommonConfig`, and
-  `ContextDataKeys`.
-- Use an `AtomicBoolean` for one deprecated property evaluated on a repeatable path. The same
-  one-warning concurrency pattern is used by
-  `instrumentation/log4j/log4j-appender-2.17/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_17/OpenTelemetryAppender.java`.
-- Omit explicit deduplication only when initialization guarantees one evaluation, as in
-  `GraphqlSingletons` and `DeprecatedInstrumentationNames`.
+  multiple properties or can warn once per key.
+- Use an `AtomicBoolean` for one deprecated property evaluated on a repeatable path.
+- Omit explicit deduplication only when initialization guarantees one evaluation.
 
 ### CHANGELOG Categorization
 
@@ -166,10 +153,7 @@ The hand-written property deprecation entry belongs under `🚫 Deprecations`. I
 deprecated property under v3 preview is a separate behavior improvement, but normal enhancement
 entries are generated from pull request metadata rather than added by hand. When checking generated
 release notes, ensure the preview behavior appears under `📈 Enhancements` instead of being combined
-with the deprecation bullet. The
-[#18934 enhancement entry](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18934)
-in `CHANGELOG.md` is the precedent: it separately records that v3 preview ignores previously
-deprecated JDBC/database sanitization names.
+with the deprecation bullet.
 
 ## Migration Support Pattern (Optional)
 
@@ -243,6 +227,8 @@ These have no flat-property fallback, so tests must cover declarative config mod
   compatibility branch so 3.0 behavior does not observe the legacy setting.
 - **Warning emitted for a value ignored under v3 preview**: warn only when the deprecated value is
   actually applied; v3-preview users should get silent 3.0 behavior.
+- **Warning emitted when the replacement already determines the value**: do not warn merely because
+  shared configuration carries both names during a mixed-version rollout.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
   properties or an `AtomicBoolean` for a single property.
 - **Generated release notes fold v3-preview behavior into the deprecation bullet**: keep the

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -49,10 +49,10 @@ Defined in [VERSIONING.md](../../../VERSIONING.md):
 
 `otel.javaagent.testing.*` — always allowed to break, regardless of marker.
 
-A property name is a stable surface even when the code reading it is alpha: users configure the
-javaagent, which is published as a stable artifact, so its user-facing names outlive the alpha
-classes behind them. A deprecated *property name* and a deprecated *Java method* introduced by the
-same PR therefore often have different removal timelines.
+A stable property name remains a stable surface even when the code reading it is alpha: users
+configure the javaagent, which is published as a stable artifact, so its user-facing names outlive
+the alpha classes behind them. A deprecated *stable property name* and a deprecated *Java method*
+introduced by the same PR therefore often have different removal timelines.
 
 Examples (flat ↔ YAML):
 
@@ -112,10 +112,12 @@ still warn outside preview mode. An `experimental`-marked property can be remove
 release, so there is nothing for preview mode to reproduce: drop the guard, the `v3Preview`
 parameter, and the v3-preview test variant, and keep only the warning.
 
-| Deprecated property                                                    | Marker         | Treatment                                 |
-| ---------------------------------------------------------------------- | -------------- | ----------------------------------------- |
-| `otel.instrumentation.grpc.capture-metadata.client.request`            | none → stable  | v3-preview gated, removed in 3.0          |
-| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor |
+These hypothetical deprecated names illustrate the two treatments:
+
+| Hypothetical deprecated property                         | Marker         | Treatment                                 |
+| -------------------------------------------------------- | -------------- | ----------------------------------------- |
+| `otel.instrumentation.<module>.old-setting`              | none (stable)  | v3-preview gated, removed in 3.0          |
+| `otel.instrumentation.<module>.experimental.old-setting` | `experimental` | ungated, may be removed in the next minor |
 
 Instrumentation enablement name aliases are an exception. Enablement resolves across an ordered list
 of equivalent names, while the warning is driven by explicit legacy-key presence, so the replacement

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -49,12 +49,10 @@ Defined in [VERSIONING.md](../../../VERSIONING.md):
 
 `otel.javaagent.testing.*` — always allowed to break, regardless of marker.
 
-A property name is a stable surface even when the code reading it is alpha. Users configure the
+A property name is a stable surface even when the code reading it is alpha: users configure the
 javaagent, which is published as a stable artifact, so its user-facing names outlive the alpha
 classes behind them. A deprecated *property name* and a deprecated *Java method* introduced by the
-same PR therefore often have different removal timelines. Reflect that in the `metadata.yaml`
-description, README config table, and runtime warning for each, rather than in the CHANGELOG, which
-does not carry removal timing.
+same PR therefore often have different removal timelines.
 
 Examples (flat ↔ YAML):
 
@@ -70,59 +68,25 @@ must be communicated through:
 1. A `🚫 Deprecations` CHANGELOG entry naming the old and new property, including instrumentation
    enablement alias renames.
 2. A comment in code near where the old property is read.
-3. **A `WARN`-level log message at startup** if the deprecated property is applied. Name the old and
-   replacement flat properties when they exist; otherwise name the declarative paths. Exact wording
-   is not standardized. Deduplicate warnings with a static, process-wide keyed set for multiple
-   properties or an `AtomicBoolean` for one. Omit the guard only when initialization guarantees one
-   evaluation. Instrumentation enablement aliases are the exception described below.
+3. **A `WARN`-level log message at startup** when the deprecated property is applied, naming the old
+   and replacement flat properties, or the declarative paths when there is no flat form. Exact
+   wording is not standardized. Deduplicate with a static `AtomicBoolean` for a single property or a
+   static keyed set for several, unless initialization guarantees one evaluation. Instrumentation
+   enablement aliases are the exception described below.
 
-### Deprecated Properties Under Common v3 Preview
+### Migration Support Pattern
 
-Configuration names are user-facing API; also see
-[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). This section applies only to
-**stable** property names — those whose deprecated spelling must survive until 3.0. Use this order:
-
-1. Read the replacement first.
-2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.
-3. Warn only when returning/applying that deprecated value.
-4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value.
-   Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the deprecated property,
-   so it will not read, apply, or warn about it. Normal preceding minor releases still warn outside
-   preview mode.
-
-**An `experimental`-marked property does not get this treatment.** It can be removed in the next
-minor release, so there is nothing for preview mode to reproduce. Read the replacement first, fall
-back to the deprecated name unconditionally, and warn once — no `v3Preview` parameter, no gate, and
-no `v3-preview` test variant.
-
-The gRPC and servlet request-capture deprecations make the contrast concrete:
-
-| Deprecated property                                                    | Marker         | Treatment                                 |
-| ---------------------------------------------------------------------- | -------------- | ----------------------------------------- |
-| `otel.instrumentation.grpc.capture-metadata.client.request`            | none → stable  | v3-preview gated, removed in 3.0          |
-| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor |
-
-Replacement-first lookup also supports warning-free upgrades with centralized configuration:
-operators can publish both names while old versions use the deprecated property and new versions
-use the replacement, then remove the deprecated property after rollout. A warning identifies a
-deployment that still depends on the deprecated value, not one merely carrying it for compatibility.
-
-Instrumentation enablement name aliases are an exception. Enablement is resolved across an ordered
-list of equivalent names, while deprecation warnings are based on whether the legacy alias is
-explicitly configured. The replacement alias can therefore determine the result while the legacy
-alias still triggers a warning. Under v3 preview, omit the legacy alias from resolution and silently
-ignore its key, matching a future runtime that no longer knows the alias. Do not copy this
-alias-specific warning behavior into ordinary property fallback.
-
-Keep the deprecated read itself inside the `!v3Preview` branch, rather than reading it eagerly and
-discarding it later:
+Configuration names are user-facing API; see also
+[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). Read the replacement first,
+fall back to the deprecated name only when the replacement is absent, and warn only when the
+deprecated value is actually applied:
 
 ```java
 Boolean value = config.getBoolean("new_key");
 if (value != null) {
   return value;
 }
-if (!v3Preview) {
+if (!v3Preview) { // stable names only; see below
   Boolean deprecatedValue = config.getBoolean("old_key");
   if (deprecatedValue != null) {
     warnOnce();
@@ -133,27 +97,31 @@ return defaultValue;
 ```
 
 The nullable reads are intentional: migration code must detect absence before applying the default.
+Keep the deprecated read inside the `!v3Preview` branch rather than reading it eagerly and
+discarding it later.
 
-## Migration Support Without Major-Preview Removal (Optional)
+Replacement-first lookup also supports warning-free upgrades with centralized configuration:
+operators can publish both names while old versions use the deprecated property and new versions use
+the replacement, then remove the deprecated property after rollout. A warning then identifies a
+deployment that still depends on the deprecated value, not one merely carrying it for compatibility.
 
-For a deprecated property that is not being removed by the active major-version preview — including
-every `experimental`-marked name — code may read both old and new names. Do not use this
-unconditional fallback for stable properties being removed by the preview; use the guarded pattern
-above instead.
+The `!v3Preview` guard applies only to **stable** property names, whose deprecated spelling must
+survive until 3.0. Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the
+deprecated property, so it will not read, apply, or warn about it, while preceding minor releases
+still warn outside preview mode. An `experimental`-marked property can be removed in the next minor
+release, so there is nothing for preview mode to reproduce: drop the guard, the `v3Preview`
+parameter, and the v3-preview test variant, and keep only the warning.
 
-```java
-// Using the declarative config API
-Boolean value = config.getBoolean("new_property_name");
-if (value == null) {
-  Boolean deprecatedValue = config.getBoolean("old_property_name");
-  if (deprecatedValue != null) {
-    warnOnce();
-    value = deprecatedValue;
-  } else {
-    value = defaultValue;
-  }
-}
-```
+| Deprecated property                                                    | Marker         | Treatment                                 |
+| ---------------------------------------------------------------------- | -------------- | ----------------------------------------- |
+| `otel.instrumentation.grpc.capture-metadata.client.request`            | none → stable  | v3-preview gated, removed in 3.0          |
+| `otel.instrumentation.servlet.experimental.capture-request-parameters` | `experimental` | ungated, may be removed in the next minor |
+
+Instrumentation enablement name aliases are an exception. Enablement resolves across an ordered list
+of equivalent names, while the warning is driven by explicit legacy-key presence, so the replacement
+alias can determine the result while the legacy alias still warns. Under v3 preview the legacy alias
+is dropped from resolution and its key silently ignored. Do not copy this behavior into ordinary
+property fallback.
 
 ## Naming Conventions
 
@@ -206,20 +174,20 @@ These have no flat-property fallback, so tests must cover declarative config mod
 
 - **Missing default values in declarative config reads**: provide defaults
   (`getBoolean(name, default)`, etc.) for graceful degradation when YAML is unavailable. Migration
-  probes are the exception: use the nullable overload to detect absence, then apply the default after
-  checking replacement and deprecated names.
+  probes are the exception: use the nullable overload to detect absence, then apply the default
+  after checking replacement and deprecated names.
 - **Wrong config scope**: `getInstrumentationConfig(ot, name)` → `java → <name>`;
   `getGeneralInstrumentationConfig(ot)` → `general`. HTTP header capture lives under `general`.
 
 **Deprecated properties under v3 preview:**
 
 - **`experimental`-marked property gated on v3 preview**: the gate only exists to reproduce 3.0
-  behavior for names that must survive until 3.0. An experimental name can simply be removed in the
-  next minor release, so it needs the warning and nothing else.
+  behavior for names that must survive until 3.0. An experimental name needs the warning and
+  nothing else.
 - **Deprecated value read or warned about under v3 preview**: preview must neither observe nor warn
   about a setting that 3.0 will not recognize.
 - **Warning emitted when the replacement already determines an ordinary property value**: do not
   warn merely because shared configuration carries both names during a mixed-version rollout. This
   does not apply to instrumentation enablement name aliases.
-- **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
-  properties or a static `AtomicBoolean` for a single property.
+- **Missing warning deduplication on a repeatable path**: use a static `AtomicBoolean` for a single
+  property or a per-key concurrent set for several.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -64,10 +64,10 @@ must be communicated through:
    enablement alias renames.
 2. A comment in code near where the old property is read.
 3. **A `WARN`-level log message at startup** if the deprecated property is applied. Name the old and
-   replacement flat properties when they exist; otherwise name the declarative paths. Deduplicate
-   warnings with a static, process-wide keyed set for multiple properties or an `AtomicBoolean` for
-   one. Omit the guard only when initialization guarantees one evaluation. Instrumentation
-   enablement aliases are the exception described below.
+   replacement flat properties when they exist; otherwise name the declarative paths. Exact wording
+   is not standardized. Deduplicate warnings with a static, process-wide keyed set for multiple
+   properties or an `AtomicBoolean` for one. Omit the guard only when initialization guarantees one
+   evaluation. Instrumentation enablement aliases are the exception described below.
 
 ### Deprecated Properties Under Common v3 Preview
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -116,11 +116,12 @@ Canonical implementations:
 - `Configuration.getQuerySanitizationEnabled` in
   `instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java`
 
-Instrumentation-name aliases are a special case rather than a canonical property fallback. When
-v3 preview is disabled, `DeprecatedInstrumentationNames` registers the current alias before the
-deprecated alias and warns whenever the deprecated alias is explicitly configured, even if the
-current alias takes precedence. Under v3 preview, it drops the deprecated alias and silently ignores
-the corresponding legacy key.
+Instrumentation-name aliases are a special case because their `.enabled` settings are resolved as
+one ordered list of equivalent instrumentation names, not as a single replacement property read
+followed by a deprecated fallback. When v3 preview is disabled, `DeprecatedInstrumentationNames`
+registers the current alias before the deprecated alias and warns whenever the deprecated alias is
+explicitly configured, even if the current alias takes precedence. Under v3 preview, it drops the
+deprecated alias and silently ignores the corresponding legacy key.
 
 ### Warning Text
 

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -155,11 +155,10 @@ Only cite a declarative path directly when the old key never had a flat-property
 
 ### CHANGELOG Categorization
 
-The hand-written property deprecation entry belongs under `🚫 Deprecations`. Ignoring that
-deprecated property under v3 preview is a separate behavior improvement, but normal enhancement
-entries are generated from pull request metadata rather than added by hand. When checking generated
-release notes, ensure the preview behavior appears under `📈 Enhancements` instead of being combined
-with the deprecation bullet.
+The hand-written property deprecation entry belongs under `🚫 Deprecations`. The release-note
+generator assigns one section per pull request and always classifies configuration-property renames
+as deprecations, so the generated deprecation bullet may also mention that v3 preview ignores the
+legacy property. Do not request a separate hand-written or generated enhancement entry.
 
 ## Migration Support Pattern (Optional)
 
@@ -238,6 +237,5 @@ These have no flat-property fallback, so tests must cover declarative config mod
   does not apply to instrumentation enablement name aliases.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
   properties or an `AtomicBoolean` for a single property.
-- **Generated release notes fold v3-preview behavior into the deprecation bullet**: keep the
-  hand-written deprecation under `🚫 Deprecations` and verify that generated release notes classify
-  the preview behavior under `📈 Enhancements`; do not request a hand-written enhancement entry.
+- **Configuration-property rename classified outside deprecations**: generated release notes assign
+  the pull request to `🚫 Deprecations`, including any v3-preview behavior described by its bullet.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -88,8 +88,14 @@ deprecated names will be removed in 3.0, use this order:
 1. Read the replacement first.
 2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.
 3. Warn only when returning/applying that deprecated value.
-4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value. The
-   user explicitly opted into 3.0 behavior, so warning about a value that is not applied is noise.
+4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value.
+   Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the deprecated property,
+   so it will not read, apply, or warn about it.
+
+Suppressing the warning in preview mode does not eliminate the deprecation warning period. The
+minor releases preceding 3.0 still recognize the deprecated property in normal mode and warn when
+they apply it. Preview mode alone omits that warning because it is intentionally exercising the
+future behavior after the property has been removed.
 
 Replacement-first lookup also supports warning-free rolling upgrades when many deployments share
 centralized configuration. Operators can temporarily publish both names: old versions use the
@@ -102,7 +108,8 @@ Instrumentation enablement name aliases are an exception. Enablement is resolved
 list of equivalent names, while deprecation warnings are based on whether the legacy alias is
 explicitly configured. The replacement alias can therefore determine the result while the legacy
 alias still triggers a warning. Under v3 preview, omit the legacy alias from resolution and silently
-ignore its key. Do not copy this alias-specific warning behavior into ordinary property fallback.
+ignore its key, matching a future runtime that no longer knows the alias. Do not copy this
+alias-specific warning behavior into ordinary property fallback.
 
 Keep the deprecated read itself inside the `!v3Preview` branch, rather than reading it eagerly and
 discarding it later:

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -3,7 +3,7 @@
 ## Quick Reference
 
 - Use when: reviewing configuration property definitions, stability, or deprecation
-- Review focus: stable vs experimental policy, deprecation communication, naming conventions
+- Review focus: stable vs unstable property policy, deprecation communication, naming conventions
 
 ## How Configuration Is Read
 
@@ -30,22 +30,23 @@ declarative API.
 
 ### Two User-Facing Surfaces
 
-| Surface       | Experimental marker             | Stable marker                 |
-| ------------- | ------------------------------- | ----------------------------- |
-| Flat property | word `experimental` in the name | no `experimental` in the name |
-| YAML key      | `/development` suffix           | no suffix                     |
+| Surface       | Unstable marker                              | Stable marker                         |
+| ------------- | -------------------------------------------- | ------------------------------------- |
+| Flat property | word `experimental` or `preview` in the name | neither `experimental` nor `preview`  |
+| YAML key      | `/development` suffix or word `preview`      | no suffix and no `preview` in the key |
 
-The bridge translates between them (underscores ↔ hyphens, `/development` ↔ `experimental.`
-prefix, `SPECIAL_MAPPINGS` for legacy renames that don't follow the mechanical rule).
+The bridge translates underscores ↔ hyphens and `/development` ↔ the `experimental.` prefix;
+`preview` remains part of the name. `SPECIAL_MAPPINGS` handles legacy renames that don't follow the
+mechanical rule.
 
 ## The Two Tiers of Stability
 
 Defined in [VERSIONING.md](../../../VERSIONING.md):
 
-| Tier             | Flat property pattern                                           | YAML key pattern          | Breaking changes allowed?                     |
-| ---------------- | --------------------------------------------------------------- | ------------------------- | --------------------------------------------- |
-| **Stable**       | No `experimental` in name, not under `otel.javaagent.testing.*` | No `/development` suffix  | ❌ Deprecate in minor, **remove only in 3.0** |
-| **Experimental** | Contains `experimental` anywhere                                | Has `/development` suffix | ✅ Deprecate in one release, remove in next   |
+| Tier         | Flat property pattern                                                | YAML key pattern                      | Breaking changes allowed?                     |
+| ------------ | -------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------- |
+| **Stable**   | No `experimental` or `preview`, not under `otel.javaagent.testing.*` | No `/development` suffix or `preview` | ❌ Deprecate in minor, **remove only in 3.0** |
+| **Unstable** | Contains `experimental` or `preview` anywhere                        | Has `/development` or `preview`       | ✅ Deprecate in one release, remove in next   |
 
 `otel.javaagent.testing.*` — always allowed to break, regardless of marker.
 
@@ -54,11 +55,12 @@ configure the javaagent, which is published as a stable artifact, so its user-fa
 the alpha classes behind them. A deprecated *stable property name* and a deprecated *Java method*
 introduced by the same PR therefore often have different removal timelines.
 
-Examples (flat ↔ YAML):
+Examples:
 
 - `otel.instrumentation.http.client.capture-request-headers` ↔ `request_captured_headers` — **stable**
 - `otel.instrumentation.common.db.experimental.sqlcommenter.enabled` ↔ `sqlcommenter/development: { enabled: true }` — **experimental**
 - `otel.instrumentation.http.client.emit-experimental-telemetry` ↔ `emit_experimental_telemetry/development: true` — **experimental**
+- `otel.instrumentation.common.v3-preview` — **preview**
 
 ## Deprecation Communication
 
@@ -108,9 +110,9 @@ deployment that still depends on the deprecated value, not one merely carrying i
 The `!v3Preview` guard applies only to **stable** property names, whose deprecated spelling must
 survive until 3.0. Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the
 deprecated property, so it will not read, apply, or warn about it, while preceding minor releases
-still warn outside preview mode. An `experimental`-marked property can be removed in the next minor
-release, so there is nothing for preview mode to reproduce: drop the guard, the `v3Preview`
-parameter, and the v3-preview test variant, and keep only the warning.
+still warn outside preview mode. An `experimental`- or `preview`-marked property can be removed in
+the next minor release, so there is nothing for preview mode to reproduce: drop the guard, the
+`v3Preview` parameter, and the v3-preview test variant, and keep only the warning.
 
 These hypothetical deprecated names illustrate the two treatments:
 
@@ -118,6 +120,7 @@ These hypothetical deprecated names illustrate the two treatments:
 | -------------------------------------------------------- | -------------- | ----------------------------------------- |
 | `otel.instrumentation.<module>.old-setting`              | none (stable)  | v3-preview gated, removed in 3.0          |
 | `otel.instrumentation.<module>.experimental.old-setting` | `experimental` | ungated, may be removed in the next minor |
+| `otel.instrumentation.<module>.preview-old-setting`      | `preview`      | ungated, may be removed in the next minor |
 
 Instrumentation enablement name aliases are an exception. Enablement resolves across an ordered list
 of equivalent names, while the warning is driven by explicit legacy-key presence, so the replacement
@@ -127,13 +130,13 @@ property fallback.
 
 ## Naming Conventions
 
-| Rule                | Flat property                                                      | YAML key                                                          |
-| ------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| Prefix              | `otel.instrumentation.<module>.` or `otel.instrumentation.common.` | Under `instrumentation/development → java → <module>` or `common` |
-| Word separator      | hyphens (kebab-case)                                               | underscores (snake_case)                                          |
-| Experimental marker | `experimental` in name                                             | `/development` suffix                                             |
-| Boolean toggle      | `.enabled` suffix                                                  | `enabled` leaf key                                                |
-| Env var form        | dots/hyphens → ALL_CAPS underscores                                | N/A                                                               |
+| Rule            | Flat property                                                      | YAML key                                                          |
+| --------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| Prefix          | `otel.instrumentation.<module>.` or `otel.instrumentation.common.` | Under `instrumentation/development → java → <module>` or `common` |
+| Word separator  | hyphens (kebab-case)                                               | underscores (snake_case)                                          |
+| Unstable marker | `experimental` or `preview` in name                                | `/development` suffix or `preview` in name                        |
+| Boolean toggle  | `.enabled` suffix                                                  | `enabled` leaf key                                                |
+| Env var form    | dots/hyphens → ALL_CAPS underscores                                | N/A                                                               |
 
 ## Structured Config (YAML-Only)
 
@@ -158,12 +161,14 @@ These have no flat-property fallback, so tests must cover declarative config mod
   (deprecated) until 3.0.
 - **Zero deprecation window** (deprecated and removed in same PR): needs strong justification.
 
-**Experimental marker issues:**
+**Unstable marker issues:**
 
 - **Experimental feature without marker**: flat property must contain `experimental`; YAML key
   must have `/development` suffix. Both must agree.
-- **Stable feature with marker**: don't use `experimental` / `/development` on features
-  intended to be stable — it misleads users about the guarantee.
+- **Preview property treated as stable**: names containing `preview` have the same breaking-change
+  exemption as names containing `experimental`.
+- **Stable feature with marker**: don't use `experimental`, `preview`, or `/development` on
+  features intended to be stable — it misleads users about the guarantee.
 
 **Naming / mapping issues:**
 
@@ -183,9 +188,9 @@ These have no flat-property fallback, so tests must cover declarative config mod
 
 **Deprecated properties under v3 preview:**
 
-- **`experimental`-marked property gated on v3 preview**: the gate only exists to reproduce 3.0
-  behavior for names that must survive until 3.0. An experimental name needs the warning and
-  nothing else.
+- **`experimental`- or `preview`-marked property gated on v3 preview**: the gate only exists to
+  reproduce 3.0 behavior for names that must survive until 3.0. An unstable name needs the warning
+  and nothing else.
 - **Deprecated value read or warned about under v3 preview**: preview must neither observe nor warn
   about a setting that 3.0 will not recognize.
 - **Warning emitted when the replacement already determines an ordinary property value**: do not

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -60,24 +60,14 @@ Examples (flat ↔ YAML):
 Config properties have no `@Deprecated` annotation and no automatic forwarding. Deprecation
 must be communicated through:
 
-1. A `🚫 Deprecations` CHANGELOG entry naming the old and new property.
+1. A `🚫 Deprecations` CHANGELOG entry naming the old and new property, including instrumentation
+   enablement alias renames.
 2. A comment in code near where the old property is read.
-3. **A `WARN`-level log message at startup** if the deprecated property is detected and applied.
-   Instrumentation enablement name aliases are the exception described below.
-   The warning message should reference the **flat system property name**
-   (`otel.instrumentation.…`) since that is what most users configure today:
-
-   ```java
-   boolean oldSetting = config.getBoolean("old_setting/development", false);
-   if (oldSetting) {
-     logger.warning(
-         "The otel.instrumentation.<module>.experimental.old-setting setting is"
-             + " deprecated and will be removed in a future version.");
-   }
-   ```
-
-   Note: the code reads via the declarative config API (YAML key), but the warning cites the
-   flat property name for user clarity.
+3. **A `WARN`-level log message at startup** if the deprecated property is applied. Name the old and
+   replacement flat properties when they exist; otherwise name the declarative paths. Deduplicate
+   warnings with a static, process-wide keyed set for multiple properties or an `AtomicBoolean` for
+   one. Omit the guard only when initialization guarantees one evaluation. Instrumentation
+   enablement aliases are the exception described below.
 
 ### Deprecated Properties Under Common v3 Preview
 
@@ -90,19 +80,13 @@ deprecated names will be removed in 3.0, use this order:
 3. Warn only when returning/applying that deprecated value.
 4. Under `otel.instrumentation.common.v3-preview=true`, silently ignore the deprecated value.
    Preview mode must reproduce 3.0 behavior: 3.0 will no longer know about the deprecated property,
-   so it will not read, apply, or warn about it.
+   so it will not read, apply, or warn about it. Normal preceding minor releases still warn outside
+   preview mode.
 
-Suppressing the warning in preview mode does not eliminate the deprecation warning period. The
-minor releases preceding 3.0 still recognize the deprecated property in normal mode and warn when
-they apply it. Preview mode alone omits that warning because it is intentionally exercising the
-future behavior after the property has been removed.
-
-Replacement-first lookup also supports warning-free rolling upgrades when many deployments share
-centralized configuration. Operators can temporarily publish both names: old versions use the
-deprecated property and ignore the replacement they do not recognize, while new versions use the
-replacement and do not warn about the redundant deprecated property. After every deployment has
-upgraded, operators can remove the deprecated property. A warning therefore identifies a deployment
-that still depends on the deprecated value, not one merely carrying it for compatibility.
+Replacement-first lookup also supports warning-free upgrades with centralized configuration:
+operators can publish both names while old versions use the deprecated property and new versions
+use the replacement, then remove the deprecated property after rollout. A warning identifies a
+deployment that still depends on the deprecated value, not one merely carrying it for compatibility.
 
 Instrumentation enablement name aliases are an exception. Enablement is resolved across an ordered
 list of equivalent names, while deprecation warnings are based on whether the legacy alias is
@@ -129,48 +113,7 @@ if (!v3Preview) {
 return defaultValue;
 ```
 
-The nullable overloads above are intentional: migration code must distinguish an absent replacement
-from an explicitly configured value before applying the default. Use the defaulted overload for
-ordinary reads, after any migration probes have completed.
-
-### Warning Text
-
-Use the flat `otel.instrumentation.*` property name in warnings even when code reads the equivalent
-declarative/YAML key. The dominant templates are:
-
-```text
-The <old-flat-property> setting and the equivalent declarative configuration property are
-deprecated and will be removed in 3.0. Use <new-flat-property> or equivalent declarative
-configuration instead.
-```
-
-```text
-The '<old-flat-property>' system property is deprecated and will be removed in 3.0. Use
-'<new-flat-property>' instead.
-```
-
-For an instrumentation-name alias, the concise form is:
-
-```text
-otel.instrumentation.<old>.enabled is deprecated; use
-otel.instrumentation.<new>.enabled instead.
-```
-
-Only cite a declarative path directly when the old key never had a flat-property equivalent.
-
-### Warning Deduplication
-
-- Use a static `ConcurrentHashMap.newKeySet()` keyed by deprecated property when a helper handles
-  multiple properties or can warn once per key.
-- Use a static `AtomicBoolean` for one deprecated property evaluated on a repeatable path.
-- Omit explicit deduplication only when initialization guarantees one evaluation.
-
-### CHANGELOG Categorization
-
-The hand-written property deprecation entry belongs under `🚫 Deprecations`. The release-note
-generator assigns one section per pull request and always classifies configuration-property renames
-as deprecations, so the generated deprecation bullet may also mention that v3 preview ignores the
-legacy property. Do not request a separate hand-written or generated enhancement entry.
+The nullable reads are intentional: migration code must detect absence before applying the default.
 
 ## Migration Support Without Major-Preview Removal (Optional)
 
@@ -250,14 +193,10 @@ These have no flat-property fallback, so tests must cover declarative config mod
 
 **Deprecated properties under v3 preview:**
 
-- **Deprecated value read before or outside the `!v3Preview` guard**: keep the read inside the
-  compatibility branch so 3.0 behavior does not observe the legacy setting.
-- **Warning emitted for a value ignored under v3 preview**: warn only when the deprecated value is
-  actually applied; v3-preview users should get silent 3.0 behavior.
+- **Deprecated value read or warned about under v3 preview**: preview must neither observe nor warn
+  about a setting that 3.0 will not recognize.
 - **Warning emitted when the replacement already determines an ordinary property value**: do not
   warn merely because shared configuration carries both names during a mixed-version rollout. This
   does not apply to instrumentation enablement name aliases.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
   properties or a static `AtomicBoolean` for a single property.
-- **Configuration-property rename classified outside deprecations**: generated release notes assign
-  the pull request to `🚫 Deprecations`, including any v3-preview behavior described by its bullet.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -191,8 +191,8 @@ These have no flat-property fallback, so tests must cover declarative config mod
 - **`experimental`- or `preview`-marked property gated on v3 preview**: the gate only exists to
   reproduce 3.0 behavior for names that must survive until 3.0. An unstable name needs the warning
   and nothing else.
-- **Deprecated value read or warned about under v3 preview**: preview must neither observe nor warn
-  about a setting that 3.0 will not recognize.
+- **Stable deprecated property value read or warned about under v3 preview**: preview must neither
+  observe nor warn about a setting that 3.0 will not recognize.
 - **Warning emitted when the replacement already determines an ordinary property value**: do not
   warn merely because shared configuration carries both names during a mixed-version rollout. This
   does not apply to instrumentation enablement name aliases.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -81,8 +81,8 @@ must be communicated through:
 ### Deprecated Properties Under Common v3 Preview
 
 Configuration names are user-facing API; also see
-[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). When a deprecated property
-will be removed in 3.0, use this order:
+[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). For ordinary replacement
+properties that will be removed in 3.0, use this order:
 
 1. Read the replacement first.
 2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.
@@ -96,6 +96,12 @@ deprecated property and ignore the replacement they do not recognize, while new 
 replacement and do not warn about the redundant deprecated property. After every deployment has
 upgraded, operators can remove the deprecated property. A warning therefore identifies a deployment
 that still depends on the deprecated value, not one merely carrying it for compatibility.
+
+Instrumentation enablement name aliases are an exception. Enablement is resolved across an ordered
+list of equivalent names, while deprecation warnings are based on whether the legacy alias is
+explicitly configured. The replacement alias can therefore determine the result while the legacy
+alias still triggers a warning. Under v3 preview, omit the legacy alias from resolution and silently
+ignore its key. Do not copy this alias-specific warning behavior into ordinary property fallback.
 
 Keep the deprecated read itself inside the `!v3Preview` branch, rather than reading it eagerly and
 discarding it later:
@@ -227,8 +233,9 @@ These have no flat-property fallback, so tests must cover declarative config mod
   compatibility branch so 3.0 behavior does not observe the legacy setting.
 - **Warning emitted for a value ignored under v3 preview**: warn only when the deprecated value is
   actually applied; v3-preview users should get silent 3.0 behavior.
-- **Warning emitted when the replacement already determines the value**: do not warn merely because
-  shared configuration carries both names during a mixed-version rollout.
+- **Warning emitted when the replacement already determines an ordinary property value**: do not
+  warn merely because shared configuration carries both names during a mixed-version rollout. This
+  does not apply to instrumentation enablement name aliases.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
   properties or an `AtomicBoolean` for a single property.
 - **Generated release notes fold v3-preview behavior into the deprecation bullet**: keep the

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -81,8 +81,8 @@ must be communicated through:
 ### Deprecated Properties Under Common v3 Preview
 
 Configuration names are user-facing API; also see
-[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). For ordinary replacement
-properties that will be removed in 3.0, use this order:
+[Breaking Changes and Deprecation Policy](api-deprecation-policy.md). For ordinary properties whose
+deprecated names will be removed in 3.0, use this order:
 
 1. Read the replacement first.
 2. Only if the replacement is absent and v3 preview is disabled, read the deprecated value.

--- a/.github/agents/knowledge/config-property-stability.md
+++ b/.github/agents/knowledge/config-property-stability.md
@@ -161,9 +161,11 @@ Only cite a declarative path directly when the old key never had a flat-property
 
 ### CHANGELOG Categorization
 
-The property deprecation belongs under `🚫 Deprecations`. Ignoring that deprecated property under
-v3 preview is a separate behavior improvement and belongs under `📈 Enhancements`; do not combine
-the preview behavior into the deprecation bullet. The
+The hand-written property deprecation entry belongs under `🚫 Deprecations`. Ignoring that
+deprecated property under v3 preview is a separate behavior improvement, but normal enhancement
+entries are generated from pull request metadata rather than added by hand. When checking generated
+release notes, ensure the preview behavior appears under `📈 Enhancements` instead of being combined
+with the deprecation bullet. The
 [#18934 enhancement entry](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18934)
 in `CHANGELOG.md` is the precedent: it separately records that v3 preview ignores previously
 deprecated JDBC/database sanitization names.
@@ -242,5 +244,6 @@ These have no flat-property fallback, so tests must cover declarative config mod
   actually applied; v3-preview users should get silent 3.0 behavior.
 - **Missing warning deduplication on a repeatable path**: use a per-key concurrent set for multiple
   properties or an `AtomicBoolean` for a single property.
-- **v3-preview behavior folded into the deprecation CHANGELOG bullet**: keep the deprecation under
-  `🚫 Deprecations` and add a separate `📈 Enhancements` bullet for ignoring it under v3 preview.
+- **Generated release notes fold v3-preview behavior into the deprecation bullet**: keep the
+  hand-written deprecation under `🚫 Deprecations` and verify that generated release notes classify
+  the preview behavior under `📈 Enhancements`; do not request a hand-written enhancement entry.


### PR DESCRIPTION
Updates the agent knowledge articles so deprecation reviews apply one rule for removal timing and one shape for deprecated configuration properties.

### Removal timing

Removal timing follows the stability of the artifact that publishes the symbol, not how public the class looks. A module is stable only when its own `gradle.properties` sets `otel.stable=true`, equivalently when its published version has no `-alpha` suffix. The article describes how to check rather than listing today's stable artifacts, since that list changes.

Classes that look like supported API are frequently alpha: `*TelemetryBuilder` and `internal.Experimental` classes in `instrumentation/**/library`, and everything in `instrumentation-api-incubator`.

The alpha case had no established phrase — 45 occurrences of `// to be removed in 3.0` against a single `// will be removed in the next release` — so it now has standard wording:

```java
/**
 * @deprecated Use {@link #newMethod()} instead. May be removed in the next minor release.
 */
@Deprecated // may be removed in the next minor release
```

That sentence is reused in the `metadata.yaml` description, README config table, and runtime warning, so one deprecation reads consistently wherever a user encounters it. The CHANGELOG bullet omits the timeline instead, because alpha and stable surfaces deprecated by the same PR often have different ones.

A carve-out lists 3.0 milestone work that correctly says 3.0 even in alpha modules — old semconv and the `SemconvStability` clusters, `@Override`s of interface methods already scheduled for 3.0, anything gated on `otel.instrumentation.common.v3-preview`, `|deprecated:<old>` instrumentation-name aliases, the Zipkin exporter removal, and the flat `ConfigProperties` bridge — so they are not "fixed" later.

### Deprecated configuration properties

A property name is a stable surface even when the code reading it is alpha, because users configure the javaagent and the javaagent artifact is stable. Deprecating one now has a documented shape: read the replacement first, fall back to the deprecated name only outside v3 preview, warn only when the deprecated value is actually applied, and deduplicate the warning on repeatable paths.

Replacement-first lookup also keeps rolling upgrades warning-free with centralized configuration. Both names can coexist while old deployments read the legacy name and new deployments read the replacement, so a warning identifies a deployment that still depends on the deprecated value rather than one merely carrying it for compatibility.

The v3-preview gate applies only to stable property names, whose deprecated spelling must survive until 3.0. `VERSIONING.md` exempts names containing `experimental` or `preview`, and an `experimental`-marked property can be removed in the next minor release, so preview mode has nothing to reproduce: no `v3Preview` parameter, no gate, and no v3-preview test variant, just the warning. gRPC `capture-metadata.*` (no marker, gated) versus servlet `…experimental.capture-request-parameters` (marked, ungated) is the worked contrast.

Instrumentation enablement name aliases remain an exception, since they resolve across ordered equivalent names while detecting deprecated-key presence separately. Their example is updated to the `expandDeprecatedNames` helper, and such renames are classified as deprecations rather than as no-op or breaking changes.