### PR TITLE
Migrate Apache Camel messaging telemetry to v1.43

### DIFF
--- a/.github/scripts/instrumentations.sh
+++ b/.github/scripts/instrumentations.sh
@@ -60,6 +60,7 @@ readonly INSTRUMENTATIONS=(
   "camel-2.20:javaagent:test"
   "camel-2.20:javaagent:testExperimental"
   "camel-2.20:javaagent:testStableSemconv"
+  "camel-2.20:javaagent:testV3Preview"
   "cassandra:cassandra-3.0:javaagent:test"
   "cassandra:cassandra-3.0:javaagent:testStableSemconv"
   "cassandra:cassandra-4.0:javaagent:test"

--- a/instrumentation/camel-2.20/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/build.gradle.kts
@@ -9,8 +9,14 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testStableMessagingSemconv = register<Test>("testStableMessagingSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.opt-in=messaging")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testStableMessagingSemconv)
   }
 }
 

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtilTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtilTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.aws.sqs.SqsComponent;
@@ -100,5 +101,19 @@ class CamelPropagationUtilTest {
     SpanContext parentSpanContext = parentSpan.getSpanContext();
     assertThat(parentSpanContext.getTraceId()).isEqualTo("5759e988bd862e3fe1be46a994272793");
     assertThat(parentSpanContext.getSpanId()).isEqualTo("53995c3f42cd8ad8");
+  }
+
+  @Test
+  void shouldClearPropagationFieldsIncludingAwsAlias() {
+    Map<String, Object> exchangeHeaders = new HashMap<>();
+    exchangeHeaders.put("traceparent", "00-1f7f8dab3f0043b1b9cf0a75caf57510-a13825abcb764bd3-01");
+    exchangeHeaders.put(
+        "AWSTraceHeader",
+        "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
+    exchangeHeaders.put("other", "value");
+
+    CamelPropagationUtil.clearPropagationFields(exchangeHeaders);
+
+    assertThat(exchangeHeaders).containsOnlyKeys("other").containsEntry("other", "value");
   }
 }

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.Decorat
 import java.util.stream.Stream;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,5 +48,54 @@ class MessagingDestinationTest {
         argumentSet("AMQP queue", "amqp", "amqp:queue:myQueue", "myQueue"),
         argumentSet("AMQP topic", "amqp", "amqp:topic:myTopic", "myTopic"),
         argumentSet("legacy AMQP alias queue", "ampq", "ampq:queue:myQueue", "myQueue"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("rabbitMqDestinations")
+  void stableRabbitMqDestination(
+      String endpointUri,
+      String headerExchange,
+      String headerRoutingKey,
+      String expectedDestination) {
+    Endpoint endpoint = mock(Endpoint.class);
+    when(endpoint.getEndpointUri()).thenReturn(endpointUri);
+    Exchange exchange = mock(Exchange.class);
+    Message message = mock(Message.class);
+    when(exchange.getIn()).thenReturn(message);
+    when(message.getHeader("rabbitmq.EXCHANGE_NAME", String.class)).thenReturn(headerExchange);
+    when(message.getHeader("rabbitmq.ROUTING_KEY", String.class)).thenReturn(headerRoutingKey);
+
+    CamelRequest request =
+        CamelRequest.create(
+            new DecoratorRegistry().forComponent("rabbitmq"),
+            exchange,
+            endpoint,
+            CamelDirection.OUTBOUND,
+            SpanKind.PRODUCER);
+
+    assertThat(request.getMessagingDestination())
+        .isEqualTo(emitStableMessagingSemconv() ? expectedDestination : null);
+  }
+
+  private static Stream<Arguments> rabbitMqDestinations() {
+    return Stream.of(
+        argumentSet(
+            "endpoint exchange and routing key",
+            "rabbitmq:localhost:5672/orders?routingKey=created",
+            null,
+            null,
+            "orders:created"),
+        argumentSet(
+            "header exchange and routing key override endpoint",
+            "rabbitmq:localhost:5672/orders?routingKey=created",
+            "priority-orders",
+            "priority-created",
+            "priority-orders:priority-created"),
+        argumentSet(
+            "bridge endpoint ignores headers",
+            "rabbitmq:localhost:5672/orders?routingKey=created&bridgeEndpoint=true",
+            "priority-orders",
+            "priority-created",
+            "orders:created"));
   }
 }

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
@@ -53,6 +53,7 @@ class MessagingDestinationTest {
   @ParameterizedTest
   @MethodSource("rabbitMqDestinations")
   void stableRabbitMqDestination(
+      CamelDirection camelDirection,
       String endpointUri,
       String headerExchange,
       String headerRoutingKey,
@@ -70,8 +71,8 @@ class MessagingDestinationTest {
             new DecoratorRegistry().forComponent("rabbitmq"),
             exchange,
             endpoint,
-            CamelDirection.OUTBOUND,
-            SpanKind.PRODUCER);
+            camelDirection,
+            camelDirection == CamelDirection.OUTBOUND ? SpanKind.PRODUCER : SpanKind.CONSUMER);
 
     assertThat(request.getMessagingDestination())
         .isEqualTo(emitStableMessagingSemconv() ? expectedDestination : null);
@@ -80,22 +81,53 @@ class MessagingDestinationTest {
   private static Stream<Arguments> rabbitMqDestinations() {
     return Stream.of(
         argumentSet(
-            "endpoint exchange and routing key",
-            "rabbitmq:localhost:5672/orders?routingKey=created",
+            "outbound queue is ignored",
+            CamelDirection.OUTBOUND,
+            "rabbitmq:localhost:5672/orders?routingKey=created&queue=workers",
             null,
             null,
             "orders:created"),
         argumentSet(
-            "header exchange and routing key override endpoint",
+            "outbound headers override endpoint",
+            CamelDirection.OUTBOUND,
             "rabbitmq:localhost:5672/orders?routingKey=created",
             "priority-orders",
             "priority-created",
             "priority-orders:priority-created"),
         argumentSet(
-            "bridge endpoint ignores headers",
+            "outbound bridge endpoint ignores headers",
+            CamelDirection.OUTBOUND,
             "rabbitmq:localhost:5672/orders?routingKey=created&bridgeEndpoint=true",
             "priority-orders",
             "priority-created",
-            "orders:created"));
+            "orders:created"),
+        argumentSet(
+            "inbound queue is included",
+            CamelDirection.INBOUND,
+            "rabbitmq:localhost:5672/orders?routingKey=created&queue=workers",
+            "orders",
+            "created",
+            "orders:created:workers"),
+        argumentSet(
+            "inbound queue matching routing key is not duplicated",
+            CamelDirection.INBOUND,
+            "rabbitmq:localhost:5672/orders?routingKey=workers&queue=workers",
+            "orders",
+            "workers",
+            "orders:workers"),
+        argumentSet(
+            "inbound bridge endpoint does not ignore headers",
+            CamelDirection.INBOUND,
+            "rabbitmq:localhost:5672/orders?routingKey=created&queue=workers&bridgeEndpoint=true",
+            "priority-orders",
+            "priority-created",
+            "priority-orders:priority-created:workers"),
+        argumentSet(
+            "empty inbound destination",
+            CamelDirection.INBOUND,
+            "rabbitmq:localhost:5672/",
+            null,
+            null,
+            null));
   }
 }

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.DecoratorRegistry;
+import java.util.stream.Stream;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Exchange;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingDestinationTest {
+
+  @ParameterizedTest
+  @MethodSource("destinations")
+  void stableDestination(String component, String endpointUri, String expectedDestination) {
+    Endpoint endpoint = mock(Endpoint.class);
+    when(endpoint.getEndpointUri()).thenReturn(endpointUri);
+
+    CamelRequest request =
+        CamelRequest.create(
+            new DecoratorRegistry().forComponent(component),
+            mock(Exchange.class),
+            endpoint,
+            CamelDirection.OUTBOUND,
+            SpanKind.PRODUCER);
+
+    assertThat(request.getMessagingDestination())
+        .isEqualTo(emitStableMessagingSemconv() ? expectedDestination : null);
+  }
+
+  private static Stream<Arguments> destinations() {
+    return Stream.of(
+        argumentSet("JMS queue", "jms", "jms:queue:myQueue", "myQueue"),
+        argumentSet("JMS topic", "jms", "jms:topic:myTopic", "myTopic"),
+        argumentSet("AMQP queue", "amqp", "amqp:queue:myQueue", "myQueue"),
+        argumentSet("AMQP topic", "amqp", "amqp:topic:myTopic", "myTopic"),
+        argumentSet("legacy AMQP alias queue", "ampq", "ampq:queue:myQueue", "myQueue"));
+  }
+}

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/MessagingDestinationTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType.SEND;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.DecoratorRegistry;
 import java.util.stream.Stream;
 import org.apache.camel.Endpoint;
@@ -25,7 +27,8 @@ class MessagingDestinationTest {
 
   @ParameterizedTest
   @MethodSource("destinations")
-  void stableDestination(String component, String endpointUri, String expectedDestination) {
+  void stableDestination(
+      String component, String endpointUri, String expectedDestination, boolean expectedTemporary) {
     Endpoint endpoint = mock(Endpoint.class);
     when(endpoint.getEndpointUri()).thenReturn(endpointUri);
 
@@ -39,15 +42,26 @@ class MessagingDestinationTest {
 
     assertThat(request.getMessagingDestination())
         .isEqualTo(emitStableMessagingSemconv() ? expectedDestination : null);
+    CamelMessagingAttributesGetter attributesGetter = new CamelMessagingAttributesGetter();
+    assertThat(attributesGetter.isTemporaryDestination(request))
+        .isEqualTo(emitStableMessagingSemconv() && expectedTemporary);
+    if (emitStableMessagingSemconv()) {
+      assertThat(MessagingSpanNameExtractor.create(attributesGetter, SEND, "send").extract(request))
+          .isEqualTo(expectedTemporary ? "send" : "send " + expectedDestination);
+    }
   }
 
   private static Stream<Arguments> destinations() {
     return Stream.of(
-        argumentSet("JMS queue", "jms", "jms:queue:myQueue", "myQueue"),
-        argumentSet("JMS topic", "jms", "jms:topic:myTopic", "myTopic"),
-        argumentSet("AMQP queue", "amqp", "amqp:queue:myQueue", "myQueue"),
-        argumentSet("AMQP topic", "amqp", "amqp:topic:myTopic", "myTopic"),
-        argumentSet("legacy AMQP alias queue", "ampq", "ampq:queue:myQueue", "myQueue"));
+        argumentSet("JMS queue", "jms", "jms:queue:myQueue", "myQueue", false),
+        argumentSet("JMS topic", "jms", "jms:topic:myTopic", "myTopic", false),
+        argumentSet("JMS temporary queue", "jms", "jms:temp-queue:reply", "reply", true),
+        argumentSet("JMS temporary topic", "jms", "jms:temp-topic:reply", "reply", true),
+        argumentSet("AMQP queue", "amqp", "amqp:queue:myQueue", "myQueue", false),
+        argumentSet("AMQP topic", "amqp", "amqp:topic:myTopic", "myTopic", false),
+        argumentSet("AMQP temporary queue", "amqp", "amqp:temp-queue:reply", "reply", true),
+        argumentSet("AMQP temporary topic", "amqp", "amqp:temp-topic:reply", "reply", true),
+        argumentSet("legacy AMQP alias queue", "ampq", "ampq:queue:myQueue", "myQueue", false));
   }
 
   @ParameterizedTest

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingMessageIdTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingMessageIdTest.java
@@ -22,7 +22,7 @@ class MessagingMessageIdTest {
   @ParameterizedTest
   @MethodSource("jmsComponents")
   void jmsMessageId(String component, String system, boolean legacyMessageIdExpected) {
-    MessagingSpanDecorator decorator = new MessagingSpanDecorator(component, system, true);
+    MessagingSpanDecorator decorator = MessagingSpanDecorator.create(component, system);
     Exchange exchange = mock(Exchange.class);
     Message message = mock(Message.class);
     when(exchange.getIn()).thenReturn(message);

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingMessageIdTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingMessageIdTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingMessageIdTest {
+
+  @ParameterizedTest
+  @MethodSource("jmsComponents")
+  void jmsMessageId(String component, String system, boolean legacyMessageIdExpected) {
+    MessagingSpanDecorator decorator = new MessagingSpanDecorator(component, system, true);
+    Exchange exchange = mock(Exchange.class);
+    Message message = mock(Message.class);
+    when(exchange.getIn()).thenReturn(message);
+    when(message.getHeader("JMSMessageID")).thenReturn("ID:123");
+
+    assertThat(decorator.getMessageId(exchange))
+        .isEqualTo(legacyMessageIdExpected ? "ID:123" : null);
+    assertThat(decorator.getStableMessageId(exchange)).isEqualTo("ID:123");
+  }
+
+  private static Stream<Arguments> jmsComponents() {
+    return Stream.of(
+        argumentSet("JMS", "jms", "jms", true),
+        argumentSet("simple JMS", "sjms", "jms", false),
+        argumentSet("AMQP", "amqp", "amqp", false),
+        argumentSet("legacy AMQP alias", "ampq", "amqp", false));
+  }
+}

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingOperationNameTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingOperationNameTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.SpanDecorator;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingOperationNameTest {
+
+  @ParameterizedTest
+  @MethodSource("operationNames")
+  void operationName(String component, String expectedOperationName) {
+    SpanDecorator decorator = new DecoratorRegistry().forComponent(component);
+
+    assertThat(decorator)
+        .isInstanceOfSatisfying(
+            MessagingSpanDecorator.class,
+            messagingDecorator ->
+                assertThat(messagingDecorator.getSendOperationName())
+                    .isEqualTo(expectedOperationName));
+  }
+
+  private static Stream<Arguments> operationNames() {
+    return Stream.of(
+        argumentSet("default send operation", "jms", "send"),
+        argumentSet("RabbitMQ publish operation", "rabbitmq", "publish"));
+  }
+}

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingPropagationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingPropagationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.SpanDecorator;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingPropagationTest {
+
+  @ParameterizedTest
+  @MethodSource("propagationSettings")
+  void spanContextPropagation(String component, boolean expected) {
+    SpanDecorator decorator = new DecoratorRegistry().forComponent(component);
+
+    assertThat(decorator)
+        .isInstanceOfSatisfying(
+            MessagingSpanDecorator.class,
+            messagingDecorator ->
+                assertThat(messagingDecorator.isSpanContextPropagated()).isEqualTo(expected));
+  }
+
+  private static Stream<Arguments> propagationSettings() {
+    return Stream.of(
+        argumentSet("JMS propagates context", "jms", true),
+        argumentSet("Camel MQTT cannot propagate context", "mqtt", false),
+        argumentSet("Paho MQTT cannot propagate context", "paho", false));
+  }
+}

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingPropagationTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingPropagationTest.java
@@ -7,9 +7,12 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.SpanDecorator;
 import java.util.stream.Stream;
+import org.apache.camel.Endpoint;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,20 +21,29 @@ class MessagingPropagationTest {
 
   @ParameterizedTest
   @MethodSource("propagationSettings")
-  void spanContextPropagation(String component, boolean expected) {
+  void spanContextPropagation(String component, String endpointUri, boolean expected) {
     SpanDecorator decorator = new DecoratorRegistry().forComponent(component);
+    Endpoint endpoint = mock(Endpoint.class);
+    when(endpoint.getEndpointUri()).thenReturn(endpointUri);
 
     assertThat(decorator)
         .isInstanceOfSatisfying(
             MessagingSpanDecorator.class,
             messagingDecorator ->
-                assertThat(messagingDecorator.isSpanContextPropagated()).isEqualTo(expected));
+                assertThat(messagingDecorator.isSpanContextPropagated(endpoint))
+                    .isEqualTo(expected));
   }
 
   private static Stream<Arguments> propagationSettings() {
     return Stream.of(
-        argumentSet("JMS propagates context", "jms", true),
-        argumentSet("Camel MQTT cannot propagate context", "mqtt", false),
-        argumentSet("Paho MQTT cannot propagate context", "paho", false));
+        argumentSet("JMS propagates context", "jms", "jms:queue", true),
+        argumentSet("Camel MQTT cannot propagate context", "mqtt", "mqtt:topic", false),
+        argumentSet("Paho MQTT cannot propagate context", "paho", "paho:topic", false),
+        argumentSet("IronMQ drops headers by default", "ironmq", "ironmq:queue", false),
+        argumentSet(
+            "IronMQ propagates preserved headers",
+            "ironmq",
+            "ironmq:queue?preserveHeaders=true",
+            true));
   }
 }

--- a/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSystemTest.java
+++ b/instrumentation/camel-2.20/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSystemTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.SpanDecorator;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MessagingSystemTest {
+
+  @ParameterizedTest
+  @MethodSource("systemMappings")
+  void systemMapping(String component, String expectedSystem) {
+    SpanDecorator decorator = new DecoratorRegistry().forComponent(component);
+
+    assertThat(decorator)
+        .isInstanceOfSatisfying(
+            MessagingSpanDecorator.class,
+            messagingDecorator ->
+                assertThat(messagingDecorator.getSystem()).isEqualTo(expectedSystem));
+  }
+
+  private static Stream<Arguments> systemMappings() {
+    Stream.Builder<Arguments> mappings =
+        Stream.<Arguments>builder()
+            .add(argumentSet("legacy AMQP alias", "ampq", "amqp"))
+            .add(argumentSet("CometD secure alias", "cometds", "cometd"))
+            .add(argumentSet("Paho MQTT alias", "paho", "mqtt"))
+            .add(argumentSet("simple JMS alias", "sjms", "jms"));
+    if (emitStableMessagingSemconv()) {
+      mappings.add(argumentSet("stable AMQP component", "amqp", "amqp"));
+    }
+    return mappings.build();
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-2.0:javaagent"))
   testInstrumentation(project(":instrumentation:servlet:servlet-3.0:javaagent"))
   testInstrumentation(project(":instrumentation:aws-sdk:aws-sdk-1.11:javaagent"))
+  testInstrumentation(project(":instrumentation:jms:jms-1.1:javaagent"))
 
   testInstrumentation(project(":instrumentation:cassandra:cassandra-3.0:javaagent"))
 

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -108,11 +108,7 @@ tasks {
 
     jvmArgs("-Dotel.instrumentation.experimental.span-suppression-strategy=semconv")
     jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty(
-      "metadataConfig",
-      "otel.instrumentation.common.v3-preview=true,otel.semconv-stability.preview=messaging/dup",
-    )
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
   }
 
   check {

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -96,12 +96,23 @@ tasks {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
-    jvmArgs("-Dotel.semconv-stability.opt-in=database")
-    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
+    jvmArgs("-Dotel.instrumentation.experimental.span-suppression-strategy=semconv")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database,messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,messaging")
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.instrumentation.experimental.span-suppression-strategy=semconv")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
   }
 
   check {
-    dependsOn(testStableSemconv, testExperimental)
+    dependsOn(testStableSemconv, testExperimental, testV3Preview)
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/camel-2.20/javaagent/build.gradle.kts
+++ b/instrumentation/camel-2.20/javaagent/build.gradle.kts
@@ -109,7 +109,10 @@ tasks {
     jvmArgs("-Dotel.instrumentation.experimental.span-suppression-strategy=semconv")
     jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    systemProperty(
+      "metadataConfig",
+      "otel.instrumentation.common.v3-preview=true,otel.semconv-stability.preview=messaging/dup",
+    )
   }
 
   check {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/ActiveContextManager.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/ActiveContextManager.java
@@ -111,7 +111,7 @@ class ActiveContextManager {
         return;
       }
       scope.close();
-      instrumenter().end(context, request, null, exception);
+      instrumenter(request).end(context, request, null, exception);
     }
 
     @Override

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
@@ -73,10 +73,10 @@ final class CamelEventNotifier extends EventNotifierSupport {
   @Nullable
   private static Context startOnExchangeSending(CamelRequest request) {
     Context parentContext = Context.current();
-    if (!instrumenter().shouldStart(parentContext, request)) {
+    if (!instrumenter(request).shouldStart(parentContext, request)) {
       return null;
     }
-    return instrumenter().start(parentContext, request);
+    return instrumenter(request).start(parentContext, request);
   }
 
   /** Camel finished sending (outbound). Finish span and remove it from CAMEL holder. */

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
@@ -23,6 +23,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelSingletons.getSpanDecorator;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelSingletons.instrumenter;
 import static java.util.logging.Level.FINE;
@@ -65,7 +66,11 @@ final class CamelEventNotifier extends EventNotifierSupport {
     Context context = startOnExchangeSending(request);
 
     ActiveContextManager.activate(context, request);
-    CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
+    if (!emitStableMessagingSemconv()
+        || !request.isMessaging()
+        || request.isMessagingSpanContextPropagated()) {
+      CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
+    }
 
     logger.log(FINE, "[Exchange sending] Initiator span started: {0}", context);
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
@@ -69,7 +69,8 @@ final class CamelEventNotifier extends EventNotifierSupport {
     if (!emitStableMessagingSemconv()
         || !request.isMessaging()
         || request.isMessagingSpanContextPropagated()) {
-      CamelPropagationUtil.injectParent(context, ese.getExchange().getIn().getHeaders());
+      CamelPropagationUtil.injectParent(
+          context != null ? context : Context.current(), ese.getExchange().getIn().getHeaders());
     }
 
     logger.log(FINE, "[Exchange sending] Initiator span started: {0}", context);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelEventNotifier.java
@@ -71,6 +71,8 @@ final class CamelEventNotifier extends EventNotifierSupport {
         || request.isMessagingSpanContextPropagated()) {
       CamelPropagationUtil.injectParent(
           context != null ? context : Context.current(), ese.getExchange().getIn().getHeaders());
+    } else {
+      CamelPropagationUtil.clearPropagationFields(ese.getExchange().getIn().getHeaders());
     }
 
     logger.log(FINE, "[Exchange sending] Initiator span started: {0}", context);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
@@ -32,7 +32,7 @@ final class CamelMessagingAttributesGetter
 
   @Override
   public boolean isTemporaryDestination(CamelRequest request) {
-    return false;
+    return request.isMessagingDestinationTemporary();
   }
 
   @Override

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.MessagingSpanDecorator;
 import javax.annotation.Nullable;
 
 final class CamelMessagingAttributesGetter
@@ -60,7 +61,8 @@ final class CamelMessagingAttributesGetter
   @Nullable
   @Override
   public String getMessageId(CamelRequest request, @Nullable Void unused) {
-    return request.getMessagingMessageId();
+    MessagingSpanDecorator spanDecorator = (MessagingSpanDecorator) request.getSpanDecorator();
+    return spanDecorator.getMessageId(request.getExchange());
   }
 
   @Nullable

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import javax.annotation.Nullable;
+
+final class CamelMessagingAttributesGetter
+    implements MessagingAttributesGetter<CamelRequest, Void> {
+
+  @Nullable
+  @Override
+  public String getSystem(CamelRequest request) {
+    return request.getMessagingSystem();
+  }
+
+  @Nullable
+  @Override
+  public String getDestination(CamelRequest request) {
+    return request.getMessagingDestination();
+  }
+
+  @Nullable
+  @Override
+  public String getDestinationTemplate(CamelRequest request) {
+    return null;
+  }
+
+  @Override
+  public boolean isTemporaryDestination(CamelRequest request) {
+    return false;
+  }
+
+  @Override
+  public boolean isAnonymousDestination(CamelRequest request) {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getConversationId(CamelRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageBodySize(CamelRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageEnvelopeSize(CamelRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getMessageId(CamelRequest request, @Nullable Void unused) {
+    return request.getMessagingMessageId();
+  }
+
+  @Nullable
+  @Override
+  public String getClientId(CamelRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getBatchMessageCount(CamelRequest request, @Nullable Void unused) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getDestinationPartitionId(CamelRequest request) {
+    return request.getMessagingDestinationPartitionId();
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelMessagingAttributesGetter.java
@@ -62,7 +62,7 @@ final class CamelMessagingAttributesGetter
   @Override
   public String getMessageId(CamelRequest request, @Nullable Void unused) {
     MessagingSpanDecorator spanDecorator = (MessagingSpanDecorator) request.getSpanDecorator();
-    return spanDecorator.getMessageId(request.getExchange());
+    return spanDecorator.getStableMessageId(request.getExchange());
   }
 
   @Nullable

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
@@ -114,7 +114,7 @@ final class CamelPropagationUtil {
       }
       Map<String, Object> headers = request.getExchange().getIn().getHeaders();
       Object value =
-          "X-Amzn-Trace-Id".equals(key) ? headers.get("AWSTraceHeader") : headers.get(key);
+          key.equals("X-Amzn-Trace-Id") ? headers.get("AWSTraceHeader") : headers.get(key);
       return value == null ? null : value.toString();
     }
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
@@ -56,6 +56,12 @@ final class CamelPropagationUtil {
         .inject(context, exchangeHeaders, MapSetter.INSTANCE);
   }
 
+  static void clearPropagationFields(Map<String, Object> exchangeHeaders) {
+    for (String field : GlobalOpenTelemetry.getPropagators().getTextMapPropagator().fields()) {
+      exchangeHeaders.remove(field);
+    }
+  }
+
   static TextMapPropagator messagingPropagator() {
     return messagingPropagator;
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
@@ -10,13 +10,19 @@ import static java.util.Collections.singletonMap;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
 
 final class CamelPropagationUtil {
+
+  private static final TextMapPropagator messagingPropagator = new CamelMessagingPropagator();
 
   private CamelPropagationUtil() {}
 
@@ -48,6 +54,62 @@ final class CamelPropagationUtil {
     GlobalOpenTelemetry.getPropagators()
         .getTextMapPropagator()
         .inject(context, exchangeHeaders, MapSetter.INSTANCE);
+  }
+
+  static TextMapPropagator messagingPropagator() {
+    return messagingPropagator;
+  }
+
+  static TextMapGetter<CamelRequest> messagingGetter() {
+    return CamelRequestGetter.INSTANCE;
+  }
+
+  private static class CamelMessagingPropagator implements TextMapPropagator {
+
+    @Override
+    public Collection<String> fields() {
+      Set<String> fields =
+          new HashSet<>(GlobalOpenTelemetry.getPropagators().getTextMapPropagator().fields());
+      fields.addAll(AwsXrayPropagator.getInstance().fields());
+      return fields;
+    }
+
+    @Override
+    public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+      GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(context, carrier, setter);
+    }
+
+    @Override
+    public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+      if (carrier instanceof CamelRequest
+          && isAwsPropagated(((CamelRequest) carrier).getEndpoint())) {
+        return AwsXrayPropagator.getInstance().extract(context, carrier, getter);
+      }
+      return GlobalOpenTelemetry.getPropagators()
+          .getTextMapPropagator()
+          .extract(context, carrier, getter);
+    }
+  }
+
+  private enum CamelRequestGetter implements TextMapGetter<CamelRequest> {
+    INSTANCE;
+
+    @Override
+    public Iterable<String> keys(CamelRequest request) {
+      return request.getExchange().getIn().getHeaders().keySet();
+    }
+
+    @Override
+    @Nullable
+    public String get(@Nullable CamelRequest request, String key) {
+      if (request == null) {
+        return null;
+      }
+      Map<String, Object> headers = request.getExchange().getIn().getHeaders();
+      Object value =
+          "X-Amzn-Trace-Id".equals(key) ? headers.get("AWSTraceHeader") : headers.get(key);
+      return value == null ? null : value.toString();
+    }
   }
 
   private enum MapGetter implements TextMapGetter<Map<String, Object>> {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelPropagationUtil.java
@@ -60,6 +60,7 @@ final class CamelPropagationUtil {
     for (String field : GlobalOpenTelemetry.getPropagators().getTextMapPropagator().fields()) {
       exchangeHeaders.remove(field);
     }
+    exchangeHeaders.remove("AWSTraceHeader");
   }
 
   static TextMapPropagator messagingPropagator() {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.MessagingSpanDecorator;
+import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
@@ -19,7 +21,30 @@ abstract class CamelRequest {
       Endpoint endpoint,
       CamelDirection camelDirection,
       SpanKind spanKind) {
-    return new AutoValue_CamelRequest(spanDecorator, exchange, endpoint, camelDirection, spanKind);
+    String messagingSystem = null;
+    String messagingDestination = null;
+    String messagingMessageId = null;
+    String messagingDestinationPartitionId = null;
+    boolean messagingSpanContextPropagated = false;
+    if (spanDecorator instanceof MessagingSpanDecorator) {
+      MessagingSpanDecorator messagingSpanDecorator = (MessagingSpanDecorator) spanDecorator;
+      messagingSystem = messagingSpanDecorator.getSystem();
+      messagingDestination = messagingSpanDecorator.getDestination(exchange, endpoint);
+      messagingMessageId = messagingSpanDecorator.getMessageId(exchange);
+      messagingDestinationPartitionId = messagingSpanDecorator.getDestinationPartitionId(exchange);
+      messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
+    }
+    return new AutoValue_CamelRequest(
+        spanDecorator,
+        exchange,
+        endpoint,
+        camelDirection,
+        spanKind,
+        messagingSystem,
+        messagingDestination,
+        messagingMessageId,
+        messagingDestinationPartitionId,
+        messagingSpanContextPropagated);
   }
 
   abstract SpanDecorator getSpanDecorator();
@@ -31,4 +56,22 @@ abstract class CamelRequest {
   abstract CamelDirection getCamelDirection();
 
   abstract SpanKind getSpanKind();
+
+  boolean isMessaging() {
+    return getMessagingSystem() != null;
+  }
+
+  @Nullable
+  abstract String getMessagingSystem();
+
+  @Nullable
+  abstract String getMessagingDestination();
+
+  @Nullable
+  abstract String getMessagingMessageId();
+
+  @Nullable
+  abstract String getMessagingDestinationPartitionId();
+
+  abstract boolean isMessagingSpanContextPropagated();
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -29,7 +29,9 @@ abstract class CamelRequest {
     if (spanDecorator instanceof MessagingSpanDecorator) {
       MessagingSpanDecorator messagingSpanDecorator = (MessagingSpanDecorator) spanDecorator;
       messagingSystem = messagingSpanDecorator.getSystem();
-      messagingDestination = messagingSpanDecorator.getDestination(exchange, endpoint);
+      messagingDestination =
+          normalizeStableMessagingDestination(
+              messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
       messagingMessageId = messagingSpanDecorator.getMessageId(exchange);
       messagingDestinationPartitionId = messagingSpanDecorator.getDestinationPartitionId(exchange);
       messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
@@ -45,6 +47,21 @@ abstract class CamelRequest {
         messagingMessageId,
         messagingDestinationPartitionId,
         messagingSpanContextPropagated);
+  }
+
+  @Nullable
+  private static String normalizeStableMessagingDestination(
+      String messagingSystem, @Nullable String messagingDestination) {
+    if (!messagingSystem.equals("jms") || messagingDestination == null) {
+      return messagingDestination;
+    }
+    if (messagingDestination.startsWith("queue:")) {
+      return messagingDestination.substring("queue:".length());
+    }
+    if (messagingDestination.startsWith("topic:")) {
+      return messagingDestination.substring("topic:".length());
+    }
+    return messagingDestination;
   }
 
   abstract SpanDecorator getSpanDecorator();

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -57,7 +57,10 @@ abstract class CamelRequest {
   @Nullable
   private static String normalizeStableMessagingDestination(
       String messagingSystem, @Nullable String messagingDestination) {
-    if (!messagingSystem.equals("jms") || messagingDestination == null) {
+    // the amqp component is the jms component with an amqp connection factory, so both use the
+    // [queue:|topic:]destinationName endpoint syntax
+    if (messagingDestination == null
+        || (!messagingSystem.equals("jms") && !messagingSystem.equals("amqp"))) {
       return messagingDestination;
     }
     if (messagingDestination.startsWith("queue:")) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -34,7 +34,8 @@ abstract class CamelRequest {
       if (emitStableMessagingSemconv()) {
         messagingDestination =
             normalizeStableMessagingDestination(
-                messagingSystem, messagingSpanDecorator.getStableDestination(exchange, endpoint));
+                messagingSystem,
+                messagingSpanDecorator.getStableDestination(exchange, endpoint, camelDirection));
         messagingDestinationPartitionId =
             messagingSpanDecorator.getDestinationPartitionId(exchange);
       }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.MessagingSpanDecorator;
@@ -29,10 +31,13 @@ abstract class CamelRequest {
     if (spanDecorator instanceof MessagingSpanDecorator) {
       MessagingSpanDecorator messagingSpanDecorator = (MessagingSpanDecorator) spanDecorator;
       messagingSystem = messagingSpanDecorator.getSystem();
-      messagingDestination =
-          normalizeStableMessagingDestination(
-              messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
-      messagingDestinationPartitionId = messagingSpanDecorator.getDestinationPartitionId(exchange);
+      if (emitStableMessagingSemconv()) {
+        messagingDestination =
+            normalizeStableMessagingDestination(
+                messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
+        messagingDestinationPartitionId =
+            messagingSpanDecorator.getDestinationPartitionId(exchange);
+      }
       messagingSendOperationName = messagingSpanDecorator.getSendOperationName();
       messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
     }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -23,7 +23,6 @@ abstract class CamelRequest {
       SpanKind spanKind) {
     String messagingSystem = null;
     String messagingDestination = null;
-    String messagingMessageId = null;
     String messagingDestinationPartitionId = null;
     boolean messagingSpanContextPropagated = false;
     if (spanDecorator instanceof MessagingSpanDecorator) {
@@ -32,7 +31,6 @@ abstract class CamelRequest {
       messagingDestination =
           normalizeStableMessagingDestination(
               messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
-      messagingMessageId = messagingSpanDecorator.getMessageId(exchange);
       messagingDestinationPartitionId = messagingSpanDecorator.getDestinationPartitionId(exchange);
       messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
     }
@@ -44,7 +42,6 @@ abstract class CamelRequest {
         spanKind,
         messagingSystem,
         messagingDestination,
-        messagingMessageId,
         messagingDestinationPartitionId,
         messagingSpanContextPropagated);
   }
@@ -83,9 +80,6 @@ abstract class CamelRequest {
 
   @Nullable
   abstract String getMessagingDestination();
-
-  @Nullable
-  abstract String getMessagingMessageId();
 
   @Nullable
   abstract String getMessagingDestinationPartitionId();

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -27,15 +27,18 @@ abstract class CamelRequest {
     String messagingDestination = null;
     String messagingDestinationPartitionId = null;
     String messagingSendOperationName = null;
+    boolean messagingDestinationTemporary = false;
     boolean messagingSpanContextPropagated = false;
     if (spanDecorator instanceof MessagingSpanDecorator) {
       MessagingSpanDecorator messagingSpanDecorator = (MessagingSpanDecorator) spanDecorator;
       messagingSystem = messagingSpanDecorator.getSystem();
       if (emitStableMessagingSemconv()) {
+        String stableMessagingDestination =
+            messagingSpanDecorator.getStableDestination(exchange, endpoint, camelDirection);
         messagingDestination =
-            normalizeStableMessagingDestination(
-                messagingSystem,
-                messagingSpanDecorator.getStableDestination(exchange, endpoint, camelDirection));
+            normalizeStableMessagingDestination(messagingSystem, stableMessagingDestination);
+        messagingDestinationTemporary =
+            isTemporaryStableMessagingDestination(messagingSystem, stableMessagingDestination);
         messagingDestinationPartitionId =
             messagingSpanDecorator.getDestinationPartitionId(exchange);
       }
@@ -52,6 +55,7 @@ abstract class CamelRequest {
         messagingDestination,
         messagingDestinationPartitionId,
         messagingSendOperationName,
+        messagingDestinationTemporary,
         messagingSpanContextPropagated);
   }
 
@@ -59,9 +63,8 @@ abstract class CamelRequest {
   private static String normalizeStableMessagingDestination(
       String messagingSystem, @Nullable String messagingDestination) {
     // the amqp component is the jms component with an amqp connection factory, so both use the
-    // [queue:|topic:]destinationName endpoint syntax
-    if (messagingDestination == null
-        || (!messagingSystem.equals("jms") && !messagingSystem.equals("amqp"))) {
+    // [queue:|topic:|temp-queue:|temp-topic:]destinationName endpoint syntax
+    if (messagingDestination == null || !isJmsMessagingSystem(messagingSystem)) {
       return messagingDestination;
     }
     if (messagingDestination.startsWith("queue:")) {
@@ -70,7 +73,25 @@ abstract class CamelRequest {
     if (messagingDestination.startsWith("topic:")) {
       return messagingDestination.substring("topic:".length());
     }
+    if (messagingDestination.startsWith("temp-queue:")) {
+      return messagingDestination.substring("temp-queue:".length());
+    }
+    if (messagingDestination.startsWith("temp-topic:")) {
+      return messagingDestination.substring("temp-topic:".length());
+    }
     return messagingDestination;
+  }
+
+  private static boolean isTemporaryStableMessagingDestination(
+      String messagingSystem, @Nullable String messagingDestination) {
+    return messagingDestination != null
+        && isJmsMessagingSystem(messagingSystem)
+        && (messagingDestination.startsWith("temp-queue:")
+            || messagingDestination.startsWith("temp-topic:"));
+  }
+
+  private static boolean isJmsMessagingSystem(String messagingSystem) {
+    return messagingSystem.equals("jms") || messagingSystem.equals("amqp");
   }
 
   abstract SpanDecorator getSpanDecorator();
@@ -98,6 +119,8 @@ abstract class CamelRequest {
 
   @Nullable
   abstract String getMessagingSendOperationName();
+
+  abstract boolean isMessagingDestinationTemporary();
 
   abstract boolean isMessagingSpanContextPropagated();
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -34,7 +34,8 @@ abstract class CamelRequest {
       if (emitStableMessagingSemconv()) {
         messagingDestination =
             normalizeStableMessagingDestination(
-                messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
+                messagingSystem,
+                messagingSpanDecorator.getStableDestination(exchange, endpoint));
         messagingDestinationPartitionId =
             messagingSpanDecorator.getDestinationPartitionId(exchange);
       }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -39,7 +39,8 @@ abstract class CamelRequest {
             messagingSpanDecorator.getDestinationPartitionId(exchange);
       }
       messagingSendOperationName = messagingSpanDecorator.getSendOperationName();
-      messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
+      messagingSpanContextPropagated =
+          messagingSpanDecorator.isSpanContextPropagated(endpoint);
     }
     return new AutoValue_CamelRequest(
         spanDecorator,

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -34,14 +34,12 @@ abstract class CamelRequest {
       if (emitStableMessagingSemconv()) {
         messagingDestination =
             normalizeStableMessagingDestination(
-                messagingSystem,
-                messagingSpanDecorator.getStableDestination(exchange, endpoint));
+                messagingSystem, messagingSpanDecorator.getStableDestination(exchange, endpoint));
         messagingDestinationPartitionId =
             messagingSpanDecorator.getDestinationPartitionId(exchange);
       }
       messagingSendOperationName = messagingSpanDecorator.getSendOperationName();
-      messagingSpanContextPropagated =
-          messagingSpanDecorator.isSpanContextPropagated(endpoint);
+      messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated(endpoint);
     }
     return new AutoValue_CamelRequest(
         spanDecorator,

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRequest.java
@@ -24,6 +24,7 @@ abstract class CamelRequest {
     String messagingSystem = null;
     String messagingDestination = null;
     String messagingDestinationPartitionId = null;
+    String messagingSendOperationName = null;
     boolean messagingSpanContextPropagated = false;
     if (spanDecorator instanceof MessagingSpanDecorator) {
       MessagingSpanDecorator messagingSpanDecorator = (MessagingSpanDecorator) spanDecorator;
@@ -32,6 +33,7 @@ abstract class CamelRequest {
           normalizeStableMessagingDestination(
               messagingSystem, messagingSpanDecorator.getDestination(exchange, endpoint));
       messagingDestinationPartitionId = messagingSpanDecorator.getDestinationPartitionId(exchange);
+      messagingSendOperationName = messagingSpanDecorator.getSendOperationName();
       messagingSpanContextPropagated = messagingSpanDecorator.isSpanContextPropagated();
     }
     return new AutoValue_CamelRequest(
@@ -43,6 +45,7 @@ abstract class CamelRequest {
         messagingSystem,
         messagingDestination,
         messagingDestinationPartitionId,
+        messagingSendOperationName,
         messagingSpanContextPropagated);
   }
 
@@ -83,6 +86,9 @@ abstract class CamelRequest {
 
   @Nullable
   abstract String getMessagingDestinationPartitionId();
+
+  @Nullable
+  abstract String getMessagingSendOperationName();
 
   abstract boolean isMessagingSpanContextPropagated();
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRoutePolicy.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelRoutePolicy.java
@@ -23,6 +23,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelSingletons.getSpanDecorator;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelSingletons.instrumenter;
 import static java.util.logging.Level.FINE;
@@ -44,20 +45,20 @@ final class CamelRoutePolicy extends RoutePolicySupport {
   private static Context spanOnExchangeBegin(
       Route route, Exchange exchange, SpanDecorator sd, Context parentContext) {
     Span activeSpan = Span.fromContext(parentContext);
-    if (!activeSpan.getSpanContext().isValid()) {
-      parentContext =
-          CamelPropagationUtil.extractParent(exchange.getIn().getHeaders(), route.getEndpoint());
-    }
-
     SpanKind spanKind = spanKind(activeSpan, sd);
     CamelRequest request =
         CamelRequest.create(sd, exchange, route.getEndpoint(), CamelDirection.INBOUND, spanKind);
+    if (!activeSpan.getSpanContext().isValid()
+        && !(request.isMessaging() && emitStableMessagingSemconv())) {
+      parentContext =
+          CamelPropagationUtil.extractParent(exchange.getIn().getHeaders(), route.getEndpoint());
+    }
     sd.updateServerSpanName(parentContext, exchange, route.getEndpoint(), CamelDirection.INBOUND);
 
-    if (!instrumenter().shouldStart(parentContext, request)) {
+    if (!instrumenter(request).shouldStart(parentContext, request)) {
       return null;
     }
-    Context context = instrumenter().start(parentContext, request);
+    Context context = instrumenter(request).start(parentContext, request);
     ActiveContextManager.activate(context, request);
     return context;
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -5,10 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType.PROCESS;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType.SEND;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
@@ -24,9 +34,13 @@ class CamelSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.camel-2.20";
 
   private static final DecoratorRegistry registry = new DecoratorRegistry();
-  private static final Instrumenter<CamelRequest, Void> instrumenter;
+  private static final Instrumenter<CamelRequest, Void> instrumenter = createInstrumenter();
+  private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
+      createMessagingInstrumenter(SEND, "send");
+  private static final Instrumenter<CamelRequest, Void> messagingProcessInstrumenter =
+      createMessagingInstrumenter(PROCESS, "process");
 
-  static {
+  private static Instrumenter<CamelRequest, Void> createInstrumenter() {
     SpanNameExtractor<CamelRequest> spanNameExtractor =
         camelRequest ->
             camelRequest
@@ -36,48 +50,66 @@ class CamelSingletons {
                     camelRequest.getEndpoint(),
                     camelRequest.getCamelDirection());
 
-    AttributesExtractor<CamelRequest, Void> attributesExtractor =
-        new AttributesExtractor<CamelRequest, Void>() {
+    return instrumenterBuilder(spanNameExtractor).buildInstrumenter(CamelRequest::getSpanKind);
+  }
 
-          @Override
-          public void onStart(
-              AttributesBuilder attributes, Context parentContext, CamelRequest camelRequest) {
-            SpanDecorator spanDecorator = camelRequest.getSpanDecorator();
-            spanDecorator.pre(
-                attributes,
-                camelRequest.getExchange(),
-                camelRequest.getEndpoint(),
-                camelRequest.getCamelDirection());
-          }
+  private static Instrumenter<CamelRequest, Void> createMessagingInstrumenter(
+      MessagingOperationType operationType, String operationName) {
+    MessagingAttributesGetter<CamelRequest, Void> getter = new CamelMessagingAttributesGetter();
+    SpanNameExtractor<CamelRequest> legacySpanNameExtractor =
+        request ->
+            request
+                .getSpanDecorator()
+                .getOperationName(
+                    request.getExchange(), request.getEndpoint(), request.getCamelDirection());
+    SpanNameExtractor<CamelRequest> spanNameExtractor =
+        emitStableMessagingSemconv()
+            ? MessagingSpanNameExtractor.create(getter, operationType, operationName)
+            : legacySpanNameExtractor;
+    InstrumenterBuilder<CamelRequest, Void> builder = instrumenterBuilder(spanNameExtractor);
+    if (emitStableMessagingSemconv()) {
+      builder.addAttributesExtractor(
+          new CamelMessagingAttributesExtractor(
+              MessagingAttributesExtractor.create(getter, operationType, operationName)));
+    }
 
-          @Override
-          public void onEnd(
-              AttributesBuilder attributes,
-              Context context,
-              CamelRequest camelRequest,
-              @Nullable Void unused,
-              @Nullable Throwable error) {
-            SpanDecorator spanDecorator = camelRequest.getSpanDecorator();
-            spanDecorator.post(attributes, camelRequest.getExchange(), camelRequest.getEndpoint());
-          }
-        };
+    if (operationType == PROCESS && emitStableMessagingSemconv()) {
+      return MessagingProcessInstrumenterFactory.create(
+          builder,
+          CamelPropagationUtil.messagingPropagator(),
+          CamelPropagationUtil.messagingGetter(),
+          false);
+    }
+    if (emitStableMessagingSemconv()) {
+      return builder.buildInstrumenter(
+          operationType == SEND
+              ? MessagingSpanKindExtractor.create(
+                  operationType, CamelRequest::isMessagingSpanContextPropagated)
+              : MessagingSpanKindExtractor.create(operationType));
+    }
+    return builder.buildInstrumenter(CamelRequest::getSpanKind);
+  }
 
+  private static InstrumenterBuilder<CamelRequest, Void> instrumenterBuilder(
+      SpanNameExtractor<CamelRequest> spanNameExtractor) {
     SpanStatusExtractor<CamelRequest, Void> spanStatusExtractor =
         (spanStatusBuilder, request, unused, error) -> {
           if (request.getExchange().isFailed()) {
             spanStatusBuilder.setStatus(StatusCode.ERROR);
           }
         };
-
-    InstrumenterBuilder<CamelRequest, Void> builder =
-        Instrumenter.builder(GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor);
-    builder.addAttributesExtractor(attributesExtractor);
-    builder.setSpanStatusExtractor(spanStatusExtractor);
-
-    instrumenter = builder.buildInstrumenter(request -> request.getSpanKind());
+    return Instrumenter.<CamelRequest, Void>builder(
+            GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor)
+        .addAttributesExtractor(new CamelAttributesExtractor())
+        .setSpanStatusExtractor(spanStatusExtractor);
   }
 
-  static Instrumenter<CamelRequest, Void> instrumenter() {
+  static Instrumenter<CamelRequest, Void> instrumenter(CamelRequest request) {
+    if (request.isMessaging()) {
+      return request.getCamelDirection() == CamelDirection.OUTBOUND
+          ? messagingSendInstrumenter
+          : messagingProcessInstrumenter;
+    }
     return instrumenter;
   }
 
@@ -89,6 +121,58 @@ class CamelSingletons {
       component = splitUri[0];
     }
     return registry.forComponent(component);
+  }
+
+  private static class CamelAttributesExtractor implements AttributesExtractor<CamelRequest, Void> {
+
+    @Override
+    public void onStart(
+        AttributesBuilder attributes, Context parentContext, CamelRequest camelRequest) {
+      SpanDecorator spanDecorator = camelRequest.getSpanDecorator();
+      spanDecorator.pre(
+          attributes,
+          camelRequest.getExchange(),
+          camelRequest.getEndpoint(),
+          camelRequest.getCamelDirection());
+    }
+
+    @Override
+    public void onEnd(
+        AttributesBuilder attributes,
+        Context context,
+        CamelRequest camelRequest,
+        @Nullable Void unused,
+        @Nullable Throwable error) {
+      SpanDecorator spanDecorator = camelRequest.getSpanDecorator();
+      spanDecorator.post(attributes, camelRequest.getExchange(), camelRequest.getEndpoint());
+    }
+  }
+
+  private static class CamelMessagingAttributesExtractor
+      implements AttributesExtractor<CamelRequest, Void> {
+
+    // Do not expose the messaging span key: AWS SDK must still create the producer span that
+    // injects SQS/SNS propagation when the surrounding Camel send span is a client span.
+    private final AttributesExtractor<CamelRequest, Void> delegate;
+
+    private CamelMessagingAttributesExtractor(AttributesExtractor<CamelRequest, Void> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onStart(AttributesBuilder attributes, Context parentContext, CamelRequest request) {
+      delegate.onStart(attributes, parentContext, request);
+    }
+
+    @Override
+    public void onEnd(
+        AttributesBuilder attributes,
+        Context context,
+        CamelRequest request,
+        @Nullable Void unused,
+        @Nullable Throwable error) {
+      delegate.onEnd(attributes, context, request, null, error);
+    }
   }
 
   private CamelSingletons() {}

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -37,6 +37,8 @@ class CamelSingletons {
   private static final Instrumenter<CamelRequest, Void> instrumenter = createInstrumenter();
   private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", true);
+  private static final Instrumenter<CamelRequest, Void> messagingPublishInstrumenter =
+      createMessagingInstrumenter(SEND, "publish", true);
   // AWS SQS sends rely on the nested AWS SDK producer span to inject propagation.
   private static final Instrumenter<CamelRequest, Void> keylessMessagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", false);
@@ -113,9 +115,12 @@ class CamelSingletons {
   static Instrumenter<CamelRequest, Void> instrumenter(CamelRequest request) {
     if (request.isMessaging()) {
       if (request.getCamelDirection() == CamelDirection.OUTBOUND) {
-        return request.isMessagingSpanContextPropagated()
-            ? messagingSendInstrumenter
-            : keylessMessagingSendInstrumenter;
+        if (!request.isMessagingSpanContextPropagated()) {
+          return keylessMessagingSendInstrumenter;
+        }
+        return "publish".equals(request.getMessagingSendOperationName())
+            ? messagingPublishInstrumenter
+            : messagingSendInstrumenter;
       }
       return messagingProcessInstrumenter;
     }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -90,10 +90,8 @@ class CamelSingletons {
     }
     if (emitStableMessagingSemconv()) {
       return builder.buildInstrumenter(
-          operationType == SEND
-              ? MessagingSpanKindExtractor.create(
-                  operationType, CamelRequest::isMessagingSpanContextPropagated)
-              : MessagingSpanKindExtractor.create(operationType));
+          MessagingSpanKindExtractor.create(
+              operationType, CamelRequest::isMessagingSpanContextPropagated));
     }
     return builder.buildInstrumenter(CamelRequest::getSpanKind);
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -36,9 +36,12 @@ class CamelSingletons {
   private static final DecoratorRegistry registry = new DecoratorRegistry();
   private static final Instrumenter<CamelRequest, Void> instrumenter = createInstrumenter();
   private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
-      createMessagingInstrumenter(SEND, "send");
+      createMessagingInstrumenter(SEND, "send", true);
+  // AWS SQS/SNS sends rely on the nested AWS SDK producer span to inject propagation.
+  private static final Instrumenter<CamelRequest, Void> keylessMessagingSendInstrumenter =
+      createMessagingInstrumenter(SEND, "send", false);
   private static final Instrumenter<CamelRequest, Void> messagingProcessInstrumenter =
-      createMessagingInstrumenter(PROCESS, "process");
+      createMessagingInstrumenter(PROCESS, "process", true);
 
   private static Instrumenter<CamelRequest, Void> createInstrumenter() {
     SpanNameExtractor<CamelRequest> spanNameExtractor =
@@ -54,7 +57,7 @@ class CamelSingletons {
   }
 
   private static Instrumenter<CamelRequest, Void> createMessagingInstrumenter(
-      MessagingOperationType operationType, String operationName) {
+      MessagingOperationType operationType, String operationName, boolean exposeSpanKey) {
     MessagingAttributesGetter<CamelRequest, Void> getter = new CamelMessagingAttributesGetter();
     SpanNameExtractor<CamelRequest> legacySpanNameExtractor =
         request ->
@@ -68,9 +71,12 @@ class CamelSingletons {
             : legacySpanNameExtractor;
     InstrumenterBuilder<CamelRequest, Void> builder = instrumenterBuilder(spanNameExtractor);
     if (emitStableMessagingSemconv()) {
+      AttributesExtractor<CamelRequest, Void> attributesExtractor =
+          MessagingAttributesExtractor.create(getter, operationType, operationName);
       builder.addAttributesExtractor(
-          new CamelMessagingAttributesExtractor(
-              MessagingAttributesExtractor.create(getter, operationType, operationName)));
+          exposeSpanKey
+              ? attributesExtractor
+              : new KeylessAttributesExtractor(attributesExtractor));
     }
 
     if (operationType == PROCESS && emitStableMessagingSemconv()) {
@@ -106,9 +112,12 @@ class CamelSingletons {
 
   static Instrumenter<CamelRequest, Void> instrumenter(CamelRequest request) {
     if (request.isMessaging()) {
-      return request.getCamelDirection() == CamelDirection.OUTBOUND
-          ? messagingSendInstrumenter
-          : messagingProcessInstrumenter;
+      if (request.getCamelDirection() == CamelDirection.OUTBOUND) {
+        return request.isMessagingSpanContextPropagated()
+            ? messagingSendInstrumenter
+            : keylessMessagingSendInstrumenter;
+      }
+      return messagingProcessInstrumenter;
     }
     return instrumenter;
   }
@@ -148,14 +157,12 @@ class CamelSingletons {
     }
   }
 
-  private static class CamelMessagingAttributesExtractor
+  private static class KeylessAttributesExtractor
       implements AttributesExtractor<CamelRequest, Void> {
 
-    // Do not expose the messaging span key: AWS SDK must still create the producer span that
-    // injects SQS/SNS propagation when the surrounding Camel send span is a client span.
     private final AttributesExtractor<CamelRequest, Void> delegate;
 
-    private CamelMessagingAttributesExtractor(AttributesExtractor<CamelRequest, Void> delegate) {
+    private KeylessAttributesExtractor(AttributesExtractor<CamelRequest, Void> delegate) {
       this.delegate = delegate;
     }
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -41,7 +41,7 @@ class CamelSingletons {
       createHttpClientInstrumenter();
   private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", true);
-  // AWS SQS/SNS sends rely on the nested AWS SDK producer span to inject propagation.
+  // AWS SQS sends rely on the nested AWS SDK producer span to inject propagation.
   private static final Instrumenter<CamelRequest, Void> keylessMessagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", false);
   private static final Instrumenter<CamelRequest, Void> messagingProcessInstrumenter =

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -136,7 +136,8 @@ class CamelSingletons {
       }
       return messagingProcessInstrumenter;
     }
-    if (request.getCamelDirection() == CamelDirection.OUTBOUND
+    if (emitStableMessagingSemconv()
+        && request.getCamelDirection() == CamelDirection.OUTBOUND
         && request.getSpanDecorator().isHttp()) {
       return httpClientInstrumenter;
     }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -24,6 +24,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.SpanKey;
+import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.DecoratorRegistry;
 import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
@@ -35,6 +37,8 @@ class CamelSingletons {
 
   private static final DecoratorRegistry registry = new DecoratorRegistry();
   private static final Instrumenter<CamelRequest, Void> instrumenter = createInstrumenter();
+  private static final Instrumenter<CamelRequest, Void> httpClientInstrumenter =
+      createHttpClientInstrumenter();
   private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", true);
   // AWS SQS/SNS sends rely on the nested AWS SDK producer span to inject propagation.
@@ -44,6 +48,11 @@ class CamelSingletons {
       createMessagingInstrumenter(PROCESS, "process", true);
 
   private static Instrumenter<CamelRequest, Void> createInstrumenter() {
+    return createInstrumenter(false);
+  }
+
+  private static Instrumenter<CamelRequest, Void> createInstrumenter(
+      boolean exposeHttpClientSpanKey) {
     SpanNameExtractor<CamelRequest> spanNameExtractor =
         camelRequest ->
             camelRequest
@@ -53,7 +62,15 @@ class CamelSingletons {
                     camelRequest.getEndpoint(),
                     camelRequest.getCamelDirection());
 
-    return instrumenterBuilder(spanNameExtractor).buildInstrumenter(CamelRequest::getSpanKind);
+    InstrumenterBuilder<CamelRequest, Void> builder = instrumenterBuilder(spanNameExtractor);
+    if (exposeHttpClientSpanKey) {
+      builder.addAttributesExtractor(new HttpClientSuppressionAttributesExtractor());
+    }
+    return builder.buildInstrumenter(CamelRequest::getSpanKind);
+  }
+
+  private static Instrumenter<CamelRequest, Void> createHttpClientInstrumenter() {
+    return createInstrumenter(true);
   }
 
   private static Instrumenter<CamelRequest, Void> createMessagingInstrumenter(
@@ -119,6 +136,10 @@ class CamelSingletons {
       }
       return messagingProcessInstrumenter;
     }
+    if (request.getCamelDirection() == CamelDirection.OUTBOUND
+        && request.getSpanDecorator().isHttp()) {
+      return httpClientInstrumenter;
+    }
     return instrumenter;
   }
 
@@ -179,6 +200,27 @@ class CamelSingletons {
         @Nullable Void unused,
         @Nullable Throwable error) {
       delegate.onEnd(attributes, context, request, null, error);
+    }
+  }
+
+  private static class HttpClientSuppressionAttributesExtractor
+      implements AttributesExtractor<CamelRequest, Void>, SpanKeyProvider {
+
+    @Override
+    public void onStart(
+        AttributesBuilder attributes, Context parentContext, CamelRequest request) {}
+
+    @Override
+    public void onEnd(
+        AttributesBuilder attributes,
+        Context context,
+        CamelRequest request,
+        @Nullable Void unused,
+        @Nullable Throwable error) {}
+
+    @Override
+    public SpanKey internalGetSpanKey() {
+      return SpanKey.HTTP_CLIENT;
     }
   }
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -24,8 +24,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
-import io.opentelemetry.instrumentation.api.internal.SpanKey;
-import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.DecoratorRegistry;
 import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
@@ -37,8 +35,6 @@ class CamelSingletons {
 
   private static final DecoratorRegistry registry = new DecoratorRegistry();
   private static final Instrumenter<CamelRequest, Void> instrumenter = createInstrumenter();
-  private static final Instrumenter<CamelRequest, Void> httpClientInstrumenter =
-      createHttpClientInstrumenter();
   private static final Instrumenter<CamelRequest, Void> messagingSendInstrumenter =
       createMessagingInstrumenter(SEND, "send", true);
   // AWS SQS sends rely on the nested AWS SDK producer span to inject propagation.
@@ -48,11 +44,6 @@ class CamelSingletons {
       createMessagingInstrumenter(PROCESS, "process", true);
 
   private static Instrumenter<CamelRequest, Void> createInstrumenter() {
-    return createInstrumenter(false);
-  }
-
-  private static Instrumenter<CamelRequest, Void> createInstrumenter(
-      boolean exposeHttpClientSpanKey) {
     SpanNameExtractor<CamelRequest> spanNameExtractor =
         camelRequest ->
             camelRequest
@@ -62,15 +53,7 @@ class CamelSingletons {
                     camelRequest.getEndpoint(),
                     camelRequest.getCamelDirection());
 
-    InstrumenterBuilder<CamelRequest, Void> builder = instrumenterBuilder(spanNameExtractor);
-    if (exposeHttpClientSpanKey) {
-      builder.addAttributesExtractor(new HttpClientSuppressionAttributesExtractor());
-    }
-    return builder.buildInstrumenter(CamelRequest::getSpanKind);
-  }
-
-  private static Instrumenter<CamelRequest, Void> createHttpClientInstrumenter() {
-    return createInstrumenter(true);
+    return instrumenterBuilder(spanNameExtractor).buildInstrumenter(CamelRequest::getSpanKind);
   }
 
   private static Instrumenter<CamelRequest, Void> createMessagingInstrumenter(
@@ -136,11 +119,6 @@ class CamelSingletons {
       }
       return messagingProcessInstrumenter;
     }
-    if (emitStableMessagingSemconv()
-        && request.getCamelDirection() == CamelDirection.OUTBOUND
-        && request.getSpanDecorator().isHttp()) {
-      return httpClientInstrumenter;
-    }
     return instrumenter;
   }
 
@@ -201,27 +179,6 @@ class CamelSingletons {
         @Nullable Void unused,
         @Nullable Throwable error) {
       delegate.onEnd(attributes, context, request, null, error);
-    }
-  }
-
-  private static class HttpClientSuppressionAttributesExtractor
-      implements AttributesExtractor<CamelRequest, Void>, SpanKeyProvider {
-
-    @Override
-    public void onStart(
-        AttributesBuilder attributes, Context parentContext, CamelRequest request) {}
-
-    @Override
-    public void onEnd(
-        AttributesBuilder attributes,
-        Context context,
-        CamelRequest request,
-        @Nullable Void unused,
-        @Nullable Throwable error) {}
-
-    @Override
-    public SpanKey internalGetSpanKey() {
-      return SpanKey.HTTP_CLIENT;
     }
   }
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SpanDecorator.java
@@ -79,6 +79,9 @@ public interface SpanDecorator {
   /** Returns the 'span.kind' value for use when the component is receiving a communication. */
   SpanKind getReceiverSpanKind();
 
+  /** Returns whether this decorator represents HTTP telemetry. */
+  boolean isHttp();
+
   void updateServerSpanName(
       Context context, Exchange exchange, Endpoint endpoint, CamelDirection camelDirection);
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SpanDecorator.java
@@ -79,9 +79,6 @@ public interface SpanDecorator {
   /** Returns the 'span.kind' value for use when the component is receiving a communication. */
   SpanKind getReceiverSpanKind();
 
-  /** Returns whether this decorator represents HTTP telemetry. */
-  boolean isHttp();
-
   void updateServerSpanName(
       Context context, Exchange exchange, Endpoint endpoint, CamelDirection camelDirection);
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/BaseSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/BaseSpanDecorator.java
@@ -122,6 +122,11 @@ class BaseSpanDecorator implements SpanDecorator {
   }
 
   @Override
+  public boolean isHttp() {
+    return false;
+  }
+
+  @Override
   public void updateServerSpanName(
       Context context, Exchange exchange, Endpoint endpoint, CamelDirection camelDirection) {}
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/BaseSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/BaseSpanDecorator.java
@@ -122,11 +122,6 @@ class BaseSpanDecorator implements SpanDecorator {
   }
 
   @Override
-  public boolean isHttp() {
-    return false;
-  }
-
-  @Override
   public void updateServerSpanName(
       Context context, Exchange exchange, Endpoint endpoint, CamelDirection camelDirection) {}
 }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.SpanDecorator;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import java.util.HashMap;
@@ -18,12 +20,15 @@ public class DecoratorRegistry {
   private static Map<String, SpanDecorator> loadDecorators() {
     Map<String, SpanDecorator> result = new HashMap<>();
     result.put("ahc", new HttpSpanDecorator());
-    result.put("ampq", new MessagingSpanDecorator("ampq"));
+    registerMessaging(result, "ampq");
+    if (emitStableMessagingSemconv()) {
+      registerMessaging(result, "amqp");
+    }
     result.put("aws-s3", new S3SpanDecorator());
-    result.put("aws-sns", new MessagingSpanDecorator("aws-sns"));
-    result.put("aws-sqs", new MessagingSpanDecorator("aws-sqs"));
-    result.put("cometd", new MessagingSpanDecorator("cometd"));
-    result.put("cometds", new MessagingSpanDecorator("cometds"));
+    registerMessaging(result, "aws-sns", "aws.sns", false);
+    registerMessaging(result, "aws-sqs", "aws_sqs", false);
+    registerMessaging(result, "cometd");
+    registerMessaging(result, "cometds");
     result.put("cql", new DbSpanDecorator("cql", DbSystemNameIncubatingValues.CASSANDRA));
     result.put("direct", new InternalSpanDecorator());
     result.put("direct-vm", new InternalSpanDecorator());
@@ -37,29 +42,46 @@ public class DecoratorRegistry {
     result.put("http4", new Http4SpanDecorator());
     result.put("https4", new Https4SpanDecorator());
     result.put("http", new HttpSpanDecorator());
-    result.put("ironmq", new MessagingSpanDecorator("ironmq"));
+    registerMessaging(result, "ironmq");
     result.put("jdbc", new DbSpanDecorator("jdbc", DbSystemNameIncubatingValues.OTHER_SQL));
     result.put("jetty", new HttpSpanDecorator());
-    result.put("jms", new MessagingSpanDecorator("jms"));
+    registerMessaging(result, "jms");
     result.put("kafka", new KafkaSpanDecorator());
     result.put("log", new LogSpanDecorator());
     result.put("mongodb", new DbSpanDecorator("mongodb", DbSystemNameIncubatingValues.MONGODB));
-    result.put("mqtt", new MessagingSpanDecorator("mqtt"));
+    registerMessaging(result, "mqtt");
     result.put("netty-http4", new HttpSpanDecorator());
     result.put("netty-http", new HttpSpanDecorator());
-    result.put("paho", new MessagingSpanDecorator("paho"));
-    result.put("rabbitmq", new MessagingSpanDecorator("rabbitmq"));
+    registerMessaging(result, "paho");
+    registerMessaging(result, "rabbitmq");
     result.put("restlet", new HttpSpanDecorator());
     result.put("rest", new RestSpanDecorator());
     result.put("seda", new InternalSpanDecorator());
     result.put("servlet", new HttpSpanDecorator());
-    result.put("sjms", new MessagingSpanDecorator("sjms"));
+    registerMessaging(result, "sjms", "jms");
     result.put("sql", new DbSpanDecorator("sql", DbSystemNameIncubatingValues.OTHER_SQL));
-    result.put("stomp", new MessagingSpanDecorator("stomp"));
+    registerMessaging(result, "stomp");
     result.put("timer", new TimerSpanDecorator());
     result.put("undertow", new HttpSpanDecorator());
     result.put("vm", new InternalSpanDecorator());
     return result;
+  }
+
+  private static void registerMessaging(
+      Map<String, SpanDecorator> decorators,
+      String component,
+      String system,
+      boolean spanContextPropagated) {
+    decorators.put(component, new MessagingSpanDecorator(component, system, spanContextPropagated));
+  }
+
+  private static void registerMessaging(
+      Map<String, SpanDecorator> decorators, String component, String system) {
+    registerMessaging(decorators, component, system, true);
+  }
+
+  private static void registerMessaging(Map<String, SpanDecorator> decorators, String component) {
+    registerMessaging(decorators, component, component);
   }
 
   public SpanDecorator forComponent(String component) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -53,7 +53,7 @@ public class DecoratorRegistry {
     result.put("netty-http4", new HttpSpanDecorator());
     result.put("netty-http", new HttpSpanDecorator());
     registerMessaging(result, "paho", "mqtt");
-    registerMessaging(result, "rabbitmq");
+    registerMessagingWithSendOperation(result, "rabbitmq", "publish");
     result.put("restlet", new HttpSpanDecorator());
     result.put("rest", new RestSpanDecorator());
     result.put("seda", new InternalSpanDecorator());
@@ -72,7 +72,18 @@ public class DecoratorRegistry {
       String component,
       String system,
       boolean spanContextPropagated) {
-    decorators.put(component, new MessagingSpanDecorator(component, system, spanContextPropagated));
+    registerMessaging(decorators, component, system, spanContextPropagated, "send");
+  }
+
+  private static void registerMessaging(
+      Map<String, SpanDecorator> decorators,
+      String component,
+      String system,
+      boolean spanContextPropagated,
+      String sendOperationName) {
+    decorators.put(
+        component,
+        new MessagingSpanDecorator(component, system, spanContextPropagated, sendOperationName));
   }
 
   private static void registerMessaging(
@@ -82,6 +93,11 @@ public class DecoratorRegistry {
 
   private static void registerMessaging(Map<String, SpanDecorator> decorators, String component) {
     registerMessaging(decorators, component, component);
+  }
+
+  private static void registerMessagingWithSendOperation(
+      Map<String, SpanDecorator> decorators, String component, String sendOperationName) {
+    registerMessaging(decorators, component, component, true, sendOperationName);
   }
 
   public SpanDecorator forComponent(String component) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -25,7 +25,7 @@ public class DecoratorRegistry {
       registerMessaging(result, "amqp");
     }
     result.put("aws-s3", new S3SpanDecorator());
-    registerMessaging(result, "aws-sns", "aws.sns", false);
+    registerMessaging(result, "aws-sns", "aws.sns");
     registerMessaging(result, "aws-sqs", "aws_sqs", false);
     registerMessaging(result, "cometd");
     registerMessaging(result, "cometds", "cometd");

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -28,7 +28,7 @@ public class DecoratorRegistry {
     registerMessaging(result, "aws-sns", "aws.sns", false);
     registerMessaging(result, "aws-sqs", "aws_sqs", false);
     registerMessaging(result, "cometd");
-    registerMessaging(result, "cometds");
+    registerMessaging(result, "cometds", "cometd");
     result.put("cql", new DbSpanDecorator("cql", DbSystemNameIncubatingValues.CASSANDRA));
     result.put("direct", new InternalSpanDecorator());
     result.put("direct-vm", new InternalSpanDecorator());
@@ -52,7 +52,7 @@ public class DecoratorRegistry {
     registerMessaging(result, "mqtt");
     result.put("netty-http4", new HttpSpanDecorator());
     result.put("netty-http", new HttpSpanDecorator());
-    registerMessaging(result, "paho");
+    registerMessaging(result, "paho", "mqtt");
     registerMessaging(result, "rabbitmq");
     result.put("restlet", new HttpSpanDecorator());
     result.put("rest", new RestSpanDecorator());

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -20,15 +20,15 @@ public class DecoratorRegistry {
   private static Map<String, SpanDecorator> loadDecorators() {
     Map<String, SpanDecorator> result = new HashMap<>();
     result.put("ahc", new HttpSpanDecorator());
-    registerMessaging(result, "ampq", "amqp");
+    result.put("ampq", MessagingSpanDecorator.create("ampq", "amqp"));
     if (emitStableMessagingSemconv()) {
-      registerMessaging(result, "amqp");
+      result.put("amqp", MessagingSpanDecorator.create("amqp"));
     }
     result.put("aws-s3", new S3SpanDecorator());
-    registerMessaging(result, "aws-sns", "aws.sns");
-    registerMessaging(result, "aws-sqs", "aws_sqs", false);
-    registerMessaging(result, "cometd");
-    registerMessaging(result, "cometds", "cometd");
+    result.put("aws-sns", MessagingSpanDecorator.create("aws-sns", "aws.sns"));
+    result.put("aws-sqs", MessagingSpanDecorator.create("aws-sqs", "aws_sqs", false));
+    result.put("cometd", MessagingSpanDecorator.create("cometd"));
+    result.put("cometds", MessagingSpanDecorator.create("cometds", "cometd"));
     result.put("cql", new DbSpanDecorator("cql", DbSystemNameIncubatingValues.CASSANDRA));
     result.put("direct", new InternalSpanDecorator());
     result.put("direct-vm", new InternalSpanDecorator());
@@ -42,62 +42,29 @@ public class DecoratorRegistry {
     result.put("http4", new Http4SpanDecorator());
     result.put("https4", new Https4SpanDecorator());
     result.put("http", new HttpSpanDecorator());
-    registerMessaging(result, "ironmq");
+    result.put("ironmq", MessagingSpanDecorator.create("ironmq"));
     result.put("jdbc", new DbSpanDecorator("jdbc", DbSystemNameIncubatingValues.OTHER_SQL));
     result.put("jetty", new HttpSpanDecorator());
-    registerMessaging(result, "jms");
+    result.put("jms", MessagingSpanDecorator.create("jms"));
     result.put("kafka", new KafkaSpanDecorator());
     result.put("log", new LogSpanDecorator());
     result.put("mongodb", new DbSpanDecorator("mongodb", DbSystemNameIncubatingValues.MONGODB));
-    registerMessaging(result, "mqtt", "mqtt", false);
+    result.put("mqtt", MessagingSpanDecorator.create("mqtt", "mqtt", false));
     result.put("netty-http4", new HttpSpanDecorator());
     result.put("netty-http", new HttpSpanDecorator());
-    registerMessaging(result, "paho", "mqtt", false);
-    registerMessagingWithSendOperation(result, "rabbitmq", "publish");
+    result.put("paho", MessagingSpanDecorator.create("paho", "mqtt", false));
+    result.put("rabbitmq", MessagingSpanDecorator.create("rabbitmq", "rabbitmq", true, "publish"));
     result.put("restlet", new HttpSpanDecorator());
     result.put("rest", new RestSpanDecorator());
     result.put("seda", new InternalSpanDecorator());
     result.put("servlet", new HttpSpanDecorator());
-    registerMessaging(result, "sjms", "jms");
+    result.put("sjms", MessagingSpanDecorator.create("sjms", "jms"));
     result.put("sql", new DbSpanDecorator("sql", DbSystemNameIncubatingValues.OTHER_SQL));
-    registerMessaging(result, "stomp");
+    result.put("stomp", MessagingSpanDecorator.create("stomp"));
     result.put("timer", new TimerSpanDecorator());
     result.put("undertow", new HttpSpanDecorator());
     result.put("vm", new InternalSpanDecorator());
     return result;
-  }
-
-  private static void registerMessaging(
-      Map<String, SpanDecorator> decorators,
-      String component,
-      String system,
-      boolean spanContextPropagated) {
-    registerMessaging(decorators, component, system, spanContextPropagated, "send");
-  }
-
-  private static void registerMessaging(
-      Map<String, SpanDecorator> decorators,
-      String component,
-      String system,
-      boolean spanContextPropagated,
-      String sendOperationName) {
-    decorators.put(
-        component,
-        new MessagingSpanDecorator(component, system, spanContextPropagated, sendOperationName));
-  }
-
-  private static void registerMessaging(
-      Map<String, SpanDecorator> decorators, String component, String system) {
-    registerMessaging(decorators, component, system, true);
-  }
-
-  private static void registerMessaging(Map<String, SpanDecorator> decorators, String component) {
-    registerMessaging(decorators, component, component);
-  }
-
-  private static void registerMessagingWithSendOperation(
-      Map<String, SpanDecorator> decorators, String component, String sendOperationName) {
-    registerMessaging(decorators, component, component, true, sendOperationName);
   }
 
   public SpanDecorator forComponent(String component) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -49,10 +49,10 @@ public class DecoratorRegistry {
     result.put("kafka", new KafkaSpanDecorator());
     result.put("log", new LogSpanDecorator());
     result.put("mongodb", new DbSpanDecorator("mongodb", DbSystemNameIncubatingValues.MONGODB));
-    registerMessaging(result, "mqtt");
+    registerMessaging(result, "mqtt", "mqtt", false);
     result.put("netty-http4", new HttpSpanDecorator());
     result.put("netty-http", new HttpSpanDecorator());
-    registerMessaging(result, "paho", "mqtt");
+    registerMessaging(result, "paho", "mqtt", false);
     registerMessagingWithSendOperation(result, "rabbitmq", "publish");
     result.put("restlet", new HttpSpanDecorator());
     result.put("rest", new RestSpanDecorator());

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/DecoratorRegistry.java
@@ -20,7 +20,7 @@ public class DecoratorRegistry {
   private static Map<String, SpanDecorator> loadDecorators() {
     Map<String, SpanDecorator> result = new HashMap<>();
     result.put("ahc", new HttpSpanDecorator());
-    registerMessaging(result, "ampq");
+    registerMessaging(result, "ampq", "amqp");
     if (emitStableMessagingSemconv()) {
       registerMessaging(result, "amqp");
     }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
@@ -56,6 +56,11 @@ class HttpSpanDecorator extends BaseSpanDecorator {
     return "http";
   }
 
+  @Override
+  public boolean isHttp() {
+    return true;
+  }
+
   protected static String getHttpMethod(Exchange exchange, Endpoint endpoint) {
     // 1. Use method provided in header.
     Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/HttpSpanDecorator.java
@@ -56,11 +56,6 @@ class HttpSpanDecorator extends BaseSpanDecorator {
     return "http";
   }
 
-  @Override
-  public boolean isHttp() {
-    return true;
-  }
-
   protected static String getHttpMethod(Exchange exchange, Endpoint endpoint) {
     // 1. Use method provided in header.
     Object method = exchange.getIn().getHeader(Exchange.HTTP_METHOD);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/KafkaSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/KafkaSpanDecorator.java
@@ -30,6 +30,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelDirection;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
@@ -81,6 +82,7 @@ class KafkaSpanDecorator extends MessagingSpanDecorator {
     }
   }
 
+  @Nullable
   @Override
   public String getDestinationPartitionId(Exchange exchange) {
     Integer partition = exchange.getIn().getHeader(PARTITION, Integer.class);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/KafkaSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/KafkaSpanDecorator.java
@@ -23,6 +23,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 
@@ -41,7 +42,7 @@ class KafkaSpanDecorator extends MessagingSpanDecorator {
   private static final String OFFSET = "kafka.OFFSET";
 
   public KafkaSpanDecorator() {
-    super("kafka");
+    super("kafka", "kafka", true);
   }
 
   @Override
@@ -63,11 +64,9 @@ class KafkaSpanDecorator extends MessagingSpanDecorator {
       CamelDirection camelDirection) {
     super.pre(attributes, exchange, endpoint, camelDirection);
 
-    attributes.put(MESSAGING_OPERATION, "process");
-
-    Integer partition = exchange.getIn().getHeader(PARTITION, Integer.class);
-    if (partition != null) {
-      attributes.put(MESSAGING_DESTINATION_PARTITION_ID, partition.toString());
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_OPERATION, "process");
+      attributes.put(MESSAGING_DESTINATION_PARTITION_ID, getDestinationPartitionId(exchange));
     }
 
     if (CAPTURE_EXPERIMENTAL_SPAN_ATTRIBUTES) {
@@ -80,6 +79,12 @@ class KafkaSpanDecorator extends MessagingSpanDecorator {
       String offset = getValue(exchange, OFFSET, Long.class);
       attributes.put("camel.kafka.offset", offset);
     }
+  }
+
+  @Override
+  public String getDestinationPartitionId(Exchange exchange) {
+    Integer partition = exchange.getIn().getHeader(PARTITION, Integer.class);
+    return partition == null ? null : partition.toString();
   }
 
   /**

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -103,7 +103,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
    * @param endpoint The endpoint
    * @return The message bus destination
    */
-  public String getDestination(Exchange exchange, Endpoint endpoint) {
+  protected String getDestination(Exchange exchange, Endpoint endpoint) {
     switch (component) {
       case "cometds":
       case "cometd":
@@ -189,7 +189,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
    * @return The message id, or null if no id exists for the exchange
    */
   @Nullable
-  public String getMessageId(Exchange exchange) {
+  protected String getMessageId(Exchange exchange) {
     switch (component) {
       case "aws-sns":
         return (String) exchange.getIn().getHeader("CamelAwsSnsMessageId");

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -59,8 +59,13 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     return system;
   }
 
-  public boolean isSpanContextPropagated() {
-    return spanContextPropagated;
+  public boolean isSpanContextPropagated(Endpoint endpoint) {
+    if (!spanContextPropagated) {
+      return false;
+    }
+    return !"ironmq".equals(component)
+        || Boolean.parseBoolean(
+            toQueryParameters(endpoint.getEndpointUri()).get("preserveHeaders"));
   }
 
   public String getSendOperationName() {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -126,6 +126,47 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     }
   }
 
+  public String getStableDestination(Exchange exchange, Endpoint endpoint) {
+    if (!"rabbitmq".equals(component)) {
+      return getDestination(exchange, endpoint);
+    }
+
+    Map<String, String> queryParameters = toQueryParameters(endpoint.getEndpointUri());
+    boolean bridgeEndpoint =
+        Boolean.parseBoolean(queryParameters.get("bridgeEndpoint"));
+    String exchangeName =
+        exchange.getIn().getHeader("rabbitmq.EXCHANGE_NAME", String.class);
+    if (exchangeName == null || bridgeEndpoint) {
+      String endpointDestination = stripSchemeAndOptions(endpoint);
+      int separator = endpointDestination.lastIndexOf('/');
+      exchangeName =
+          separator == -1
+              ? endpointDestination
+              : endpointDestination.substring(separator + 1);
+    }
+    String routingKey =
+        exchange.getIn().getHeader("rabbitmq.ROUTING_KEY", String.class);
+    if (routingKey == null || bridgeEndpoint) {
+      routingKey = queryParameters.get("routingKey");
+    }
+
+    StringBuilder destination = new StringBuilder();
+    appendDestinationPart(destination, exchangeName);
+    appendDestinationPart(destination, routingKey);
+    return destination.length() == 0 ? "amq.default" : destination.toString();
+  }
+
+  private static void appendDestinationPart(
+      StringBuilder destination, @Nullable String part) {
+    if (part == null || part.isEmpty()) {
+      return;
+    }
+    if (destination.length() != 0) {
+      destination.append(':');
+    }
+    destination.append(part);
+  }
+
   @Override
   public SpanKind getInitiatorSpanKind() {
     switch (component) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -43,11 +43,29 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
   private final boolean spanContextPropagated;
   private final String sendOperationName;
 
+  static MessagingSpanDecorator create(String component) {
+    return create(component, component);
+  }
+
+  static MessagingSpanDecorator create(String component, String system) {
+    return create(component, system, true);
+  }
+
+  static MessagingSpanDecorator create(
+      String component, String system, boolean spanContextPropagated) {
+    return new MessagingSpanDecorator(component, system, spanContextPropagated);
+  }
+
+  static MessagingSpanDecorator create(
+      String component, String system, boolean spanContextPropagated, String sendOperationName) {
+    return new MessagingSpanDecorator(component, system, spanContextPropagated, sendOperationName);
+  }
+
   MessagingSpanDecorator(String component, String system, boolean spanContextPropagated) {
     this(component, system, spanContextPropagated, "send");
   }
 
-  MessagingSpanDecorator(
+  private MessagingSpanDecorator(
       String component, String system, boolean spanContextPropagated, String sendOperationName) {
     this.component = component;
     this.system = system;

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -41,11 +41,18 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
   private final String component;
   private final String system;
   private final boolean spanContextPropagated;
+  private final String sendOperationName;
 
   MessagingSpanDecorator(String component, String system, boolean spanContextPropagated) {
+    this(component, system, spanContextPropagated, "send");
+  }
+
+  MessagingSpanDecorator(
+      String component, String system, boolean spanContextPropagated, String sendOperationName) {
     this.component = component;
     this.system = system;
     this.spanContextPropagated = spanContextPropagated;
+    this.sendOperationName = sendOperationName;
   }
 
   public String getSystem() {
@@ -54,6 +61,10 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
 
   public boolean isSpanContextPropagated() {
     return spanContextPropagated;
+  }
+
+  public String getSendOperationName() {
+    return sendOperationName;
   }
 
   @Override

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -205,6 +205,14 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
   }
 
   @Nullable
+  public String getStableMessageId(Exchange exchange) {
+    if (system.equals("jms") || system.equals("amqp")) {
+      return (String) exchange.getIn().getHeader("JMSMessageID");
+    }
+    return getMessageId(exchange);
+  }
+
+  @Nullable
   public String getDestinationPartitionId(Exchange exchange) {
     return null;
   }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -132,20 +132,15 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     }
 
     Map<String, String> queryParameters = toQueryParameters(endpoint.getEndpointUri());
-    boolean bridgeEndpoint =
-        Boolean.parseBoolean(queryParameters.get("bridgeEndpoint"));
-    String exchangeName =
-        exchange.getIn().getHeader("rabbitmq.EXCHANGE_NAME", String.class);
+    boolean bridgeEndpoint = Boolean.parseBoolean(queryParameters.get("bridgeEndpoint"));
+    String exchangeName = exchange.getIn().getHeader("rabbitmq.EXCHANGE_NAME", String.class);
     if (exchangeName == null || bridgeEndpoint) {
       String endpointDestination = stripSchemeAndOptions(endpoint);
       int separator = endpointDestination.lastIndexOf('/');
       exchangeName =
-          separator == -1
-              ? endpointDestination
-              : endpointDestination.substring(separator + 1);
+          separator == -1 ? endpointDestination : endpointDestination.substring(separator + 1);
     }
-    String routingKey =
-        exchange.getIn().getHeader("rabbitmq.ROUTING_KEY", String.class);
+    String routingKey = exchange.getIn().getHeader("rabbitmq.ROUTING_KEY", String.class);
     if (routingKey == null || bridgeEndpoint) {
       routingKey = queryParameters.get("routingKey");
     }
@@ -156,8 +151,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     return destination.length() == 0 ? "amq.default" : destination.toString();
   }
 
-  private static void appendDestinationPart(
-      StringBuilder destination, @Nullable String part) {
+  private static void appendDestinationPart(StringBuilder destination, @Nullable String part) {
     if (part == null || part.isEmpty()) {
       return;
     }

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -126,6 +126,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     }
   }
 
+  @Nullable
   public String getStableDestination(Exchange exchange, Endpoint endpoint) {
     if (!component.equals("rabbitmq")) {
       return getDestination(exchange, endpoint);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -63,7 +63,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     if (!spanContextPropagated) {
       return false;
     }
-    return !"ironmq".equals(component)
+    return !component.equals("ironmq")
         || Boolean.parseBoolean(
             toQueryParameters(endpoint.getEndpointUri()).get("preserveHeaders"));
   }
@@ -127,7 +127,7 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
   }
 
   public String getStableDestination(Exchange exchange, Endpoint endpoint) {
-    if (!"rabbitmq".equals(component)) {
+    if (!component.equals("rabbitmq")) {
       return getDestination(exchange, endpoint);
     }
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -145,13 +145,16 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
   }
 
   @Nullable
-  public String getStableDestination(Exchange exchange, Endpoint endpoint) {
+  public String getStableDestination(
+      Exchange exchange, Endpoint endpoint, CamelDirection camelDirection) {
     if (!component.equals("rabbitmq")) {
       return getDestination(exchange, endpoint);
     }
 
     Map<String, String> queryParameters = toQueryParameters(endpoint.getEndpointUri());
-    boolean bridgeEndpoint = Boolean.parseBoolean(queryParameters.get("bridgeEndpoint"));
+    boolean outbound = camelDirection == CamelDirection.OUTBOUND;
+    boolean bridgeEndpoint =
+        outbound && Boolean.parseBoolean(queryParameters.get("bridgeEndpoint"));
     String exchangeName = exchange.getIn().getHeader("rabbitmq.EXCHANGE_NAME", String.class);
     if (exchangeName == null || bridgeEndpoint) {
       String endpointDestination = stripSchemeAndOptions(endpoint);
@@ -167,7 +170,16 @@ public class MessagingSpanDecorator extends BaseSpanDecorator {
     StringBuilder destination = new StringBuilder();
     appendDestinationPart(destination, exchangeName);
     appendDestinationPart(destination, routingKey);
-    return destination.length() == 0 ? "amq.default" : destination.toString();
+    if (!outbound) {
+      String queue = queryParameters.get("queue");
+      if (queue != null && !queue.equals(routingKey)) {
+        appendDestinationPart(destination, queue);
+      }
+    }
+    if (destination.length() == 0) {
+      return outbound ? "amq.default" : null;
+    }
+    return destination.toString();
   }
 
   private static void appendDestinationPart(StringBuilder destination, @Nullable String part) {

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/MessagingSpanDecorator.java
@@ -23,6 +23,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 
@@ -35,12 +36,24 @@ import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 
-class MessagingSpanDecorator extends BaseSpanDecorator {
+public class MessagingSpanDecorator extends BaseSpanDecorator {
 
   private final String component;
+  private final String system;
+  private final boolean spanContextPropagated;
 
-  public MessagingSpanDecorator(String component) {
+  MessagingSpanDecorator(String component, String system, boolean spanContextPropagated) {
     this.component = component;
+    this.system = system;
+    this.spanContextPropagated = spanContextPropagated;
+  }
+
+  public String getSystem() {
+    return system;
+  }
+
+  public boolean isSpanContextPropagated() {
+    return spanContextPropagated;
   }
 
   @Override
@@ -61,9 +74,10 @@ class MessagingSpanDecorator extends BaseSpanDecorator {
       CamelDirection camelDirection) {
     super.pre(attributes, exchange, endpoint, camelDirection);
 
-    attributes.put(MESSAGING_DESTINATION_NAME, getDestination(exchange, endpoint));
-
-    attributes.put(MESSAGING_MESSAGE_ID, getMessageId(exchange));
+    if (emitOldMessagingSemconv()) {
+      attributes.put(MESSAGING_DESTINATION_NAME, getDestination(exchange, endpoint));
+      attributes.put(MESSAGING_MESSAGE_ID, getMessageId(exchange));
+    }
   }
 
   /**
@@ -73,7 +87,7 @@ class MessagingSpanDecorator extends BaseSpanDecorator {
    * @param endpoint The endpoint
    * @return The message bus destination
    */
-  protected String getDestination(Exchange exchange, Endpoint endpoint) {
+  public String getDestination(Exchange exchange, Endpoint endpoint) {
     switch (component) {
       case "cometds":
       case "cometd":
@@ -124,7 +138,7 @@ class MessagingSpanDecorator extends BaseSpanDecorator {
    * @return The message id, or null if no id exists for the exchange
    */
   @Nullable
-  protected String getMessageId(Exchange exchange) {
+  public String getMessageId(Exchange exchange) {
     switch (component) {
       case "aws-sns":
         return (String) exchange.getIn().getHeader("CamelAwsSnsMessageId");
@@ -137,5 +151,10 @@ class MessagingSpanDecorator extends BaseSpanDecorator {
       default:
         return null;
     }
+  }
+
+  @Nullable
+  public String getDestinationPartitionId(Exchange exchange) {
+    return null;
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
@@ -6,16 +6,21 @@
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import javax.jms.ConnectionFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
@@ -74,20 +79,44 @@ class JmsCamelTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("input").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("queue:testQueue")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send queue:testQueue"
+                                : "queue:testQueue")
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
                             equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "send" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "send" : null),
                             equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue"))),
-                span ->
-                    span.hasName("queue:testQueue")
-                        .hasKind(SpanKind.CONSUMER)
-                        .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
-                            equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue")),
-                            satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))),
+                span -> {
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process queue:testQueue"
+                              : "queue:testQueue")
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(1))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
+                          equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                          equalTo(
+                              MESSAGING_OPERATION_NAME,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          equalTo(
+                              MESSAGING_OPERATION_TYPE,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue")),
+                          satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+                  }
+                },
                 span -> span.hasName("mock").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(2))));
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
@@ -20,7 +20,13 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Consumer;
 import javax.jms.ConnectionFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
@@ -74,49 +80,83 @@ class JmsCamelTest {
     ProducerTemplate template = camelContext.createProducerTemplate();
     template.sendBody("direct:input", "test message");
 
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("input").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "send queue:testQueue"
-                                : "queue:testQueue")
-                        .hasKind(SpanKind.PRODUCER)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
-                            equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
-                            equalTo(
-                                MESSAGING_OPERATION_NAME,
-                                emitStableMessagingSemconv() ? "send" : null),
-                            equalTo(
-                                MESSAGING_OPERATION_TYPE,
-                                emitStableMessagingSemconv() ? "send" : null),
-                            equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue"))),
-                span -> {
-                  span.hasName(
-                          emitStableMessagingSemconv()
-                              ? "process queue:testQueue"
-                              : "queue:testQueue")
-                      .hasKind(SpanKind.CONSUMER)
-                      .hasParent(trace.getSpan(1))
-                      .hasAttributesSatisfyingExactly(
-                          equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
-                          equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
-                          equalTo(
-                              MESSAGING_OPERATION_NAME,
-                              emitStableMessagingSemconv() ? "process" : null),
-                          equalTo(
-                              MESSAGING_OPERATION_TYPE,
-                              emitStableMessagingSemconv() ? "process" : null),
-                          equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue")),
-                          satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
-                  if (emitStableMessagingSemconv()) {
-                    span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
-                  }
-                },
-                span -> span.hasName("mock").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(2))));
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          Comparator.comparingInt(trace -> trace.size()),
+          JmsCamelTest::assertJmsReceiveTrace,
+          JmsCamelTest::assertCamelTrace);
+    }
+    if (!emitStableMessagingSemconv()) {
+      testing.waitAndAssertTraces(JmsCamelTest::assertCamelTrace);
+    }
+  }
+
+  private static void assertJmsReceiveTrace(TraceAssert trace) {
+    trace.hasSpansSatisfyingExactly(
+        span ->
+            span.hasName("receive testQueue")
+                .hasKind(SpanKind.CLIENT)
+                .hasNoParent()
+                .hasTotalRecordedLinks(1)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(MESSAGING_SYSTEM, "jms"),
+                    equalTo(MESSAGING_DESTINATION_NAME, "testQueue"),
+                    equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                    equalTo(MESSAGING_OPERATION_TYPE, "receive"),
+                    satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
+  }
+
+  private static void assertCamelTrace(TraceAssert trace) {
+    List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+    assertions.add(span -> span.hasName("input").hasKind(SpanKind.INTERNAL).hasNoParent());
+    assertions.add(
+        span ->
+            span.hasName(emitStableMessagingSemconv() ? "send queue:testQueue" : "queue:testQueue")
+                .hasKind(SpanKind.PRODUCER)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                    equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
+                    equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                    equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                    equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+                    equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue"))));
+    if (!emitStableMessagingSemconv()) {
+      assertions.add(
+          span ->
+              span.hasName("testQueue receive")
+                  .hasKind(SpanKind.CONSUMER)
+                  .hasParent(trace.getSpan(1))
+                  .hasTotalRecordedLinks(0)
+                  .hasAttributesSatisfyingExactly(
+                      equalTo(MESSAGING_SYSTEM, "jms"),
+                      equalTo(MESSAGING_DESTINATION_NAME, "testQueue"),
+                      equalTo(stringKey("messaging.operation"), "receive"),
+                      satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class))));
+    }
+    int processSpanIndex = assertions.size();
+    assertions.add(
+        span -> {
+          span.hasName(emitStableMessagingSemconv() ? "process queue:testQueue" : "queue:testQueue")
+              .hasKind(SpanKind.CONSUMER)
+              .hasParent(trace.getSpan(1))
+              .hasAttributesSatisfyingExactly(
+                  equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
+                  equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                  equalTo(
+                      MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+                  equalTo(
+                      MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
+                  equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue")),
+                  satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
+          if (emitStableMessagingSemconv()) {
+            span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+          }
+        });
+    assertions.add(
+        span ->
+            span.hasName("mock")
+                .hasKind(SpanKind.CLIENT)
+                .hasParent(trace.getSpan(processSpanIndex)));
+    trace.hasSpansSatisfyingExactly(assertions);
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
@@ -111,12 +111,14 @@ class JmsCamelTest {
     assertions.add(span -> span.hasName("input").hasKind(SpanKind.INTERNAL).hasNoParent());
     assertions.add(
         span ->
-            span.hasName(emitStableMessagingSemconv() ? "send queue:testQueue" : "queue:testQueue")
+            span.hasName(emitStableMessagingSemconv() ? "send testQueue" : "queue:testQueue")
                 .hasKind(SpanKind.PRODUCER)
                 .hasParent(trace.getSpan(0))
                 .hasAttributesSatisfyingExactly(
                     equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
-                    equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                    equalTo(
+                        MESSAGING_DESTINATION_NAME,
+                        emitStableMessagingSemconv() ? "testQueue" : "queue:testQueue"),
                     equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
                     equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
                     equalTo(stringKey("camel.uri"), experimental("jms://queue:testQueue"))));
@@ -136,12 +138,14 @@ class JmsCamelTest {
     int processSpanIndex = assertions.size();
     assertions.add(
         span -> {
-          span.hasName(emitStableMessagingSemconv() ? "process queue:testQueue" : "queue:testQueue")
+          span.hasName(emitStableMessagingSemconv() ? "process testQueue" : "queue:testQueue")
               .hasKind(SpanKind.CONSUMER)
               .hasParent(trace.getSpan(1))
               .hasAttributesSatisfyingExactly(
                   equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "jms" : null),
-                  equalTo(MESSAGING_DESTINATION_NAME, "queue:testQueue"),
+                  equalTo(
+                      MESSAGING_DESTINATION_NAME,
+                      emitStableMessagingSemconv() ? "testQueue" : "queue:testQueue"),
                   equalTo(
                       MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
                   equalTo(

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/RestCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/RestCamelTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimentalSatisfies;
+import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.SuppressionTest.addNestedHttpClientSpan;
+import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.SuppressionTest.nestedHttpClientSpans;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
@@ -29,6 +31,10 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.AfterAll;
@@ -88,56 +94,71 @@ class RestCamelTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
         .start();
 
     testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName("start")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(stringKey("camel.uri"), experimental("direct://start"))),
-                span ->
-                    span.hasName("GET")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(
-                                stringKey("camel.uri"),
-                                experimental("rest://get:api/%7Bmodule%7D/unit/%7BunitId%7D")),
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)),
-                span ->
-                    span.hasName("GET /api/{module}/unit/{unitId}")
-                        .hasKind(SpanKind.SERVER)
-                        .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(URL_SCHEME, "http"),
-                            equalTo(URL_PATH, "/api/firstModule/unit/unitOne"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(HTTP_ROUTE, "/api/{module}/unit/{unitId}"),
-                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(SERVER_ADDRESS, "localhost"),
-                            equalTo(SERVER_PORT, Long.valueOf(port)),
-                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
-                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
-                span ->
-                    span.hasName("GET /api/{module}/unit/{unitId}")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(2))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "GET"),
-                            equalTo(
-                                URL_FULL,
-                                "http://localhost:" + port + "/api/firstModule/unit/unitOne"),
-                            experimentalSatisfies(
-                                stringKey("camel.uri"), val -> val.isInstanceOf(String.class))),
-                span ->
-                    span.hasName("moduleUnit")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(3))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(stringKey("camel.uri"), experimental("direct://moduleUnit")))));
+        trace -> {
+          int nested = nestedHttpClientSpans();
+          List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+          assertions.add(
+              span ->
+                  span.hasName("start")
+                      .hasKind(SpanKind.INTERNAL)
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(stringKey("camel.uri"), experimental("direct://start"))));
+          assertions.add(
+              span ->
+                  span.hasName("GET")
+                      .hasKind(SpanKind.CLIENT)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(
+                              stringKey("camel.uri"),
+                              experimental("rest://get:api/%7Bmodule%7D/unit/%7BunitId%7D")),
+                          equalTo(HTTP_REQUEST_METHOD, "GET"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L)));
+          addNestedHttpClientSpan(
+              assertions,
+              "GET",
+              "http://localhost:" + port + "/api/firstModule/unit/unitOne",
+              "localhost",
+              port,
+              trace.getSpan(1));
+          assertions.add(
+              span ->
+                  span.hasName("GET /api/{module}/unit/{unitId}")
+                      .hasKind(SpanKind.SERVER)
+                      .hasParent(trace.getSpan(1 + nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(URL_SCHEME, "http"),
+                          equalTo(URL_PATH, "/api/firstModule/unit/unitOne"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                          equalTo(HTTP_REQUEST_METHOD, "GET"),
+                          equalTo(HTTP_ROUTE, "/api/{module}/unit/{unitId}"),
+                          equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                          equalTo(SERVER_ADDRESS, "localhost"),
+                          equalTo(SERVER_PORT, Long.valueOf(port)),
+                          equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                          equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                          satisfies(USER_AGENT_ORIGINAL, val -> val.isInstanceOf(String.class)),
+                          satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))));
+          assertions.add(
+              span ->
+                  span.hasName("GET /api/{module}/unit/{unitId}")
+                      .hasKind(SpanKind.INTERNAL)
+                      .hasParent(trace.getSpan(2 + nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "GET"),
+                          equalTo(
+                              URL_FULL,
+                              "http://localhost:" + port + "/api/firstModule/unit/unitOne"),
+                          experimentalSatisfies(
+                              stringKey("camel.uri"), val -> val.isInstanceOf(String.class))));
+          assertions.add(
+              span ->
+                  span.hasName("moduleUnit")
+                      .hasKind(SpanKind.INTERNAL)
+                      .hasParent(trace.getSpan(3 + nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(stringKey("camel.uri"), experimental("direct://moduleUnit"))));
+          trace.hasSpansSatisfyingExactly(assertions);
+        });
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SingleServiceCamelTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
+import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.SuppressionTest.addNestedHttpClientSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -16,7 +17,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -95,16 +100,17 @@ class SingleServiceCamelTest extends AbstractHttpServerUsingTest<ConfigurableApp
     try {
       clientContext.createProducerTemplate().sendBody("direct:input", "testContent");
 
+      String url = "http://localhost:" + port + "/camelService?sig=REDACTED";
       testing.waitAndAssertTraces(
-          trace ->
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("input").hasKind(SpanKind.INTERNAL),
-                  span ->
-                      span.hasName("GET")
-                          .hasKind(SpanKind.CLIENT)
-                          .hasAttribute(
-                              URL_FULL, "http://localhost:" + port + "/camelService?sig=REDACTED"),
-                  span -> span.hasName("GET /camelService").hasKind(SpanKind.SERVER)));
+          trace -> {
+            List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+            assertions.add(span -> span.hasName("input").hasKind(SpanKind.INTERNAL));
+            assertions.add(
+                span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasAttribute(URL_FULL, url));
+            addNestedHttpClientSpan(assertions, "GET", url, "localhost", port, trace.getSpan(1));
+            assertions.add(span -> span.hasName("GET /camelService").hasKind(SpanKind.SERVER));
+            trace.hasSpansSatisfyingExactly(assertions);
+          });
     } finally {
       clientContext.stop();
     }
@@ -126,16 +132,28 @@ class SingleServiceCamelTest extends AbstractHttpServerUsingTest<ConfigurableApp
       clientContext.createProducerTemplate().sendBody("direct:userInfoInput", "testContent");
 
       testing.waitAndAssertTraces(
-          trace ->
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("userInfoInput").hasKind(SpanKind.INTERNAL),
-                  span ->
-                      span.hasName("POST")
-                          .hasKind(SpanKind.CLIENT)
-                          .hasAttribute(
-                              URL_FULL,
-                              "http://REDACTED:REDACTED@localhost:" + port + "/camelService"),
-                  span -> span.hasName("POST /camelService").hasKind(SpanKind.SERVER)));
+          trace -> {
+            List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+            assertions.add(span -> span.hasName("userInfoInput").hasKind(SpanKind.INTERNAL));
+            assertions.add(
+                span ->
+                    span.hasName("POST")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttribute(
+                            URL_FULL,
+                            "http://REDACTED:REDACTED@localhost:" + port + "/camelService"));
+            // the http client library strips the user info before the nested http client
+            // instrumentation sees the url
+            addNestedHttpClientSpan(
+                assertions,
+                "POST",
+                "http://localhost:" + port + "/camelService",
+                "localhost",
+                port,
+                trace.getSpan(1));
+            assertions.add(span -> span.hasName("POST /camelService").hasKind(SpanKind.SERVER));
+            trace.hasSpansSatisfyingExactly(assertions);
+          });
     } finally {
       clientContext.stop();
     }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
@@ -21,10 +21,10 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Camel does not use the semantic attributes extractors, so its spans do not claim any span key.
- * Under the {@code semconv} span suppression strategy the http client instrumentation nested inside
- * a Camel http producer is therefore not suppressed and emits its own span, while under the {@code
- * span-kind} strategy the Camel client span suppresses it.
+ * Camel http producer spans do not use the http semantic attributes extractor, so they do not claim
+ * the http client span key. Under the {@code semconv} span suppression strategy the http client
+ * instrumentation nested inside a Camel http producer is therefore not suppressed and emits its own
+ * span, while under the {@code span-kind} strategy the Camel client span suppresses it.
  */
 class SuppressionTest {
 

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
  * a Camel http producer is therefore not suppressed and emits its own span, while under the {@code
  * span-kind} strategy the Camel client span suppresses it.
  */
-public class SuppressionTest {
+class SuppressionTest {
 
   private static final boolean NESTED_HTTP_CLIENT_SPAN =
       "semconv"

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/SuppressionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
+
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Camel does not use the semantic attributes extractors, so its spans do not claim any span key.
+ * Under the {@code semconv} span suppression strategy the http client instrumentation nested inside
+ * a Camel http producer is therefore not suppressed and emits its own span, while under the {@code
+ * span-kind} strategy the Camel client span suppresses it.
+ */
+public class SuppressionTest {
+
+  private static final boolean NESTED_HTTP_CLIENT_SPAN =
+      "semconv"
+          .equals(
+              System.getProperty("otel.instrumentation.experimental.span-suppression-strategy"));
+
+  /** Returns the number of spans that the nested http client instrumentation adds to a trace. */
+  static int nestedHttpClientSpans() {
+    return NESTED_HTTP_CLIENT_SPAN ? 1 : 0;
+  }
+
+  static void addNestedHttpClientSpan(
+      List<Consumer<SpanDataAssert>> assertions,
+      String method,
+      String url,
+      String serverAddress,
+      long serverPort,
+      SpanData parent) {
+    if (!NESTED_HTTP_CLIENT_SPAN) {
+      return;
+    }
+    assertions.add(
+        span ->
+            span.hasName(method)
+                .hasKind(SpanKind.CLIENT)
+                .hasParent(parent)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(HTTP_REQUEST_METHOD, method),
+                    equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                    equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                    equalTo(maybeStablePeerService(), "test-peer-service"),
+                    equalTo(SERVER_ADDRESS, serverAddress),
+                    equalTo(SERVER_PORT, serverPort),
+                    equalTo(URL_FULL, url)));
+  }
+
+  private SuppressionTest() {}
+}

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/TwoServicesWithDirectClientCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/TwoServicesWithDirectClientCamelTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
+import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.SuppressionTest.addNestedHttpClientSpan;
+import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.SuppressionTest.nestedHttpClientSpans;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.ClientAttributes.CLIENT_ADDRESS;
@@ -30,6 +32,10 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerUsingTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
@@ -104,76 +110,97 @@ class TwoServicesWithDirectClientCamelTest
     template.sendBody("direct:input", "Example request");
 
     testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName("input")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(stringKey("camel.uri"), experimental("direct://input"))),
-                span ->
-                    span.hasName("POST")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasParent(trace.getSpan(0))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(
-                                stringKey("camel.uri"),
-                                experimental("http://localhost:" + portOne + "/serviceOne"))),
-                span ->
-                    span.hasName("POST /serviceOne")
-                        .hasKind(SpanKind.SERVER)
-                        .hasParent(trace.getSpan(1))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(
-                                stringKey("camel.uri"),
-                                experimental("http://0.0.0.0:" + portOne + "/serviceOne"))),
-                span ->
-                    span.hasName("POST")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasParent(trace.getSpan(2))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(
-                                stringKey("camel.uri"),
-                                experimental("http://127.0.0.1:" + portTwo + "/serviceTwo"))),
-                span ->
-                    span.hasName("POST /serviceTwo")
-                        .hasKind(SpanKind.SERVER)
-                        .hasParent(trace.getSpan(3))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
-                            equalTo(URL_SCHEME, "http"),
-                            equalTo(URL_PATH, "/serviceTwo"),
-                            equalTo(USER_AGENT_ORIGINAL, "Jakarta Commons-HttpClient/3.1"),
-                            equalTo(HTTP_ROUTE, "/serviceTwo"),
-                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
-                            equalTo(SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(SERVER_PORT, portTwo),
-                            equalTo(CLIENT_ADDRESS, "127.0.0.1"),
-                            equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
-                            satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))),
-                span ->
-                    span.hasName("POST /serviceTwo")
-                        .hasKind(SpanKind.INTERNAL)
-                        .hasParent(trace.getSpan(4))
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(HTTP_REQUEST_METHOD, "POST"),
-                            equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
-                            equalTo(
-                                stringKey("camel.uri"),
-                                experimental(
-                                    "jetty:http://0.0.0.0:"
-                                        + portTwo
-                                        + "/serviceTwo?arg=value")))));
+        trace -> {
+          int nested = nestedHttpClientSpans();
+          List<Consumer<SpanDataAssert>> assertions = new ArrayList<>();
+          assertions.add(
+              span ->
+                  span.hasName("input")
+                      .hasKind(SpanKind.INTERNAL)
+                      .hasNoParent()
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(stringKey("camel.uri"), experimental("direct://input"))));
+          assertions.add(
+              span ->
+                  span.hasName("POST")
+                      .hasKind(SpanKind.CLIENT)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "POST"),
+                          equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                          equalTo(
+                              stringKey("camel.uri"),
+                              experimental("http://localhost:" + portOne + "/serviceOne"))));
+          addNestedHttpClientSpan(
+              assertions,
+              "POST",
+              "http://localhost:" + portOne + "/serviceOne",
+              "localhost",
+              portOne,
+              trace.getSpan(1));
+          assertions.add(
+              span ->
+                  span.hasName("POST /serviceOne")
+                      .hasKind(SpanKind.SERVER)
+                      .hasParent(trace.getSpan(1 + nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "POST"),
+                          equalTo(URL_FULL, "http://localhost:" + portOne + "/serviceOne"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                          equalTo(
+                              stringKey("camel.uri"),
+                              experimental("http://0.0.0.0:" + portOne + "/serviceOne"))));
+          assertions.add(
+              span ->
+                  span.hasName("POST")
+                      .hasKind(SpanKind.CLIENT)
+                      .hasParent(trace.getSpan(2 + nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "POST"),
+                          equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                          equalTo(
+                              stringKey("camel.uri"),
+                              experimental("http://127.0.0.1:" + portTwo + "/serviceTwo"))));
+          addNestedHttpClientSpan(
+              assertions,
+              "POST",
+              "http://127.0.0.1:" + portTwo + "/serviceTwo",
+              "127.0.0.1",
+              portTwo,
+              trace.getSpan(3 + nested));
+          assertions.add(
+              span ->
+                  span.hasName("POST /serviceTwo")
+                      .hasKind(SpanKind.SERVER)
+                      .hasParent(trace.getSpan(3 + 2 * nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "POST"),
+                          equalTo(HTTP_RESPONSE_STATUS_CODE, 200L),
+                          equalTo(URL_SCHEME, "http"),
+                          equalTo(URL_PATH, "/serviceTwo"),
+                          equalTo(USER_AGENT_ORIGINAL, "Jakarta Commons-HttpClient/3.1"),
+                          equalTo(HTTP_ROUTE, "/serviceTwo"),
+                          equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                          equalTo(SERVER_ADDRESS, "127.0.0.1"),
+                          equalTo(SERVER_PORT, portTwo),
+                          equalTo(CLIENT_ADDRESS, "127.0.0.1"),
+                          equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
+                          satisfies(NETWORK_PEER_PORT, val -> val.isInstanceOf(Long.class))));
+          assertions.add(
+              span ->
+                  span.hasName("POST /serviceTwo")
+                      .hasKind(SpanKind.INTERNAL)
+                      .hasParent(trace.getSpan(4 + 2 * nested))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(HTTP_REQUEST_METHOD, "POST"),
+                          equalTo(URL_FULL, "http://127.0.0.1:" + portTwo + "/serviceTwo"),
+                          equalTo(
+                              stringKey("camel.uri"),
+                              experimental(
+                                  "jetty:http://0.0.0.0:" + portTwo + "/serviceTwo?arg=value"))));
+          trace.hasSpansSatisfyingExactly(assertions);
+        });
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsConnector.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsConnector.java
@@ -147,11 +147,21 @@ class AwsConnector {
     sqsClient.sendMessage(send);
   }
 
-  void receiveMessage(String queueUrl) {
+  Message receiveMessage(String queueUrl) {
     logger.info("Receive message from queue {}", queueUrl);
     ReceiveMessageResult receiveMessageResult =
-        sqsClient.receiveMessage(new ReceiveMessageRequest(queueUrl).withWaitTimeSeconds(20));
-    for (Message ignored : receiveMessageResult.getMessages()) {}
+        sqsClient.receiveMessage(
+            new ReceiveMessageRequest(queueUrl)
+                .withWaitTimeSeconds(20)
+                .withMessageAttributeNames("All"));
+    Message receivedMessage = null;
+    for (Message message : receiveMessageResult.getMessages()) {
+      receivedMessage = message;
+    }
+    if (receivedMessage == null) {
+      throw new IllegalStateException("No message received from " + queueUrl);
+    }
+    return receivedMessage;
   }
 
   void disconnect() {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
@@ -81,7 +81,7 @@ class AwsSpanAssertions {
         String destinationName = spanName.substring(0, operationSeparator);
         String operationName = spanName.substring(operationSeparator + 1);
         expectedSpanName =
-            ("publish".equals(operationName) ? "send" : operationName) + " " + destinationName;
+            (operationName.equals("publish") ? "send" : operationName) + " " + destinationName;
       }
     }
 

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
@@ -71,13 +71,18 @@ class AwsSpanAssertions {
       throw new IllegalStateException("can't get rpc method from span name " + spanName);
     }
 
+    boolean deleteMessage = spanName.equals("SQS.DeleteMessage");
     String expectedSpanName = spanName;
-    if (emitStableMessagingSemconv() && !spanName.startsWith("SQS.")) {
-      int operationSeparator = spanName.lastIndexOf(' ');
-      String destinationName = spanName.substring(0, operationSeparator);
-      String operationName = spanName.substring(operationSeparator + 1);
-      expectedSpanName =
-          ("publish".equals(operationName) ? "send" : operationName) + " " + destinationName;
+    if (emitStableMessagingSemconv()) {
+      if (deleteMessage) {
+        expectedSpanName = "delete " + queueName;
+      } else if (!spanName.startsWith("SQS.")) {
+        int operationSeparator = spanName.lastIndexOf(' ');
+        String destinationName = spanName.substring(0, operationSeparator);
+        String operationName = spanName.substring(operationSeparator + 1);
+        expectedSpanName =
+            ("publish".equals(operationName) ? "send" : operationName) + " " + destinationName;
+      }
     }
 
     List<AttributeAssertion> attributeAssertions =
@@ -112,11 +117,17 @@ class AwsSpanAssertions {
 
     if (spanName.endsWith("receive")
         || spanName.endsWith("process")
-        || spanName.endsWith("publish")) {
+        || spanName.endsWith("publish")
+        || (deleteMessage && emitStableMessagingSemconv())) {
       attributeAssertions.addAll(
           asList(
               equalTo(MESSAGING_DESTINATION_NAME, queueName), equalTo(MESSAGING_SYSTEM, AWS_SQS)));
-      if (spanName.endsWith("receive")) {
+      if (deleteMessage) {
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null));
+        attributeAssertions.add(equalTo(MESSAGING_OPERATION_NAME, "delete"));
+        attributeAssertions.add(equalTo(MESSAGING_OPERATION_TYPE, "settle"));
+      } else if (spanName.endsWith("receive")) {
         attributeAssertions.add(
             equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null));
         attributeAssertions.add(

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/AwsSpanAssertions.java
@@ -7,6 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -21,6 +23,8 @@ import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_SQ
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static io.opentelemetry.semconv.incubating.RpcIncubatingAttributes.RPC_METHOD;
@@ -67,6 +71,15 @@ class AwsSpanAssertions {
       throw new IllegalStateException("can't get rpc method from span name " + spanName);
     }
 
+    String expectedSpanName = spanName;
+    if (emitStableMessagingSemconv() && !spanName.startsWith("SQS.")) {
+      int operationSeparator = spanName.lastIndexOf(' ');
+      String destinationName = spanName.substring(0, operationSeparator);
+      String operationName = spanName.substring(operationSeparator + 1);
+      expectedSpanName =
+          ("publish".equals(operationName) ? "send" : operationName) + " " + destinationName;
+    }
+
     List<AttributeAssertion> attributeAssertions =
         new ArrayList<>(
             asList(
@@ -104,17 +117,32 @@ class AwsSpanAssertions {
           asList(
               equalTo(MESSAGING_DESTINATION_NAME, queueName), equalTo(MESSAGING_SYSTEM, AWS_SQS)));
       if (spanName.endsWith("receive")) {
-        attributeAssertions.add(equalTo(MESSAGING_OPERATION, "receive"));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "receive" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "receive" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "receive" : null));
       } else if (spanName.endsWith("process")) {
-        attributeAssertions.add(equalTo(MESSAGING_OPERATION, "process"));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "process" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null));
         attributeAssertions.add(satisfies(MESSAGING_MESSAGE_ID, val -> val.isNotNull()));
       } else if (spanName.endsWith("publish")) {
-        attributeAssertions.add(equalTo(MESSAGING_OPERATION, "publish"));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "publish" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null));
+        attributeAssertions.add(
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null));
         attributeAssertions.add(satisfies(MESSAGING_MESSAGE_ID, val -> val.isNotNull()));
       }
     }
 
-    return span.hasName(spanName)
+    return span.hasName(expectedSpanName)
         .hasKind(spanKind)
         .hasAttributesSatisfyingExactly(attributeAssertions);
   }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
@@ -66,7 +66,7 @@ class CamelSpanAssertions {
 
   static SpanDataAssert snsPublish(SpanDataAssert span, String topicName) {
     return span.hasName(emitStableMessagingSemconv() ? "send " + topicName : topicName)
-        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.INTERNAL)
+        .hasKind(emitStableMessagingSemconv() ? SpanKind.PRODUCER : SpanKind.INTERNAL)
         .hasAttributesSatisfyingExactly(
             equalTo(
                 stringKey("camel.uri"),

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
@@ -74,7 +74,8 @@ class CamelSpanAssertions {
             equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws.sns" : null),
             equalTo(MESSAGING_DESTINATION_NAME, topicName),
             equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
-            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null));
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
+            equalTo(MESSAGING_MESSAGE_ID, emitStableMessagingSemconv() ? "message-id" : null));
   }
 
   static SpanDataAssert s3(SpanDataAssert span, String bucketName) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
@@ -6,11 +6,15 @@
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.ExperimentalTest.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
@@ -28,14 +32,17 @@ class CamelSpanAssertions {
   }
 
   static SpanDataAssert sqsProduce(SpanDataAssert span, String queueName) {
-    return span.hasName(queueName)
-        .hasKind(SpanKind.INTERNAL)
+    return span.hasName(emitStableMessagingSemconv() ? "send " + queueName : queueName)
+        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.INTERNAL)
         .hasAttributesSatisfyingExactly(
             equalTo(
                 stringKey("camel.uri"),
                 experimental(
                     "aws-sqs://" + queueName + "?amazonSQSClient=%23sqsClient&delay=1000")),
-            equalTo(MESSAGING_DESTINATION_NAME, queueName));
+            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws_sqs" : null),
+            equalTo(MESSAGING_DESTINATION_NAME, queueName),
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null));
   }
 
   static SpanDataAssert sqsConsume(SpanDataAssert span, String queueName) {
@@ -43,25 +50,31 @@ class CamelSpanAssertions {
   }
 
   static SpanDataAssert sqsConsume(SpanDataAssert span, String queueName, int delay) {
-    return span.hasName(queueName)
-        .hasKind(SpanKind.INTERNAL)
+    return span.hasName(emitStableMessagingSemconv() ? "process " + queueName : queueName)
+        .hasKind(emitStableMessagingSemconv() ? SpanKind.CONSUMER : SpanKind.INTERNAL)
         .hasAttributesSatisfyingExactly(
             equalTo(
                 stringKey("camel.uri"),
                 experimental(
                     "aws-sqs://" + queueName + "?amazonSQSClient=%23sqsClient&delay=" + delay)),
+            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws_sqs" : null),
             equalTo(MESSAGING_DESTINATION_NAME, queueName),
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "process" : null),
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "process" : null),
             satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
   }
 
   static SpanDataAssert snsPublish(SpanDataAssert span, String topicName) {
-    return span.hasName(topicName)
-        .hasKind(SpanKind.INTERNAL)
+    return span.hasName(emitStableMessagingSemconv() ? "send " + topicName : topicName)
+        .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.INTERNAL)
         .hasAttributesSatisfyingExactly(
             equalTo(
                 stringKey("camel.uri"),
                 experimental("aws-sns://" + topicName + "?amazonSNSClient=%23snsClient")),
-            equalTo(MESSAGING_DESTINATION_NAME, topicName));
+            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws.sns" : null),
+            equalTo(MESSAGING_DESTINATION_NAME, topicName),
+            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null));
   }
 
   static SpanDataAssert s3(SpanDataAssert span, String bucketName) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
@@ -15,9 +15,13 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import java.util.ArrayList;
+import java.util.List;
 
 class CamelSpanAssertions {
 
@@ -32,17 +36,25 @@ class CamelSpanAssertions {
   }
 
   static SpanDataAssert sqsProduce(SpanDataAssert span, String queueName) {
+    List<AttributeAssertion> attributeAssertions =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    stringKey("camel.uri"),
+                    experimental(
+                        "aws-sqs://" + queueName + "?amazonSQSClient=%23sqsClient&delay=1000")),
+                equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws_sqs" : null),
+                equalTo(MESSAGING_DESTINATION_NAME, queueName),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)));
+    if (emitStableMessagingSemconv()) {
+      attributeAssertions.add(
+          satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
+    }
+
     return span.hasName(emitStableMessagingSemconv() ? "send " + queueName : queueName)
         .hasKind(emitStableMessagingSemconv() ? SpanKind.CLIENT : SpanKind.INTERNAL)
-        .hasAttributesSatisfyingExactly(
-            equalTo(
-                stringKey("camel.uri"),
-                experimental(
-                    "aws-sqs://" + queueName + "?amazonSQSClient=%23sqsClient&delay=1000")),
-            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws_sqs" : null),
-            equalTo(MESSAGING_DESTINATION_NAME, queueName),
-            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
-            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null));
+        .hasAttributesSatisfyingExactly(attributeAssertions);
   }
 
   static SpanDataAssert sqsConsume(SpanDataAssert span, String queueName) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/CamelSpanAssertions.java
@@ -77,17 +77,24 @@ class CamelSpanAssertions {
   }
 
   static SpanDataAssert snsPublish(SpanDataAssert span, String topicName) {
+    List<AttributeAssertion> attributeAssertions =
+        new ArrayList<>(
+            asList(
+                equalTo(
+                    stringKey("camel.uri"),
+                    experimental("aws-sns://" + topicName + "?amazonSNSClient=%23snsClient")),
+                equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws.sns" : null),
+                equalTo(MESSAGING_DESTINATION_NAME, topicName),
+                equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
+                equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null)));
+    if (emitStableMessagingSemconv()) {
+      attributeAssertions.add(
+          satisfies(MESSAGING_MESSAGE_ID, val -> val.isInstanceOf(String.class)));
+    }
+
     return span.hasName(emitStableMessagingSemconv() ? "send " + topicName : topicName)
         .hasKind(emitStableMessagingSemconv() ? SpanKind.PRODUCER : SpanKind.INTERNAL)
-        .hasAttributesSatisfyingExactly(
-            equalTo(
-                stringKey("camel.uri"),
-                experimental("aws-sns://" + topicName + "?amazonSNSClient=%23snsClient")),
-            equalTo(MESSAGING_SYSTEM, emitStableMessagingSemconv() ? "aws.sns" : null),
-            equalTo(MESSAGING_DESTINATION_NAME, topicName),
-            equalTo(MESSAGING_OPERATION_NAME, emitStableMessagingSemconv() ? "send" : null),
-            equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? "send" : null),
-            equalTo(MESSAGING_MESSAGE_ID, emitStableMessagingSemconv() ? "message-id" : null));
+        .hasAttributesSatisfyingExactly(attributeAssertions);
   }
 
   static SpanDataAssert s3(SpanDataAssert span, String bucketName) {

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/S3CamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/S3CamelTest.java
@@ -78,7 +78,9 @@ class S3CamelTest {
         // camel cleaning received msg
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
+                span ->
+                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl, queueName)
+                        .hasNoParent()));
 
     camelApp.stop();
     awsConnector.deleteBucket(bucketName);

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsCamelTest.java
@@ -74,7 +74,7 @@ class SnsCamelTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", metaData.queueUrl)
+                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", metaData.queueUrl, queueName)
                         .hasNoParent()));
 
     try {
@@ -125,7 +125,9 @@ class SnsCamelTest {
                     CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(2))),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
+                span ->
+                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl, queueName)
+                        .hasNoParent()));
 
     try {
       awsConnector.purgeQueue(queueUrl);

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerCamelTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.instrumentation.test.utils.PortUtils;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class SnsProducerCamelTest {
+
+  private static final String topicName = "snsCamelTest";
+  private static final String topicArn = "arn:aws:sns:us-east-1:123456789012:" + topicName;
+  private static final AtomicReference<String> publishRequest = new AtomicReference<>();
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  private static HttpServer server;
+  private static AmazonSNSAsyncClient snsClient;
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("localhost", PortUtils.findOpenPort()), 0);
+    server.createContext("/", SnsProducerCamelTest::handleRequest);
+    server.start();
+
+    AWSStaticCredentialsProvider credentials =
+        new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x"));
+    AwsClientBuilder.EndpointConfiguration endpoint =
+        new AwsClientBuilder.EndpointConfiguration(
+            "http://localhost:" + server.getAddress().getPort(), "us-east-1");
+    snsClient =
+        (AmazonSNSAsyncClient)
+            AmazonSNSAsyncClient.asyncBuilder()
+                .withCredentials(credentials)
+                .withEndpointConfiguration(endpoint)
+                .build();
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    snsClient.shutdown();
+    server.stop(0);
+  }
+
+  @Test
+  void camelSnsSendAllowsNestedAwsSpanAndPropagatesContext() {
+    AwsConnector awsConnector = new AwsConnector(null, null, snsClient, null);
+    CamelSpringApplication camelApp =
+        new CamelSpringApplication(
+            awsConnector, SnsProducerConfig.class, ImmutableMap.of("topicName", topicName));
+    camelApp.start();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> AwsSpanAssertions.sns(span, "SNS.ListTopics", null, null).hasNoParent()));
+    testing.clearData();
+
+    camelApp.producerTemplate().sendBody("direct:input", "{\"type\": \"hello\"}");
+
+    AtomicReference<SpanData> camelSend = new AtomicReference<>();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> CamelSpanAssertions.direct(span, "input"),
+                span -> {
+                  camelSend.set(trace.getSpan(1));
+                  CamelSpanAssertions.snsPublish(span, topicName).hasParent(trace.getSpan(0));
+                },
+                span -> {
+                  AwsSpanAssertions.sns(span, "SNS.Publish", topicArn, topicArn)
+                      .hasParent(trace.getSpan(1));
+                }));
+
+    assertThat(publishRequest.get())
+        .contains("Name=traceparent")
+        .contains("-" + camelSend.get().getSpanId() + "-");
+    camelApp.stop();
+  }
+
+  private static void handleRequest(HttpExchange exchange) throws IOException {
+    String requestBody = new String(ByteStreams.toByteArray(exchange.getRequestBody()), UTF_8);
+    String decodedRequest = URLDecoder.decode(requestBody, UTF_8.name());
+    String response;
+    if (decodedRequest.contains("Action=ListTopics")) {
+      response =
+          "<ListTopicsResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
+              + "<ListTopicsResult><Topics><member><TopicArn>"
+              + topicArn
+              + "</TopicArn></member></Topics></ListTopicsResult>"
+              + "<ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata>"
+              + "</ListTopicsResponse>";
+    } else {
+      publishRequest.set(requestBody);
+      response =
+          "<PublishResponse xmlns=\"https://sns.amazonaws.com/doc/2010-03-31/\">"
+              + "<PublishResult><MessageId>message-id</MessageId></PublishResult>"
+              + "<ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata>"
+              + "</PublishResponse>";
+    }
+    byte[] responseBytes = response.getBytes(UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "text/xml");
+    exchange.sendResponseHeaders(200, responseBytes.length);
+    try (OutputStream output = exchange.getResponseBody()) {
+      output.write(responseBytes);
+    }
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerCamelTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -90,6 +92,9 @@ class SnsProducerCamelTest {
                 span -> {
                   camelSend.set(trace.getSpan(1));
                   CamelSpanAssertions.snsPublish(span, topicName).hasParent(trace.getSpan(0));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasAttribute(MESSAGING_MESSAGE_ID, "message-id");
+                  }
                 },
                 span -> {
                   AwsSpanAssertions.sns(span, "SNS.Publish", topicArn, topicArn)

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerConfig.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SnsProducerConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+class SnsProducerConfig {
+
+  @Bean
+  RouteBuilder snsProducerRoute(@Value("${topicName}") String topicName) {
+    return new RouteBuilder() {
+      @Override
+      public void configure() {
+        from("direct:input").to("aws-sns://" + topicName + "?amazonSNSClient=#snsClient");
+      }
+    };
+  }
+}

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
@@ -5,10 +5,16 @@
 
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -62,8 +68,12 @@ class SqsCamelTest {
                     AwsSpanAssertions.sqs(
                             span, "sqsCamelTest process", queueUrl, queueName, SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(2)),
-                span ->
-                    CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(2))),
+                span -> {
+                  CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(2));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasLinks(propagatedLink(trace.getSpan(2)));
+                  }
+                }),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
@@ -97,8 +107,12 @@ class SqsCamelTest {
                     AwsSpanAssertions.sqs(
                             span, "sqsCamelTest process", queueUrl, queueName, SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(0)),
-                span ->
-                    CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(0))),
+                span -> {
+                  CamelSpanAssertions.sqsConsume(span, queueName).hasParent(trace.getSpan(0));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasLinks(propagatedLink(trace.getSpan(0)));
+                  }
+                }),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
@@ -143,5 +157,15 @@ class SqsCamelTest {
                             SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(2))));
     camelApp.stop();
+  }
+
+  private static LinkData propagatedLink(SpanData producerSpan) {
+    SpanContext producerContext = producerSpan.getSpanContext();
+    return LinkData.create(
+        SpanContext.create(
+            producerContext.getTraceId(),
+            producerContext.getSpanId(),
+            TraceFlags.getSampled(),
+            producerContext.getTraceState()));
   }
 }

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.camel.v2_20.aws;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.amazonaws.services.sqs.model.Message;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -131,7 +133,13 @@ class SqsCamelTest {
 
     camelApp.start();
     camelApp.producerTemplate().sendBody("direct:inputSdkConsumer", "{\"type\": \"hello\"}");
-    awsConnector.receiveMessage(queueUrl);
+    Message receivedMessage = awsConnector.receiveMessage(queueUrl);
+    assertThat(receivedMessage.getAttributes()).containsKey("AWSTraceHeader");
+    if (emitStableMessagingSemconv()) {
+      assertThat(receivedMessage.getMessageAttributes()).doesNotContainKey("traceparent");
+    } else {
+      assertThat(receivedMessage.getMessageAttributes()).containsKey("traceparent");
+    }
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/aws/SqsCamelTest.java
@@ -78,7 +78,9 @@ class SqsCamelTest {
                 }),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
+                span ->
+                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl, queueName)
+                        .hasNoParent()));
     camelApp.stop();
   }
 
@@ -117,7 +119,9 @@ class SqsCamelTest {
                 }),
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl).hasNoParent()));
+                span ->
+                    AwsSpanAssertions.sqs(span, "SQS.DeleteMessage", queueUrl, queueName)
+                        .hasNoParent()));
     camelApp.stop();
   }
 


### PR DESCRIPTION
Adds v1.43 messaging semantic conventions to Apache Camel when `otel.semconv-stability.opt-in=messaging` is enabled.

For a JMS send to `jms://queue:testQueue`:

```text
# before
queue:testQueue  PRODUCER
messaging.destination.name = queue:testQueue

# with messaging opt-in
send testQueue   PRODUCER
messaging.system = jms
messaging.destination.name = testQueue
messaging.operation.name = send
messaging.operation.type = send
```

The opt-in updates span names, kinds, messaging attributes, destination formatting, and message context links across Camel messaging components.

Without the opt-in, Camel keeps its existing messaging telemetry. Non-messaging components are unchanged.

### Propagation

With the messaging opt-in, Camel injects context only when it owns propagation for the transport. For AWS SQS, the nested AWS SDK producer span injects its context through the `AWSTraceHeader` system attribute, so Camel removes its own `traceparent` message attribute to avoid propagating two contexts. On receive, Camel reads `AWSTraceHeader` using the AWS X-Ray propagator and records the propagated producer context on the processing span.

AWS SNS does not use that SQS propagation path. Camel injects the configured propagator into SNS message attributes, so the propagated context identifies the Camel producer span while the nested AWS SDK `SNS.Publish` span remains its child.

Part of #19254.