### PR TITLE
Fix changelog link spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3525,7 +3525,7 @@ too disruptive to adopt right away.
   ([#7904](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7904))
 - Upgrade to gradle 8.0.2
   ([#7910](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7910),
-  [ 7978](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7978))
+  [7978](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7978))
 - Replace the test-sets plugin with Gradle test suites
   ([#7930](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7930),
   [#7933](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/7933),


### PR DESCRIPTION
Fix the pre-existing MD039 violation in the historical changelog link so future changelog edits do not acquire unrelated formatter churn.

This cleanup was extracted from #19180 to keep that PR focused.