### PR TITLE
Pulsar - split batch attributes onto span links

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
@@ -6,9 +6,7 @@ dependencies {
   testImplementation(project(":instrumentation:pulsar:pulsar-2.8:javaagent"))
   testImplementation(project(":instrumentation-api"))
   testImplementation(project(":instrumentation-api-incubator"))
-  testImplementation("io.opentelemetry:opentelemetry-api")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-  testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
   testImplementation("org.apache.pulsar:pulsar-client:2.8.0")
 }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 dependencies {
   testImplementation(project(":instrumentation:pulsar:pulsar-2.8:javaagent"))
   testImplementation(project(":instrumentation-api"))
+  testImplementation(project(":instrumentation-api-incubator"))
+  testImplementation("io.opentelemetry:opentelemetry-api")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+  testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
   testImplementation("org.apache.pulsar:pulsar-client:2.8.0")
 }
 
@@ -15,7 +19,13 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testMessagingPreview)
+    dependsOn(testMessagingPreview, testBothSemconv)
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequestSpanLinksExtractorTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequestSpanLinksExtractorTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksBuilder;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Messages;
+import org.junit.jupiter.api.Test;
+
+class PulsarBatchRequestSpanLinksExtractorTest {
+
+  private static final String TRACE_ID = TraceId.fromLongs(0, 123);
+  private static final String SPAN_ID_1 = SpanId.fromLong(456);
+  private static final String SPAN_ID_2 = SpanId.fromLong(789);
+
+  private final PulsarBatchRequestSpanLinksExtractor extractor =
+      new PulsarBatchRequestSpanLinksExtractor(W3CTraceContextPropagator.getInstance());
+
+  @Test
+  void addsOnlyPerMessageAttributesWhenBatchAttributesAgree() {
+    String topic = "persistent://public/default/test";
+    String partitionTopic = topic + "-partition-0";
+    Message<?> message1 = message(partitionTopic, "message-1", SPAN_ID_1);
+    Message<?> message2 = message(partitionTopic, "message-2", SPAN_ID_2);
+    PulsarBatchRequest request = request(message1, message2);
+    RecordingSpanLinksBuilder spanLinks = new RecordingSpanLinksBuilder();
+
+    extractor.extract(spanLinks, Context.root(), request);
+
+    Attributes batchAttributes = batchSpanAttributes(request);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_NAME))
+        .isEqualTo(emitStableMessagingSemconv() ? topic : partitionTopic);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_PARTITION_ID)).isEqualTo("0");
+    assertThat(spanLinks.links)
+        .containsExactly(
+            linkData(SPAN_ID_1, linkAttributes("message-1").build()),
+            linkData(SPAN_ID_2, linkAttributes("message-2").build()));
+  }
+
+  @Test
+  void keepsSharedDestinationOnBatchWhenPartitionsDiffer() {
+    String topic = "persistent://public/default/test";
+    Message<?> message1 = message(topic + "-partition-0", "message-1", SPAN_ID_1);
+    Message<?> message2 = message(topic + "-partition-1", "message-2", SPAN_ID_2);
+    PulsarBatchRequest request = request(message1, message2);
+    RecordingSpanLinksBuilder spanLinks = new RecordingSpanLinksBuilder();
+
+    extractor.extract(spanLinks, Context.root(), request);
+
+    Attributes batchAttributes = batchSpanAttributes(request);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_NAME)).isEqualTo(topic);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_PARTITION_ID)).isNull();
+    assertThat(spanLinks.links)
+        .containsExactly(
+            linkData(
+                SPAN_ID_1,
+                linkAttributes("message-1").put(MESSAGING_DESTINATION_PARTITION_ID, "0").build()),
+            linkData(
+                SPAN_ID_2,
+                linkAttributes("message-2").put(MESSAGING_DESTINATION_PARTITION_ID, "1").build()));
+  }
+
+  @Test
+  void addsEveryDestinationWhenBatchSpansMultipleTopics() {
+    String topic1 = "persistent://public/default/topic-1";
+    String topic2 = "persistent://public/default/topic-2";
+    Message<?> message1 = message(topic1, "message-1", SPAN_ID_1);
+    Message<?> message2 = message(topic2, "message-2", SPAN_ID_2);
+    PulsarBatchRequest request = request(message1, message2);
+    RecordingSpanLinksBuilder spanLinks = new RecordingSpanLinksBuilder();
+
+    extractor.extract(spanLinks, Context.root(), request);
+
+    assertThat(batchSpanAttributes(request).get(MESSAGING_DESTINATION_NAME))
+        .isEqualTo(emitStableMessagingSemconv() ? null : topic1);
+    assertThat(spanLinks.links)
+        .containsExactly(
+            linkData(
+                SPAN_ID_1,
+                linkAttributes("message-1").put(MESSAGING_DESTINATION_NAME, topic1).build()),
+            linkData(
+                SPAN_ID_2,
+                linkAttributes("message-2").put(MESSAGING_DESTINATION_NAME, topic2).build()));
+  }
+
+  @Test
+  void movesSharedPartitionToLinksWhenDestinationsDiffer() {
+    String topic1 = "persistent://public/default/topic-1";
+    String topic2 = "persistent://public/default/topic-2";
+    Message<?> message1 = message(topic1 + "-partition-0", "message-1", SPAN_ID_1);
+    Message<?> message2 = message(topic2 + "-partition-0", "message-2", SPAN_ID_2);
+    PulsarBatchRequest request = request(message1, message2);
+    RecordingSpanLinksBuilder spanLinks = new RecordingSpanLinksBuilder();
+
+    extractor.extract(spanLinks, Context.root(), request);
+
+    // a partition id is only unique within a destination name, so it is not recorded on the batch
+    // span when the destination name is not recorded there either
+    Attributes batchAttributes = batchSpanAttributes(request);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_NAME))
+        .isEqualTo(emitStableMessagingSemconv() ? null : topic1);
+    assertThat(batchAttributes.get(MESSAGING_DESTINATION_PARTITION_ID)).isNull();
+    assertThat(spanLinks.links)
+        .containsExactly(
+            linkData(
+                SPAN_ID_1,
+                linkAttributes("message-1")
+                    .put(MESSAGING_DESTINATION_NAME, topic1)
+                    .put(MESSAGING_DESTINATION_PARTITION_ID, "0")
+                    .build()),
+            linkData(
+                SPAN_ID_2,
+                linkAttributes("message-2")
+                    .put(MESSAGING_DESTINATION_NAME, topic2)
+                    .put(MESSAGING_DESTINATION_PARTITION_ID, "0")
+                    .build()));
+  }
+
+  private static Message<?> message(String topic, String messageId, String spanId) {
+    Message<?> message = mock(Message.class);
+    MessageId id = mock(MessageId.class);
+    when(id.toString()).thenReturn(messageId);
+    when(message.getMessageId()).thenReturn(id);
+    when(message.getTopicName()).thenReturn(topic);
+    when(message.getProperties())
+        .thenReturn(singletonMap("traceparent", String.format("00-%s-%s-01", TRACE_ID, spanId)));
+    return message;
+  }
+
+  private static PulsarBatchRequest request(Message<?>... messages) {
+    List<Message<?>> messageList = asList(messages);
+    @SuppressWarnings("unchecked")
+    Messages<Object> batch = mock(Messages.class);
+    when(batch.iterator()).thenAnswer(invocation -> messageList.iterator());
+    when(batch.size()).thenReturn(messageList.size());
+    @SuppressWarnings("unchecked")
+    Consumer<Object> consumer = mock(Consumer.class);
+    when(consumer.getSubscription()).thenReturn("subscription");
+    return PulsarBatchRequest.create(batch, null, consumer);
+  }
+
+  private static AttributesBuilder linkAttributes(String messageId) {
+    return Attributes.builder().put(MESSAGING_MESSAGE_ID, messageId);
+  }
+
+  private static LinkData linkData(String spanId, Attributes stableAttributes) {
+    SpanContext spanContext =
+        SpanContext.createFromRemoteParent(
+            TRACE_ID, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+    return LinkData.create(
+        spanContext, emitStableMessagingSemconv() ? stableAttributes : Attributes.empty());
+  }
+
+  private static Attributes batchSpanAttributes(PulsarBatchRequest request) {
+    AttributesBuilder attributes = Attributes.builder();
+    MessagingAttributesExtractor.<PulsarBatchRequest, Void>create(
+            new PulsarBatchMessagingAttributesGetter(), MessagingOperationType.RECEIVE, "receive")
+        .onStart(attributes, Context.root(), request);
+    return attributes.build();
+  }
+
+  private static final class RecordingSpanLinksBuilder implements SpanLinksBuilder {
+    private final List<LinkData> links = new ArrayList<>();
+
+    @Override
+    public SpanLinksBuilder addLink(SpanContext spanContext) {
+      links.add(LinkData.create(spanContext));
+      return this;
+    }
+
+    @Override
+    public SpanLinksBuilder addLink(SpanContext spanContext, Attributes attributes) {
+      links.add(LinkData.create(spanContext, attributes));
+      return this;
+    }
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
@@ -24,7 +24,10 @@ final class PulsarBatchMessagingAttributesGetter
   @Nullable
   @Override
   public String getDestination(PulsarBatchRequest request) {
-    return request.getDestination();
+    PulsarBatchRecordAttributes batchRecordAttributes = request.getBatchRecordAttributes();
+    return batchRecordAttributes != null
+        ? batchRecordAttributes.getCommonDestination()
+        : request.getDestination();
   }
 
   @Nullable
@@ -87,7 +90,10 @@ final class PulsarBatchMessagingAttributesGetter
   @Nullable
   @Override
   public String getDestinationPartitionId(PulsarBatchRequest request) {
-    return request.getDestinationPartitionId();
+    PulsarBatchRecordAttributes batchRecordAttributes = request.getBatchRecordAttributes();
+    return batchRecordAttributes != null
+        ? batchRecordAttributes.getCommonPartitionId()
+        : request.getDestinationPartitionId();
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRecordAttributes.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRecordAttributes.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
+
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_PARTITION_ID;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Messages;
+
+/**
+ * Splits the attributes describing the individual messages of a batch into the ones that are shared
+ * by every message in the batch, which belong on the batch span, and the ones that vary, which
+ * belong on the links describing the individual messages.
+ */
+class PulsarBatchRecordAttributes {
+
+  private static final PulsarMessagingAttributesGetter messagingAttributesGetter =
+      new PulsarMessagingAttributesGetter();
+
+  private boolean initialized;
+  @Nullable private String commonDestination;
+  @Nullable private String commonPartitionId;
+  private boolean destinationVaries;
+  private boolean partitionVaries;
+
+  static PulsarBatchRecordAttributes create(Messages<?> messages) {
+    PulsarBatchRecordAttributes attributes = new PulsarBatchRecordAttributes();
+    for (Message<?> message : messages) {
+      attributes.accept(message.getTopicName());
+    }
+    return attributes;
+  }
+
+  private PulsarBatchRecordAttributes() {}
+
+  private void accept(String topicName) {
+    String destination = BasePulsarRequest.destination(topicName);
+    String partitionId = BasePulsarRequest.destinationPartitionId(topicName);
+    if (!initialized) {
+      initialized = true;
+      commonDestination = destination;
+      commonPartitionId = partitionId;
+      return;
+    }
+    destinationVaries |= !Objects.equals(commonDestination, destination);
+    partitionVaries |= !Objects.equals(commonPartitionId, partitionId);
+  }
+
+  @Nullable
+  String getCommonDestination() {
+    return destinationVaries ? null : commonDestination;
+  }
+
+  /**
+   * Returns the partition id to record on the batch span, if any. A partition id is only unique
+   * within a destination name, so it is only meaningful on the batch span when the destination name
+   * is recorded there too.
+   */
+  @Nullable
+  String getCommonPartitionId() {
+    return destinationVaries || partitionVaries ? null : commonPartitionId;
+  }
+
+  Attributes getLinkAttributes(PulsarRequest request) {
+    AttributesBuilder attributes = Attributes.builder();
+    attributes.put(MESSAGING_MESSAGE_ID, messagingAttributesGetter.getMessageId(request, null));
+    if (destinationVaries) {
+      attributes.put(MESSAGING_DESTINATION_NAME, messagingAttributesGetter.getDestination(request));
+    }
+    if (destinationVaries || partitionVaries) {
+      attributes.put(
+          MESSAGING_DESTINATION_PARTITION_ID,
+          messagingAttributesGetter.getDestinationPartitionId(request));
+    }
+    return attributes.build();
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRecordAttributes.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRecordAttributes.java
@@ -17,9 +17,11 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
 
 /**
- * Splits the attributes describing the individual messages of a batch into the ones that are shared
- * by every message in the batch, which belong on the batch span, and the ones that vary, which
- * belong on the links describing the individual messages.
+ * Splits the attributes describing the individual messages of a batch between the batch span and
+ * the links describing the individual messages. Attributes belong on the batch span when they are
+ * shared by every message and meaningful without attributes that vary. In particular, a common
+ * partition id belongs on the links when the destination varies because partition ids are only
+ * unique within a destination.
  */
 class PulsarBatchRecordAttributes {
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.parseUrl;
 
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
@@ -15,20 +16,27 @@ import org.apache.pulsar.client.api.Messages;
 
 public class PulsarBatchRequest extends BasePulsarRequest {
   private final Messages<?> messages;
+  @Nullable private final PulsarBatchRecordAttributes batchRecordAttributes;
 
   public static PulsarBatchRequest create(
       Messages<?> messages, @Nullable String url, Consumer<?> consumer) {
     return new PulsarBatchRequest(
-        messages, getTopicName(messages), parseUrl(url), consumer.getSubscription());
+        messages,
+        getTopicName(messages),
+        emitStableMessagingSemconv() ? PulsarBatchRecordAttributes.create(messages) : null,
+        parseUrl(url),
+        consumer.getSubscription());
   }
 
   private PulsarBatchRequest(
       Messages<?> messages,
       String topicName,
+      @Nullable PulsarBatchRecordAttributes batchRecordAttributes,
       @Nullable UrlData urlData,
       @Nullable String subscription) {
     super(topicName, urlData, subscription);
     this.messages = messages;
+    this.batchRecordAttributes = batchRecordAttributes;
   }
 
   private static String getTopicName(Messages<?> messages) {
@@ -49,5 +57,15 @@ public class PulsarBatchRequest extends BasePulsarRequest {
 
   public Messages<?> getMessages() {
     return messages;
+  }
+
+  /**
+   * Returns the split of the per-message attributes into the ones shared by the whole batch and the
+   * ones that vary, or {@code null} when the stable messaging semantic conventions are not emitted
+   * and the batch is therefore not split.
+   */
+  @Nullable
+  PulsarBatchRecordAttributes getBatchRecordAttributes() {
+    return batchRecordAttributes;
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequestSpanLinksExtractor.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequestSpanLinksExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanLinksBuilder;
@@ -13,9 +14,12 @@ import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExt
 import org.apache.pulsar.client.api.Message;
 
 final class PulsarBatchRequestSpanLinksExtractor implements SpanLinksExtractor<PulsarBatchRequest> {
+
+  private final TextMapPropagator propagator;
   private final SpanLinksExtractor<PulsarRequest> singleRecordLinkExtractor;
 
   PulsarBatchRequestSpanLinksExtractor(TextMapPropagator propagator) {
+    this.propagator = propagator;
     this.singleRecordLinkExtractor =
         new PropagatorBasedSpanLinksExtractor<>(propagator, MessageTextMapGetter.INSTANCE);
   }
@@ -24,11 +28,20 @@ final class PulsarBatchRequestSpanLinksExtractor implements SpanLinksExtractor<P
   public void extract(
       SpanLinksBuilder spanLinks, Context parentContext, PulsarBatchRequest request) {
 
+    PulsarBatchRecordAttributes batchRecordAttributes = request.getBatchRecordAttributes();
     for (Message<?> message : request.getMessages()) {
-      singleRecordLinkExtractor.extract(
-          spanLinks,
-          parentContext,
-          PulsarRequest.create(message, request.getUrlData(), request.getSubscription()));
+      PulsarRequest messageRequest =
+          PulsarRequest.create(message, request.getUrlData(), request.getSubscription());
+      if (batchRecordAttributes == null) {
+        singleRecordLinkExtractor.extract(spanLinks, parentContext, messageRequest);
+        continue;
+      }
+
+      Context extracted =
+          propagator.extract(Context.root(), messageRequest, MessageTextMapGetter.INSTANCE);
+      spanLinks.addLink(
+          Span.fromContext(extracted).getSpanContext(),
+          batchRecordAttributes.getLinkAttributes(messageRequest));
     }
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -30,6 +30,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -190,7 +191,7 @@ abstract class AbstractPulsarClientTest {
                     span.hasName(
                             emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
                         .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
-                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                        .hasLinks(batchLink(producerSpan.get(), msgId.toString()))
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             batchReceiveAttributes(topic, null, false))));
@@ -317,7 +318,7 @@ abstract class AbstractPulsarClientTest {
                             emitStableMessagingSemconv() ? "receive " + topic : topic + " receive")
                         .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
                         .hasParent(trace.getSpan(0))
-                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                        .hasLinks(batchLink(producerSpan.get(), msgId.toString()))
                         .hasAttributesSatisfyingExactly(batchReceiveAttributes(topic, null, false)),
                 span ->
                     span.hasName("callback")
@@ -425,6 +426,14 @@ abstract class AbstractPulsarClientTest {
   static List<AttributeAssertion> batchReceiveAttributes(
       String destination, String messageId, boolean testHeaders) {
     return receiveAttributes(destination, messageId, testHeaders, true);
+  }
+
+  private static LinkData batchLink(SpanData producerSpan, String messageId) {
+    return LinkData.create(
+        producerSpan.getSpanContext(),
+        emitStableMessagingSemconv()
+            ? Attributes.of(MESSAGING_MESSAGE_ID, messageId)
+            : Attributes.empty());
   }
 
   static List<AttributeAssertion> receiveAttributes(


### PR DESCRIPTION
Splits the attributes of a Pulsar batch receive between the batch span and its links. An attribute whose value is the same for every message in the batch describes the batch, so it stays on the span; an attribute whose value varies describes an individual message, so it moves to that message's link.

For a batch drawn from several partitions of one topic, `messaging.destination.name` is shared and stays on the batch span while `messaging.destination.partition.id` moves to the links. For a batch spanning several topics, both move to the links.

That second case follows from a general rule worth stating explicitly, because it is easy to get wrong in exactly the way this instrumentation did: an attribute that is only meaningful relative to another must follow its prerequisite down to the links rather than being left on the batch span with nothing to interpret it against. `messaging.destination.partition.id` is defined as being unique *within* `messaging.destination.name`, so a partition id recorded on a span that has no destination name does not identify anything. Dropping it instead would lose information that the links can still carry correctly. The same defect appeared twice in the Kafka work in #19504, once in `KafkaBatchRecordAttributes` and again in its `KafkaConnectBatchRecordAttributes` copy, so it is not a Pulsar quirk.

The link attributes come directly from each Pulsar message: `messaging.message.id`, `messaging.destination.name`, and `messaging.destination.partition.id`.

### Batch analysis

`PulsarBatchRecordAttributes` walks the batch once and records both the values common to every message and whether each of them varies, which is all the information the batch span and the links need. This replaces a second pass over the batch and a comparison that could never be true, and follows the pattern used by the Kafka instrumentation so that Pulsar, Kafka, and RocketMQ share one shape.

### Default-path impact

None. When `otel.semconv-stability.opt-in` selects neither `messaging` nor `messaging/dup` and `otel.instrumentation.common.v3-preview` is absent or `false`, batch links carry no attributes and the batch span keeps its existing destination and partition values.

Depends on #19535, which stops the Pulsar destination name from embedding the partition. Without it a batch span and its own links would use `messaging.destination.name` to mean two different things, so the split only makes sense on top of that change.

Part of #19254.