### PR TITLE
Add basic settle spans for synchronous Kafka commits

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.consumerCommitInstrumenter;
 import static io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11.KafkaSingletons.consumerReceiveInstrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -15,10 +16,13 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaCommitRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
+import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.bootstrap.kafka.KafkaClientsConsumerProcessTracing;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -30,6 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 class KafkaConsumerInstrumentation implements TypeInstrumentation {
 
@@ -47,6 +52,9 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
             .and(takesArgument(0, long.class).or(takesArgument(0, Duration.class)))
             .and(returns(named("org.apache.kafka.clients.consumer.ConsumerRecords"))),
         getClass().getName() + "$PollAdvice");
+    transformer.applyAdviceToMethod(
+        named("commitSync").and(isPublic()).and(returns(void.class)),
+        getClass().getName() + "$CommitSyncAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -99,6 +107,70 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
       } finally {
         KafkaClientsConsumerProcessTracing.setWrappingEnabled(previousValue);
       }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class CommitSyncAdvice {
+
+    public static class AdviceScope {
+      private final CallDepth callDepth;
+      @Nullable private final TracingState tracingState;
+
+      private AdviceScope(CallDepth callDepth, @Nullable TracingState tracingState) {
+        this.callDepth = callDepth;
+        this.tracingState = tracingState;
+      }
+
+      public static AdviceScope start(@Nullable Object argument) {
+        CallDepth callDepth = CallDepth.forClass(KafkaConsumer.class);
+        if (callDepth.getAndIncrement() > 0) {
+          return new AdviceScope(callDepth, null);
+        }
+
+        KafkaCommitRequest request = KafkaCommitRequest.create(argument);
+        Context parentContext = Context.current();
+        if (!consumerCommitInstrumenter().shouldStart(parentContext, request)) {
+          return new AdviceScope(callDepth, null);
+        }
+
+        Context context = consumerCommitInstrumenter().start(parentContext, request);
+        return new AdviceScope(
+            callDepth, new TracingState(context, context.makeCurrent(), request));
+      }
+
+      public void end(@Nullable Throwable error) {
+        if (callDepth.decrementAndGet() > 0 || tracingState == null) {
+          return;
+        }
+
+        tracingState.scope.close();
+        consumerCommitInstrumenter().end(tracingState.context, tracingState.request, null, error);
+      }
+    }
+
+    static class TracingState {
+      final Context context;
+      final Scope scope;
+      final KafkaCommitRequest request;
+
+      TracingState(Context context, Scope scope, KafkaCommitRequest request) {
+        this.context = context;
+        this.scope = scope;
+        this.request = request;
+      }
+    }
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static AdviceScope onEnter(
+        @Advice.Argument(value = 0, optional = true) @Nullable Object argument) {
+      return AdviceScope.start(argument);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Thrown @Nullable Throwable error, @Advice.Enter AdviceScope adviceScope) {
+      adviceScope.end(error);
     }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -128,15 +128,25 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
           return new AdviceScope(callDepth, null);
         }
 
-        KafkaCommitRequest request = KafkaCommitRequest.create(argument);
-        Context parentContext = Context.current();
-        if (!consumerCommitInstrumenter().shouldStart(parentContext, request)) {
-          return new AdviceScope(callDepth, null);
-        }
+        boolean scopeCreated = false;
+        try {
+          KafkaCommitRequest request = KafkaCommitRequest.create(argument);
+          Context parentContext = Context.current();
+          if (!consumerCommitInstrumenter().shouldStart(parentContext, request)) {
+            scopeCreated = true;
+            return new AdviceScope(callDepth, null);
+          }
 
-        Context context = consumerCommitInstrumenter().start(parentContext, request);
-        return new AdviceScope(
-            callDepth, new TracingState(context, context.makeCurrent(), request));
+          Context context = consumerCommitInstrumenter().start(parentContext, request);
+          AdviceScope adviceScope =
+              new AdviceScope(callDepth, new TracingState(context, context.makeCurrent(), request));
+          scopeCreated = true;
+          return adviceScope;
+        } finally {
+          if (!scopeCreated) {
+            callDepth.decrementAndGet();
+          }
+        }
       }
 
       public void end(@Nullable Throwable error) {
@@ -169,8 +179,10 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.Thrown @Nullable Throwable error, @Advice.Enter AdviceScope adviceScope) {
-      adviceScope.end(error);
+        @Advice.Thrown @Nullable Throwable error, @Advice.Enter @Nullable AdviceScope adviceScope) {
+      if (adviceScope != null) {
+        adviceScope.end(error);
+      }
     }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaSingletons.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaCommitRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProducerRequest;
@@ -32,6 +33,7 @@ public class KafkaSingletons {
   private static final Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter;
   private static final Instrumenter<KafkaReceiveRequest, Void> consumerReceiveInstrumenter;
   private static final Instrumenter<KafkaProcessRequest, Void> consumerProcessInstrumenter;
+  private static final Instrumenter<KafkaCommitRequest, Void> consumerCommitInstrumenter;
 
   static {
     DeclarativeConfigProperties commonConfig =
@@ -51,6 +53,7 @@ public class KafkaSingletons {
     producerInstrumenter = instrumenterFactory.createProducerInstrumenter();
     consumerReceiveInstrumenter = instrumenterFactory.createConsumerReceiveInstrumenter();
     consumerProcessInstrumenter = instrumenterFactory.createConsumerProcessInstrumenter();
+    consumerCommitInstrumenter = instrumenterFactory.createConsumerCommitInstrumenter();
   }
 
   public static Instrumenter<KafkaProducerRequest, RecordMetadata> producerInstrumenter() {
@@ -63,6 +66,10 @@ public class KafkaSingletons {
 
   public static Instrumenter<KafkaProcessRequest, Void> consumerProcessInstrumenter() {
     return consumerProcessInstrumenter;
+  }
+
+  public static Instrumenter<KafkaCommitRequest, Void> consumerCommitInstrumenter() {
+    return consumerCommitInstrumenter;
   }
 
   private KafkaSingletons() {}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess.getAndResetAdviceFailureCount;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
@@ -17,6 +18,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -31,9 +33,11 @@ import io.opentelemetry.sdk.trace.data.StatusData;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -148,6 +152,33 @@ class KafkaConsumerCommitTest {
     Consumer<Integer, String> consumer = closedConsumer();
     testing.clearData();
 
+    assertThatThrownBy(consumer::commitSync).isInstanceOf(IllegalStateException.class);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    assertCommitSpan(span, null, null, IllegalStateException.class.getName())
+                        .hasStatus(StatusData.error())
+                        .hasNoParent()));
+  }
+
+  @Test
+  void instrumentationFailureDoesNotDisableCommitSpans() {
+    assumeTrue(emitStableMessagingSemconv());
+    Consumer<Integer, String> consumer = closedConsumer();
+    Map<TopicPartition, OffsetAndMetadata> throwingOffsets =
+        new AbstractMap<TopicPartition, OffsetAndMetadata>() {
+          @Override
+          public Set<Entry<TopicPartition, OffsetAndMetadata>> entrySet() {
+            throw new IllegalStateException("test instrumentation failure");
+          }
+        };
+    testing.clearData();
+
+    assertThatThrownBy(() -> consumer.commitSync(throwingOffsets))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(getAndResetAdviceFailureCount()).isEqualTo(1);
     assertThatThrownBy(consumer::commitSync).isInstanceOf(IllegalStateException.class);
 
     testing.waitAndAssertTraces(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
@@ -5,12 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
@@ -45,6 +47,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class KafkaConsumerCommitTest {
 
   private static final String TOPIC = "test.topic";
@@ -175,6 +178,7 @@ class KafkaConsumerCommitTest {
             equalTo(MESSAGING_SYSTEM, "kafka"),
             equalTo(MESSAGING_OPERATION_NAME, "commit"),
             equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+            equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
             equalTo(MESSAGING_DESTINATION_NAME, destination),
             equalTo(ERROR_TYPE, errorType));
     if (parentSpan != null) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@SuppressWarnings("deprecation") // using deprecated semconv
 class KafkaConsumerCommitTest {
 
   private static final String TOPIC = "test.topic";
@@ -201,6 +200,7 @@ class KafkaConsumerCommitTest {
     return consumer;
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   private static SpanDataAssert assertCommitSpan(
       SpanDataAssert span, SpanData parentSpan, String destination, String errorType) {
     span.hasName(destination == null ? "commit" : "commit " + destination)

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerCommitTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class KafkaConsumerCommitTest {
+
+  private static final String TOPIC = "test.topic";
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, 0);
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Test
+  void commitSyncIsDisabledByDefault() {
+    assumeFalse(emitStableMessagingSemconv());
+    Consumer<Integer, String> consumer = closedConsumer();
+    testing.clearData();
+
+    assertThatThrownBy(consumer::commitSync).isInstanceOf(IllegalStateException.class);
+
+    assertThat(testing.spans()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("commitSyncOverloads")
+  void commitSyncOverloads(CommitAction commitAction, String expectedDestination) {
+    assumeTrue(emitStableMessagingSemconv());
+    Consumer<Integer, String> consumer = closedConsumer();
+    testing.clearData();
+
+    testing.runWithSpan(
+        "parent",
+        () ->
+            assertThatThrownBy(() -> commitAction.commit(consumer))
+                .isInstanceOf(IllegalStateException.class));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertCommitSpan(
+                            span,
+                            trace.getSpan(0),
+                            expectedDestination,
+                            IllegalStateException.class.getName())
+                        .hasStatus(StatusData.error())));
+  }
+
+  private static Stream<Arguments> commitSyncOverloads() {
+    Stream.Builder<Arguments> arguments = Stream.builder();
+    arguments.add(argumentSet("no arguments", (CommitAction) Consumer::commitSync, null));
+    arguments.add(
+        argumentSet(
+            "explicit offsets",
+            (CommitAction)
+                consumer ->
+                    consumer.commitSync(singletonMap(TOPIC_PARTITION, new OffsetAndMetadata(1))),
+            TOPIC));
+
+    Map<TopicPartition, OffsetAndMetadata> sameTopicBatch = new LinkedHashMap<>();
+    sameTopicBatch.put(TOPIC_PARTITION, new OffsetAndMetadata(1));
+    sameTopicBatch.put(new TopicPartition(TOPIC, 1), new OffsetAndMetadata(2));
+    arguments.add(
+        argumentSet(
+            "single-topic offset batch",
+            (CommitAction) consumer -> consumer.commitSync(sameTopicBatch),
+            TOPIC));
+
+    Map<TopicPartition, OffsetAndMetadata> multipleTopicBatch = new LinkedHashMap<>();
+    multipleTopicBatch.put(TOPIC_PARTITION, new OffsetAndMetadata(1));
+    multipleTopicBatch.put(new TopicPartition("other.topic", 0), new OffsetAndMetadata(2));
+    arguments.add(
+        argumentSet(
+            "multiple-topic offset batch",
+            (CommitAction) consumer -> consumer.commitSync(multipleTopicBatch),
+            null));
+
+    if (testLatestDeps()) {
+      arguments.add(
+          argumentSet(
+              "timeout",
+              (CommitAction) consumer -> invokeCommitSync(consumer, Duration.ofSeconds(5)),
+              null));
+      arguments.add(
+          argumentSet(
+              "explicit offsets and timeout",
+              (CommitAction)
+                  consumer ->
+                      invokeCommitSync(
+                          consumer,
+                          singletonMap(TOPIC_PARTITION, new OffsetAndMetadata(1)),
+                          Duration.ofSeconds(5)),
+              TOPIC));
+    }
+    return arguments.build();
+  }
+
+  @Test
+  void commitSyncWithoutAmbientContextCreatesRootSpan() {
+    assumeTrue(emitStableMessagingSemconv());
+    Consumer<Integer, String> consumer = closedConsumer();
+    testing.clearData();
+
+    assertThatThrownBy(consumer::commitSync).isInstanceOf(IllegalStateException.class);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    assertCommitSpan(span, null, null, IllegalStateException.class.getName())
+                        .hasStatus(StatusData.error())
+                        .hasNoParent()));
+  }
+
+  private static Consumer<Integer, String> closedConsumer() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("bootstrap.servers", "localhost:9092");
+    properties.put("group.id", "test");
+    properties.put("key.deserializer", IntegerDeserializer.class.getName());
+    properties.put("value.deserializer", StringDeserializer.class.getName());
+    Consumer<Integer, String> consumer = new KafkaConsumer<>(properties);
+    consumer.close();
+    return consumer;
+  }
+
+  private static SpanDataAssert assertCommitSpan(
+      SpanDataAssert span, SpanData parentSpan, String destination, String errorType) {
+    span.hasName(destination == null ? "commit" : "commit " + destination)
+        .hasKind(SpanKind.CLIENT)
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_SYSTEM, "kafka"),
+            equalTo(MESSAGING_OPERATION_NAME, "commit"),
+            equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+            equalTo(MESSAGING_DESTINATION_NAME, destination),
+            equalTo(ERROR_TYPE, errorType));
+    if (parentSpan != null) {
+      span.hasParent(parentSpan);
+    }
+    return span;
+  }
+
+  private static void invokeCommitSync(Consumer<?, ?> consumer, Object... arguments) {
+    Class<?>[] argumentTypes = new Class<?>[arguments.length];
+    for (int i = 0; i < arguments.length; i++) {
+      argumentTypes[i] = arguments[i] instanceof Map ? Map.class : arguments[i].getClass();
+    }
+    try {
+      Method method = consumer.getClass().getMethod("commitSync", argumentTypes);
+      method.invoke(consumer, arguments);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw new IllegalStateException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @FunctionalInterface
+  private interface CommitAction {
+    void commit(Consumer<Integer, String> consumer);
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaCommitAttributesGetter.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaCommitAttributesGetter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
+
+import static java.util.Collections.emptyList;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.kafka.common.TopicPartition;
+
+final class KafkaCommitAttributesGetter
+    implements MessagingAttributesGetter<KafkaCommitRequest, Void> {
+
+  @Override
+  public String getSystem(KafkaCommitRequest request) {
+    return "kafka";
+  }
+
+  @Nullable
+  @Override
+  public String getDestination(KafkaCommitRequest request) {
+    Map<?, ?> offsets = request.getOffsets();
+    if (offsets == null || offsets.isEmpty()) {
+      return null;
+    }
+
+    String destination = null;
+    for (Object key : offsets.keySet()) {
+      if (!(key instanceof TopicPartition)) {
+        return null;
+      }
+      String topic = ((TopicPartition) key).topic();
+      if (destination == null) {
+        destination = topic;
+      } else if (!destination.equals(topic)) {
+        return null;
+      }
+    }
+    return destination;
+  }
+
+  @Nullable
+  @Override
+  public String getDestinationTemplate(KafkaCommitRequest request) {
+    return null;
+  }
+
+  @Override
+  public boolean isTemporaryDestination(KafkaCommitRequest request) {
+    return false;
+  }
+
+  @Override
+  public boolean isAnonymousDestination(KafkaCommitRequest request) {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getConversationId(KafkaCommitRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageBodySize(KafkaCommitRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageEnvelopeSize(KafkaCommitRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getMessageId(KafkaCommitRequest request, @Nullable Void unused) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getClientId(KafkaCommitRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getBatchMessageCount(KafkaCommitRequest request, @Nullable Void unused) {
+    return null;
+  }
+
+  @Override
+  public List<String> getMessageHeader(KafkaCommitRequest request, String name) {
+    return emptyList();
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaCommitRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaCommitRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class KafkaCommitRequest {
+
+  @Nullable private final Map<?, ?> offsets;
+
+  public static KafkaCommitRequest create(@Nullable Object argument) {
+    return new KafkaCommitRequest(argument instanceof Map ? (Map<?, ?>) argument : null);
+  }
+
+  private KafkaCommitRequest(@Nullable Map<?, ?> offsets) {
+    this.offsets = offsets;
+  }
+
+  @Nullable
+  Map<?, ?> getOffsets() {
+    return offsets;
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSettleExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
 
@@ -38,6 +39,7 @@ public final class KafkaInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String POLL_OPERATION_NAME = "poll";
   private static final String PROCESS_OPERATION_NAME = "process";
+  private static final String COMMIT_OPERATION_NAME = "commit";
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
@@ -170,6 +172,24 @@ public final class KafkaInstrumenterFactory {
         openTelemetry.getPropagators().getTextMapPropagator(),
         new KafkaConsumerRecordGetter(),
         receiveInstrumentationEnabled());
+  }
+
+  public Instrumenter<KafkaCommitRequest, Void> createConsumerCommitInstrumenter() {
+    KafkaCommitAttributesGetter getter = new KafkaCommitAttributesGetter();
+    MessagingOperationType operationType = MessagingOperationType.SETTLE;
+
+    InstrumenterBuilder<KafkaCommitRequest, Void> builder =
+        Instrumenter.<KafkaCommitRequest, Void>builder(
+                openTelemetry,
+                instrumentationName,
+                MessagingSpanNameExtractor.create(getter, operationType, COMMIT_OPERATION_NAME))
+            .addAttributesExtractor(
+                buildMessagingAttributesExtractor(
+                    getter, operationType, COMMIT_OPERATION_NAME, emptyList()))
+            .setErrorCauseExtractor(errorCauseExtractor)
+            .setEnabled(emitStableMessagingSemconv());
+    setMessagingSettleExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   private boolean receiveInstrumentationEnabled() {

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaInstrumentationTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafkaInstrumentationTest.java
@@ -24,6 +24,6 @@ class ReactorKafkaInstrumentationTest extends AbstractReactorKafkaTest {
   @Test
   void testReceiveAtMostOnce() {
     testSingleRecordProcess(
-        recordConsumer -> receiver.receiveAtmostOnce().subscribe(recordConsumer));
+        recordConsumer -> receiver.receiveAtmostOnce().subscribe(recordConsumer), true);
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/testV1_3_3/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafka133InstrumentationTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/src/testV1_3_3/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/ReactorKafka133InstrumentationTest.java
@@ -24,6 +24,6 @@ class ReactorKafka133InstrumentationTest extends AbstractReactorKafkaTest {
   @Test
   void testReceiveAtMostOnce() {
     testSingleRecordProcess(
-        recordConsumer -> receiver.receiveAtmostOnce(1).subscribe(recordConsumer));
+        recordConsumer -> receiver.receiveAtmostOnce(1).subscribe(recordConsumer), true);
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -34,6 +34,7 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.lang.reflect.InvocationTargetException;
@@ -150,6 +151,12 @@ public abstract class AbstractReactorKafkaTest {
 
   protected void testSingleRecordProcess(
       Function<Consumer<ConsumerRecord<String, String>>, Disposable> subscriptionFunction) {
+    testSingleRecordProcess(subscriptionFunction, false);
+  }
+
+  protected void testSingleRecordProcess(
+      Function<Consumer<ConsumerRecord<String, String>>, Disposable> subscriptionFunction,
+      boolean expectCommitSpan) {
     Disposable disposable =
         subscriptionFunction.apply(record -> testing.runWithSpan("consumer", () -> {}));
     cleanup.deferCleanup(disposable::dispose);
@@ -160,18 +167,19 @@ public abstract class AbstractReactorKafkaTest {
     testing.runWithSpan("producer", () -> producer.blockLast(Duration.ofSeconds(30)));
 
     if (RECEIVE_TELEMETRY_ENABLED) {
-      assertWithReceiveTelemetry(record);
+      assertWithReceiveTelemetry(record, expectCommitSpan);
     } else {
-      assertWithoutReceiveTelemetry(record);
+      assertWithoutReceiveTelemetry(record, expectCommitSpan);
     }
   }
 
-  private static void assertWithReceiveTelemetry(SenderRecord<String, String, Object> record) {
+  private static void assertWithReceiveTelemetry(
+      SenderRecord<String, String, Object> record, boolean expectCommitSpan) {
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
 
     if (emitStableMessagingSemconv()) {
-      testing.waitAndAssertSortedTraces(
-          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT),
+      List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+      assertions.add(
           trace -> {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
@@ -189,7 +197,8 @@ public abstract class AbstractReactorKafkaTest {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
 
             producerSpan.set(trace.getSpan(1));
-          },
+          });
+      assertions.add(
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span ->
@@ -198,6 +207,11 @@ public abstract class AbstractReactorKafkaTest {
                           .hasNoParent()
                           .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                           .hasAttributesSatisfyingExactly(receiveAttributes("testTopic"))));
+      if (expectCommitSpan) {
+        assertions.add(AbstractReactorKafkaTest::assertCommitTrace);
+      }
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), assertions);
       return;
     }
 
@@ -230,8 +244,10 @@ public abstract class AbstractReactorKafkaTest {
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
   }
 
-  private static void assertWithoutReceiveTelemetry(SenderRecord<String, String, Object> record) {
-    testing.waitAndAssertTraces(
+  private static void assertWithoutReceiveTelemetry(
+      SenderRecord<String, String, Object> record, boolean expectCommitSpan) {
+    List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+    assertions.add(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("producer"),
@@ -250,6 +266,24 @@ public abstract class AbstractReactorKafkaTest {
                   }
                 },
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
+    if (expectCommitSpan && emitStableMessagingSemconv()) {
+      assertions.add(AbstractReactorKafkaTest::assertCommitTrace);
+    }
+    testing.waitAndAssertTraces(assertions);
+  }
+
+  private static void assertCommitTrace(TraceAssert trace) {
+    trace.hasSpansSatisfyingExactly(
+        span ->
+            span.hasName("commit testTopic")
+                .hasKind(SpanKind.CLIENT)
+                .hasNoParent()
+                .hasAttributesSatisfyingExactly(
+                   equalTo(MESSAGING_SYSTEM, "kafka"),
+                   equalTo(MESSAGING_OPERATION_NAME, "commit"),
+                   equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+                   equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
+                   equalTo(MESSAGING_DESTINATION_NAME, "testTopic")));
   }
 
   private static List<AttributeAssertion> sendAttributes(ProducerRecord<String, String> record) {

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -279,11 +279,11 @@ public abstract class AbstractReactorKafkaTest {
                 .hasKind(SpanKind.CLIENT)
                 .hasNoParent()
                 .hasAttributesSatisfyingExactly(
-                   equalTo(MESSAGING_SYSTEM, "kafka"),
-                   equalTo(MESSAGING_OPERATION_NAME, "commit"),
-                   equalTo(MESSAGING_OPERATION_TYPE, "settle"),
-                   equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
-                   equalTo(MESSAGING_DESTINATION_NAME, "testTopic")));
+                    equalTo(MESSAGING_SYSTEM, "kafka"),
+                    equalTo(MESSAGING_OPERATION_NAME, "commit"),
+                    equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+                    equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
+                    equalTo(MESSAGING_DESTINATION_NAME, "testTopic")));
   }
 
   private static List<AttributeAssertion> sendAttributes(ProducerRecord<String, String> record) {

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -114,7 +114,8 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                           .hasNoParent()
                           .hasLinks(LinkData.create(producer.get().getSpanContext()))
                           .hasAttributesSatisfyingExactly(
-                              receiveAttributes("testSingleTopic", "testSingleListener", 1))));
+                              receiveAttributes("testSingleTopic", "testSingleListener", 1))),
+          trace -> assertCommitSpan(trace, "testSingleTopic"));
       return;
     }
 
@@ -204,6 +205,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                         assertStableReceiveSpan(
                             span, producer.get(), "testSingleTopic", "testSingleListener")));
       }
+      assertions.add(trace -> assertCommitSpan(trace, "testSingleTopic"));
       testing.waitAndAssertSortedTraces(
           orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), assertions);
       return;
@@ -361,7 +363,8 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                               LinkData.create(producer1.get().getSpanContext()),
                               LinkData.create(producer2.get().getSpanContext()))
                           .hasAttributesSatisfyingExactly(
-                              receiveAttributes("testBatchTopic", "testBatchListener", 2))));
+                              receiveAttributes("testBatchTopic", "testBatchListener", 2))),
+          trace -> assertCommitSpan(trace, "testBatchTopic"));
       return;
     }
 
@@ -445,6 +448,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
                         assertStableReceiveSpan(
                             span, producer.get(), "testBatchTopic", "testBatchListener")));
       }
+      assertions.add(trace -> assertCommitSpan(trace, "testBatchTopic"));
       testing.waitAndAssertSortedTraces(
           orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT), assertions);
       return;
@@ -559,6 +563,20 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         .hasNoParent()
         .hasLinks(LinkData.create(producer.getSpanContext()))
         .hasAttributesSatisfyingExactly(receiveAttributes(topic, group, 1));
+  }
+
+  private static void assertCommitSpan(TraceAssert trace, String topic) {
+    trace.hasSpansSatisfyingExactly(
+        span ->
+            span.hasName("commit " + topic)
+                .hasKind(SpanKind.CLIENT)
+                .hasNoParent()
+                .hasAttributesSatisfyingExactly(
+                    equalTo(MESSAGING_SYSTEM, "kafka"),
+                    equalTo(MESSAGING_OPERATION_NAME, "commit"),
+                    equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+                    equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
+                    equalTo(MESSAGING_DESTINATION_NAME, topic)));
   }
 
   private static void assertProcessSpan(

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -32,6 +32,7 @@ import static java.util.Arrays.asList;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -63,29 +64,31 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                   });
             });
 
+    List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+    assertions.add(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("producer"),
+                span ->
+                    span.hasName(spanName("testSingleTopic", "publish", "send"))
+                        .hasKind(SpanKind.PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(sendAttributes("testSingleTopic", "10")),
+                span -> {
+                  span.hasName(spanName("testSingleTopic", "process", "process"))
+                      .hasKind(SpanKind.CONSUMER)
+                      .hasParent(trace.getSpan(1))
+                      .hasAttributesSatisfyingExactly(
+                          singleProcessAttributes("testSingleTopic", "testSingleListener", "10"));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+                  }
+                },
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
+    addCommitSpanAssertion(assertions, "testSingleTopic");
     testing()
-        .waitAndAssertTraces(
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("producer"),
-                    span ->
-                        span.hasName(spanName("testSingleTopic", "publish", "send"))
-                            .hasKind(SpanKind.PRODUCER)
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                sendAttributes("testSingleTopic", "10")),
-                    span -> {
-                      span.hasName(spanName("testSingleTopic", "process", "process"))
-                          .hasKind(SpanKind.CONSUMER)
-                          .hasParent(trace.getSpan(1))
-                          .hasAttributesSatisfyingExactly(
-                              singleProcessAttributes(
-                                  "testSingleTopic", "testSingleListener", "10"));
-                      if (emitStableMessagingSemconv()) {
-                        span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
-                      }
-                    },
-                    span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), assertions);
   }
 
   @Test
@@ -104,38 +107,19 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
     List<AttributeAssertion> processAttributes =
         singleProcessAttributes("testSingleTopic", "testSingleListener", "10");
 
-    testing()
-        .waitAndAssertTraces(
-            trace -> {
-              List<Consumer<SpanDataAssert>> assertions =
-                  new ArrayList<>(
-                      asList(
-                          span -> span.hasName("producer"),
-                          span ->
-                              span.hasName(spanName("testSingleTopic", "publish", "send"))
-                                  .hasKind(SpanKind.PRODUCER)
-                                  .hasParent(trace.getSpan(0))
-                                  .hasAttributesSatisfyingExactly(
-                                      sendAttributes("testSingleTopic", "10")),
-                          span -> {
-                            span.hasName(spanName("testSingleTopic", "process", "process"))
-                                .hasKind(SpanKind.CONSUMER)
-                                .hasParent(trace.getSpan(1))
-                                .hasStatus(StatusData.error())
-                                .hasException(new IllegalArgumentException("boom"))
-                                .hasAttributesSatisfyingExactly(
-                                    withErrorType(processAttributes, true));
-                            if (emitStableMessagingSemconv()) {
-                              span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
-                            }
-                          },
-                          span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
-              if (testLatestDeps()) {
-                assertions.add(
-                    span -> span.hasName("handle exception").hasParent(trace.getSpan(2)));
-              }
-              assertions.addAll(
+    List<Consumer<TraceAssert>> traceAssertions = new ArrayList<>();
+    traceAssertions.add(
+        trace -> {
+          List<Consumer<SpanDataAssert>> assertions =
+              new ArrayList<>(
                   asList(
+                      span -> span.hasName("producer"),
+                      span ->
+                          span.hasName(spanName("testSingleTopic", "publish", "send"))
+                              .hasKind(SpanKind.PRODUCER)
+                              .hasParent(trace.getSpan(0))
+                              .hasAttributesSatisfyingExactly(
+                                  sendAttributes("testSingleTopic", "10")),
                       span -> {
                         span.hasName(spanName("testSingleTopic", "process", "process"))
                             .hasKind(SpanKind.CONSUMER)
@@ -147,31 +131,49 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                           span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
                         }
                       },
-                      span ->
-                          span.hasName("consumer")
-                              .hasParent(trace.getSpan(testLatestDeps() ? 5 : 4))));
-              if (testLatestDeps()) {
-                assertions.add(
-                    span -> span.hasName("handle exception").hasParent(trace.getSpan(5)));
-              }
-              assertions.addAll(
-                  asList(
-                      span -> {
-                        span.hasName(spanName("testSingleTopic", "process", "process"))
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasParent(trace.getSpan(1))
-                            .hasStatus(StatusData.unset())
-                            .hasAttributesSatisfyingExactly(processAttributes);
-                        if (emitStableMessagingSemconv()) {
-                          span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
-                        }
-                      },
-                      span ->
-                          span.hasName("consumer")
-                              .hasParent(trace.getSpan(testLatestDeps() ? 8 : 6))));
+                      span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
+          if (testLatestDeps()) {
+            assertions.add(span -> span.hasName("handle exception").hasParent(trace.getSpan(2)));
+          }
+          assertions.addAll(
+              asList(
+                  span -> {
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasStatus(StatusData.error())
+                        .hasException(new IllegalArgumentException("boom"))
+                        .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true));
+                    if (emitStableMessagingSemconv()) {
+                      span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+                    }
+                  },
+                  span ->
+                      span.hasName("consumer").hasParent(trace.getSpan(testLatestDeps() ? 5 : 4))));
+          if (testLatestDeps()) {
+            assertions.add(span -> span.hasName("handle exception").hasParent(trace.getSpan(5)));
+          }
+          assertions.addAll(
+              asList(
+                  span -> {
+                    span.hasName(spanName("testSingleTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasStatus(StatusData.unset())
+                        .hasAttributesSatisfyingExactly(processAttributes);
+                    if (emitStableMessagingSemconv()) {
+                      span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+                    }
+                  },
+                  span ->
+                      span.hasName("consumer").hasParent(trace.getSpan(testLatestDeps() ? 8 : 6))));
 
-              trace.hasSpansSatisfyingExactly(assertions);
-            });
+          trace.hasSpansSatisfyingExactly(assertions);
+        });
+    addCommitSpanAssertion(traceAssertions, "testSingleTopic");
+    testing()
+        .waitAndAssertSortedTraces(
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CLIENT), traceAssertions);
   }
 
   @Test
@@ -184,39 +186,42 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
     AtomicReference<SpanData> producer1 = new AtomicReference<>();
     AtomicReference<SpanData> producer2 = new AtomicReference<>();
 
+    List<Consumer<TraceAssert>> assertions = new ArrayList<>();
+    assertions.add(
+        trace -> {
+          trace.hasSpansSatisfyingExactlyInAnyOrder(
+              span -> span.hasName("producer"),
+              span ->
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")),
+              span ->
+                  span.hasName(spanName("testBatchTopic", "publish", "send"))
+                      .hasKind(SpanKind.PRODUCER)
+                      .hasParent(trace.getSpan(0))
+                      .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "20")));
+
+          producer1.set(trace.getSpan(1));
+          producer2.set(trace.getSpan(2));
+        });
+    assertions.add(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(spanName("testBatchTopic", "process", "process"))
+                        .hasKind(SpanKind.CONSUMER)
+                        .hasNoParent()
+                        .hasLinksSatisfying(
+                            links(
+                                producer1.get().getSpanContext(), producer2.get().getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
+    addCommitSpanAssertion(assertions, "testBatchTopic");
     testing()
         .waitAndAssertSortedTraces(
-            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER),
-            trace -> {
-              trace.hasSpansSatisfyingExactlyInAnyOrder(
-                  span -> span.hasName("producer"),
-                  span ->
-                      span.hasName(spanName("testBatchTopic", "publish", "send"))
-                          .hasKind(SpanKind.PRODUCER)
-                          .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")),
-                  span ->
-                      span.hasName(spanName("testBatchTopic", "publish", "send"))
-                          .hasKind(SpanKind.PRODUCER)
-                          .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "20")));
-
-              producer1.set(trace.getSpan(1));
-              producer2.set(trace.getSpan(2));
-            },
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(spanName("testBatchTopic", "process", "process"))
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasNoParent()
-                            .hasLinksSatisfying(
-                                links(
-                                    producer1.get().getSpanContext(),
-                                    producer2.get().getSpanContext()))
-                            .hasAttributesSatisfyingExactly(
-                                batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
-                    span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
+            orderByRootSpanKind(SpanKind.INTERNAL, SpanKind.CONSUMER, SpanKind.CLIENT), assertions);
   }
 
   @Test
@@ -237,65 +242,107 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
     List<AttributeAssertion> processAttributes =
         batchProcessAttributes("testBatchTopic", "testBatchListener", 1);
 
+    List<Consumer<TraceAssert>> assertions =
+        new ArrayList<>(
+            asList(
+                trace -> {
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("producer"),
+                      span ->
+                          span.hasName(spanName("testBatchTopic", "publish", "send"))
+                              .hasKind(SpanKind.PRODUCER)
+                              .hasParent(trace.getSpan(0))
+                              .hasAttributesSatisfyingExactly(
+                                  sendAttributes("testBatchTopic", "10")));
+
+                  producer.set(trace.getSpan(1));
+                },
+                trace ->
+                    trace.hasSpansSatisfyingExactly(
+                        span ->
+                            span.hasName(spanName("testBatchTopic", "process", "process"))
+                                .hasKind(SpanKind.CONSUMER)
+                                .hasNoParent()
+                                .hasLinksSatisfying(links(producer.get().getSpanContext()))
+                                .hasStatus(StatusData.error())
+                                .hasException(new IllegalArgumentException("boom"))
+                                .hasAttributesSatisfyingExactly(
+                                    withErrorType(processAttributes, true)),
+                        span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
+                trace -> {
+                  if (isLibraryInstrumentationTest() && testLatestDeps()) {
+                    // in latest dep tests process spans are not created for retries because spring
+                    // does
+                    // not call the success/failure methods on the BatchInterceptor for retries
+                    trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer").hasNoParent());
+                  } else {
+                    trace.hasSpansSatisfyingExactly(
+                        span ->
+                            span.hasName(spanName("testBatchTopic", "process", "process"))
+                                .hasKind(SpanKind.CONSUMER)
+                                .hasNoParent()
+                                .hasLinksSatisfying(links(producer.get().getSpanContext()))
+                                .hasStatus(StatusData.error())
+                                .hasException(new IllegalArgumentException("boom"))
+                                .hasAttributesSatisfyingExactly(
+                                    withErrorType(processAttributes, true)),
+                        span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
+                  }
+                },
+                trace -> {
+                  if (isLibraryInstrumentationTest() && testLatestDeps()) {
+                    trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer").hasNoParent());
+                  } else {
+                    trace.hasSpansSatisfyingExactly(
+                        span ->
+                            span.hasName(spanName("testBatchTopic", "process", "process"))
+                                .hasKind(SpanKind.CONSUMER)
+                                .hasNoParent()
+                                .hasLinksSatisfying(links(producer.get().getSpanContext()))
+                                .hasStatus(StatusData.unset())
+                                .hasAttributesSatisfyingExactly(processAttributes),
+                        span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
+                  }
+                }));
+
+    if (!isLibraryInstrumentationTest() && emitStableMessagingSemconv()) {
+      addCommitSpanAssertion(assertions, "testBatchTopic");
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanName(
+                  "producer",
+                  spanName("testBatchTopic", "process", "process"),
+                  "consumer",
+                  "commit testBatchTopic"),
+              assertions);
+      return;
+    }
+
     testing()
         .waitAndAssertSortedTraces(
             orderByRootSpanName(
                 "producer", spanName("testBatchTopic", "process", "process"), "consumer"),
-            trace -> {
-              trace.hasSpansSatisfyingExactly(
-                  span -> span.hasName("producer"),
-                  span ->
-                      span.hasName(spanName("testBatchTopic", "publish", "send"))
-                          .hasKind(SpanKind.PRODUCER)
-                          .hasParent(trace.getSpan(0))
-                          .hasAttributesSatisfyingExactly(sendAttributes("testBatchTopic", "10")));
+            assertions);
+  }
 
-              producer.set(trace.getSpan(1));
-            },
-            trace ->
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(spanName("testBatchTopic", "process", "process"))
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasNoParent()
-                            .hasLinksSatisfying(links(producer.get().getSpanContext()))
-                            .hasStatus(StatusData.error())
-                            .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
-                    span -> span.hasName("consumer").hasParent(trace.getSpan(0))),
-            trace -> {
-              if (isLibraryInstrumentationTest() && testLatestDeps()) {
-                // in latest dep tests process spans are not created for retries because spring does
-                // not call the success/failure methods on the BatchInterceptor for retries
-                trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer").hasNoParent());
-              } else {
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(spanName("testBatchTopic", "process", "process"))
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasNoParent()
-                            .hasLinksSatisfying(links(producer.get().getSpanContext()))
-                            .hasStatus(StatusData.error())
-                            .hasException(new IllegalArgumentException("boom"))
-                            .hasAttributesSatisfyingExactly(withErrorType(processAttributes, true)),
-                    span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
-              }
-            },
-            trace -> {
-              if (isLibraryInstrumentationTest() && testLatestDeps()) {
-                trace.hasSpansSatisfyingExactly(span -> span.hasName("consumer").hasNoParent());
-              } else {
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(spanName("testBatchTopic", "process", "process"))
-                            .hasKind(SpanKind.CONSUMER)
-                            .hasNoParent()
-                            .hasLinksSatisfying(links(producer.get().getSpanContext()))
-                            .hasStatus(StatusData.unset())
-                            .hasAttributesSatisfyingExactly(processAttributes),
-                    span -> span.hasName("consumer").hasParent(trace.getSpan(0)));
-              }
-            });
+  private void addCommitSpanAssertion(List<Consumer<TraceAssert>> assertions, String topic) {
+    if (!isLibraryInstrumentationTest() && emitStableMessagingSemconv()) {
+      assertions.add(trace -> assertCommitSpan(trace, topic));
+    }
+  }
+
+  private static void assertCommitSpan(TraceAssert trace, String topic) {
+    trace.hasSpansSatisfyingExactly(
+        span ->
+            span.hasName("commit " + topic)
+                .hasKind(SpanKind.CLIENT)
+                .hasNoParent()
+                .hasAttributesSatisfyingExactly(
+                    equalTo(MESSAGING_SYSTEM, "kafka"),
+                    equalTo(MESSAGING_OPERATION_NAME, "commit"),
+                    equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+                    equalTo(MESSAGING_OPERATION, emitOldMessagingSemconv() ? "settle" : null),
+                    equalTo(MESSAGING_DESTINATION_NAME, topic)));
   }
 
   private static List<AttributeAssertion> sendAttributes(String topic, String messageKey) {


### PR DESCRIPTION
Adds `CLIENT` settle spans around the public `KafkaConsumer.commitSync` overloads, so offset commits are visible as spans named `commit` or `commit <topic>`.

The spans carry `messaging.system=kafka`, `messaging.operation.name=commit`, and `messaging.operation.type=settle`, use the ambient context as parent, and set `messaging.destination.name` only when an explicit offset map names exactly one topic.

Commit spans are emitted only when stable messaging semantic conventions are enabled, through `otel.semconv-stability.opt-in=messaging` (or `messaging/dup`) or `otel.instrumentation.common.v3-preview=true`. With neither set, `commitSync` behaves exactly as before and emits nothing.

This covers only the javaagent instrumentation; the kafka-clients library instrumentation is unchanged.

The scope is deliberately narrow: only synchronous commits, and only attributes available directly from the call arguments or the thrown error. It does not retain processed-record state, correlate commits to process spans, add links, infer a destination for the no-argument overload, or wrap async commit callbacks.

Commits driven by frameworks such as Spring Kafka and Reactor Kafka happen outside any ambient context, so their settle spans are roots of their own traces.

Addresses the synchronous slice of #19403.

Part of #19254.