### PR TITLE
Add basic RocketMQ 5 settle spans

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 tasks {
   withType<Test>().configureEach {
     systemProperty("collectMetadata", otelProps.collectMetadata)
-    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
   }
 
   val testReceiveSpanDisabled = register<Test>("testReceiveSpanDisabled") {
@@ -40,10 +39,43 @@ tasks {
     classpath = sourceSets.test.get().runtimeClasspath
     filter {
       excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
+      excludeTestsMatching("SimpleConsumerAckOperationTest")
     }
+
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testAckDefault = register<Test>("testAckDefault") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SimpleConsumerAckOperationTest")
+    }
+    include("**/SimpleConsumerAckOperationTest.*")
+  }
+
+  val testMessagingOptIn = register<Test>("testMessagingOptIn") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SimpleConsumerAckOperationTest")
+    }
+    include("**/SimpleConsumerAckOperationTest.*")
+    jvmArgs("-Dotel.semconv-stability.opt-in=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=messaging")
+  }
+
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SimpleConsumerAckOperationTest")
+    }
+    include("**/SimpleConsumerAckOperationTest.*")
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+    systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
   }
 
   val testSimpleConsumerReceiveSpanDisabled =
@@ -73,6 +105,7 @@ tasks {
   test {
     filter {
       excludeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
+      excludeTestsMatching("SimpleConsumerAckOperationTest")
     }
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     systemProperty(
@@ -81,18 +114,43 @@ tasks {
     )
   }
 
+  listOf(
+    "test",
+    "testReceiveSpanDisabled",
+    "testMessagingPreview",
+    "testSimpleConsumerReceiveSpanDisabled",
+    "testBothSemconv",
+  ).forEach { taskName ->
+    named<Test>(taskName) {
+      usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    }
+  }
+
   check {
     dependsOn(
+      testAckDefault,
       testReceiveSpanDisabled,
       testMessagingPreview,
+      testMessagingOptIn,
       testSimpleConsumerReceiveSpanDisabled,
       testBothSemconv,
+      testV3Preview,
     )
   }
 
   if (otelProps.denyUnsafe) {
     withType<Test>().configureEach {
       enabled = false
+    }
+  }
+}
+
+// The javaagent test convention removes main output from test classpaths. These helper-level tests
+// exercise the async lifecycle directly without loading the container-backed client.
+afterEvaluate {
+  listOf("testAckDefault", "testMessagingOptIn", "testV3Preview").forEach { taskName ->
+    tasks.named<Test>(taskName) {
+      classpath += sourceSets.main.get().output
     }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckAttributeExtractor.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckAttributeExtractor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import javax.annotation.Nullable;
+
+class RocketMqAckAttributeExtractor implements AttributesExtractor<RocketMqAckRequest, Void> {
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Override
+  public void onStart(
+      AttributesBuilder attributes, Context parentContext, RocketMqAckRequest request) {
+    attributes.put(MESSAGING_CONSUMER_GROUP_NAME, request.getConsumerGroup());
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      RocketMqAckRequest request,
+      @Nullable Void response,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckAttributeGetter.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckAttributeGetter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import javax.annotation.Nullable;
+
+class RocketMqAckAttributeGetter implements MessagingAttributesGetter<RocketMqAckRequest, Void> {
+
+  @Override
+  public String getSystem(RocketMqAckRequest request) {
+    return "rocketmq";
+  }
+
+  @Override
+  public String getDestination(RocketMqAckRequest request) {
+    return request.getMessage().getTopic();
+  }
+
+  @Nullable
+  @Override
+  public String getDestinationTemplate(RocketMqAckRequest request) {
+    return null;
+  }
+
+  @Override
+  public boolean isTemporaryDestination(RocketMqAckRequest request) {
+    return false;
+  }
+
+  @Override
+  public boolean isAnonymousDestination(RocketMqAckRequest request) {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getConversationId(RocketMqAckRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageBodySize(RocketMqAckRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getMessageEnvelopeSize(RocketMqAckRequest request) {
+    return null;
+  }
+
+  @Override
+  public String getMessageId(RocketMqAckRequest request, @Nullable Void unused) {
+    return request.getMessage().getMessageId().toString();
+  }
+
+  @Nullable
+  @Override
+  public String getClientId(RocketMqAckRequest request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Long getBatchMessageCount(RocketMqAckRequest request, @Nullable Void unused) {
+    return null;
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckRequest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqAckRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+class RocketMqAckRequest {
+
+  private final String consumerGroup;
+  private final MessageView message;
+
+  RocketMqAckRequest(String consumerGroup, MessageView message) {
+    this.consumerGroup = consumerGroup;
+    this.message = message;
+  }
+
+  String getConsumerGroup() {
+    return consumerGroup;
+  }
+
+  MessageView getMessage() {
+    return message;
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -8,7 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSettleExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
@@ -35,6 +37,7 @@ final class RocketMqInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String RECEIVE_OPERATION_NAME = "receive";
   private static final String PROCESS_OPERATION_NAME = "process";
+  private static final String ACK_OPERATION_NAME = "ack";
 
   private RocketMqInstrumenterFactory() {}
 
@@ -130,6 +133,24 @@ final class RocketMqInstrumenterFactory {
         openTelemetry.getPropagators().getTextMapPropagator(),
         new MessageMapGetter(),
         receiveInstrumentationEnabled);
+  }
+
+  public static Instrumenter<RocketMqAckRequest, Void> createSimpleConsumerAckInstrumenter(
+      OpenTelemetry openTelemetry) {
+    RocketMqAckAttributeGetter getter = new RocketMqAckAttributeGetter();
+    MessagingOperationType operationType = MessagingOperationType.SETTLE;
+    InstrumenterBuilder<RocketMqAckRequest, Void> instrumenterBuilder =
+        Instrumenter.<RocketMqAckRequest, Void>builder(
+                openTelemetry,
+                INSTRUMENTATION_NAME,
+                MessagingSpanNameExtractor.create(getter, operationType, ACK_OPERATION_NAME))
+            .setEnabled(emitStableMessagingSemconv())
+            .addAttributesExtractor(
+                buildMessagingAttributesExtractor(
+                    getter, operationType, ACK_OPERATION_NAME, emptyList()))
+            .addAttributesExtractor(new RocketMqAckAttributeExtractor());
+    setMessagingSettleExceptionEventExtractor(instrumenterBuilder);
+    return instrumenterBuilder.buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
   private static <T, R> AttributesExtractor<T, R> buildMessagingAttributesExtractor(

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
@@ -23,6 +23,7 @@ public class RocketMqSingletons {
   private static final Instrumenter<RocketMqReceiveRequest, List<MessageView>>
       simpleConsumerReceiveInstrumenter;
   private static final Instrumenter<MessageView, ConsumeResult> consumerProcessInstrumenter;
+  private static final Instrumenter<RocketMqAckRequest, Void> simpleConsumerAckInstrumenter;
 
   static {
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
@@ -41,6 +42,8 @@ public class RocketMqSingletons {
     consumerProcessInstrumenter =
         RocketMqInstrumenterFactory.createConsumerProcessInstrumenter(
             openTelemetry, messagingHeaders, receiveInstrumentationEnabled);
+    simpleConsumerAckInstrumenter =
+        RocketMqInstrumenterFactory.createSimpleConsumerAckInstrumenter(openTelemetry);
   }
 
   public static Instrumenter<PublishingMessageImpl, SendReceiptImpl> producerInstrumenter() {
@@ -59,6 +62,10 @@ public class RocketMqSingletons {
   public static Instrumenter<RocketMqReceiveRequest, List<MessageView>>
       simpleConsumerReceiveInstrumenter() {
     return simpleConsumerReceiveInstrumenter;
+  }
+
+  public static Instrumenter<RocketMqAckRequest, Void> simpleConsumerAckInstrumenter() {
+    return simpleConsumerAckInstrumenter;
   }
 
   private RocketMqSingletons() {}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0.RocketMqSingletons.simpleConsumerAckInstrumenter;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.javaagent.bootstrap.CallDepth;
+import io.opentelemetry.javaagent.bootstrap.ExceptionLogger;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+public class SimpleConsumerAckOperation {
+
+  private final CallDepth callDepth;
+  @Nullable private final RocketMqAckRequest request;
+  @Nullable private final Context context;
+  @Nullable private final Scope scope;
+
+  @Nullable
+  public static SimpleConsumerAckOperation start(
+      SimpleConsumer simpleConsumer, MessageView message) {
+    if (!emitStableMessagingSemconv()) {
+      return null;
+    }
+
+    CallDepth callDepth = CallDepth.forClass(SimpleConsumer.class);
+    if (callDepth.getAndIncrement() > 0) {
+      return new SimpleConsumerAckOperation(callDepth, null, null, null);
+    }
+
+    try {
+      RocketMqAckRequest request =
+          new RocketMqAckRequest(simpleConsumer.getConsumerGroup(), message);
+      Context parentContext = Context.current();
+      Instrumenter<RocketMqAckRequest, Void> instrumenter = simpleConsumerAckInstrumenter();
+      if (!instrumenter.shouldStart(parentContext, request)) {
+        return new SimpleConsumerAckOperation(callDepth, null, null, null);
+      }
+
+      Context context = instrumenter.start(parentContext, request);
+      return new SimpleConsumerAckOperation(callDepth, request, context, context.makeCurrent());
+    } catch (Throwable t) {
+      callDepth.decrementAndGet();
+      ExceptionLogger.logSuppressedError(
+          "Error instrumenting RocketMQ SimpleConsumer ack start", t);
+      return null;
+    }
+  }
+
+  private SimpleConsumerAckOperation(
+      CallDepth callDepth,
+      @Nullable RocketMqAckRequest request,
+      @Nullable Context context,
+      @Nullable Scope scope) {
+    this.callDepth = callDepth;
+    this.request = request;
+    this.context = context;
+    this.scope = scope;
+  }
+
+  public void end(@Nullable Throwable error) {
+    if (!closeScope() || context == null || request == null) {
+      return;
+    }
+    simpleConsumerAckInstrumenter().end(context, request, null, error);
+  }
+
+  public void endAsync(@Nullable CompletableFuture<Void> future, @Nullable Throwable methodError) {
+    if (!closeScope() || context == null || request == null) {
+      return;
+    }
+    if (methodError != null || future == null) {
+      simpleConsumerAckInstrumenter().end(context, request, null, methodError);
+      return;
+    }
+    future.whenComplete((unused, error) -> endSafely(error));
+  }
+
+  private boolean closeScope() {
+    if (callDepth.decrementAndGet() > 0) {
+      return false;
+    }
+    if (scope == null || context == null || request == null) {
+      return false;
+    }
+    scope.close();
+    return true;
+  }
+
+  private void endSafely(@Nullable Throwable error) {
+    if (context == null || request == null) {
+      return;
+    }
+    try {
+      simpleConsumerAckInstrumenter().end(context, request, null, error);
+    } catch (Throwable t) {
+      ExceptionLogger.logSuppressedError(
+          "Error instrumenting RocketMQ SimpleConsumer ack completion", t);
+    }
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerImplInstrumentation.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerImplInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -13,6 +14,8 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned;
 import net.bytebuddy.description.type.TypeDescription;
@@ -36,6 +39,18 @@ final class SimpleConsumerImplInstrumentation implements TypeInstrumentation {
             .and(takesArgument(0, int.class))
             .and(takesArgument(1, Duration.class)),
         getClass().getName() + "$ReceiveAdvice");
+    transformer.applyAdviceToMethod(
+        named("ack")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.apache.rocketmq.client.apis.message.MessageView")))
+            .and(returns(void.class)),
+        getClass().getName() + "$AckAdvice");
+    transformer.applyAdviceToMethod(
+        named("ackAsync")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.apache.rocketmq.client.apis.message.MessageView")))
+            .and(returns(CompletableFuture.class)),
+        getClass().getName() + "$AckAsyncAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -53,6 +68,47 @@ final class SimpleConsumerImplInstrumentation implements TypeInstrumentation {
         @Advice.Enter SimpleConsumerReceiveOperation operation,
         @Advice.Return ListenableFuture<List<MessageView>> future) {
       return operation == null ? future : operation.wrap(future);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class AckAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Nullable
+    public static SimpleConsumerAckOperation onEnter(
+        @Advice.This SimpleConsumer simpleConsumer, @Advice.Argument(0) MessageView message) {
+      return SimpleConsumerAckOperation.start(simpleConsumer, message);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Enter @Nullable SimpleConsumerAckOperation operation,
+        @Advice.Thrown @Nullable Throwable error) {
+      if (operation != null) {
+        operation.end(error);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class AckAsyncAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Nullable
+    public static SimpleConsumerAckOperation onEnter(
+        @Advice.This SimpleConsumer simpleConsumer, @Advice.Argument(0) MessageView message) {
+      return SimpleConsumerAckOperation.start(simpleConsumer, message);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Enter @Nullable SimpleConsumerAckOperation operation,
+        @Advice.Return @Nullable CompletableFuture<Void> future,
+        @Advice.Thrown @Nullable Throwable error) {
+      if (operation != null) {
+        operation.endAsync(future, error);
+      }
     }
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -44,6 +46,7 @@ import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.FilterExpressionType;
 import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
 import org.apache.rocketmq.client.apis.message.Message;
+import org.apache.rocketmq.client.apis.message.MessageId;
 import org.apache.rocketmq.client.apis.message.MessageView;
 import org.apache.rocketmq.client.apis.producer.Producer;
 import org.apache.rocketmq.client.apis.producer.SendReceipt;
@@ -109,17 +112,26 @@ class RocketMqSimpleConsumerTest {
   void shouldInstrumentSynchronousReceive() throws ClientException {
     assumeTrue(emitStableMessagingSemconv());
     SpanData sendSpan = sendMessage();
+    AtomicReference<MessageView> acknowledgedMessage = new AtomicReference<>();
 
     testing.runWithSpan(
         "sync receive parent",
         () -> {
           List<MessageView> messages = consumer.receive(1, Duration.ofSeconds(10));
           for (MessageView message : messages) {
+            acknowledgedMessage.set(message);
             consumer.ack(message);
           }
         });
 
-    assertSuccessfulReceiveTrace("sync receive parent", sendSpan);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("sync receive parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertReceiveSpan(span, sendSpan).hasParent(trace.getSpan(0)),
+                span ->
+                    assertAckSpan(span, acknowledgedMessage.get()).hasParent(trace.getSpan(0))));
   }
 
   @Test
@@ -130,11 +142,24 @@ class RocketMqSimpleConsumerTest {
     List<MessageView> messages =
         testing.runWithSpan(
             "async receive parent", () -> consumer.receiveAsync(1, Duration.ofSeconds(10)).join());
-    for (MessageView message : messages) {
-      consumer.ack(message);
-    }
+    testing.runWithSpan(
+        "async ack parent",
+        () -> {
+          for (MessageView message : messages) {
+            consumer.ackAsync(message).join();
+          }
+        });
 
-    assertSuccessfulReceiveTrace("async receive parent", sendSpan);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("async receive parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertReceiveSpan(span, sendSpan).hasParent(trace.getSpan(0))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("async ack parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertAckSpan(span, messages.get(0)).hasParent(trace.getSpan(0))));
   }
 
   @Test
@@ -188,12 +213,14 @@ class RocketMqSimpleConsumerTest {
     assumeTrue(emitStableMessagingSemconv());
     assumeFalse(RECEIVE_TELEMETRY_ENABLED);
     sendMessage();
+    AtomicReference<MessageView> acknowledgedMessage = new AtomicReference<>();
 
     testing.runWithSpan(
         "disabled receive parent",
         () -> {
           List<MessageView> messages = consumer.receive(1, Duration.ofSeconds(10));
           assertThat(messages).hasSize(1);
+          acknowledgedMessage.set(messages.get(0));
           consumer.ack(messages.get(0));
         });
 
@@ -203,7 +230,9 @@ class RocketMqSimpleConsumerTest {
                 span ->
                     span.hasName("disabled receive parent")
                         .hasKind(SpanKind.INTERNAL)
-                        .hasNoParent()));
+                        .hasNoParent(),
+                span ->
+                    assertAckSpan(span, acknowledgedMessage.get()).hasParent(trace.getSpan(0))));
   }
 
   @Test
@@ -260,6 +289,33 @@ class RocketMqSimpleConsumerTest {
     assertReceiveErrorTrace("async error parent");
   }
 
+  @Test
+  void shouldInstrumentSynchronousAckError() {
+    assumeTrue(emitStableMessagingSemconv());
+    MessageView message = invalidMessage();
+
+    testing.runWithSpan(
+        "sync ack error parent",
+        () -> assertThatThrownBy(() -> consumer.ack(message)).isInstanceOf(ClientException.class));
+
+    assertAckErrorTrace("sync ack error parent", message, ClientException.class);
+  }
+
+  @Test
+  void shouldInstrumentAsynchronousAckError() {
+    assumeTrue(emitStableMessagingSemconv());
+    MessageView message = invalidMessage();
+
+    testing.runWithSpan(
+        "async ack error parent",
+        () ->
+            assertThatThrownBy(() -> consumer.ackAsync(message).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class));
+
+    assertAckErrorTrace("async ack error parent", message, IllegalArgumentException.class);
+  }
+
   private SpanData sendMessage() throws ClientException {
     Message message =
         provider
@@ -284,12 +340,13 @@ class RocketMqSimpleConsumerTest {
     return sendSpan.get();
   }
 
-  private static void assertSuccessfulReceiveTrace(String parentName, SpanData sendSpan) {
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent(),
-                span -> assertReceiveSpan(span, sendSpan).hasParent(trace.getSpan(0))));
+  private static MessageView invalidMessage() {
+    MessageView message = mock(MessageView.class);
+    when(message.getTopic()).thenReturn(TOPIC);
+    MessageId messageId = mock(MessageId.class);
+    when(messageId.toString()).thenReturn("invalid-message-id");
+    when(message.getMessageId()).thenReturn(messageId);
+    return message;
   }
 
   private static void assertReceiveErrorTrace(String parentName) {
@@ -342,5 +399,39 @@ class RocketMqSimpleConsumerTest {
             equalTo(MESSAGING_OPERATION_NAME, "receive"),
             equalTo(MESSAGING_OPERATION_TYPE, "receive"),
             equalTo(MESSAGING_BATCH_MESSAGE_COUNT, 0));
+  }
+
+  private static SpanDataAssert assertAckSpan(SpanDataAssert span, MessageView message) {
+    return span.hasKind(SpanKind.CLIENT)
+        .hasName("ack " + TOPIC)
+        .hasStatus(StatusData.unset())
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+            equalTo(MESSAGING_MESSAGE_ID, message.getMessageId().toString()),
+            equalTo(MESSAGING_OPERATION_NAME, "ack"),
+            equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+            equalTo(MESSAGING_SYSTEM, "rocketmq"));
+  }
+
+  private static void assertAckErrorTrace(
+      String parentName, MessageView message, Class<? extends Throwable> errorType) {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName(parentName).hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasName("ack " + TOPIC)
+                        .hasStatus(StatusData.error())
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+                            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+                            equalTo(MESSAGING_MESSAGE_ID, message.getMessageId().toString()),
+                            equalTo(MESSAGING_OPERATION_NAME, "ack"),
+                            equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+                            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                            equalTo(ERROR_TYPE, errorType.getName()))));
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
@@ -296,9 +296,11 @@ class RocketMqSimpleConsumerTest {
 
     testing.runWithSpan(
         "sync ack error parent",
-        () -> assertThatThrownBy(() -> consumer.ack(message)).isInstanceOf(ClientException.class));
+        () ->
+            assertThatThrownBy(() -> consumer.ack(message))
+                .isInstanceOf(IllegalArgumentException.class));
 
-    assertAckErrorTrace("sync ack error parent", message, ClientException.class);
+    assertAckErrorTrace("sync ack error parent", message, IllegalArgumentException.class);
   }
 
   @Test

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperationTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperationTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.javaagent.testing.common.TestAgentListenerAccess.getAndResetAdviceFailureCount;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import org.apache.rocketmq.client.apis.ClientException;
+import org.apache.rocketmq.client.apis.consumer.SimpleConsumer;
+import org.apache.rocketmq.client.apis.message.MessageId;
+import org.apache.rocketmq.client.apis.message.MessageView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@SuppressWarnings("deprecation") // using deprecated semconv
+class SimpleConsumerAckOperationTest {
+
+  private static final String TOPIC = "settle-topic";
+  private static final String CONSUMER_GROUP = "settle-consumer-group";
+  private static final String MESSAGE_ID = "settle-message-id";
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  private SimpleConsumer consumer;
+  private MessageView message;
+
+  @BeforeEach
+  void setUp() {
+    consumer = mock(SimpleConsumer.class);
+    when(consumer.getConsumerGroup()).thenReturn(CONSUMER_GROUP);
+    message = mock(MessageView.class);
+    when(message.getTopic()).thenReturn(TOPIC);
+    MessageId messageId = mock(MessageId.class);
+    when(messageId.toString()).thenReturn(MESSAGE_ID);
+    when(message.getMessageId()).thenReturn(messageId);
+  }
+
+  @Test
+  void shouldHonorStableMessagingGating() {
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          SimpleConsumerAckOperation operation =
+              SimpleConsumerAckOperation.start(consumer, message);
+          if (emitStableMessagingSemconv()) {
+            assertThat(operation).isNotNull();
+            operation.end(null);
+          } else {
+            assertThat(operation).isNull();
+          }
+        });
+
+    testing.waitAndAssertTraces(
+        trace -> {
+          if (emitStableMessagingSemconv()) {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertAckSpan(span, null).hasName("ack " + TOPIC).hasParent(trace.getSpan(0)));
+          } else {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent());
+          }
+        });
+  }
+
+  @Test
+  void shouldEndSynchronousError() {
+    assumeTrue(emitStableMessagingSemconv());
+    ClientException error = new ClientException("ack failed");
+
+    testing.runWithSpan(
+        "parent", () -> SimpleConsumerAckOperation.start(consumer, message).end(error));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertAckSpan(span, ClientException.class)
+                        .hasStatus(StatusData.error())
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldRestoreCallDepthWhenSpanStartFails() {
+    assumeTrue(emitStableMessagingSemconv());
+    MessageView invalidMessage = mock(MessageView.class);
+    when(invalidMessage.getTopic()).thenThrow(new IllegalStateException("invalid message"));
+
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          assertThat(SimpleConsumerAckOperation.start(consumer, invalidMessage)).isNull();
+          assertThat(getAndResetAdviceFailureCount()).isEqualTo(1);
+          SimpleConsumerAckOperation operation =
+              SimpleConsumerAckOperation.start(consumer, message);
+          assertThat(operation).isNotNull();
+          operation.end(null);
+        });
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertAckSpan(span, null).hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldEndAsynchronousSuccessOnCompletion() {
+    assumeTrue(emitStableMessagingSemconv());
+    CompletableFuture<Void> future = new CompletableFuture<>();
+
+    testing.runWithSpan(
+        "parent", () -> SimpleConsumerAckOperation.start(consumer, message).endAsync(future, null));
+
+    assertThat(testing.spans()).hasSize(1);
+    future.complete(null);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> assertAckSpan(span, null).hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldEndAsynchronousErrorOnCompletion() {
+    assumeTrue(emitStableMessagingSemconv());
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    ClientException error = new ClientException("ack failed");
+
+    testing.runWithSpan(
+        "parent", () -> SimpleConsumerAckOperation.start(consumer, message).endAsync(future, null));
+
+    assertThat(testing.spans()).hasSize(1);
+    future.completeExceptionally(error);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertAckSpan(span, ClientException.class)
+                        .hasStatus(StatusData.error())
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void shouldEndAsynchronousCancellationOnCompletion() {
+    assumeTrue(emitStableMessagingSemconv());
+    CompletableFuture<Void> future = new CompletableFuture<>();
+
+    testing.runWithSpan(
+        "parent", () -> SimpleConsumerAckOperation.start(consumer, message).endAsync(future, null));
+
+    assertThat(testing.spans()).hasSize(1);
+    assertThat(future.cancel(false)).isTrue();
+    assertThat(future).isCancelled();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    assertAckSpan(span, CancellationException.class)
+                        .hasStatus(StatusData.error())
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  private static SpanDataAssert assertAckSpan(
+      SpanDataAssert span, Class<? extends Throwable> errorType) {
+    return span.hasName("ack " + TOPIC)
+        .hasKind(SpanKind.CLIENT)
+        .hasAttributesSatisfyingExactly(
+            equalTo(MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+            equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+            equalTo(MESSAGING_MESSAGE_ID, MESSAGE_ID),
+            equalTo(MESSAGING_OPERATION_NAME, "ack"),
+            equalTo(MESSAGING_OPERATION_TYPE, "settle"),
+            equalTo(MESSAGING_SYSTEM, "rocketmq"),
+            equalTo(ERROR_TYPE, errorType == null ? null : errorType.getName()));
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperationTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/SimpleConsumerAckOperationTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@SuppressWarnings("deprecation") // using deprecated semconv
 class SimpleConsumerAckOperationTest {
 
   private static final String TOPIC = "settle-topic";
@@ -192,6 +191,7 @@ class SimpleConsumerAckOperationTest {
                         .hasParent(trace.getSpan(0))));
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   private static SpanDataAssert assertAckSpan(
       SpanDataAssert span, Class<? extends Throwable> errorType) {
     return span.hasName("ack " + TOPIC)


### PR DESCRIPTION
Adds settle spans for RocketMQ 5 `SimpleConsumer` acknowledgement. Calls to `ack` and `ackAsync` now produce a CLIENT span named `ack <topic>` carrying `messaging.operation.name=ack`, `messaging.operation.type=settle`, `messaging.system`, `messaging.destination.name`, `messaging.message.id`, and `messaging.consumer.group.name`, parented to the ambient context.

These spans appear only when stable messaging conventions are selected, through `otel.semconv-stability.opt-in=messaging`, `otel.semconv-stability.opt-in=messaging/dup`, or `otel.instrumentation.common.v3-preview=true`. With none of those set, acknowledgement telemetry is unchanged.

`ackAsync` still returns the client's own `CompletableFuture`; the instrumentation observes that future rather than replacing it, and ends the span when it completes, fails, or is cancelled.

This is deliberately the minimal layer: no delivery tracking, no correlation between receive or process spans and the settle span, no message links, and no delivery-to-ack timing.

Stacked on #19480 and intended to merge after it.

Addresses #19401.

Part of #19254.