### PR TITLE
Add per-message attributes to AWS SQS receive links

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -173,15 +173,13 @@ public final class AwsSdkInstrumenterFactory {
             // span. the creation context is linked even when it ends up being this span's parent,
             // which happens when there is no ambient span, because semconv asks for a link to the
             // creation context for every message the span accounts for
-            SqsMessage message = request.getMessage();
+            //
+            // the link carries no messaging.message.id: a process span accounts for a single
+            // message, so that attribute belongs on the span itself, where it already is
             SpanContext creationSpanContext =
-                Span.fromContext(message.getCreationContext()).getSpanContext();
+                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
             if (creationSpanContext.isValid()) {
-              if (emitStableMessagingSemconv()) {
-                spanLinks.addLink(creationSpanContext, messageLinkAttributes(message));
-              } else {
-                spanLinks.addLink(creationSpanContext);
-              }
+              spanLinks.addLink(creationSpanContext);
             }
           });
     }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -193,7 +193,8 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    return Attributes.builder().put(MESSAGING_MESSAGE_ID, message.getMessageId()).build();
+    String messageId = message.getMessageId();
+    return messageId == null ? Attributes.empty() : Attributes.of(MESSAGING_MESSAGE_ID, messageId);
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response<?>>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v1_11.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
@@ -17,6 +18,8 @@ import static java.util.Collections.singletonList;
 import com.amazonaws.Request;
 import com.amazonaws.Response;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
@@ -51,6 +54,10 @@ public final class AwsSdkInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String RECEIVE_OPERATION_NAME = "receive";
   private static final String PROCESS_OPERATION_NAME = "process";
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_MESSAGE_ID =
+      stringKey("messaging.message.id");
 
   private static final List<AttributesExtractor<Request<?>, Response<?>>>
       defaultAttributesExtractors = createAttributesExtractors(false);
@@ -134,7 +141,7 @@ public final class AwsSdkInstrumenterFactory {
                     SpanContext spanContext =
                         Span.fromContext(message.getCreationContext()).getSpanContext();
                     if (spanContext.isValid()) {
-                      spanLinks.addLink(spanContext);
+                      spanLinks.addLink(spanContext, messageLinkAttributes(message));
                     }
                   }
                 });
@@ -166,10 +173,15 @@ public final class AwsSdkInstrumenterFactory {
             // span. the creation context is linked even when it ends up being this span's parent,
             // which happens when there is no ambient span, because semconv asks for a link to the
             // creation context for every message the span accounts for
+            SqsMessage message = request.getMessage();
             SpanContext creationSpanContext =
-                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
+                Span.fromContext(message.getCreationContext()).getSpanContext();
             if (creationSpanContext.isValid()) {
-              spanLinks.addLink(creationSpanContext);
+              if (emitStableMessagingSemconv()) {
+                spanLinks.addLink(creationSpanContext, messageLinkAttributes(message));
+              } else {
+                spanLinks.addLink(creationSpanContext);
+              }
             }
           });
     }
@@ -180,6 +192,10 @@ public final class AwsSdkInstrumenterFactory {
                   parentContext.with(Span.fromContext(request.getMessage().getCreationContext()))));
     }
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+  }
+
+  private static Attributes messageLinkAttributes(SqsMessage message) {
+    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response<?>>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -193,8 +193,7 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    String messageId = message.getMessageId();
-    return messageId == null ? Attributes.empty() : Attributes.of(MESSAGING_MESSAGE_ID, messageId);
+    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response<?>>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -193,7 +193,7 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
+    return Attributes.builder().put(MESSAGING_MESSAGE_ID, message.getMessageId()).build();
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response<?>>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -392,9 +392,7 @@ public abstract class AbstractSqsTracingTest {
                                     assertThat(links)
                                         .singleElement()
                                         .satisfies(
-                                            link ->
-                                                assertThat(link.getSpanContext().getSpanId())
-                                                    .isEqualTo(publishSpan.get().getSpanId())))),
+                                            link -> assertBareLink(link, publishSpan.get())))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -756,5 +754,10 @@ public abstract class AbstractSqsTracingTest {
   private static void assertMessageLink(LinkData link, SpanData creationContext, String messageId) {
     assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
     assertThat(link.getAttributes()).isEqualTo(Attributes.of(MESSAGING_MESSAGE_ID, messageId));
+  }
+
+  private static void assertBareLink(LinkData link, SpanData creationContext) {
+    assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
+    assertThat(link.getAttributes()).isEqualTo(Attributes.empty());
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -365,7 +365,8 @@ public abstract class AbstractSqsTracingTest {
     sqsClient.createQueue("testSdkSqs");
     sqsClient.sendMessage(new SendMessageRequest(queueUrl, "hello"));
     ReceiveMessageResult response = sqsClient.receiveMessage(queueUrl);
-    Message message = response.getMessages().get(0);
+    String messageId = response.getMessages().get(0).getMessageId();
+    // iterating the returned message list is what starts the process spans
     response.getMessages().forEach(unused -> {});
 
     AtomicReference<SpanData> publishSpan = new AtomicReference<>();
@@ -380,6 +381,8 @@ public abstract class AbstractSqsTracingTest {
                       publishSpan.set(trace.getSpan(0));
                       span.hasName("send testSdkSqs").hasKind(SpanKind.PRODUCER);
                     },
+                    // the process span accounts for a single message, so its link carries no
+                    // per-message attributes
                     span ->
                         span.hasName("process testSdkSqs")
                             .hasKind(SpanKind.CONSUMER)
@@ -390,10 +393,8 @@ public abstract class AbstractSqsTracingTest {
                                         .singleElement()
                                         .satisfies(
                                             link ->
-                                                assertMessageLink(
-                                                    link,
-                                                    publishSpan.get(),
-                                                    message.getMessageId())))),
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(publishSpan.get().getSpanId())))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -407,9 +408,7 @@ public abstract class AbstractSqsTracingTest {
                                         .satisfies(
                                             link ->
                                                 assertMessageLink(
-                                                    link,
-                                                    publishSpan.get(),
-                                                    message.getMessageId())))));
+                                                    link, publishSpan.get(), messageId)))));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -48,11 +48,13 @@ import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.List;
@@ -362,7 +364,76 @@ public abstract class AbstractSqsTracingTest {
     String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
     sqsClient.createQueue("testSdkSqs");
     sqsClient.sendMessage(new SendMessageRequest(queueUrl, "hello"));
-    sqsClient.receiveMessage(queueUrl);
+    ReceiveMessageResult response = sqsClient.receiveMessage(queueUrl);
+    Message message = response.getMessages().get(0);
+    response.getMessages().forEach(unused -> {});
+
+    AtomicReference<SpanData> publishSpan = new AtomicReference<>();
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("SQS.CreateQueue").hasKind(SpanKind.CLIENT)),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> {
+                      publishSpan.set(trace.getSpan(0));
+                      span.hasName("send testSdkSqs").hasKind(SpanKind.PRODUCER);
+                    },
+                    span ->
+                        span.hasName("process testSdkSqs")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(0))
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertMessageLink(
+                                                    link,
+                                                    publishSpan.get(),
+                                                    message.getMessageId())))),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("receive testSdkSqs")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasNoParent()
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertMessageLink(
+                                                    link,
+                                                    publishSpan.get(),
+                                                    message.getMessageId())))));
+  }
+
+  @Test
+  void testBatchReceiveLinkAttributes() {
+    assumeTrue(emitStableMessagingSemconv());
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+    sqsClient.createQueue("testSdkSqs");
+    sqsClient.sendMessageBatch(
+        new SendMessageBatchRequest()
+            .withQueueUrl(queueUrl)
+            .withEntries(
+                new SendMessageBatchRequestEntry("i1", "e1"),
+                new SendMessageBatchRequestEntry("i2", "e2"),
+                new SendMessageBatchRequestEntry("i3", "e3")));
+
+    ReceiveMessageResult response =
+        sqsClient.receiveMessage(
+            new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(3).withWaitTimeSeconds(5));
+    assertThat(response.getMessages()).hasSize(3);
+
+    List<String> messageIds = new ArrayList<>();
+    for (int i = 0; i < response.getMessages().size(); i++) {
+      messageIds.add(response.getMessages().get(i).getMessageId());
+    }
 
     AtomicReference<SpanData> publishSpan = new AtomicReference<>();
     testing()
@@ -381,15 +452,14 @@ public abstract class AbstractSqsTracingTest {
                     span ->
                         span.hasName("receive testSdkSqs")
                             .hasKind(SpanKind.CLIENT)
-                            .hasNoParent()
                             .hasLinksSatisfying(
-                                links ->
-                                    assertThat(links)
-                                        .singleElement()
-                                        .satisfies(
-                                            link ->
-                                                assertThat(link.getSpanContext().getSpanId())
-                                                    .isEqualTo(publishSpan.get().getSpanId())))));
+                                links -> {
+                                  assertThat(links).hasSize(3);
+                                  for (int i = 0; i < links.size(); i++) {
+                                    assertMessageLink(
+                                        links.get(i), publishSpan.get(), messageIds.get(i));
+                                  }
+                                })));
   }
 
   @Test
@@ -682,5 +752,10 @@ public abstract class AbstractSqsTracingTest {
     } else {
       val.isInstanceOf(String.class);
     }
+  }
+
+  private static void assertMessageLink(LinkData link, SpanData creationContext, String messageId) {
+    assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
+    assertThat(link.getAttributes()).isEqualTo(Attributes.of(MESSAGING_MESSAGE_ID, messageId));
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -225,7 +225,7 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
+    return Attributes.builder().put(MESSAGING_MESSAGE_ID, message.getMessageId()).build();
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -225,8 +225,7 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    String messageId = message.getMessageId();
-    return messageId == null ? Attributes.empty() : Attributes.of(MESSAGING_MESSAGE_ID, messageId);
+    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -225,7 +225,8 @@ public final class AwsSdkInstrumenterFactory {
   }
 
   private static Attributes messageLinkAttributes(SqsMessage message) {
-    return Attributes.builder().put(MESSAGING_MESSAGE_ID, message.getMessageId()).build();
+    String messageId = message.getMessageId();
+    return messageId == null ? Attributes.empty() : Attributes.of(MESSAGING_MESSAGE_ID, messageId);
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -201,15 +201,13 @@ public final class AwsSdkInstrumenterFactory {
             // span. the creation context is linked even when it ends up being this span's parent,
             // which happens when there is no ambient span, because semconv asks for a link to the
             // creation context for every message the span accounts for
-            SqsMessage message = request.getMessage();
+            //
+            // the link carries no messaging.message.id: a process span accounts for a single
+            // message, so that attribute belongs on the span itself, where it already is
             SpanContext creationSpanContext =
-                Span.fromContext(message.getCreationContext()).getSpanContext();
+                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
             if (creationSpanContext.isValid()) {
-              if (emitStableMessagingSemconv()) {
-                spanLinks.addLink(creationSpanContext, messageLinkAttributes(message));
-              } else {
-                spanLinks.addLink(creationSpanContext);
-              }
+              spanLinks.addLink(creationSpanContext);
             }
           });
     }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.internal.GenAiExceptionEventExtractors.setGenAiClientExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
@@ -16,6 +17,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.trace.Span;
@@ -57,6 +60,10 @@ public final class AwsSdkInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String RECEIVE_OPERATION_NAME = "receive";
   private static final String PROCESS_OPERATION_NAME = "process";
+
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<String> MESSAGING_MESSAGE_ID =
+      stringKey("messaging.message.id");
 
   private static final AttributesExtractor<ExecutionAttributes, Response> rpcAttributesExtractor =
       RpcClientAttributesExtractor.create(new AwsSdkRpcAttributesGetter());
@@ -163,7 +170,7 @@ public final class AwsSdkInstrumenterFactory {
                     SpanContext spanContext =
                         Span.fromContext(message.getCreationContext()).getSpanContext();
                     if (spanContext.isValid()) {
-                      spanLinks.addLink(spanContext);
+                      spanLinks.addLink(spanContext, messageLinkAttributes(message));
                     }
                   }
                 });
@@ -194,10 +201,15 @@ public final class AwsSdkInstrumenterFactory {
             // span. the creation context is linked even when it ends up being this span's parent,
             // which happens when there is no ambient span, because semconv asks for a link to the
             // creation context for every message the span accounts for
+            SqsMessage message = request.getMessage();
             SpanContext creationSpanContext =
-                Span.fromContext(request.getMessage().getCreationContext()).getSpanContext();
+                Span.fromContext(message.getCreationContext()).getSpanContext();
             if (creationSpanContext.isValid()) {
-              spanLinks.addLink(creationSpanContext);
+              if (emitStableMessagingSemconv()) {
+                spanLinks.addLink(creationSpanContext, messageLinkAttributes(message));
+              } else {
+                spanLinks.addLink(creationSpanContext);
+              }
             }
           });
     }
@@ -212,6 +224,10 @@ public final class AwsSdkInstrumenterFactory {
                       useXrayPropagator)));
     }
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+  }
+
+  private static Attributes messageLinkAttributes(SqsMessage message) {
+    return Attributes.of(MESSAGING_MESSAGE_ID, message.getMessageId());
   }
 
   private static List<AttributesExtractor<AbstractSqsRequest, Response>> toSqsRequestExtractors(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -379,9 +379,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                     assertThat(links)
                                         .singleElement()
                                         .satisfies(
-                                            link ->
-                                                assertThat(link.getSpanContext().getSpanId())
-                                                    .isEqualTo(publishSpan.get().getSpanId())))),
+                                            link -> assertBareLink(link, publishSpan.get())))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -589,5 +587,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
   private static void assertMessageLink(LinkData link, SpanData creationContext, String messageId) {
     assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
     assertThat(link.getAttributes()).isEqualTo(Attributes.of(MESSAGING_MESSAGE_ID, messageId));
+  }
+
+  private static void assertBareLink(LinkData link, SpanData creationContext) {
+    assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
+    assertThat(link.getAttributes()).isEqualTo(Attributes.empty());
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -34,10 +34,12 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.testing.internal.armeria.internal.shaded.guava.collect.ImmutableList;
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
@@ -349,7 +352,9 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
 
     client.createQueue(createQueueRequest);
     client.sendMessage(sendMessageRequest);
-    client.receiveMessage(receiveMessageRequest);
+    ReceiveMessageResponse response = client.receiveMessage(receiveMessageRequest);
+    Message message = response.messages().get(0);
+    response.messages().forEach(unused -> {});
 
     AtomicReference<SpanData> publishSpan = new AtomicReference<>();
     getTesting()
@@ -362,7 +367,21 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                     span -> {
                       publishSpan.set(trace.getSpan(0));
                       span.hasName("send testSdkSqs").hasKind(SpanKind.PRODUCER);
-                    }),
+                    },
+                    span ->
+                        span.hasName("process testSdkSqs")
+                            .hasKind(SpanKind.CONSUMER)
+                            .hasParent(trace.getSpan(0))
+                            .hasLinksSatisfying(
+                                links ->
+                                    assertThat(links)
+                                        .singleElement()
+                                        .satisfies(
+                                            link ->
+                                                assertMessageLink(
+                                                    link,
+                                                    publishSpan.get(),
+                                                    message.messageId())))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -375,8 +394,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                         .singleElement()
                                         .satisfies(
                                             link ->
-                                                assertThat(link.getSpanContext().getSpanId())
-                                                    .isEqualTo(publishSpan.get().getSpanId())))));
+                                                assertMessageLink(
+                                                    link,
+                                                    publishSpan.get(),
+                                                    message.messageId())))));
   }
 
   @Test
@@ -437,6 +458,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     client.sendMessageBatch(sendMessageBatchRequest);
 
     ReceiveMessageResponse response = client.receiveMessage(receiveMessageBatchRequest);
+    List<String> messageIds = new ArrayList<>();
+    for (int i = 0; i < response.messages().size(); i++) {
+      messageIds.add(response.messages().get(i).messageId());
+    }
     response.messages().forEach(message -> getTesting().runWithSpan("process child", () -> {}));
 
     int totalAttrs =
@@ -515,13 +540,12 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                 if (emitStableMessagingSemconv()) {
                   // one link per message whose creation context could be propagated
                   span.hasLinksSatisfying(
-                      links ->
-                          assertThat(links)
-                              .hasSize(propagatedMessages)
-                              .allSatisfy(
-                                  link ->
-                                      assertThat(link.getSpanContext().getSpanId())
-                                          .isEqualTo(publishSpan.get().getSpanId())));
+                      links -> {
+                        assertThat(links).hasSize(propagatedMessages);
+                        for (int i = 0; i < links.size(); i++) {
+                          assertMessageLink(links.get(i), publishSpan.get(), messageIds.get(i));
+                        }
+                      });
                 } else {
                   span.hasTotalRecordedLinks(0);
                 }
@@ -562,5 +586,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     }
 
     getTesting().waitAndAssertTraces(traceAsserts);
+  }
+
+  private static void assertMessageLink(LinkData link, SpanData creationContext, String messageId) {
+    assertThat(link.getSpanContext().getSpanId()).isEqualTo(creationContext.getSpanId());
+    assertThat(link.getAttributes()).isEqualTo(Attributes.of(MESSAGING_MESSAGE_ID, messageId));
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -51,7 +51,6 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
-import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
@@ -353,7 +352,8 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     client.createQueue(createQueueRequest);
     client.sendMessage(sendMessageRequest);
     ReceiveMessageResponse response = client.receiveMessage(receiveMessageRequest);
-    Message message = response.messages().get(0);
+    String messageId = response.messages().get(0).messageId();
+    // iterating the returned message list is what starts the process spans
     response.messages().forEach(unused -> {});
 
     AtomicReference<SpanData> publishSpan = new AtomicReference<>();
@@ -368,6 +368,8 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                       publishSpan.set(trace.getSpan(0));
                       span.hasName("send testSdkSqs").hasKind(SpanKind.PRODUCER);
                     },
+                    // the process span accounts for a single message, so its link carries no
+                    // per-message attributes
                     span ->
                         span.hasName("process testSdkSqs")
                             .hasKind(SpanKind.CONSUMER)
@@ -378,10 +380,8 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                         .singleElement()
                                         .satisfies(
                                             link ->
-                                                assertMessageLink(
-                                                    link,
-                                                    publishSpan.get(),
-                                                    message.messageId())))),
+                                                assertThat(link.getSpanContext().getSpanId())
+                                                    .isEqualTo(publishSpan.get().getSpanId())))),
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
@@ -395,9 +395,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                                         .satisfies(
                                             link ->
                                                 assertMessageLink(
-                                                    link,
-                                                    publishSpan.get(),
-                                                    message.messageId())))));
+                                                    link, publishSpan.get(), messageId)))));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
@@ -454,9 +455,15 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     client.sendMessageBatch(sendMessageBatchRequest);
 
     ReceiveMessageResponse response = client.receiveMessage(receiveMessageBatchRequest);
-    List<String> messageIds = new ArrayList<>();
+    // ids of the messages that carry a creation context, in the order they were received, which is
+    // the order the receive span links them in. indexed access avoids the tracing iterator, which
+    // would start the process spans too early
+    List<String> propagatedMessageIds = new ArrayList<>();
     for (int i = 0; i < response.messages().size(); i++) {
-      messageIds.add(response.messages().get(i).messageId());
+      Message message = response.messages().get(i);
+      if (isXrayInjectionEnabled() || message.messageAttributes().containsKey("traceparent")) {
+        propagatedMessageIds.add(message.messageId());
+      }
     }
     response.messages().forEach(message -> getTesting().runWithSpan("process child", () -> {}));
 
@@ -470,6 +477,7 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
 
     // the last message in the batch has too many attributes for the tracing header to be injected
     int propagatedMessages = isXrayInjectionEnabled() ? 3 : 2;
+    assertThat(propagatedMessageIds).hasSize(propagatedMessages);
     // without an ambient span the process spans are parented to the message creation context, which
     // puts them in the same trace as the publish span
     boolean processInPublishTrace = emitStableMessagingSemconv();
@@ -539,7 +547,8 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
                       links -> {
                         assertThat(links).hasSize(propagatedMessages);
                         for (int i = 0; i < links.size(); i++) {
-                          assertMessageLink(links.get(i), publishSpan.get(), messageIds.get(i));
+                          assertMessageLink(
+                              links.get(i), publishSpan.get(), propagatedMessageIds.get(i));
                         }
                       });
                 } else {


### PR DESCRIPTION
Adds `messaging.message.id` to the creation-context links on SQS receive spans in `aws-sdk-1.11` and `aws-sdk-2.2`, so a batch receive that accounts for several messages identifies which message each link refers to. Batch receives keep one link per propagated message, and each link's ID is sourced from the corresponding returned message.

Process links are deliberately left bare. A process span accounts for a single message, so `messaging.message.id` applies to every message the span accounts for and belongs on the span itself, where `SqsProcessRequestAttributesGetter` already puts it.

Link attributes are emitted only when stable messaging semantic conventions are enabled. When `otel.semconv-stability.opt-in` selects neither `messaging` nor `messaging/dup` and `otel.instrumentation.common.v3-preview` is absent or `false`, receive and process links are unchanged.

Part of #19254.