### PR TITLE
Add messaging v1.43 metrics to NATS

### DIFF
--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -10,7 +10,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -55,7 +58,8 @@ public final class NatsInstrumenterFactory {
                         MessagingOperationType.SEND,
                         operationName)
                     .setCapturedHeaders(capturedHeaders)
-                    .build());
+                    .build())
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationType());
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new NatsRequestTextMapSetter());
   }
@@ -76,7 +80,9 @@ public final class NatsInstrumenterFactory {
                         MessagingOperationType.PROCESS,
                         PROCESS_OPERATION_NAME)
                     .setCapturedHeaders(capturedHeaders)
-                    .build());
+                    .build())
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     setMessagingProcessExceptionEventExtractor(builder);
 
     return MessagingProcessInstrumenterFactory.create(

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsDispatcherTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.nats.v2_17.NatsTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -22,6 +23,7 @@ import io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,38 @@ public abstract class AbstractNatsDispatcherTest extends AbstractNatsTest {
     // finally, to make sure we're unwrapping properly the
     // OpenTelemetryDispatcher in the library
     assertThatNoException().isThrownBy(() -> connection.closeDispatcher(d1));
+  }
+
+  @Test
+  void testProcessMetrics() throws InterruptedException {
+    CountDownLatch handled = new CountDownLatch(1);
+    Dispatcher dispatcher =
+        connection.createDispatcher(msg -> handled.countDown()).subscribe("metrics");
+    cleanup.deferCleanup(() -> connection.closeDispatcher(dispatcher));
+
+    connection.publish("metrics", new byte[] {0});
+
+    assertThat(handled.await(10, SECONDS)).isTrue();
+    assertProcessMetrics("metrics", null);
+  }
+
+  @Test
+  void testProcessErrorMetrics() throws InterruptedException {
+    CountDownLatch handled = new CountDownLatch(1);
+    Dispatcher dispatcher =
+        connection
+            .createDispatcher(
+                msg -> {
+                  handled.countDown();
+                  throw new IllegalStateException("test");
+                })
+            .subscribe("error");
+    cleanup.deferCleanup(() -> connection.closeDispatcher(dispatcher));
+
+    connection.publish("error", new byte[] {0});
+
+    assertThat(handled.await(10, SECONDS)).isTrue();
+    assertProcessMetrics("error", IllegalStateException.class.getName());
   }
 
   @Test

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsPublishTest.java
@@ -37,6 +37,7 @@ public abstract class AbstractNatsPublishTest extends AbstractNatsTest {
     // then
     assertPublishSpan();
     assertTraceparentHeader(subscription);
+    assertProducerMetrics("publish", "sub", null);
   }
 
   @Test

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsRequestTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
                             .hasAttributesSatisfyingExactly(
                                 messagingAttributes("request", "sub", clientId))));
     assertTraceparentHeader(subscription);
+    assertProducerMetrics("request", "sub", null);
   }
 
   @Test
@@ -242,6 +243,7 @@ public abstract class AbstractNatsRequestTest extends AbstractNatsTest {
     assertCancellationPublishSpan();
     assertTraceparentHeader(subscription);
     assertThat(message).isCompletedExceptionally();
+    assertProducerMetrics("request", "sub", CancellationException.class.getName());
   }
 
   @Test

--- a/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsTest.java
+++ b/instrumentation/nats/nats-2.17/testing/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/AbstractNatsTest.java
@@ -5,6 +5,15 @@
 
 package io.opentelemetry.instrumentation.nats.v2_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+
 import io.nats.client.Connection;
 import io.nats.client.Nats;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -18,7 +27,13 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SuppressWarnings("deprecation") // using deprecated semconv
 abstract class AbstractNatsTest {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.nats-2.17";
+  private static final double[] DURATION_BUCKETS = {
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0
+  };
 
   @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
@@ -26,6 +41,142 @@ abstract class AbstractNatsTest {
   Connection connection;
 
   protected abstract InstrumentationExtension testing();
+
+  void assertProducerMetrics(String operationName, String destination, String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoMessagingMetrics();
+      return;
+    }
+
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            "messaging.client.operation.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasUnit("s")
+                            .hasDescription(
+                                "Duration of messaging operation initiated by a producer or consumer client.")
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasSumGreaterThan(0)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(
+                                                        MESSAGING_OPERATION_NAME, operationName),
+                                                    equalTo(MESSAGING_SYSTEM, "nats"),
+                                                    equalTo(ERROR_TYPE, errorType),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME, destination),
+                                                    equalTo(MESSAGING_OPERATION_TYPE, "send"))
+                                                .hasBucketBoundaries(DURATION_BUCKETS)))));
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            "messaging.client.sent.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasUnit("{message}")
+                            .hasDescription(
+                                "Number of messages producer attempted to send to the broker.")
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(
+                                                        MESSAGING_OPERATION_NAME, operationName),
+                                                    equalTo(MESSAGING_SYSTEM, "nats"),
+                                                    equalTo(ERROR_TYPE, errorType),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        destination))))));
+    assertNoDeprecatedMessagingMetrics();
+  }
+
+  void assertProcessMetrics(String destination, String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoMessagingMetrics();
+      return;
+    }
+
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            "messaging.process.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasUnit("s")
+                            .hasDescription("Duration of processing operation.")
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasSumGreaterThan(0)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "nats"),
+                                                    equalTo(ERROR_TYPE, errorType),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME, destination))
+                                                .hasBucketBoundaries(DURATION_BUCKETS)))));
+    testing()
+        .waitAndAssertMetrics(
+            INSTRUMENTATION_NAME,
+            "messaging.client.consumed.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasUnit("{message}")
+                            .hasDescription(
+                                "Number of messages that were delivered to the application.")
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "nats"),
+                                                    equalTo(ERROR_TYPE, errorType),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        destination))))));
+    assertNoDeprecatedMessagingMetrics();
+  }
+
+  private void assertNoMessagingMetrics() {
+    assertThat(testing().metrics())
+        .filteredOn(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME)
+                    && metric.getName().startsWith("messaging."))
+        .isEmpty();
+  }
+
+  private void assertNoDeprecatedMessagingMetrics() {
+    assertThat(testing().metrics())
+        .filteredOn(
+            metric -> metric.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME))
+        .extracting(metric -> metric.getName())
+        .doesNotContain(
+            "messaging.publish.duration",
+            "messaging.receive.duration",
+            "messaging.receive.messages");
+  }
 
   @BeforeAll
   void beforeAll() throws IOException, InterruptedException {


### PR DESCRIPTION
Adds the stable messaging v1.43 metrics to NATS. Publish and request operations now record `messaging.client.operation.duration` and `messaging.client.sent.messages`, and messages delivered to a NATS message handler record `messaging.process.duration` and `messaging.client.consumed.messages`.

Nothing changes by default. The new metrics are emitted only when `otel.semconv-stability.opt-in` selects `messaging` or `messaging/dup`, or when `otel.instrumentation.common.v3-preview` is enabled.

The metrics are recorded by the same instrumenters that already produce the NATS producer and process spans, so each operation and each delivered message is counted once, and failed operations carry `error.type`.

Part of #19254.