### PR TITLE
Add messaging v1.43 metrics to AWS Lambda SQS

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsEventHandlerTest.java
@@ -28,6 +28,11 @@ class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest 
     return testing;
   }
 
+  @Override
+  protected String instrumentationName() {
+    return "io.opentelemetry.aws-lambda-events-2.2";
+  }
+
   private static class TestRequestHandler implements RequestHandler<SQSEvent, Void> {
     @Override
     public Void handleRequest(SQSEvent input, Context context) {

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AbstractAwsLambdaSqsEventHandlerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.awslambdaevents.v2_2.AwsLambdaSqsMetricsAssertions.assertMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
@@ -52,6 +53,8 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
   protected abstract RequestHandler<SQSEvent, ?> handler();
 
   protected abstract InstrumentationExtension testing();
+
+  protected abstract String instrumentationName();
 
   @Mock private Context context;
 
@@ -126,6 +129,7 @@ public abstract class AbstractAwsLambdaSqsEventHandlerTest {
                                                     ? Attributes.of(
                                                         MESSAGING_MESSAGE_ID, "message1")
                                                     : Attributes.empty())))));
+    assertMetrics(testing(), instrumentationName(), "queue1", 1, 2, null);
   }
 
   @Test

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awslambdaevents.v2_2;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
+
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+
+@SuppressWarnings("deprecation") // using deprecated semconv
+public class AwsLambdaSqsMetricsAssertions {
+
+  public static void assertMetrics(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      long processCount,
+      long consumedMessageCount,
+      String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertMetricNamesAbsent(
+          testing,
+          "messaging.process.duration",
+          "messaging.client.consumed.messages",
+          "messaging.publish.duration",
+          "messaging.publish.messages",
+          "messaging.receive.duration",
+          "messaging.receive.messages");
+      return;
+    }
+
+    testing.waitAndAssertMetrics(
+        instrumentationName,
+        "messaging.process.duration",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("s")
+                        .hasDescription("Duration of processing operation.")
+                        .satisfies(
+                            data -> assertThat(data.getHistogramData().getPoints()).hasSize(1))
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .satisfies(
+                                                data ->
+                                                    assertThat(data.getCount())
+                                                        .isEqualTo(processCount))
+                                            .hasSumGreaterThan(0.0)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
+                                                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                                                equalTo(ERROR_TYPE, errorType))))));
+    testing.waitAndAssertMetrics(
+        instrumentationName,
+        "messaging.client.consumed.messages",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasUnit("{message}")
+                        .hasDescription(
+                            "Number of messages that were delivered to the application.")
+                        .satisfies(data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(consumedMessageCount)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                equalTo(MESSAGING_SYSTEM, AWS_SQS),
+                                                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                                                equalTo(ERROR_TYPE, errorType))))));
+    assertMetricNamesAbsent(
+        testing,
+        "messaging.publish.duration",
+        "messaging.publish.messages",
+        "messaging.receive.duration",
+        "messaging.receive.messages");
+  }
+
+  private static void assertMetricNamesAbsent(
+      InstrumentationExtension testing, String... metricNames) {
+    assertThat(testing.metrics()).extracting(MetricData::getName).doesNotContain(metricNames);
+  }
+
+  private AwsLambdaSqsMetricsAssertions() {}
+}

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
@@ -17,9 +17,9 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 
-@SuppressWarnings("deprecation") // using deprecated semconv
 public class AwsLambdaSqsMetricsAssertions {
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   public static void assertMetrics(
       InstrumentationExtension testing,
       String instrumentationName,

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
@@ -48,8 +48,6 @@ public class AwsLambdaSqsMetricsAssertions {
                     assertThat(metric)
                         .hasUnit("s")
                         .hasDescription("Duration of processing operation.")
-                        .satisfies(
-                            data -> assertThat(data.getHistogramData().getPoints()).hasSize(1))
                         .hasHistogramSatisfying(
                             histogram ->
                                 histogram.hasPointsSatisfying(
@@ -75,7 +73,6 @@ public class AwsLambdaSqsMetricsAssertions {
                         .hasUnit("{message}")
                         .hasDescription(
                             "Number of messages that were delivered to the application.")
-                        .satisfies(data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
                         .hasLongSumSatisfying(
                             sum ->
                                 sum.hasPointsSatisfying(

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/AwsLambdaSqsMetricsAssertions.java
@@ -19,7 +19,6 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 
 public class AwsLambdaSqsMetricsAssertions {
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   public static void assertMetrics(
       InstrumentationExtension testing,
       String instrumentationName,

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventHandlerTest.java
@@ -30,6 +30,11 @@ class AwsLambdaSqsEventHandlerTest extends AbstractAwsLambdaSqsEventHandlerTest 
     return testing;
   }
 
+  @Override
+  protected String instrumentationName() {
+    return TracingSqsEventHandler.INSTRUMENTATION_NAME;
+  }
+
   private static class TestHandler extends TracingSqsEventHandler {
 
     TestHandler(OpenTelemetrySdk openTelemetrySdk) {

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventWrapperTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsEventWrapperTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.awslambdaevents.v2_2.AwsLambdaSqsMetricsAssertions.assertMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
@@ -112,6 +113,7 @@ class AwsLambdaSqsEventWrapperTest {
                             equalTo(
                                 MESSAGING_BATCH_MESSAGE_COUNT,
                                 emitStableMessagingSemconv() ? Long.valueOf(1) : null))));
+    assertMetrics(testing, TracingSqsEventHandler.INSTRUMENTATION_NAME, "otel", 1, 1, null);
   }
 
   public static class TestRequestHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {

--- a/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsMessageHandlerTest.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-3.11/library/src/test/java/io/opentelemetry/instrumentation/awslambdaevents/v3_11/AwsLambdaSqsMessageHandlerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awslambdaevents.v3_11;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.awslambdaevents.v2_2.AwsLambdaSqsMetricsAssertions.assertMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INVOCATION_ID;
@@ -19,7 +20,9 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingSystemIncubatingValues.AWS_SQS;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -196,6 +199,31 @@ class AwsLambdaSqsMessageHandlerTest {
                                     "53995c3f42cd8ad9",
                                     TraceFlags.getSampled(),
                                     TraceState.getDefault())))));
+    assertMetrics(testing, TracingSqsEventHandler.INSTRUMENTATION_NAME, "queue1", 3, 2, null);
+  }
+
+  @Test
+  void processFailureMetrics() {
+    SQSEvent.SQSMessage message = newMessage();
+    message.setAttributes(emptyMap());
+    message.setMessageId("message1");
+    message.setEventSource("aws:sqs");
+    message.setEventSourceArn("arn:aws:sqs:us-east-2:123456789012:queue1");
+
+    SQSEvent event = new SQSEvent();
+    event.setRecords(asList(message));
+
+    assertThatThrownBy(
+            () -> new FailingHandler(testing.getOpenTelemetrySdk()).handleRequest(event, context))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertMetrics(
+        testing,
+        TracingSqsEventHandler.INSTRUMENTATION_NAME,
+        "queue1",
+        2,
+        1,
+        IllegalStateException.class.getName());
   }
 
   @Test
@@ -279,6 +307,18 @@ class AwsLambdaSqsMessageHandlerTest {
     @Override
     protected boolean handleMessage(SQSEvent.SQSMessage message, Context context) {
       return "message1".equals(message.getMessageId());
+    }
+  }
+
+  private static class FailingHandler extends TracingSqsMessageHandler {
+
+    FailingHandler(OpenTelemetrySdk openTelemetrySdk) {
+      super(openTelemetrySdk);
+    }
+
+    @Override
+    protected boolean handleMessage(SQSEvent.SQSMessage message, Context context) {
+      throw new IllegalStateException("test");
     }
   }
 

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/AwsLambdaSqsInstrumenterFactory.java
@@ -13,7 +13,9 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -42,7 +44,9 @@ public final class AwsLambdaSqsInstrumenterFactory {
                 new SpanKeyOmittingAttributesExtractor<>(
                     MessagingAttributesExtractor.create(
                         getter, MessagingOperationType.PROCESS, PROCESS_OPERATION_NAME)))
-            .addSpanLinksExtractor(new SqsEventSpanLinksExtractor());
+            .addSpanLinksExtractor(new SqsEventSpanLinksExtractor())
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
@@ -64,7 +68,8 @@ public final class AwsLambdaSqsInstrumenterFactory {
                         getter, MessagingOperationType.PROCESS, PROCESS_OPERATION_NAME)
                     : new SpanKeyOmittingAttributesExtractor<>(
                         MessagingAttributesExtractor.create(
-                            getter, MessagingOperationType.PROCESS, PROCESS_OPERATION_NAME)));
+                            getter, MessagingOperationType.PROCESS, PROCESS_OPERATION_NAME)))
+            .addOperationMetrics(MessagingProcessMetrics.get());
     setMessagingProcessExceptionEventExtractor(builder);
     return MessagingProcessInstrumenterFactory.create(
         builder, AwsXrayPropagator.getInstance(), SqsMessageTextMapGetter.INSTANCE, true);

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
@@ -119,8 +119,6 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
                           .hasUnit("{message}")
                           .hasDescription(
                               "Number of messages that were delivered to the application.")
-                          .satisfies(
-                              data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
                           .hasLongSumSatisfying(
                               sum ->
                                   sum.hasPointsSatisfying(

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -102,8 +102,6 @@ class PulsarClientTest extends AbstractPulsarClientTest {
                           .hasUnit("{message}")
                           .hasDescription(
                               "Number of messages that were delivered to the application.")
-                          .satisfies(
-                              data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
                           .hasLongSumSatisfying(
                               sum ->
                                   sum.hasPointsSatisfying(


### PR DESCRIPTION
Adds the v1.43 messaging metrics to AWS Lambda SQS processing, so Lambda functions consuming SQS events now report `messaging.process.duration` and `messaging.client.consumed.messages` alongside their existing process spans.

The batch event instrumenter records both metrics, counting every SQS record delivered in the event exactly once. The nested per-message instrumenter records only `messaging.process.duration`, so consumed messages are not double counted. A processing exception that propagates out adds `error.type` to both.

Nothing changes on the default path: the new instruments are only created when the stable messaging semantic conventions are enabled, and no spans are affected either way.

Stacked on #19478. Part of #19254.