### PR TITLE
Add messaging v1.43 metrics to RocketMQ

### DIFF
--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/build.gradle.kts
@@ -38,7 +38,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
   }
 
+  val testV3Preview = register<Test>("testV3Preview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+  }
+
   check {
-    dependsOn(testMessagingPreview, testBothSemconv)
+    dependsOn(testMessagingPreview, testBothSemconv, testV3Preview)
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -17,7 +17,10 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
@@ -63,7 +66,8 @@ class RocketMqInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operationType, SEND_OPERATION_NAME))
             .addAttributesExtractor(
                 buildMessagingAttributesExtractor(
-                    getter, operationType, SEND_OPERATION_NAME, capturedHeaders));
+                    getter, operationType, SEND_OPERATION_NAME, capturedHeaders))
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationType());
     if (emitStableMessagingSemconv()) {
       instrumenterBuilder.addAttributesExtractor(
           new AttributesExtractor<SendMessageContext, Void>() {
@@ -137,6 +141,8 @@ class RocketMqInstrumenterFactory {
             .addSpanLinksExtractor(
                 new RocketMqBatchProcessSpanLinksExtractor(
                     openTelemetry.getPropagators().getTextMapPropagator()))
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages())
             .setSpanStatusExtractor(consumeStatusExtractor());
     setMessagingProcessExceptionEventExtractor(builder);
 
@@ -165,6 +171,8 @@ class RocketMqInstrumenterFactory {
     builder.addAttributesExtractor(
         buildMessagingAttributesExtractor(
             getter, operationType, PROCESS_OPERATION_NAME, capturedHeaders));
+    builder.addOperationMetrics(MessagingProcessMetrics.get());
+    builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     if (emitStableMessagingSemconv()) {
       builder.addAttributesExtractor(consumerAttributesExtractor());
     }

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.rocketmq.client.consumer.listener.ConsumeReturnType;
+import org.apache.rocketmq.client.hook.ConsumeMessageContext;
+import org.apache.rocketmq.client.hook.SendMessageContext;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageBatch;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings("deprecation") // using deprecated semconv constants in metric assertions
+class RocketMqMetricsTest {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rocketmq-client-4.8";
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @BeforeEach
+  void clearData() {
+    testing.clearData();
+  }
+
+  @ParameterizedTest
+  @MethodSource("producerCases")
+  void recordsProducerMetrics(
+      Message message, long expectedCount, Throwable error, String errorType) {
+    assumeTrue(emitStableMessagingSemconv());
+    SendMessageContext request = mock(SendMessageContext.class);
+    when(request.getMessage()).thenReturn(message);
+    Instrumenter<SendMessageContext, Void> instrumenter =
+        RocketMqInstrumenterFactory.createProducerInstrumenter(
+            testing.getOpenTelemetry(), emptyList(), false);
+
+    Context context = instrumenter.start(Context.root(), request);
+    instrumenter.end(context, request, null, error);
+
+    assertMessageCount(
+        "messaging.client.sent.messages",
+        expectedCount,
+        "send",
+        message.getTopic(),
+        null,
+        errorType);
+    assertDuration(
+        "messaging.client.operation.duration", "send", message.getTopic(), null, "send", errorType);
+    assertNoDeprecatedMetrics();
+  }
+
+  private static Stream<Arguments> producerCases() {
+    return Stream.of(
+        argumentSet("single success", message("single-success"), 1, null, null),
+        argumentSet(
+            "single error",
+            message("single-error"),
+            1,
+            new IllegalStateException("test"),
+            IllegalStateException.class.getName()),
+        argumentSet(
+            "batch success",
+            MessageBatch.generateFromList(
+                asList(message("batch-success"), message("batch-success"))),
+            2,
+            null,
+            null),
+        argumentSet(
+            "batch error",
+            MessageBatch.generateFromList(asList(message("batch-error"), message("batch-error"))),
+            2,
+            new IllegalStateException("test"),
+            IllegalStateException.class.getName()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("consumerCases")
+  void recordsProcessMetrics(
+      List<MessageExt> messages, String consumeErrorType, long expectedCount) {
+    assumeTrue(emitStableMessagingSemconv());
+    ConsumeMessageContext response = new ConsumeMessageContext();
+    response.setSuccess(consumeErrorType == null);
+    response.setProps(
+        singletonMap(
+            MixAll.CONSUME_CONTEXT_TYPE,
+            consumeErrorType == null ? ConsumeReturnType.SUCCESS.name() : consumeErrorType));
+    RocketMqConsumerInstrumenter instrumenter =
+        RocketMqInstrumenterFactory.createConsumerInstrumenter(
+            testing.getOpenTelemetry(), emptyList(), false);
+
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        requireNonNull(instrumenter.start(Context.root(), messages, "consumer-group", null));
+    instrumenter.end(consumerContext, response);
+
+    String destination = messages.get(0).getTopic();
+    assertMessageCount(
+        "messaging.client.consumed.messages",
+        expectedCount,
+        "process",
+        destination,
+        "consumer-group",
+        consumeErrorType);
+    assertDuration(
+        "messaging.process.duration",
+        "process",
+        destination,
+        "consumer-group",
+        null,
+        consumeErrorType);
+    assertNoDeprecatedMetrics();
+  }
+
+  private static Stream<Arguments> consumerCases() {
+    return Stream.of(
+        argumentSet("single success", singletonList(messageExt("single-success")), null, 1),
+        argumentSet(
+            "single error",
+            singletonList(messageExt("single-error")),
+            ConsumeReturnType.EXCEPTION.name(),
+            1),
+        argumentSet(
+            "batch success",
+            asList(messageExt("batch-success"), messageExt("batch-success")),
+            null,
+            2),
+        argumentSet(
+            "batch error",
+            asList(messageExt("batch-error"), messageExt("batch-error")),
+            ConsumeReturnType.RETURNNULL.name(),
+            2));
+  }
+
+  @Test
+  void emitsNoMetricsWithoutStableMessagingSemconv() {
+    assumeFalse(emitStableMessagingSemconv());
+    SendMessageContext sendRequest = mock(SendMessageContext.class);
+    when(sendRequest.getMessage()).thenReturn(message("default-send"));
+    Instrumenter<SendMessageContext, Void> producerInstrumenter =
+        RocketMqInstrumenterFactory.createProducerInstrumenter(
+            testing.getOpenTelemetry(), emptyList(), false);
+    Context sendContext = producerInstrumenter.start(Context.root(), sendRequest);
+    producerInstrumenter.end(sendContext, sendRequest, null, null);
+
+    List<MessageExt> messages =
+        asList(messageExt("default-process"), messageExt("default-process"));
+    RocketMqConsumerInstrumenter consumerInstrumenter =
+        RocketMqInstrumenterFactory.createConsumerInstrumenter(
+            testing.getOpenTelemetry(), emptyList(), false);
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        requireNonNull(
+            consumerInstrumenter.start(Context.root(), messages, "consumer-group", null));
+    consumerInstrumenter.end(consumerContext, new ConsumeMessageContext());
+
+    assertThat(testing.metrics())
+        .noneMatch(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME)
+                    && isMessagingMetric(metric.getName()));
+  }
+
+  private static Message message(String topic) {
+    return new Message(topic, new byte[0]);
+  }
+
+  private static MessageExt messageExt(String topic) {
+    MessageExt message = new MessageExt();
+    message.setTopic(topic);
+    message.setMsgId("message-id");
+    message.setBody(new byte[0]);
+    message.putUserProperty("test", "value");
+    return message;
+  }
+
+  private static void assertMessageCount(
+      String metricName,
+      long expectedCount,
+      String operationName,
+      String destination,
+      String consumerGroup,
+      String errorType) {
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        metricName,
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(expectedCount)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, operationName),
+                                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                equalTo(ERROR_TYPE, errorType),
+                                                equalTo(
+                                                    MESSAGING_CONSUMER_GROUP_NAME, consumerGroup),
+                                                equalTo(
+                                                    MESSAGING_DESTINATION_NAME, destination))))));
+  }
+
+  private static void assertDuration(
+      String metricName,
+      String operationName,
+      String destination,
+      String consumerGroup,
+      String operationType,
+      String errorType) {
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        metricName,
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasCount(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, operationName),
+                                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                equalTo(ERROR_TYPE, errorType),
+                                                equalTo(
+                                                    MESSAGING_CONSUMER_GROUP_NAME, consumerGroup),
+                                                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                                                equalTo(
+                                                    MESSAGING_OPERATION_TYPE, operationType))))));
+  }
+
+  private static void assertNoDeprecatedMetrics() {
+    assertThat(testing.metrics())
+        .noneMatch(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME)
+                    && (metric.getName().equals("messaging.publish.duration")
+                        || metric.getName().equals("messaging.receive.duration")
+                        || metric.getName().equals("messaging.receive.messages")));
+  }
+
+  private static boolean isMessagingMetric(String metricName) {
+    return metricName.equals("messaging.client.operation.duration")
+        || metricName.equals("messaging.client.sent.messages")
+        || metricName.equals("messaging.client.consumed.messages")
+        || metricName.equals("messaging.process.duration")
+        || metricName.equals("messaging.publish.duration")
+        || metricName.equals("messaging.receive.duration")
+        || metricName.equals("messaging.receive.messages");
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/build.gradle.kts
@@ -46,6 +46,18 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testMessagingPreviewReceiveTelemetryDisabled =
+    register<Test>("testMessagingPreviewReceiveTelemetryDisabled") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+      filter {
+        includeTestsMatching("RocketMqClientSuppressReceiveSpanTest")
+      }
+      include("**/RocketMqClientSuppressReceiveSpanTest.*")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   // A SimpleConsumer pull has no process span, so it gets a receive span even when receive
   // telemetry is disabled by default.
   val testSimpleConsumerReceiveTelemetryDisabled =
@@ -89,6 +101,7 @@ tasks {
     dependsOn(
       testReceiveSpanDisabled,
       testMessagingPreview,
+      testMessagingPreviewReceiveTelemetryDisabled,
       testSimpleConsumerReceiveTelemetryDisabled,
       testBothSemconv,
     )

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -14,7 +14,10 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
@@ -53,7 +56,8 @@ final class RocketMqInstrumenterFactory {
                 INSTRUMENTATION_NAME,
                 MessagingSpanNameExtractor.create(getter, operationType, SEND_OPERATION_NAME))
             .addAttributesExtractor(attributesExtractor)
-            .addAttributesExtractor(new RocketMqProducerAttributeExtractor());
+            .addAttributesExtractor(new RocketMqProducerAttributeExtractor())
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationType());
     setMessagingSendExceptionEventExtractor(instrumenterBuilder);
     return instrumenterBuilder.buildProducerInstrumenter(new MessageMapSetter());
   }
@@ -75,7 +79,8 @@ final class RocketMqInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operationType, RECEIVE_OPERATION_NAME))
             .setEnabled(enabled)
             .addAttributesExtractor(attributesExtractor)
-            .addAttributesExtractor(new RocketMqConsumerReceiveAttributeExtractor());
+            .addAttributesExtractor(new RocketMqConsumerReceiveAttributeExtractor())
+            .addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
     if (emitStableMessagingSemconv()) {
       instrumenterBuilder.addSpanLinksExtractor(
           new RocketMqReceiveSpanLinksExtractor(
@@ -103,6 +108,7 @@ final class RocketMqInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
             .addAttributesExtractor(attributesExtractor)
             .addAttributesExtractor(new RocketMqConsumerProcessAttributeExtractor())
+            .addOperationMetrics(MessagingProcessMetrics.get())
             .setSpanStatusExtractor(
                 (spanStatusBuilder, messageView, consumeResult, error) -> {
                   if (consumeResult == ConsumeResult.FAILURE) {
@@ -112,6 +118,9 @@ final class RocketMqInstrumenterFactory {
                         .extract(spanStatusBuilder, messageView, consumeResult, error);
                   }
                 });
+    if (!receiveInstrumentationEnabled && emitStableMessagingSemconv()) {
+      instrumenterBuilder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
+    }
     setMessagingProcessExceptionEventExtractor(instrumenterBuilder);
 
     return MessagingProcessInstrumenterFactory.create(

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
@@ -128,42 +128,38 @@ abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                 return;
               }
               trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        span.hasKind(SpanKind.PRODUCER)
-                            .hasName(topic + " publish")
-                            .hasStatus(StatusData.unset())
-                            .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, NORMAL),
-                                equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
-                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
-                                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                                equalTo(MESSAGING_OPERATION, "publish")),
-                    span ->
-                        span.hasKind(SpanKind.CONSUMER)
-                            .hasName(topic + " process")
-                            .hasStatus(StatusData.unset())
-                            // As the child of send span.
-                            .hasParent(trace.getSpan(1))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
-                                equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
-                                equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
-                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                equalTo(
-                                    MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
-                                equalTo(MESSAGING_DESTINATION_NAME, topic),
-                                equalTo(MESSAGING_OPERATION, "process")),
-                    span ->
-                        span.hasName("child")
-                            .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(2)));
+                  span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                  span ->
+                      span.hasKind(SpanKind.PRODUCER)
+                          .hasName(topic + " publish")
+                          .hasStatus(StatusData.unset())
+                          .hasParent(trace.getSpan(0))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
+                              equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
+                              equalTo(MESSAGING_ROCKETMQ_MESSAGE_TYPE, NORMAL),
+                              equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
+                              equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                              equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
+                              equalTo(MESSAGING_DESTINATION_NAME, topic),
+                              equalTo(MESSAGING_OPERATION, "publish")),
+                  span ->
+                      span.hasKind(SpanKind.CONSUMER)
+                          .hasName(topic + " process")
+                          .hasStatus(StatusData.unset())
+                          // As the child of send span.
+                          .hasParent(trace.getSpan(1))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_ROCKETMQ_CLIENT_GROUP, consumerGroup),
+                              equalTo(MESSAGING_ROCKETMQ_MESSAGE_TAG, tag),
+                              equalTo(MESSAGING_ROCKETMQ_MESSAGE_KEYS, asList(keys)),
+                              equalTo(MESSAGING_MESSAGE_BODY_SIZE, (long) body.length),
+                              equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                              equalTo(MESSAGING_MESSAGE_ID, sendReceipt.getMessageId().toString()),
+                              equalTo(MESSAGING_DESTINATION_NAME, topic),
+                              equalTo(MESSAGING_OPERATION, "process")),
+                  span ->
+                      span.hasName("child").hasKind(SpanKind.INTERNAL).hasParent(trace.getSpan(2)));
             });
     if (emitStableMessagingSemconv()) {
       assertMetrics(topic, consumerGroup);
@@ -284,5 +280,4 @@ abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                         || metric.getName().equals("messaging.receive.duration")
                         || metric.getName().equals("messaging.receive.messages")));
   }
-
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientSuppressReceiveSpanTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.instrumentation.rocketmqclient.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_CONSUMER_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_BODY_SIZE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_CLIENT_GROUP;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_KEYS;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_MESSAGE_TAG;
@@ -104,8 +109,25 @@ abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                 (ThrowingSupplier<SendReceipt, ClientException>) () -> producer.send(message));
     testing()
         .waitAndAssertTraces(
-            trace ->
+            trace -> {
+              if (emitStableMessagingSemconv()) {
                 trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasKind(SpanKind.PRODUCER)
+                            .hasName("send " + topic)
+                            .hasParent(trace.getSpan(0)),
+                    span ->
+                        span.hasKind(SpanKind.CONSUMER)
+                            .hasName("process " + topic)
+                            .hasParent(trace.getSpan(1)),
+                    span ->
+                        span.hasName("child")
+                            .hasKind(SpanKind.INTERNAL)
+                            .hasParent(trace.getSpan(2)));
+                return;
+              }
+              trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                     span ->
                         span.hasKind(SpanKind.PRODUCER)
@@ -141,6 +163,126 @@ abstract class AbstractRocketMqClientSuppressReceiveSpanTest {
                     span ->
                         span.hasName("child")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(2))));
+                            .hasParent(trace.getSpan(2)));
+            });
+    if (emitStableMessagingSemconv()) {
+      assertMetrics(topic, consumerGroup);
+    } else {
+      assertNoMessagingMetrics();
+    }
   }
+
+  private void assertMetrics(String topic, String consumerGroup) {
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.sent.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .satisfies(
+                                data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(MESSAGING_DESTINATION_NAME, topic))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.operation.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasCount(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(MESSAGING_DESTINATION_NAME, topic),
+                                                    equalTo(MESSAGING_OPERATION_TYPE, "send"))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.process.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasCount(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        consumerGroup),
+                                                    equalTo(MESSAGING_DESTINATION_NAME, topic))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.consumed.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .satisfies(
+                                data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        consumerGroup),
+                                                    equalTo(MESSAGING_DESTINATION_NAME, topic))))));
+    assertThat(testing().metrics())
+        .noneMatch(
+            metric ->
+                metric
+                        .getInstrumentationScopeInfo()
+                        .getName()
+                        .equals("io.opentelemetry.rocketmq-client-5.0")
+                    && (metric.getName().equals("messaging.publish.duration")
+                        || metric.getName().equals("messaging.receive.duration")
+                        || metric.getName().equals("messaging.receive.messages")));
+  }
+
+  private void assertNoMessagingMetrics() {
+    assertThat(testing().metrics())
+        .noneMatch(
+            metric ->
+                metric
+                        .getInstrumentationScopeInfo()
+                        .getName()
+                        .equals("io.opentelemetry.rocketmq-client-5.0")
+                    && (metric.getName().equals("messaging.client.operation.duration")
+                        || metric.getName().equals("messaging.client.sent.messages")
+                        || metric.getName().equals("messaging.client.consumed.messages")
+                        || metric.getName().equals("messaging.process.duration")
+                        || metric.getName().equals("messaging.publish.duration")
+                        || metric.getName().equals("messaging.receive.duration")
+                        || metric.getName().equals("messaging.receive.messages")));
+  }
+
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -35,9 +35,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
 import static org.awaitility.Awaitility.await;
 
 import io.opentelemetry.api.trace.SpanKind;

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -35,6 +35,10 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.awaitility.Awaitility.await;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -50,6 +54,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
@@ -85,6 +90,7 @@ abstract class AbstractRocketMqClientTest {
 
   private final ClientServiceProvider provider = ClientServiceProvider.loadService();
   private final AtomicBoolean failurePending = new AtomicBoolean();
+  private final AtomicReference<CountDownLatch> failureRetryGate = new AtomicReference<>();
   private PushConsumer consumer;
   private Producer producer;
 
@@ -112,10 +118,22 @@ abstract class AbstractRocketMqClientTest {
             .setSubscriptionExpressions(subscriptionExpressions)
             .setMessageListener(
                 messageView -> {
-                  testing().runWithSpan("messageListener", () -> {});
                   if (failurePending.compareAndSet(true, false)) {
+                    testing().runWithSpan("messageListener", () -> {});
                     return ConsumeResult.FAILURE;
                   }
+                  CountDownLatch retryGate = failureRetryGate.get();
+                  if (retryGate != null) {
+                    try {
+                      if (!retryGate.await(45, SECONDS)) {
+                        return ConsumeResult.FAILURE;
+                      }
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      return ConsumeResult.FAILURE;
+                    }
+                  }
+                  testing().runWithSpan("messageListener", () -> {});
                   return ConsumeResult.SUCCESS;
                 })
             .build();
@@ -210,6 +228,9 @@ abstract class AbstractRocketMqClientTest {
                           .hasKind(SpanKind.INTERNAL)
                           .hasParent(trace.getSpan(1)));
             });
+    if (emitStableMessagingSemconv()) {
+      assertMetrics();
+    }
   }
 
   @Test
@@ -225,73 +246,87 @@ abstract class AbstractRocketMqClientTest {
             .setBody(body)
             .build();
 
+    CountDownLatch retryGate = new CountDownLatch(1);
+    failureRetryGate.set(retryGate);
     failurePending.set(true);
-    SendReceipt sendReceipt =
-        testing()
-            .runWithSpan(
-                "parent",
-                (ThrowingSupplier<SendReceipt, ClientException>) () -> producer.send(message));
+    SendReceipt sendReceipt;
     AtomicReference<SpanData> sendSpanData = new AtomicReference<>();
-    testing()
-        .waitAndAssertSortedTraces(
-            orderByRootSpanKind(
-                SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
-            trace -> {
-              if (emitStableMessagingSemconv()) {
+    try {
+      sendReceipt =
+          testing()
+              .runWithSpan(
+                  "parent",
+                  (ThrowingSupplier<SendReceipt, ClientException>) () -> producer.send(message));
+      testing()
+          .waitAndAssertSortedTraces(
+              orderByRootSpanKind(
+                  SpanKind.INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
+              trace -> {
+                if (emitStableMessagingSemconv()) {
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                      span ->
+                          assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                              .hasParent(trace.getSpan(0)),
+                      span ->
+                          assertFailedProcessSpan(
+                                  span,
+                                  trace.getSpan(1),
+                                  NORMAL_TOPIC,
+                                  CONSUMER_GROUP,
+                                  TAG,
+                                  keys,
+                                  body,
+                                  sendReceipt)
+                              .hasParent(trace.getSpan(1)),
+                      span ->
+                          span.hasName("messageListener")
+                              .hasKind(SpanKind.INTERNAL)
+                              .hasParent(trace.getSpan(2)));
+                } else {
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                      span ->
+                          assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
+                              .hasParent(trace.getSpan(0)));
+                }
+                sendSpanData.set(trace.getSpan(1));
+              },
+              trace -> {
+                if (emitStableMessagingSemconv()) {
+                  trace.hasSpansSatisfyingExactly(
+                      span ->
+                          assertReceiveSpan(
+                              span, NORMAL_TOPIC, CONSUMER_GROUP, sendSpanData.get()));
+                  return;
+                }
                 trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
-                            .hasParent(trace.getSpan(0)),
+                    span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
                     span ->
                         assertFailedProcessSpan(
                                 span,
-                                trace.getSpan(1),
+                                sendSpanData.get(),
                                 NORMAL_TOPIC,
                                 CONSUMER_GROUP,
                                 TAG,
                                 keys,
                                 body,
                                 sendReceipt)
-                            .hasParent(trace.getSpan(1)),
+                            .hasParent(trace.getSpan(0)),
                     span ->
                         span.hasName("messageListener")
                             .hasKind(SpanKind.INTERNAL)
-                            .hasParent(trace.getSpan(2)));
-              } else {
-                trace.hasSpansSatisfyingExactly(
-                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
-                    span ->
-                        assertProducerSpan(span, NORMAL_TOPIC, TAG, keys, body, sendReceipt)
-                            .hasParent(trace.getSpan(0)));
-              }
-              sendSpanData.set(trace.getSpan(1));
-            },
-            trace -> {
-              if (emitStableMessagingSemconv()) {
-                trace.hasSpansSatisfyingExactly(
-                    span ->
-                        assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP, sendSpanData.get()));
-                return;
-              }
-              trace.hasSpansSatisfyingExactly(
-                  span -> assertReceiveSpan(span, NORMAL_TOPIC, CONSUMER_GROUP),
-                  span ->
-                      assertFailedProcessSpan(
-                              span,
-                              sendSpanData.get(),
-                              NORMAL_TOPIC,
-                              CONSUMER_GROUP,
-                              TAG,
-                              keys,
-                              body,
-                              sendReceipt)
-                          .hasParent(trace.getSpan(0)),
-                  span ->
-                      span.hasName("messageListener")
-                          .hasKind(SpanKind.INTERNAL)
-                          .hasParent(trace.getSpan(1)));
-            });
+                            .hasParent(trace.getSpan(1)));
+              });
+      if (emitStableMessagingSemconv()) {
+        assertFailureMetrics();
+      }
+      testing().clearData();
+    } finally {
+      retryGate.countDown();
+      failureRetryGate.compareAndSet(retryGate, null);
+    }
+    waitForSuccessfulRedelivery(sendReceipt);
   }
 
   @Test
@@ -959,6 +994,190 @@ abstract class AbstractRocketMqClientTest {
             .hasStatus(StatusData.unset())
             .hasAttributesSatisfyingExactly(attributeAssertions);
     return result.hasLinks(LinkData.create(linkedSpan.getSpanContext()));
+  }
+
+  private void assertFailureMetrics() {
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.process.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasCount(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        ERROR_TYPE, ConsumeResult.FAILURE.name()),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        CONSUMER_GROUP),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        NORMAL_TOPIC))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.consumed.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .satisfies(
+                                data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        CONSUMER_GROUP),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        NORMAL_TOPIC))))));
+  }
+
+  private void waitForSuccessfulRedelivery(SendReceipt sendReceipt) {
+    await()
+        .atMost(Duration.ofSeconds(45))
+        .untilAsserted(
+            () ->
+                assertThat(testing().spans())
+                    .filteredOn(
+                        span ->
+                            sendReceipt
+                                    .getMessageId()
+                                    .toString()
+                                    .equals(span.getAttributes().get(MESSAGING_MESSAGE_ID))
+                                && span.getStatus().equals(StatusData.unset())
+                                && ("process"
+                                        .equals(span.getAttributes().get(MESSAGING_OPERATION_NAME))
+                                    || "process"
+                                        .equals(span.getAttributes().get(MESSAGING_OPERATION))))
+                    .hasSize(1));
+  }
+
+  private void assertMetrics() {
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.sent.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        NORMAL_TOPIC))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.operation.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasCount(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "send"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME, NORMAL_TOPIC),
+                                                    equalTo(MESSAGING_OPERATION_TYPE, "send")),
+                                        // the consumer keeps polling, so the number of recorded
+                                        // receives is not deterministic
+                                        point ->
+                                            point.hasAttributesSatisfyingExactly(
+                                                equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                equalTo(
+                                                    MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+                                                equalTo(MESSAGING_DESTINATION_NAME, NORMAL_TOPIC),
+                                                equalTo(MESSAGING_OPERATION_TYPE, "receive"))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.process.duration",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .hasHistogramSatisfying(
+                                histogram ->
+                                    histogram.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasCount(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "process"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        CONSUMER_GROUP),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        NORMAL_TOPIC))))));
+    testing()
+        .waitAndAssertMetrics(
+            "io.opentelemetry.rocketmq-client-5.0",
+            "messaging.client.consumed.messages",
+            metrics ->
+                metrics.satisfiesExactly(
+                    metric ->
+                        assertThat(metric)
+                            .satisfies(
+                                data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
+                            .hasLongSumSatisfying(
+                                sum ->
+                                    sum.hasPointsSatisfying(
+                                        point ->
+                                            point
+                                                .hasValue(1)
+                                                .hasAttributesSatisfyingExactly(
+                                                    equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                    equalTo(
+                                                        MESSAGING_CONSUMER_GROUP_NAME,
+                                                        CONSUMER_GROUP),
+                                                    equalTo(
+                                                        MESSAGING_DESTINATION_NAME,
+                                                        NORMAL_TOPIC))))));
+    assertThat(testing().metrics())
+        .noneMatch(
+            metric ->
+                metric
+                        .getInstrumentationScopeInfo()
+                        .getName()
+                        .equals("io.opentelemetry.rocketmq-client-5.0")
+                    && (metric.getName().equals("messaging.publish.duration")
+                        || metric.getName().equals("messaging.receive.duration")
+                        || metric.getName().equals("messaging.receive.messages")));
   }
 
   private static AttributeAssertion bodySize(byte[] body) {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/AbstractRocketMqClientTest.java
@@ -1021,31 +1021,9 @@ abstract class AbstractRocketMqClientTest {
                                                     equalTo(
                                                         MESSAGING_DESTINATION_NAME,
                                                         NORMAL_TOPIC))))));
-    testing()
-        .waitAndAssertMetrics(
-            "io.opentelemetry.rocketmq-client-5.0",
-            "messaging.client.consumed.messages",
-            metrics ->
-                metrics.satisfiesExactly(
-                    metric ->
-                        assertThat(metric)
-                            .satisfies(
-                                data -> assertThat(data.getLongSumData().getPoints()).hasSize(1))
-                            .hasLongSumSatisfying(
-                                sum ->
-                                    sum.hasPointsSatisfying(
-                                        point ->
-                                            point
-                                                .hasValue(1)
-                                                .hasAttributesSatisfyingExactly(
-                                                    equalTo(MESSAGING_OPERATION_NAME, "receive"),
-                                                    equalTo(MESSAGING_SYSTEM, "rocketmq"),
-                                                    equalTo(
-                                                        MESSAGING_CONSUMER_GROUP_NAME,
-                                                        CONSUMER_GROUP),
-                                                    equalTo(
-                                                        MESSAGING_DESTINATION_NAME,
-                                                        NORMAL_TOPIC))))));
+    // messaging.client.consumed.messages is owned by the receive operation here, which the retry
+    // gate cannot hold back, so the redelivery would race this assertion; the counter is asserted
+    // in testSendAndConsumeNormalMessage instead
   }
 
   private void waitForSuccessfulRedelivery(SendReceipt sendReceipt) {

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v5_0/RocketMqSimpleConsumerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.rocketmqclient.v5_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
@@ -57,6 +58,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RocketMqSimpleConsumerTest {
 
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rocketmq-client-5.0";
   private static final String TOPIC = "normal-topic-0";
   private static final String TAG = "tagA";
   private static final String CONSUMER_GROUP = "simple-consumer-group";
@@ -194,6 +196,45 @@ class RocketMqSimpleConsumerTest {
         });
 
     assertSuccessfulReceiveTrace("disabled receive parent", sendSpan);
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasCount(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(
+                                                    MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+                                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+                                                equalTo(MESSAGING_OPERATION_NAME, "receive"),
+                                                equalTo(MESSAGING_OPERATION_TYPE, "receive"))))));
+    testing.waitAndAssertMetrics(
+        INSTRUMENTATION_NAME,
+        "messaging.client.consumed.messages",
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(metric)
+                        .hasLongSumSatisfying(
+                            sum ->
+                                sum.hasPointsSatisfying(
+                                    point ->
+                                        point
+                                            .hasValue(1)
+                                            .hasAttributesSatisfyingExactly(
+                                                equalTo(
+                                                    MESSAGING_CONSUMER_GROUP_NAME, CONSUMER_GROUP),
+                                                equalTo(MESSAGING_SYSTEM, "rocketmq"),
+                                                equalTo(MESSAGING_DESTINATION_NAME, TOPIC),
+                                                equalTo(MESSAGING_OPERATION_NAME, "receive"))))));
   }
 
   @Test


### PR DESCRIPTION
RocketMQ 4.8 and 5.0 now emit the stable v1.43 messaging metrics alongside their existing telemetry: `messaging.client.operation.duration` for send and receive operations, `messaging.client.sent.messages` for producers, `messaging.process.duration` for message processing, and `messaging.client.consumed.messages` once per delivery.

The metrics are emitted only under stable messaging semantic conventions, selected with `otel.semconv-stability.preview=messaging` or `otel.instrumentation.common.v3-preview=true`, so legacy output is unchanged.

Because `messaging.client.consumed.messages` is recorded exactly once per delivered message, which operation owns it depends on which operations are instrumented.

For RocketMQ 5 PushConsumer, the receive instrumenter emits nothing while `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` remains at its default `false`, so the process operation owns the count. When receive telemetry is enabled, the receive operation owns it instead.

An application-initiated `SimpleConsumer` pull always has its receive operation under stable conventions because no process span otherwise represents delivery, so that receive operation owns both its duration and consumed-message count.

RocketMQ 4.8 has no stable receive operation, so its process operation always owns the count.

No deprecated `messaging.publish.duration`, `messaging.receive.duration`, or `messaging.receive.messages` instruments are emitted.

Stacked on #19480.

Part of #19254.