### PR TITLE
Add messaging v1.43 metrics to Spring Integration

### DIFF
--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationAndRabbitTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertNoMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -183,6 +184,10 @@ class SpringIntegrationAndRabbitTest {
                     span.hasName(emitStableMessagingSemconv() ? "ack" : "basic.ack")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(ackAssertions())));
+
+    // Rabbit and Spring Rabbit own the active messaging layers, so Spring Integration must not
+    // start operation listeners that could duplicate their metric points.
+    assertNoMetrics(testing);
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -14,7 +14,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -95,7 +98,9 @@ public final class SpringIntegrationTelemetryBuilder {
                     consumerGetter,
                     MessagingOperationType.PROCESS,
                     PROCESS_OPERATION_NAME,
-                    capturedHeaders));
+                    capturedHeaders))
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     setMessagingProcessExceptionEventExtractor(consumerBuilder);
     Instrumenter<MessageWithChannel, Void> consumerInstrumenter =
         MessagingProcessInstrumenterFactory.create(
@@ -118,7 +123,8 @@ public final class SpringIntegrationTelemetryBuilder {
                     producerGetter,
                     MessagingOperationType.SEND,
                     SEND_OPERATION_NAME,
-                    capturedHeaders));
+                    capturedHeaders))
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationType());
     setMessagingSendExceptionEventExtractor(producerBuilder);
     Instrumenter<MessageWithChannel, Void> producerInstrumenter =
         producerBuilder.buildInstrumenter(SpanKindExtractor.alwaysProducer());

--- a/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationMetricsTest.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationMetricsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertNoMetrics;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertSendMetrics;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.spring.integration.v4_1.SpringIntegrationTelemetry;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.cloud.stream.messaging.DirectWithAttributesChannel;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+class SpringIntegrationMetricsTest {
+
+  private static final String LOWER_CLIENT_INSTRUMENTATION_NAME = "test-lower-messaging-client";
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Test
+  void shouldRecordSendMetricsOnlyForStableSemconv() {
+    DirectWithAttributesChannel channel = new DirectWithAttributesChannel();
+    channel.setBeanName("output");
+    channel.setAttribute("type", "output");
+    channel.addInterceptor(
+        SpringIntegrationTelemetry.builder(GlobalOpenTelemetry.get())
+            .setProducerSpanEnabled(true)
+            .build()
+            .createChannelInterceptor());
+    channel.subscribe(message -> {});
+
+    channel.send(MessageBuilder.withPayload("test").build());
+
+    if (emitStableMessagingSemconv()) {
+      assertSendMetrics(testing, "output");
+    } else {
+      assertNoMetrics(testing);
+    }
+  }
+
+  @Test
+  void lowerMessagingClientPreventsDuplicateConsumedMetrics() {
+    assumeTrue(emitStableMessagingSemconv());
+
+    DirectWithAttributesChannel channel = new DirectWithAttributesChannel();
+    channel.setBeanName("input");
+    channel.addInterceptor(
+        SpringIntegrationTelemetry.create(GlobalOpenTelemetry.get()).createChannelInterceptor());
+    channel.subscribe(message -> {});
+
+    Instrumenter<Message<?>, Void> lowerClientInstrumenter =
+        Instrumenter.<Message<?>, Void>builder(
+                GlobalOpenTelemetry.get(), LOWER_CLIENT_INSTRUMENTATION_NAME, message -> "receive")
+            .addAttributesExtractor(AttributesExtractor.constant(MESSAGING_SYSTEM, "test"))
+            .addAttributesExtractor(
+                AttributesExtractor.constant(MESSAGING_OPERATION_NAME, "receive"))
+            .addAttributesExtractor(
+                AttributesExtractor.constant(MESSAGING_OPERATION_TYPE, "receive"))
+            .addAttributesExtractor(
+                AttributesExtractor.constant(MESSAGING_DESTINATION_NAME, "input"))
+            .addOperationMetrics(MessagingConsumerMetrics.getForOperationType())
+            .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+
+    Message<String> message = MessageBuilder.withPayload("test").build();
+    Context context = lowerClientInstrumenter.start(Context.current(), message);
+    try (Scope ignored = context.makeCurrent()) {
+      channel.send(message);
+    }
+    lowerClientInstrumenter.end(context, message, null, null);
+
+    testing.waitAndAssertMetrics(
+        LOWER_CLIENT_INSTRUMENTATION_NAME,
+        "messaging.client.consumed.messages",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                equalTo(MESSAGING_SYSTEM, "test"),
+                                                equalTo(MESSAGING_DESTINATION_NAME, "input"))))));
+    assertNoMetrics(testing);
+  }
+}

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringCloudStreamProducerTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertNoMetrics;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertSendMetrics;
 import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -75,5 +77,11 @@ abstract class AbstractSpringCloudStreamProducerTest {
                     span.hasName("consumer")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(2))));
+
+    if (emitStableMessagingSemconv()) {
+      assertSendMetrics(testing, "testProducer.output");
+    } else {
+      assertNoMetrics(testing);
+    }
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/AbstractSpringIntegrationTracingTest.java
@@ -8,11 +8,15 @@ package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertNoMetrics;
+import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.assertProcessMetrics;
 import static io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1.SpringIntegrationTestHelper.messagingAttributes;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -102,7 +106,30 @@ abstract class AbstractSpringIntegrationTracingTest {
                 },
                 span -> span.hasName("handler").hasParent(trace.getSpan(0))));
 
+    if (emitStableMessagingSemconv()) {
+      assertProcessMetrics(testing, destinationName, false);
+    } else {
+      assertNoMetrics(testing);
+    }
+
     channel.unsubscribe(messageHandler);
+  }
+
+  @Test
+  void shouldRecordFailedProcessMetrics() {
+    assumeTrue(emitStableMessagingSemconv());
+
+    SubscribableChannel channel =
+        applicationContext.getBean("directChannel", SubscribableChannel.class);
+    channel.subscribe(
+        message -> {
+          throw new IllegalStateException("test");
+        });
+
+    assertThatThrownBy(() -> channel.send(MessageBuilder.withPayload("test").build()))
+        .isInstanceOf(RuntimeException.class);
+
+    assertProcessMetrics(testing, "application.directChannel", true);
   }
 
   @Test

--- a/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
+++ b/instrumentation/spring/spring-integration-4.1/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationTestHelper.java
@@ -7,16 +7,24 @@ package io.opentelemetry.javaagent.instrumentation.spring.integration.v4_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import org.assertj.core.api.AbstractStringAssert;
 
 final class SpringIntegrationTestHelper {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-integration-4.1";
 
   static AttributeAssertion[] messagingAttributes(String operationName, String destinationName) {
     return messagingAttributes(operationName, destinationName, new AttributeAssertion[0]);
@@ -41,6 +49,111 @@ final class SpringIntegrationTestHelper {
     System.arraycopy(standard, 0, result, 0, standard.length);
     System.arraycopy(additionalAssertions, 0, result, standard.length, additionalAssertions.length);
     return result;
+  }
+
+  static void assertProcessMetrics(
+      InstrumentationExtension testing, String destinationName, boolean failed) {
+    AttributeAssertion errorType =
+        failed
+            ? satisfies(ERROR_TYPE, AbstractStringAssert::isNotEmpty)
+            : equalTo(ERROR_TYPE, null);
+
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.process.duration",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("s")
+                        .hasDescription("Duration of processing operation.")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasCount(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                equalTo(MESSAGING_SYSTEM, "spring_integration"),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME, destinationName),
+                                                errorType)))));
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.client.consumed.messages",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("{message}")
+                        .hasDescription(
+                            "Number of messages that were delivered to the application.")
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                equalTo(MESSAGING_SYSTEM, "spring_integration"),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME, destinationName),
+                                                errorType)))));
+  }
+
+  static void assertSendMetrics(InstrumentationExtension testing, String destinationName) {
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("s")
+                        .hasDescription(
+                            "Duration of messaging operation initiated by a producer or consumer client.")
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasCount(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                equalTo(MESSAGING_SYSTEM, "spring_integration"),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME, destinationName),
+                                                equalTo(MESSAGING_OPERATION_TYPE, "send"))))));
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.client.sent.messages",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("{message}")
+                        .hasDescription(
+                            "Number of messages producer attempted to send to the broker.")
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                equalTo(MESSAGING_SYSTEM, "spring_integration"),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME,
+                                                    destinationName))))));
+  }
+
+  static void assertNoMetrics(InstrumentationExtension testing) {
+    assertThat(testing.metrics())
+        .noneMatch(
+            metric -> metric.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME));
   }
 
   private SpringIntegrationTestHelper() {}


### PR DESCRIPTION
Spring Integration now records the messaging v1.43 metrics for the send and process operations it already instruments.

Sends record `messaging.client.operation.duration` and `messaging.client.sent.messages`. Since the producer span is opt-in, this covers only output-channel sends that Spring Integration owns.

Processing records `messaging.process.duration` and `messaging.client.consumed.messages`.

Failed operations carry `error.type`.

When a lower messaging layer such as Spring Rabbit is already active, it suppresses the Spring Integration instrumenter, so that layer reports the operation and no points are duplicated.

Nothing changes on the default path. The metrics appear only with `otel.semconv-stability.opt-in=messaging` (or `messaging/dup`), or with `otel.instrumentation.common.v3-preview=true`; otherwise the existing spans are unchanged and no metrics are emitted.

Part of #19254.