### PR TITLE
Instrument RocketMQ 5 SimpleConsumer receive operations

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
@@ -46,6 +46,22 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  // A SimpleConsumer pull has no process span, so it gets a receive span even when receive
+  // telemetry is disabled by default.
+  val testSimpleConsumerReceiveTelemetryDisabled =
+    register<Test>("testSimpleConsumerReceiveTelemetryDisabled") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+      filter {
+        includeTestsMatching(
+          "RocketMqSimpleConsumerTest.shouldInstrumentReceiveWhenReceiveTelemetryDisabled",
+        )
+      }
+      include("**/RocketMqSimpleConsumerTest.*")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -70,7 +86,12 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpanDisabled, testMessagingPreview, testBothSemconv)
+    dependsOn(
+      testReceiveSpanDisabled,
+      testMessagingPreview,
+      testSimpleConsumerReceiveTelemetryDisabled,
+      testBothSemconv,
+    )
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ConsumerImplInstrumentation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/ConsumerImplInstrumentation.java
@@ -42,7 +42,12 @@ final class ConsumerImplInstrumentation implements TypeInstrumentation {
   public static class ReceiveMessageAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static Timer onStart() {
+    public static Timer onStart(@Advice.This Object consumer) {
+      // SimpleConsumer receives are recorded at the application-facing SimpleConsumerImpl level
+      // under stable/v3 semconv, so the per-queue calls underneath are not recorded again.
+      if (SimpleConsumerReceiveOperation.handlesReceive(consumer)) {
+        return null;
+      }
       return Timer.start();
     }
 
@@ -51,6 +56,9 @@ final class ConsumerImplInstrumentation implements TypeInstrumentation {
         @Advice.Argument(0) ReceiveMessageRequest request,
         @Advice.Enter Timer timer,
         @Advice.Return ListenableFuture<ReceiveMessageResult> future) {
+      if (timer == null) {
+        return;
+      }
       ReceiveSpanFinishingCallback spanFinishingCallback =
           new ReceiveSpanFinishingCallback(request, timer);
       Futures.addCallback(future, spanFinishingCallback, MoreExecutors.directExecutor());

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeExtractor.java
@@ -25,12 +25,10 @@ class RocketMqConsumerReceiveAttributeExtractor
   @Override
   public void onStart(
       AttributesBuilder attributes, Context parentContext, RocketMqReceiveRequest request) {
-    String consumerGroup = request.getRequest().getGroup().getName();
+    String consumerGroup = request.getConsumerGroup();
     if (emitStableMessagingSemconv()) {
       attributes.put(MESSAGING_CONSUMER_GROUP_NAME, consumerGroup);
-      attributes.put(
-          MESSAGING_ROCKETMQ_NAMESPACE,
-          request.getRequest().getMessageQueue().getTopic().getResourceNamespace());
+      attributes.put(MESSAGING_ROCKETMQ_NAMESPACE, request.getNamespace());
     }
     if (emitOldMessagingSemconv()) {
       attributes.put(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup);

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqConsumerReceiveAttributeGetter.java
@@ -19,8 +19,9 @@ class RocketMqConsumerReceiveAttributeGetter
   }
 
   @Override
+  @Nullable
   public String getDestination(RocketMqReceiveRequest request) {
-    return request.getRequest().getMessageQueue().getTopic().getName();
+    return request.getDestination();
   }
 
   @Nullable

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumentationModule.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumentationModule.java
@@ -21,7 +21,10 @@ public class RocketMqInstrumentationModule extends InstrumentationModule {
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
-        new PublishingMessageImplInstrumentation(), new ProducerImplInstrumentation(),
-        new ConsumerImplInstrumentation(), new ConsumeServiceInstrumentation());
+        new PublishingMessageImplInstrumentation(),
+        new ProducerImplInstrumentation(),
+        new ConsumerImplInstrumentation(),
+        new ConsumeServiceInstrumentation(),
+        new SimpleConsumerImplInstrumentation());
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqReceiveRequest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqReceiveRequest.java
@@ -7,24 +7,63 @@ package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.rocketmq.client.apis.message.MessageView;
+import org.apache.rocketmq.client.java.message.MessageViewImpl;
 
 class RocketMqReceiveRequest {
 
-  private final ReceiveMessageRequest request;
+  @Nullable private final String destination;
+  @Nullable private final String namespace;
+  private final String consumerGroup;
   private final List<MessageView> messages;
 
-  private RocketMqReceiveRequest(ReceiveMessageRequest request, List<MessageView> messages) {
-    this.request = request;
+  private RocketMqReceiveRequest(
+      @Nullable String destination,
+      @Nullable String namespace,
+      String consumerGroup,
+      List<MessageView> messages) {
+    this.destination = destination;
+    this.namespace = namespace;
+    this.consumerGroup = consumerGroup;
     this.messages = messages;
   }
 
   static RocketMqReceiveRequest create(ReceiveMessageRequest request, List<MessageView> messages) {
-    return new RocketMqReceiveRequest(request, messages);
+    return new RocketMqReceiveRequest(
+        request.getMessageQueue().getTopic().getName(),
+        request.getMessageQueue().getTopic().getResourceNamespace(),
+        request.getGroup().getName(),
+        messages);
   }
 
-  ReceiveMessageRequest getRequest() {
-    return request;
+  /**
+   * Creates a request for an application-initiated pull, where the destination comes from the
+   * received messages and falls back to {@code subscribedTopic} when the pull came back empty.
+   */
+  static RocketMqReceiveRequest create(
+      String consumerGroup, @Nullable String subscribedTopic, List<MessageView> messages) {
+    if (messages.isEmpty()) {
+      return new RocketMqReceiveRequest(subscribedTopic, null, consumerGroup, messages);
+    }
+    MessageView message = messages.get(0);
+    String namespace =
+        ((MessageViewImpl) message).getMessageQueue().getTopicResource().getNamespace();
+    return new RocketMqReceiveRequest(message.getTopic(), namespace, consumerGroup, messages);
+  }
+
+  @Nullable
+  String getDestination() {
+    return destination;
+  }
+
+  @Nullable
+  String getNamespace() {
+    return namespace;
+  }
+
+  String getConsumerGroup() {
+    return consumerGroup;
   }
 
   List<MessageView> getMessages() {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqReceiveRequest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqReceiveRequest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
+import static java.util.Collections.emptyList;
+
 import apache.rocketmq.v2.ReceiveMessageRequest;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -37,15 +39,11 @@ class RocketMqReceiveRequest {
         messages);
   }
 
-  /**
-   * Creates a request for an application-initiated pull, where the destination comes from the
-   * received messages and falls back to {@code subscribedTopic} when the pull came back empty.
-   */
-  static RocketMqReceiveRequest create(
-      String consumerGroup, @Nullable String subscribedTopic, List<MessageView> messages) {
-    if (messages.isEmpty()) {
-      return new RocketMqReceiveRequest(subscribedTopic, null, consumerGroup, messages);
-    }
+  static RocketMqReceiveRequest create(String consumerGroup) {
+    return new RocketMqReceiveRequest(null, null, consumerGroup, emptyList());
+  }
+
+  static RocketMqReceiveRequest create(String consumerGroup, List<MessageView> messages) {
     MessageView message = messages.get(0);
     String namespace =
         ((MessageViewImpl) message).getMessageQueue().getTopicResource().getNamespace();

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
@@ -20,6 +20,8 @@ public class RocketMqSingletons {
   private static final Instrumenter<PublishingMessageImpl, SendReceiptImpl> producerInstrumenter;
   private static final Instrumenter<RocketMqReceiveRequest, List<MessageView>>
       consumerReceiveInstrumenter;
+  private static final Instrumenter<RocketMqReceiveRequest, List<MessageView>>
+      simpleConsumerReceiveInstrumenter;
   private static final Instrumenter<MessageView, ConsumeResult> consumerProcessInstrumenter;
 
   static {
@@ -33,6 +35,9 @@ public class RocketMqSingletons {
     consumerReceiveInstrumenter =
         RocketMqInstrumenterFactory.createConsumerReceiveInstrumenter(
             openTelemetry, messagingHeaders, receiveInstrumentationEnabled);
+    simpleConsumerReceiveInstrumenter =
+        RocketMqInstrumenterFactory.createConsumerReceiveInstrumenter(
+            openTelemetry, messagingHeaders, true);
     consumerProcessInstrumenter =
         RocketMqInstrumenterFactory.createConsumerProcessInstrumenter(
             openTelemetry, messagingHeaders, receiveInstrumentationEnabled);
@@ -45,6 +50,11 @@ public class RocketMqSingletons {
   public static Instrumenter<RocketMqReceiveRequest, List<MessageView>>
       consumerReceiveInstrumenter() {
     return consumerReceiveInstrumenter;
+  }
+
+  public static Instrumenter<RocketMqReceiveRequest, List<MessageView>>
+      simpleConsumerReceiveInstrumenter() {
+    return simpleConsumerReceiveInstrumenter;
   }
 
   public static Instrumenter<MessageView, ConsumeResult> consumerProcessInstrumenter() {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerImplInstrumentation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerImplInstrumentation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.time.Duration;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
+import org.apache.rocketmq.client.apis.message.MessageView;
+import org.apache.rocketmq.shaded.com.google.common.util.concurrent.ListenableFuture;
+
+final class SimpleConsumerImplInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.apache.rocketmq.client.java.impl.consumer.SimpleConsumerImpl");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("receive0")
+            .and(takesArguments(2))
+            .and(takesArgument(0, int.class))
+            .and(takesArgument(1, Duration.class)),
+        getClass().getName() + "$ReceiveAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ReceiveAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static SimpleConsumerReceiveOperation onEnter(
+        @Advice.This SimpleConsumer simpleConsumer) {
+      return SimpleConsumerReceiveOperation.start(simpleConsumer);
+    }
+
+    @AssignReturned.ToReturned
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static ListenableFuture<List<MessageView>> onExit(
+        @Advice.Enter SimpleConsumerReceiveOperation operation,
+        @Advice.Return ListenableFuture<List<MessageView>> future) {
+      return operation == null ? future : operation.wrap(future);
+    }
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0.RocketMqSingletons.simpleConsumerReceiveInstrumenter;
-import static java.util.Collections.emptyList;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -15,9 +14,7 @@ import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import io.opentelemetry.javaagent.bootstrap.ExceptionLogger;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
 import org.apache.rocketmq.client.apis.message.MessageView;
 import org.apache.rocketmq.shaded.com.google.common.util.concurrent.FutureCallback;
@@ -28,7 +25,6 @@ import org.apache.rocketmq.shaded.com.google.common.util.concurrent.MoreExecutor
 public class SimpleConsumerReceiveOperation {
 
   private final String consumerGroup;
-  @Nullable private final String subscribedTopic;
   private final Context parentContext;
   private final Timer timer;
 
@@ -46,29 +42,11 @@ public class SimpleConsumerReceiveOperation {
       return null;
     }
     return new SimpleConsumerReceiveOperation(
-        consumer.getConsumerGroup(),
-        singleSubscribedTopic(consumer),
-        Context.current(),
-        Timer.start());
+        consumer.getConsumerGroup(), Context.current(), Timer.start());
   }
 
-  /**
-   * Returns the only topic this consumer subscribes to, or {@code null} when it subscribes to
-   * several. It is the destination of a pull that came back with no messages to read it from.
-   */
-  @Nullable
-  private static String singleSubscribedTopic(SimpleConsumer consumer) {
-    Map<String, FilterExpression> subscriptions = consumer.getSubscriptionExpressions();
-    if (subscriptions.size() != 1) {
-      return null;
-    }
-    return subscriptions.keySet().iterator().next();
-  }
-
-  private SimpleConsumerReceiveOperation(
-      String consumerGroup, @Nullable String subscribedTopic, Context parentContext, Timer timer) {
+  private SimpleConsumerReceiveOperation(String consumerGroup, Context parentContext, Timer timer) {
     this.consumerGroup = consumerGroup;
-    this.subscribedTopic = subscribedTopic;
     this.parentContext = parentContext;
     this.timer = timer;
   }
@@ -114,9 +92,13 @@ public class SimpleConsumerReceiveOperation {
   }
 
   private void end(@Nullable List<MessageView> messages, @Nullable Throwable error) {
-    List<MessageView> requestMessages = messages == null ? emptyList() : messages;
+    if (error == null && messages != null && messages.isEmpty()) {
+      return;
+    }
     RocketMqReceiveRequest request =
-        RocketMqReceiveRequest.create(consumerGroup, subscribedTopic, requestMessages);
+        messages == null
+            ? RocketMqReceiveRequest.create(consumerGroup)
+            : RocketMqReceiveRequest.create(consumerGroup, messages);
     Instrumenter<RocketMqReceiveRequest, List<MessageView>> instrumenter =
         simpleConsumerReceiveInstrumenter();
     if (instrumenter.shouldStart(parentContext, request)) {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
@@ -121,13 +121,7 @@ public class SimpleConsumerReceiveOperation {
         simpleConsumerReceiveInstrumenter();
     if (instrumenter.shouldStart(parentContext, request)) {
       InstrumenterUtil.startAndEnd(
-          instrumenter,
-          parentContext,
-          request,
-          messages,
-          error,
-          timer.startTime(),
-          timer.now());
+          instrumenter, parentContext, request, messages, error, timer.startTime(), timer.now());
     }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerReceiveOperation.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0.RocketMqSingletons.simpleConsumerReceiveInstrumenter;
+import static java.util.Collections.emptyList;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
+import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.javaagent.bootstrap.ExceptionLogger;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.rocketmq.client.apis.consumer.FilterExpression;
+import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
+import org.apache.rocketmq.client.apis.message.MessageView;
+import org.apache.rocketmq.shaded.com.google.common.util.concurrent.FutureCallback;
+import org.apache.rocketmq.shaded.com.google.common.util.concurrent.Futures;
+import org.apache.rocketmq.shaded.com.google.common.util.concurrent.ListenableFuture;
+import org.apache.rocketmq.shaded.com.google.common.util.concurrent.MoreExecutors;
+
+public class SimpleConsumerReceiveOperation {
+
+  private final String consumerGroup;
+  @Nullable private final String subscribedTopic;
+  private final Context parentContext;
+  private final Timer timer;
+
+  /**
+   * Returns whether the receive that {@code consumer} is about to perform is recorded here instead
+   * of by the per-message-queue instrumentation underneath it.
+   */
+  public static boolean handlesReceive(Object consumer) {
+    return emitStableMessagingSemconv() && consumer instanceof SimpleConsumer;
+  }
+
+  @Nullable
+  public static SimpleConsumerReceiveOperation start(SimpleConsumer consumer) {
+    if (!emitStableMessagingSemconv()) {
+      return null;
+    }
+    return new SimpleConsumerReceiveOperation(
+        consumer.getConsumerGroup(),
+        singleSubscribedTopic(consumer),
+        Context.current(),
+        Timer.start());
+  }
+
+  /**
+   * Returns the only topic this consumer subscribes to, or {@code null} when it subscribes to
+   * several. It is the destination of a pull that came back with no messages to read it from.
+   */
+  @Nullable
+  private static String singleSubscribedTopic(SimpleConsumer consumer) {
+    Map<String, FilterExpression> subscriptions = consumer.getSubscriptionExpressions();
+    if (subscriptions.size() != 1) {
+      return null;
+    }
+    return subscriptions.keySet().iterator().next();
+  }
+
+  private SimpleConsumerReceiveOperation(
+      String consumerGroup, @Nullable String subscribedTopic, Context parentContext, Timer timer) {
+    this.consumerGroup = consumerGroup;
+    this.subscribedTopic = subscribedTopic;
+    this.parentContext = parentContext;
+    this.timer = timer;
+  }
+
+  public ListenableFuture<List<MessageView>> wrap(
+      ListenableFuture<List<MessageView>> originalFuture) {
+    Futures.addCallback(
+        originalFuture,
+        new FutureCallback<List<MessageView>>() {
+          @Override
+          public void onSuccess(List<MessageView> unused) {}
+
+          @Override
+          public void onFailure(Throwable t) {
+            endSafely(null, t);
+          }
+        },
+        MoreExecutors.directExecutor());
+    return Futures.transform(
+        originalFuture,
+        messages -> {
+          endSuccessfully(messages);
+          return messages;
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  private void endSuccessfully(List<MessageView> messages) {
+    try {
+      end(messages, null);
+    } catch (Throwable t) {
+      ExceptionLogger.logSuppressedError("Error instrumenting RocketMQ SimpleConsumer receive", t);
+    }
+  }
+
+  private void endSafely(@Nullable List<MessageView> messages, Throwable error) {
+    try {
+      end(messages, error);
+    } catch (Throwable t) {
+      ExceptionLogger.logSuppressedError(
+          "Error instrumenting RocketMQ SimpleConsumer receive failure", t);
+    }
+  }
+
+  private void end(@Nullable List<MessageView> messages, @Nullable Throwable error) {
+    List<MessageView> requestMessages = messages == null ? emptyList() : messages;
+    RocketMqReceiveRequest request =
+        RocketMqReceiveRequest.create(consumerGroup, subscribedTopic, requestMessages);
+    Instrumenter<RocketMqReceiveRequest, List<MessageView>> instrumenter =
+        simpleConsumerReceiveInstrumenter();
+    if (instrumenter.shouldStart(parentContext, request)) {
+      InstrumenterUtil.startAndEnd(
+          instrumenter,
+          parentContext,
+          request,
+          messages,
+          error,
+          timer.startTime(),
+          timer.now());
+    }
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v5_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.rocketmq.client.apis.ClientConfiguration;
+import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.ClientServiceProvider;
+import org.apache.rocketmq.client.apis.consumer.FilterExpression;
+import org.apache.rocketmq.client.apis.consumer.FilterExpressionType;
+import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
+import org.apache.rocketmq.client.apis.message.Message;
+import org.apache.rocketmq.client.apis.message.MessageView;
+import org.apache.rocketmq.client.apis.producer.Producer;
+import org.apache.rocketmq.client.apis.producer.SendReceipt;
+import org.apache.rocketmq.client.java.impl.ClientImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@SuppressWarnings("deprecation") // using deprecated semconv
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RocketMqSimpleConsumerTest {
+
+  private static final String TOPIC = "normal-topic-0";
+  private static final String TAG = "tagA";
+  private static final String CONSUMER_GROUP = "simple-consumer-group";
+  private static final String EMPTY_CONSUMER_GROUP = "empty-simple-consumer-group";
+  private static final String[] KEYS = {"simple-key-0", "simple-key-1"};
+  private static final byte[] BODY = "simple-consumer".getBytes(UTF_8);
+  private static final boolean RECEIVE_TELEMETRY_ENABLED =
+      Boolean.getBoolean("otel.instrumentation.messaging.experimental.receive-telemetry.enabled");
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  private final ClientServiceProvider provider = ClientServiceProvider.loadService();
+  private final RocketMqProxyContainer container = new RocketMqProxyContainer();
+  private SimpleConsumer consumer;
+  private Producer producer;
+
+  @BeforeAll
+  void setUp() throws ClientException {
+    container.start();
+    cleanup.deferAfterAll(container::close);
+    ClientConfiguration clientConfiguration =
+        ClientConfiguration.newBuilder()
+            .setEndpoints(container.endpoints)
+            .setRequestTimeout(Duration.ofSeconds(10))
+            .build();
+    Map<String, FilterExpression> subscriptionExpressions = new HashMap<>();
+    subscriptionExpressions.put(TOPIC, new FilterExpression(TAG, FilterExpressionType.TAG));
+    consumer =
+        provider
+            .newSimpleConsumerBuilder()
+            .setClientConfiguration(clientConfiguration)
+            .setConsumerGroup(CONSUMER_GROUP)
+            .setAwaitDuration(Duration.ofSeconds(5))
+            .setSubscriptionExpressions(subscriptionExpressions)
+            .build();
+    cleanup.deferAfterAll(() -> ((ClientImpl) consumer).stopAsync());
+    producer =
+        provider
+            .newProducerBuilder()
+            .setClientConfiguration(clientConfiguration)
+            .setTopics(TOPIC)
+            .build();
+    cleanup.deferAfterAll(producer);
+  }
+
+  @Test
+  void shouldInstrumentSynchronousReceive() throws ClientException {
+    assumeTrue(emitStableMessagingSemconv());
+    SpanData sendSpan = sendMessage();
+
+    testing.runWithSpan(
+        "sync receive parent",
+        () -> {
+          List<MessageView> messages = consumer.receive(1, Duration.ofSeconds(10));
+          for (MessageView message : messages) {
+            consumer.ack(message);
+          }
+        });
+
+    assertSuccessfulReceiveTrace("sync receive parent", sendSpan);
+  }
+
+  @Test
+  void shouldInstrumentAsynchronousReceive() throws ClientException {
+    assumeTrue(emitStableMessagingSemconv());
+    SpanData sendSpan = sendMessage();
+
+    List<MessageView> messages =
+        testing.runWithSpan(
+            "async receive parent", () -> consumer.receiveAsync(1, Duration.ofSeconds(10)).join());
+    for (MessageView message : messages) {
+      consumer.ack(message);
+    }
+
+    assertSuccessfulReceiveTrace("async receive parent", sendSpan);
+  }
+
+  @Test
+  void shouldInstrumentEmptySynchronousAndAsynchronousReceive() throws ClientException {
+    assumeTrue(emitStableMessagingSemconv());
+
+    Map<String, FilterExpression> subscriptionExpressions = new HashMap<>();
+    subscriptionExpressions.put(
+        TOPIC, new FilterExpression("missing-tag", FilterExpressionType.TAG));
+    SimpleConsumer emptyConsumer =
+        provider
+            .newSimpleConsumerBuilder()
+            .setClientConfiguration(
+                ClientConfiguration.newBuilder()
+                    .setEndpoints(container.endpoints)
+                    .setRequestTimeout(Duration.ofSeconds(10))
+                    .build())
+            .setConsumerGroup(EMPTY_CONSUMER_GROUP)
+            .setAwaitDuration(Duration.ofSeconds(1))
+            .setSubscriptionExpressions(subscriptionExpressions)
+            .build();
+    cleanup.deferCleanup(() -> ((ClientImpl) emptyConsumer).stopAsync());
+
+    List<MessageView> syncMessages =
+        testing.runWithSpan(
+            "sync empty parent", () -> emptyConsumer.receive(1, Duration.ofSeconds(1)));
+    List<MessageView> asyncMessages =
+        testing.runWithSpan(
+            "async empty parent",
+            () -> emptyConsumer.receiveAsync(1, Duration.ofSeconds(1)).join());
+
+    assertThat(syncMessages).isEmpty();
+    assertThat(asyncMessages).isEmpty();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("sync empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertEmptyReceiveSpan(span, EMPTY_CONSUMER_GROUP).hasParent(trace.getSpan(0))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("async empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertEmptyReceiveSpan(span, EMPTY_CONSUMER_GROUP)
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldInstrumentReceiveWhenReceiveTelemetryDisabled() throws ClientException {
+    assumeTrue(emitStableMessagingSemconv());
+    assumeFalse(RECEIVE_TELEMETRY_ENABLED);
+    SpanData sendSpan = sendMessage();
+
+    testing.runWithSpan(
+        "disabled receive parent",
+        () -> {
+          List<MessageView> messages = consumer.receive(1, Duration.ofSeconds(10));
+          assertThat(messages).hasSize(1);
+          consumer.ack(messages.get(0));
+        });
+
+    assertSuccessfulReceiveTrace("disabled receive parent", sendSpan);
+  }
+
+  @Test
+  void shouldPreserveLegacySuccessfulReceive() throws ClientException {
+    assumeFalse(emitStableMessagingSemconv());
+    sendMessage();
+
+    testing.runWithSpan(
+        "legacy receive parent",
+        () -> {
+          List<MessageView> messages = consumer.receive(1, Duration.ofSeconds(10));
+          for (MessageView message : messages) {
+            testing.runWithSpan("legacy process child", () -> {});
+            consumer.ack(message);
+          }
+        });
+
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanKind(SpanKind.CONSUMER, SpanKind.INTERNAL),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName(TOPIC + " receive").hasKind(SpanKind.CONSUMER).hasNoParent()),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("legacy receive parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("legacy process child")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldInstrumentSynchronousReceiveErrorOnlyInStableMode() {
+    assertThatThrownBy(
+            () ->
+                testing.runWithSpan(
+                    "sync error parent", () -> consumer.receive(0, Duration.ofSeconds(1))))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertReceiveErrorTrace("sync error parent");
+  }
+
+  @Test
+  void shouldInstrumentAsynchronousReceiveErrorOnlyInStableMode() {
+    assertThatThrownBy(
+            () ->
+                testing.runWithSpan(
+                    "async error parent",
+                    () -> consumer.receiveAsync(0, Duration.ofSeconds(1)).join()))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+
+    assertReceiveErrorTrace("async error parent");
+  }
+
+  private SpanData sendMessage() throws ClientException {
+    Message message =
+        provider
+            .newMessageBuilder()
+            .setTopic(TOPIC)
+            .setTag(TAG)
+            .setKeys(KEYS)
+            .setBody(BODY)
+            .build();
+    SendReceipt receipt = producer.send(message);
+    AtomicReference<SpanData> sendSpan = new AtomicReference<>();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> {
+                  span.hasKind(SpanKind.PRODUCER)
+                      .hasName(emitStableMessagingSemconv() ? "send " + TOPIC : TOPIC + " publish")
+                      .hasAttribute(MESSAGING_MESSAGE_ID, receipt.getMessageId().toString());
+                  sendSpan.set(span.actual());
+                }));
+    testing.clearData();
+    return sendSpan.get();
+  }
+
+  private static void assertSuccessfulReceiveTrace(String parentName, SpanData sendSpan) {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertReceiveSpan(span, sendSpan).hasParent(trace.getSpan(0))));
+  }
+
+  private static void assertReceiveErrorTrace(String parentName) {
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      span.hasName("receive " + TOPIC)
+                          .hasKind(SpanKind.CLIENT)
+                          .hasStatus(StatusData.error())
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+                              equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                              equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+                              equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                              equalTo(MESSAGING_OPERATION_TYPE, "receive"),
+                              equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()))));
+      return;
+    }
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent()));
+  }
+
+  private static SpanDataAssert assertReceiveSpan(SpanDataAssert span, SpanData sendSpan) {
+    return span.hasKind(SpanKind.CLIENT)
+        .hasName("receive " + TOPIC)
+        .hasStatus(StatusData.unset())
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+            equalTo(MESSAGING_ROCKETMQ_NAMESPACE, ""),
+            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+            equalTo(MESSAGING_OPERATION_NAME, "receive"),
+            equalTo(MESSAGING_OPERATION_TYPE, "receive"),
+            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1))
+        .hasLinks(LinkData.create(sendSpan.getSpanContext()));
+  }
+
+  private static SpanDataAssert assertEmptyReceiveSpan(SpanDataAssert span, String consumerGroup) {
+    return span.hasKind(SpanKind.CLIENT)
+        .hasName("receive " + TOPIC)
+        .hasStatus(StatusData.unset())
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_CONSUMER_GROUP_NAME, consumerGroup),
+            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+            equalTo(MESSAGING_OPERATION_NAME, "receive"),
+            equalTo(MESSAGING_OPERATION_TYPE, "receive"),
+            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 0));
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
@@ -138,7 +138,7 @@ class RocketMqSimpleConsumerTest {
   }
 
   @Test
-  void shouldInstrumentEmptySynchronousAndAsynchronousReceive() throws ClientException {
+  void shouldNotInstrumentEmptySynchronousAndAsynchronousReceive() throws ClientException {
     assumeTrue(emitStableMessagingSemconv());
 
     Map<String, FilterExpression> subscriptionExpressions = new HashMap<>();
@@ -172,15 +172,11 @@ class RocketMqSimpleConsumerTest {
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("sync empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                span ->
-                    assertEmptyReceiveSpan(span, EMPTY_CONSUMER_GROUP).hasParent(trace.getSpan(0))),
+                span -> span.hasName("sync empty parent").hasKind(SpanKind.INTERNAL).hasNoParent()),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("async empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    assertEmptyReceiveSpan(span, EMPTY_CONSUMER_GROUP)
-                        .hasParent(trace.getSpan(0))));
+                    span.hasName("async empty parent").hasKind(SpanKind.INTERNAL).hasNoParent()));
   }
 
   @Test
@@ -293,14 +289,13 @@ class RocketMqSimpleConsumerTest {
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent(),
                   span ->
-                      span.hasName("receive " + TOPIC)
+                      span.hasName("receive")
                           .hasKind(SpanKind.CLIENT)
                           .hasStatus(StatusData.error())
                           .hasParent(trace.getSpan(0))
                           .hasAttributesSatisfyingExactly(
                               equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
                               equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                              equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
                               equalTo(MESSAGING_OPERATION_NAME, "receive"),
                               equalTo(MESSAGING_OPERATION_TYPE, "receive"),
                               equalTo(ERROR_TYPE, IllegalArgumentException.class.getName()))));
@@ -325,18 +320,5 @@ class RocketMqSimpleConsumerTest {
             equalTo(MESSAGING_OPERATION_TYPE, "receive"),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 1))
         .hasLinks(LinkData.create(sendSpan.getSpanContext()));
-  }
-
-  private static SpanDataAssert assertEmptyReceiveSpan(SpanDataAssert span, String consumerGroup) {
-    return span.hasKind(SpanKind.CLIENT)
-        .hasName("receive " + TOPIC)
-        .hasStatus(StatusData.unset())
-        .hasAttributesSatisfyingExactly(
-            equalTo(MESSAGING_CONSUMER_GROUP_NAME, consumerGroup),
-            equalTo(MESSAGING_SYSTEM, "rocketmq"),
-            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
-            equalTo(MESSAGING_OPERATION_NAME, "receive"),
-            equalTo(MESSAGING_OPERATION_TYPE, "receive"),
-            equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 0));
   }
 }


### PR DESCRIPTION
RocketMQ 5 `SimpleConsumer.receive` and `receiveAsync` are now recorded as a single application-facing receive operation covering the whole API call, rather than as one operation per underlying network request.

Successful receives are named `receive <topic>` and carry consumer group, destination, RocketMQ namespace, and batch message count, with links to the producer spans of returned messages. Failed pulls are recorded as destination-less `receive` spans with `error.type`.

Empty pulls are deliberately not recorded, consistent with other messaging pull instrumentations and the direction in #19433.

A `SimpleConsumer` pull has no process span to represent delivery, so this receive operation is created under stable messaging semantic conventions even when `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` remains at its default `false`. The low-level per-request receive instrumentation is suppressed for these calls to avoid duplicates; PushConsumer behavior and RocketMQ 4.8 remain unchanged.

Legacy semantic conventions keep their existing per-request behavior. Acknowledgement and invisible-duration operations are unchanged, and no process span is added because the API exposes no reliable processing-completion boundary.

Part of #19254.