### PR TITLE
Add messaging v1.43 metrics to JMS

### DIFF
--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JavaxMessageAdapter.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JavaxMessageAdapter.java
@@ -17,7 +17,7 @@ import javax.jms.Message;
 
 public class JavaxMessageAdapter implements MessageAdapter {
 
-  private static final VirtualField<Message, Boolean> CONSUMED_MESSAGE_RECORDED =
+  private static final VirtualField<Message, Boolean> RECEIVE_TELEMETRY_RECORDED =
       VirtualField.find(Message.class, Boolean.class);
 
   public static MessageAdapter create(Message message) {
@@ -76,12 +76,12 @@ public class JavaxMessageAdapter implements MessageAdapter {
   }
 
   @Override
-  public boolean isConsumedMessageRecorded() {
-    return Boolean.TRUE.equals(CONSUMED_MESSAGE_RECORDED.get(message));
+  public boolean wasReceiveTelemetryRecorded() {
+    return Boolean.TRUE.equals(RECEIVE_TELEMETRY_RECORDED.get(message));
   }
 
   @Override
-  public void setConsumedMessageRecorded() {
-    CONSUMED_MESSAGE_RECORDED.set(message, Boolean.TRUE);
+  public void markReceiveTelemetryRecorded() {
+    RECEIVE_TELEMETRY_RECORDED.set(message, Boolean.TRUE);
   }
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JavaxMessageAdapter.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JavaxMessageAdapter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.DestinationAdapter;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.MessageAdapter;
 import java.util.Collections;
@@ -15,6 +16,9 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 
 public class JavaxMessageAdapter implements MessageAdapter {
+
+  private static final VirtualField<Message, Boolean> CONSUMED_MESSAGE_RECORDED =
+      VirtualField.find(Message.class, Boolean.class);
 
   public static MessageAdapter create(Message message) {
     return new JavaxMessageAdapter(message);
@@ -69,5 +73,15 @@ public class JavaxMessageAdapter implements MessageAdapter {
   @Override
   public String getJmsMessageId() throws JMSException {
     return message.getJMSMessageID();
+  }
+
+  @Override
+  public boolean isConsumedMessageRecorded() {
+    return Boolean.TRUE.equals(CONSUMED_MESSAGE_RECORDED.get(message));
+  }
+
+  @Override
+  public void setConsumedMessageRecorded() {
+    CONSUMED_MESSAGE_RECORDED.set(message, Boolean.TRUE);
   }
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageListenerInstrumentation.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageListenerInstrumentation.java
@@ -14,6 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.MessageWithDestination;
@@ -47,6 +48,7 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
   public static class MessageListenerAdvice {
 
     public static class AdviceScope {
+      private final Instrumenter<MessageWithDestination, Void> instrumenter;
       private final MessageWithDestination messageWithDestination;
       @Nullable private final Context context;
       @Nullable private final Scope scope;
@@ -55,10 +57,12 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
       @Nullable private final Message messageWithListenerSubscriptionName;
 
       private AdviceScope(
+          Instrumenter<MessageWithDestination, Void> instrumenter,
           MessageWithDestination messageWithDestination,
           @Nullable Context context,
           @Nullable Scope scope,
           @Nullable Message messageWithListenerSubscriptionName) {
+        this.instrumenter = instrumenter;
         this.messageWithDestination = messageWithDestination;
         this.context = context;
         this.scope = scope;
@@ -73,15 +77,22 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
                 JavaxMessageAdapter.create(message), null, JmsSubscriptionNames.get(message));
 
         Context parentContext = Context.current();
-        if (!consumerProcessInstrumenter().shouldStart(parentContext, messageWithDestination)) {
+        Instrumenter<MessageWithDestination, Void> instrumenter =
+            consumerProcessInstrumenter(
+                messageWithDestination.message().wasReceiveTelemetryRecorded());
+        if (!instrumenter.shouldStart(parentContext, messageWithDestination)) {
           // an advice scope is still needed, to clear the listener's subscription name on exit
           return new AdviceScope(
-              messageWithDestination, null, null, messageWithListenerSubscriptionName);
+              instrumenter,
+              messageWithDestination,
+              null,
+              null,
+              messageWithListenerSubscriptionName);
         }
 
-        Context context =
-            consumerProcessInstrumenter().start(parentContext, messageWithDestination);
+        Context context = instrumenter.start(parentContext, messageWithDestination);
         return new AdviceScope(
+            instrumenter,
             messageWithDestination,
             context,
             context.makeCurrent(),
@@ -111,7 +122,7 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
         try {
           if (context != null && scope != null) {
             scope.close();
-            consumerProcessInstrumenter().end(context, messageWithDestination, null, throwable);
+            instrumenter.end(context, messageWithDestination, null, throwable);
           }
         } finally {
           if (messageWithListenerSubscriptionName != null) {

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v1_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -17,6 +19,8 @@ public class JmsSingletons {
   private static final Instrumenter<MessageWithDestination, Void> producerInstrumenter;
   private static final Instrumenter<MessageWithDestination, Void> consumerReceiveInstrumenter;
   private static final Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter;
+  private static final Instrumenter<MessageWithDestination, Void>
+      consumerProcessInstrumenterWithConsumedMessages;
 
   static {
     JmsInstrumenterFactory factory =
@@ -27,7 +31,11 @@ public class JmsSingletons {
 
     producerInstrumenter = factory.createProducerInstrumenter();
     consumerReceiveInstrumenter = factory.createConsumerReceiveInstrumenter();
-    consumerProcessInstrumenter = factory.createConsumerProcessInstrumenter(false);
+    consumerProcessInstrumenter = factory.createConsumerProcessInstrumenter(false, false);
+    consumerProcessInstrumenterWithConsumedMessages =
+        emitStableMessagingSemconv()
+            ? factory.createConsumerProcessInstrumenter(false, true)
+            : consumerProcessInstrumenter;
   }
 
   public static Instrumenter<MessageWithDestination, Void> producerInstrumenter() {
@@ -38,8 +46,11 @@ public class JmsSingletons {
     return consumerReceiveInstrumenter;
   }
 
-  public static Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter() {
-    return consumerProcessInstrumenter;
+  public static Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter(
+      boolean receiveTelemetryRecorded) {
+    return receiveTelemetryRecorded
+        ? consumerProcessInstrumenter
+        : consumerProcessInstrumenterWithConsumedMessages;
   }
 
   private JmsSingletons() {}

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -68,6 +68,7 @@ abstract class AbstractJms1Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms1Test.class);
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.jms-1.1";
+
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -43,6 +43,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
@@ -425,6 +426,50 @@ abstract class AbstractJms1Test {
     assertCounter(
         testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, receiveAttributes);
     assertNoMetric(testing, INSTRUMENTATION_NAME, "messaging.process.duration");
+  }
+
+  @Test
+  void shouldRecordConsumedMessagesOnceWhenReceivedMessageIsDispatchedToListener()
+      throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsReceiveAndDispatchQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer::close);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer::close);
+
+    // when
+    producer.send(sentMessage);
+    // frameworks that poll for messages themselves dispatch them to a message listener afterwards
+    Message receivedMessage = consumer.receive();
+    MessageListener listener = message -> {};
+    listener.onMessage(receivedMessage);
+
+    // then
+    assertThat(((TextMessage) receivedMessage).getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(3));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.process.duration",
+        messagingMetricAttributes("process", "metricsReceiveAndDispatchQueue"));
+    // the receive operation already counted this delivery, so the process operation must not count
+    // it again
+    assertCounter(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.consumed.messages",
+        1,
+        messagingMetricAttributes("receive", "metricsReceiveAndDispatchQueue"));
   }
 
   private static Attributes messagingMetricAttributes(String operationName, String destination) {

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/AbstractJms1Test.java
@@ -11,6 +11,10 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertHistogram;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -24,8 +28,10 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -44,6 +50,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,6 +66,7 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 abstract class AbstractJms1Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms1Test.class);
 
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.jms-1.1";
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
@@ -335,6 +343,98 @@ abstract class AbstractJms1Test {
                             operationType("receive"),
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
+  }
+
+  @Test
+  void shouldRecordSendAndProcessMetrics() throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsListenerQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer::close);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer::close);
+
+    CompletableFuture<TextMessage> receivedMessageFuture = new CompletableFuture<>();
+    consumer.setMessageListener(message -> receivedMessageFuture.complete((TextMessage) message));
+
+    // when
+    producer.send(sentMessage);
+
+    // then
+    assertThat(receivedMessageFuture.get(10, SECONDS).getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(2));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    Attributes sendAttributes = messagingMetricAttributes("send", "metricsListenerQueue");
+    Attributes processAttributes = messagingMetricAttributes("process", "metricsListenerQueue");
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        sendAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "send").build());
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.sent.messages", 1, sendAttributes);
+    assertHistogram(testing, INSTRUMENTATION_NAME, "messaging.process.duration", processAttributes);
+    // A pushed message has no separate receive operation, so process owns the consumed count.
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, processAttributes);
+  }
+
+  @Test
+  void shouldRecordReceiveMetrics() throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsReceiveQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer::close);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer::close);
+
+    // when
+    producer.send(sentMessage);
+    TextMessage receivedMessage = (TextMessage) consumer.receive();
+
+    // then
+    assertThat(receivedMessage.getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(2));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    Attributes receiveAttributes = messagingMetricAttributes("receive", "metricsReceiveQueue");
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        messagingMetricAttributes("send", "metricsReceiveQueue").toBuilder()
+            .put(MESSAGING_OPERATION_TYPE, "send")
+            .build(),
+        receiveAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "receive").build());
+    // the receive operation owns the consumed messages count whenever there is one
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, receiveAttributes);
+    assertNoMetric(testing, INSTRUMENTATION_NAME, "messaging.process.duration");
+  }
+
+  private static Attributes messagingMetricAttributes(String operationName, String destination) {
+    return Attributes.of(
+        MESSAGING_OPERATION_NAME,
+        operationName,
+        MESSAGING_SYSTEM,
+        "jms",
+        MESSAGING_DESTINATION_NAME,
+        destination);
   }
 
   static AttributeAssertion messagingTempDestination(boolean isTemporary) {

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JakartaMessageAdapter.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JakartaMessageAdapter.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.DestinationAdapter;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.MessageAdapter;
 import jakarta.jms.Destination;
@@ -15,6 +16,9 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public class JakartaMessageAdapter implements MessageAdapter {
+
+  private static final VirtualField<Message, Boolean> CONSUMED_MESSAGE_RECORDED =
+      VirtualField.find(Message.class, Boolean.class);
 
   public static MessageAdapter create(Message message) {
     return new JakartaMessageAdapter(message);
@@ -69,5 +73,15 @@ public class JakartaMessageAdapter implements MessageAdapter {
   @Override
   public String getJmsMessageId() throws JMSException {
     return message.getJMSMessageID();
+  }
+
+  @Override
+  public boolean isConsumedMessageRecorded() {
+    return Boolean.TRUE.equals(CONSUMED_MESSAGE_RECORDED.get(message));
+  }
+
+  @Override
+  public void setConsumedMessageRecorded() {
+    CONSUMED_MESSAGE_RECORDED.set(message, Boolean.TRUE);
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JakartaMessageAdapter.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JakartaMessageAdapter.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 
 public class JakartaMessageAdapter implements MessageAdapter {
 
-  private static final VirtualField<Message, Boolean> CONSUMED_MESSAGE_RECORDED =
+  private static final VirtualField<Message, Boolean> RECEIVE_TELEMETRY_RECORDED =
       VirtualField.find(Message.class, Boolean.class);
 
   public static MessageAdapter create(Message message) {
@@ -76,12 +76,12 @@ public class JakartaMessageAdapter implements MessageAdapter {
   }
 
   @Override
-  public boolean isConsumedMessageRecorded() {
-    return Boolean.TRUE.equals(CONSUMED_MESSAGE_RECORDED.get(message));
+  public boolean wasReceiveTelemetryRecorded() {
+    return Boolean.TRUE.equals(RECEIVE_TELEMETRY_RECORDED.get(message));
   }
 
   @Override
-  public void setConsumedMessageRecorded() {
-    CONSUMED_MESSAGE_RECORDED.set(message, Boolean.TRUE);
+  public void markReceiveTelemetryRecorded() {
+    RECEIVE_TELEMETRY_RECORDED.set(message, Boolean.TRUE);
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageListenerInstrumentation.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageListenerInstrumentation.java
@@ -14,6 +14,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.jms.common.v1_1.MessageWithDestination;
@@ -47,6 +48,7 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
   public static class MessageListenerAdvice {
 
     public static class AdviceScope {
+      private final Instrumenter<MessageWithDestination, Void> instrumenter;
       private final MessageWithDestination messageWithDestination;
       @Nullable private final Context context;
       @Nullable private final Scope scope;
@@ -55,10 +57,12 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
       @Nullable private final Message messageWithListenerSubscriptionName;
 
       private AdviceScope(
+          Instrumenter<MessageWithDestination, Void> instrumenter,
           MessageWithDestination messageWithDestination,
           @Nullable Context context,
           @Nullable Scope scope,
           @Nullable Message messageWithListenerSubscriptionName) {
+        this.instrumenter = instrumenter;
         this.messageWithDestination = messageWithDestination;
         this.context = context;
         this.scope = scope;
@@ -73,15 +77,22 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
                 JakartaMessageAdapter.create(message), null, JmsSubscriptionNames.get(message));
 
         Context parentContext = Context.current();
-        if (!consumerProcessInstrumenter().shouldStart(parentContext, messageWithDestination)) {
+        Instrumenter<MessageWithDestination, Void> instrumenter =
+            consumerProcessInstrumenter(
+                messageWithDestination.message().wasReceiveTelemetryRecorded());
+        if (!instrumenter.shouldStart(parentContext, messageWithDestination)) {
           // an advice scope is still needed, to clear the listener's subscription name on exit
           return new AdviceScope(
-              messageWithDestination, null, null, messageWithListenerSubscriptionName);
+              instrumenter,
+              messageWithDestination,
+              null,
+              null,
+              messageWithListenerSubscriptionName);
         }
 
-        Context context =
-            consumerProcessInstrumenter().start(parentContext, messageWithDestination);
+        Context context = instrumenter.start(parentContext, messageWithDestination);
         return new AdviceScope(
+            instrumenter,
             messageWithDestination,
             context,
             context.makeCurrent(),
@@ -111,7 +122,7 @@ class JmsMessageListenerInstrumentation implements TypeInstrumentation {
         try {
           if (context != null && scope != null) {
             scope.close();
-            consumerProcessInstrumenter().end(context, messageWithDestination, null, throwable);
+            instrumenter.end(context, messageWithDestination, null, throwable);
           }
         } finally {
           if (messageWithListenerSubscriptionName != null) {

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.jms.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -17,6 +19,8 @@ public class JmsSingletons {
   private static final Instrumenter<MessageWithDestination, Void> producerInstrumenter;
   private static final Instrumenter<MessageWithDestination, Void> consumerReceiveInstrumenter;
   private static final Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter;
+  private static final Instrumenter<MessageWithDestination, Void>
+      consumerProcessInstrumenterWithConsumedMessages;
 
   static {
     JmsInstrumenterFactory factory =
@@ -27,7 +31,11 @@ public class JmsSingletons {
 
     producerInstrumenter = factory.createProducerInstrumenter();
     consumerReceiveInstrumenter = factory.createConsumerReceiveInstrumenter();
-    consumerProcessInstrumenter = factory.createConsumerProcessInstrumenter(false);
+    consumerProcessInstrumenter = factory.createConsumerProcessInstrumenter(false, false);
+    consumerProcessInstrumenterWithConsumedMessages =
+        emitStableMessagingSemconv()
+            ? factory.createConsumerProcessInstrumenter(false, true)
+            : consumerProcessInstrumenter;
   }
 
   public static Instrumenter<MessageWithDestination, Void> producerInstrumenter() {
@@ -38,8 +46,11 @@ public class JmsSingletons {
     return consumerReceiveInstrumenter;
   }
 
-  public static Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter() {
-    return consumerProcessInstrumenter;
+  public static Instrumenter<MessageWithDestination, Void> consumerProcessInstrumenter(
+      boolean receiveTelemetryRecorded) {
+    return receiveTelemetryRecorded
+        ? consumerProcessInstrumenter
+        : consumerProcessInstrumenterWithConsumedMessages;
   }
 
   private JmsSingletons() {}

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -40,6 +40,7 @@ import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageListener;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
@@ -280,6 +281,50 @@ abstract class AbstractJms3Test {
     assertCounter(
         testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, receiveAttributes);
     assertNoMetric(testing, INSTRUMENTATION_NAME, "messaging.process.duration");
+  }
+
+  @Test
+  void shouldRecordConsumedMessagesOnceWhenReceivedMessageIsDispatchedToListener()
+      throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsReceiveAndDispatchQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer);
+
+    // when
+    producer.send(sentMessage);
+    // frameworks that poll for messages themselves dispatch them to a message listener afterwards
+    Message receivedMessage = consumer.receive();
+    MessageListener listener = message -> {};
+    listener.onMessage(receivedMessage);
+
+    // then
+    assertThat(((TextMessage) receivedMessage).getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(3));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.process.duration",
+        messagingMetricAttributes("process", "metricsReceiveAndDispatchQueue"));
+    // the receive operation already counted this delivery, so the process operation must not count
+    // it again
+    assertCounter(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.consumed.messages",
+        1,
+        messagingMetricAttributes("receive", "metricsReceiveAndDispatchQueue"));
   }
 
   private static Attributes messagingMetricAttributes(String operationName, String destination) {

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -69,6 +69,7 @@ abstract class AbstractJms3Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms3Test.class);
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.jms-3.0";
+
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/AbstractJms3Test.java
@@ -10,6 +10,10 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertHistogram;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -23,8 +27,10 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -44,6 +50,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +67,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 abstract class AbstractJms3Test {
   private static final Logger logger = LoggerFactory.getLogger(AbstractJms3Test.class);
 
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.jms-3.0";
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
@@ -191,6 +199,97 @@ abstract class AbstractJms3Test {
     assertThat(message).isNull();
 
     testing.waitForTraces(0);
+  }
+
+  @Test
+  void shouldRecordSendAndProcessMetrics() throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsListenerQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer);
+
+    CompletableFuture<TextMessage> receivedMessageFuture = new CompletableFuture<>();
+    consumer.setMessageListener(message -> receivedMessageFuture.complete((TextMessage) message));
+
+    // when
+    producer.send(sentMessage);
+
+    // then
+    assertThat(receivedMessageFuture.get(10, SECONDS).getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(2));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    Attributes sendAttributes = messagingMetricAttributes("send", "metricsListenerQueue");
+    Attributes processAttributes = messagingMetricAttributes("process", "metricsListenerQueue");
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        sendAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "send").build());
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.sent.messages", 1, sendAttributes);
+    assertHistogram(testing, INSTRUMENTATION_NAME, "messaging.process.duration", processAttributes);
+    // A pushed message has no separate receive operation, so process owns the consumed count.
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, processAttributes);
+  }
+
+  @Test
+  void shouldRecordReceiveMetrics() throws Exception {
+
+    // given
+    Destination destination = session.createQueue("metricsReceiveQueue");
+    TextMessage sentMessage = session.createTextMessage("a message");
+
+    MessageProducer producer = session.createProducer(destination);
+    cleanup.deferCleanup(producer);
+    MessageConsumer consumer = session.createConsumer(destination);
+    cleanup.deferCleanup(consumer);
+
+    // when
+    producer.send(sentMessage);
+    TextMessage receivedMessage = (TextMessage) consumer.receive();
+
+    // then
+    assertThat(receivedMessage.getText()).isEqualTo("a message");
+
+    if (!emitStableMessagingSemconv()) {
+      await().untilAsserted(() -> assertThat(testing.spans()).hasSize(2));
+      assertNoStableMetrics(testing, INSTRUMENTATION_NAME);
+      return;
+    }
+
+    Attributes receiveAttributes = messagingMetricAttributes("receive", "metricsReceiveQueue");
+    assertHistogram(
+        testing,
+        INSTRUMENTATION_NAME,
+        "messaging.client.operation.duration",
+        messagingMetricAttributes("send", "metricsReceiveQueue").toBuilder()
+            .put(MESSAGING_OPERATION_TYPE, "send")
+            .build(),
+        receiveAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "receive").build());
+    assertCounter(
+        testing, INSTRUMENTATION_NAME, "messaging.client.consumed.messages", 1, receiveAttributes);
+    assertNoMetric(testing, INSTRUMENTATION_NAME, "messaging.process.duration");
+  }
+
+  private static Attributes messagingMetricAttributes(String operationName, String destination) {
+    return Attributes.of(
+        MESSAGING_OPERATION_NAME,
+        operationName,
+        MESSAGING_SYSTEM,
+        "jms",
+        MESSAGING_DESTINATION_NAME,
+        destination);
   }
 
   @ParameterizedTest

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -12,6 +12,9 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
@@ -24,6 +27,8 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 
 public class JmsInstrumenterFactory {
@@ -32,6 +37,9 @@ public class JmsInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String RECEIVE_OPERATION_NAME = "receive";
   private static final String PROCESS_OPERATION_NAME = "process";
+
+  private static final ContextKey<Boolean> CONSUMED_MESSAGE_ALREADY_RECORDED =
+      ContextKey.named("jms-consumed-message-already-recorded");
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
@@ -111,8 +119,17 @@ public class JmsInstrumenterFactory {
             .addOperationMetrics(MessagingProcessMetrics.get());
     boolean receiveOperationExists =
         canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled;
-    if (!receiveOperationExists && emitStableMessagingSemconv()) {
-      builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
+    if (emitStableMessagingSemconv()) {
+      // whether a receive operation counted a delivery can only be known per message: an
+      // application can receive a message and dispatch it to a message listener itself, and a
+      // framework that receives messages can be used while the JMS instrumentation that would
+      // create the receive operation is disabled
+      builder.addContextCustomizer(
+          (context, request, startAttributes) ->
+              request.message().isConsumedMessageRecorded()
+                  ? context.with(CONSUMED_MESSAGE_ALREADY_RECORDED, Boolean.TRUE)
+                  : context);
+      builder.addOperationMetrics(consumedMessagesForUncountedDeliveries());
     }
     setMessagingProcessExceptionEventExtractor(builder);
     return MessagingProcessInstrumenterFactory.create(
@@ -128,5 +145,25 @@ public class JmsInstrumenterFactory {
             new JmsMessageAttributesGetter(), operationType, operationName)
         .setHeaders(headers)
         .build();
+  }
+
+  private static OperationMetrics consumedMessagesForUncountedDeliveries() {
+    OperationMetrics consumedMessages = MessagingConsumerMetrics.getConsumedMessages();
+    return meter -> {
+      OperationListener listener = consumedMessages.create(meter);
+      return new OperationListener() {
+        @Override
+        public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+          return listener.onStart(context, startAttributes, startNanos);
+        }
+
+        @Override
+        public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+          if (context.get(CONSUMED_MESSAGE_ALREADY_RECORDED) == null) {
+            listener.onEnd(context, endAttributes, endNanos);
+          }
+        }
+      };
+    };
   }
 }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -14,7 +14,10 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProducerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingProcessInstrumenterFactory;
@@ -63,7 +66,8 @@ public class JmsInstrumenterFactory {
                 instrumentationName,
                 MessagingSpanNameExtractor.create(getter, operationType, SEND_OPERATION_NAME))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(operationType, SEND_OPERATION_NAME));
+                createMessagingAttributesExtractor(operationType, SEND_OPERATION_NAME))
+            .addOperationMetrics(MessagingProducerMetrics.getForOperationType());
     setMessagingSendExceptionEventExtractor(builder);
     return builder.buildProducerInstrumenter(new MessagePropertySetter());
   }
@@ -78,7 +82,8 @@ public class JmsInstrumenterFactory {
                 instrumentationName,
                 MessagingSpanNameExtractor.create(getter, operationType, RECEIVE_OPERATION_NAME))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(operationType, RECEIVE_OPERATION_NAME));
+                createMessagingAttributesExtractor(operationType, RECEIVE_OPERATION_NAME))
+            .addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
     setMessagingReceiveExceptionEventExtractor(builder);
     // with the stable messaging semantic conventions the producer is always linked, since it is
     // never used as the parent of the receive span
@@ -102,13 +107,19 @@ public class JmsInstrumenterFactory {
                 instrumentationName,
                 MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
             .addAttributesExtractor(
-                createMessagingAttributesExtractor(operationType, PROCESS_OPERATION_NAME));
+                createMessagingAttributesExtractor(operationType, PROCESS_OPERATION_NAME))
+            .addOperationMetrics(MessagingProcessMetrics.get());
+    boolean receiveOperationExists =
+        canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled;
+    if (!receiveOperationExists && emitStableMessagingSemconv()) {
+      builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
+    }
     setMessagingProcessExceptionEventExtractor(builder);
     return MessagingProcessInstrumenterFactory.create(
         builder,
         openTelemetry.getPropagators().getTextMapPropagator(),
         MessagePropertyGetter.INSTANCE,
-        canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled);
+        receiveOperationExists);
   }
 
   private AttributesExtractor<MessageWithDestination, Void> createMessagingAttributesExtractor(

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -12,9 +12,6 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
@@ -27,8 +24,6 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
-import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 
 public class JmsInstrumenterFactory {
@@ -37,9 +32,6 @@ public class JmsInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String RECEIVE_OPERATION_NAME = "receive";
   private static final String PROCESS_OPERATION_NAME = "process";
-
-  private static final ContextKey<Boolean> CONSUMED_MESSAGE_ALREADY_RECORDED =
-      ContextKey.named("jms-consumed-message-already-recorded");
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
@@ -105,7 +97,7 @@ public class JmsInstrumenterFactory {
   }
 
   public Instrumenter<MessageWithDestination, Void> createConsumerProcessInstrumenter(
-      boolean canHaveReceiveInstrumentation) {
+      boolean canHaveReceiveInstrumentation, boolean recordConsumedMessages) {
     JmsMessageAttributesGetter getter = new JmsMessageAttributesGetter();
     MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
@@ -119,17 +111,8 @@ public class JmsInstrumenterFactory {
             .addOperationMetrics(MessagingProcessMetrics.get());
     boolean receiveOperationExists =
         canHaveReceiveInstrumentation && messagingReceiveInstrumentationEnabled;
-    if (emitStableMessagingSemconv()) {
-      // whether a receive operation counted a delivery can only be known per message: an
-      // application can receive a message and dispatch it to a message listener itself, and a
-      // framework that receives messages can be used while the JMS instrumentation that would
-      // create the receive operation is disabled
-      builder.addContextCustomizer(
-          (context, request, startAttributes) ->
-              request.message().isConsumedMessageRecorded()
-                  ? context.with(CONSUMED_MESSAGE_ALREADY_RECORDED, Boolean.TRUE)
-                  : context);
-      builder.addOperationMetrics(consumedMessagesForUncountedDeliveries());
+    if (recordConsumedMessages && emitStableMessagingSemconv()) {
+      builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     }
     setMessagingProcessExceptionEventExtractor(builder);
     return MessagingProcessInstrumenterFactory.create(
@@ -145,25 +128,5 @@ public class JmsInstrumenterFactory {
             new JmsMessageAttributesGetter(), operationType, operationName)
         .setHeaders(headers)
         .build();
-  }
-
-  private static OperationMetrics consumedMessagesForUncountedDeliveries() {
-    OperationMetrics consumedMessages = MessagingConsumerMetrics.getConsumedMessages();
-    return meter -> {
-      OperationListener listener = consumedMessages.create(meter);
-      return new OperationListener() {
-        @Override
-        public Context onStart(Context context, Attributes startAttributes, long startNanos) {
-          return listener.onStart(context, startAttributes, startNanos);
-        }
-
-        @Override
-        public void onEnd(Context context, Attributes endAttributes, long endNanos) {
-          if (context.get(CONSUMED_MESSAGE_ALREADY_RECORDED) == null) {
-            listener.onEnd(context, endAttributes, endNanos);
-          }
-        }
-      };
-    };
   }
 }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
@@ -48,11 +48,7 @@ public class JmsReceiveSpanUtil {
               timer.startTime(),
               timer.now());
       JmsReceiveContextHolder.set(receiveContext);
-      if (emitStableMessagingSemconv()) {
-        // this receive operation counted the delivered message, so a process operation for the same
-        // message must not count it again
-        request.message().setConsumedMessageRecorded();
-      }
+      request.message().markReceiveTelemetryRecorded();
     }
   }
 

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsReceiveSpanUtil.java
@@ -48,6 +48,11 @@ public class JmsReceiveSpanUtil {
               timer.startTime(),
               timer.now());
       JmsReceiveContextHolder.set(receiveContext);
+      if (emitStableMessagingSemconv()) {
+        // this receive operation counted the delivered message, so a process operation for the same
+        // message must not count it again
+        request.message().setConsumedMessageRecorded();
+      }
     }
   }
 

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageAdapter.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageAdapter.java
@@ -29,12 +29,9 @@ public interface MessageAdapter {
   @Nullable
   String getJmsMessageId() throws Exception;
 
-  /**
-   * Tells whether the consumed messages metric was already recorded for this message by a receive
-   * operation.
-   */
-  boolean isConsumedMessageRecorded();
+  /** Tells whether receive telemetry was already recorded for this message. */
+  boolean wasReceiveTelemetryRecorded();
 
-  /** Remembers that the consumed messages metric was recorded for this message. */
-  void setConsumedMessageRecorded();
+  /** Remembers that receive telemetry was recorded for this message. */
+  void markReceiveTelemetryRecorded();
 }

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageAdapter.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/MessageAdapter.java
@@ -28,4 +28,13 @@ public interface MessageAdapter {
 
   @Nullable
   String getJmsMessageId() throws Exception;
+
+  /**
+   * Tells whether the consumed messages metric was already recorded for this message by a receive
+   * operation.
+   */
+  boolean isConsumedMessageRecorded();
+
+  /** Remembers that the consumed messages metric was recorded for this message. */
+  void setConsumedMessageRecorded();
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -64,6 +64,15 @@ tasks {
   withType<Test>().configureEach {
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
+
+  val testMessagingPreviewReceiveSpansDisabled =
+    register<Test>("testMessagingPreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
+      classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   // this does not apply to testReceiveSpansDisabled
   test {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
@@ -103,6 +112,12 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testMessagingPreview, testJmsDisabled, testBothSemconv)
+    dependsOn(
+      testing.suites,
+      testMessagingPreview,
+      testMessagingPreviewReceiveSpansDisabled,
+      testJmsDisabled,
+      testBothSemconv,
+    )
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -99,6 +99,9 @@ tasks {
       )
     }
     jvmArgs("-Dotel.instrumentation.jms.enabled=false")
+    // receive telemetry is enabled here because the jms instrumentation that would create the
+    // receive operation is disabled, so the process operation has to count the consumed message
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
     systemProperty("testJmsDisabled", "true")
   }

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsMessageListenerInstrumentation.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsMessageListenerInstrumentation.java
@@ -16,6 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.jms.JmsReceiveContextHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -55,11 +56,17 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
   public static class MessageListenerAdvice {
 
     public static class AdviceScope {
+      private final Instrumenter<MessageWithDestination, Void> instrumenter;
       private final MessageWithDestination request;
       private final Context context;
       private final Scope scope;
 
-      private AdviceScope(MessageWithDestination request, Context context, Scope scope) {
+      private AdviceScope(
+          Instrumenter<MessageWithDestination, Void> instrumenter,
+          MessageWithDestination request,
+          Context context,
+          Scope scope) {
+        this.instrumenter = instrumenter;
         this.request = request;
         this.context = context;
         this.scope = scope;
@@ -79,16 +86,18 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
             MessageWithDestination.create(
                 JavaxMessageAdapter.create(message), null, JmsSubscriptionNames.get(message));
 
-        if (!listenerInstrumenter().shouldStart(parentContext, request)) {
+        Instrumenter<MessageWithDestination, Void> instrumenter =
+            listenerInstrumenter(request.message().wasReceiveTelemetryRecorded());
+        if (!instrumenter.shouldStart(parentContext, request)) {
           return null;
         }
-        Context context = listenerInstrumenter().start(parentContext, request);
-        return new AdviceScope(request, context, context.makeCurrent());
+        Context context = instrumenter.start(parentContext, request);
+        return new AdviceScope(instrumenter, request, context, context.makeCurrent());
       }
 
       public void exit(@Nullable Throwable throwable) {
         scope.close();
-        listenerInstrumenter().end(context, request, null, throwable);
+        instrumenter.end(context, request, null, throwable);
       }
     }
 

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -17,6 +19,8 @@ public class SpringJmsSingletons {
   public static final boolean RECEIVE_TELEMETRY_ENABLED =
       ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
   private static final Instrumenter<MessageWithDestination, Void> listenerInstrumenter;
+  private static final Instrumenter<MessageWithDestination, Void>
+      listenerInstrumenterWithConsumedMessages;
   private static final Instrumenter<MessageWithDestination, Void> receiveInstrumenter;
 
   static {
@@ -25,12 +29,19 @@ public class SpringJmsSingletons {
             .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
-    listenerInstrumenter = factory.createConsumerProcessInstrumenter(true);
+    listenerInstrumenter = factory.createConsumerProcessInstrumenter(true, false);
+    listenerInstrumenterWithConsumedMessages =
+        emitStableMessagingSemconv()
+            ? factory.createConsumerProcessInstrumenter(true, true)
+            : listenerInstrumenter;
     receiveInstrumenter = factory.createConsumerReceiveInstrumenter();
   }
 
-  public static Instrumenter<MessageWithDestination, Void> listenerInstrumenter() {
-    return listenerInstrumenter;
+  public static Instrumenter<MessageWithDestination, Void> listenerInstrumenter(
+      boolean receiveTelemetryRecorded) {
+    return receiveTelemetryRecorded
+        ? listenerInstrumenter
+        : listenerInstrumenterWithConsumedMessages;
   }
 
   public static Instrumenter<MessageWithDestination, Void> receiveInstrumenter() {

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -11,8 +11,6 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
-import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
-import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -269,27 +269,21 @@ class SpringListenerTest extends AbstractJmsTest {
                         null,
                         "durable-subscription")));
 
-    if (!emitStableMessagingSemconv()) {
-      assertNoStableMetrics(testing, "io.opentelemetry.jms-1.1");
-      assertNoStableMetrics(testing, "io.opentelemetry.spring-jms-2.0");
-      return;
-    }
-
-    Attributes receiveAttributes =
+    // the jms instrumentation that would create the receive operation is disabled, so the process
+    // operation counts the consumed message
+    Attributes processAttributes =
         Attributes.builder()
-            .put(MESSAGING_OPERATION_NAME, "receive")
+            .put(MESSAGING_OPERATION_NAME, "process")
             .put(MESSAGING_SYSTEM, "jms")
             .put(MESSAGING_DESTINATION_NAME, "SpringListenerJms2")
             .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
             .build();
     assertCounter(
         testing,
-        "io.opentelemetry.jms-1.1",
+        "io.opentelemetry.spring-jms-2.0",
         "messaging.client.consumed.messages",
         1,
-        receiveAttributes);
-    assertNoMetric(
-        testing, "io.opentelemetry.spring-jms-2.0", "messaging.client.consumed.messages");
+        processAttributes);
   }
 
   @TestConfiguration

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -5,16 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -53,6 +62,10 @@ import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class SpringListenerTest extends AbstractJmsTest {
+
+  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      stringKey("messaging.destination.subscription.name");
 
   @RegisterExtension
   private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -255,6 +268,28 @@ class SpringListenerTest extends AbstractJmsTest {
                         false,
                         null,
                         "durable-subscription")));
+
+    if (!emitStableMessagingSemconv()) {
+      assertNoStableMetrics(testing, "io.opentelemetry.jms-1.1");
+      assertNoStableMetrics(testing, "io.opentelemetry.spring-jms-2.0");
+      return;
+    }
+
+    Attributes receiveAttributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION_NAME, "receive")
+            .put(MESSAGING_SYSTEM, "jms")
+            .put(MESSAGING_DESTINATION_NAME, "SpringListenerJms2")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
+            .build();
+    assertCounter(
+        testing,
+        "io.opentelemetry.jms-1.1",
+        "messaging.client.consumed.messages",
+        1,
+        receiveAttributes);
+    assertNoMetric(
+        testing, "io.opentelemetry.spring-jms-2.0", "messaging.client.consumed.messages");
   }
 
   @TestConfiguration

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
@@ -14,13 +13,13 @@ import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAss
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -60,10 +59,6 @@ import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class SpringListenerTest extends AbstractJmsTest {
-
-  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
-  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
-      stringKey("messaging.destination.subscription.name");
 
   @RegisterExtension
   private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerSuppressReceiveSpansTest.java
@@ -5,19 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
 import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertHistogram;
 import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
 import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.awaitility.Awaitility.await;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.spring.jms.v2_0.AbstractJmsTest;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -32,10 +31,6 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 class SpringListenerSuppressReceiveSpansTest extends AbstractJmsTest {
-
-  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
-  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
-      stringKey("messaging.destination.subscription.name");
 
   @RegisterExtension
   private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/testReceiveSpansDisabled/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerSuppressReceiveSpansTest.java
@@ -5,8 +5,20 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertHistogram;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static org.awaitility.Awaitility.await;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.spring.jms.v2_0.AbstractJmsTest;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -20,6 +32,10 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 class SpringListenerSuppressReceiveSpansTest extends AbstractJmsTest {
+
+  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      stringKey("messaging.destination.subscription.name");
 
   @RegisterExtension
   private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -51,12 +67,52 @@ class SpringListenerSuppressReceiveSpansTest extends AbstractJmsTest {
                 span ->
                     assertConsumerSpan(
                         span,
-                        null,
+                        emitStableMessagingSemconv() ? trace.getSpan(0) : null,
                         trace.getSpan(0),
                         "SpringListenerJms2",
                         "process",
                         false,
                         null,
                         "durable-subscription")));
+
+    if (!emitStableMessagingSemconv()) {
+      assertNoStableMetrics(testing, "io.opentelemetry.jms-1.1");
+      assertNoStableMetrics(testing, "io.opentelemetry.spring-jms-2.0");
+      return;
+    }
+
+    Attributes sendAttributes =
+        Attributes.of(
+            MESSAGING_OPERATION_NAME,
+            "send",
+            MESSAGING_SYSTEM,
+            "jms",
+            MESSAGING_DESTINATION_NAME,
+            "SpringListenerJms2");
+    assertHistogram(
+        testing,
+        "io.opentelemetry.jms-1.1",
+        "messaging.client.operation.duration",
+        sendAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "send").build());
+    assertNoMetric(testing, "io.opentelemetry.jms-1.1", "messaging.client.consumed.messages");
+
+    Attributes processAttributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION_NAME, "process")
+            .put(MESSAGING_SYSTEM, "jms")
+            .put(MESSAGING_DESTINATION_NAME, "SpringListenerJms2")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
+            .build();
+    assertHistogram(
+        testing,
+        "io.opentelemetry.spring-jms-2.0",
+        "messaging.process.duration",
+        processAttributes);
+    assertCounter(
+        testing,
+        "io.opentelemetry.spring-jms-2.0",
+        "messaging.client.consumed.messages",
+        1,
+        processAttributes);
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -86,6 +86,18 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
+  val testV3PreviewReceiveSpansDisabled =
+    register<Test>("testV3PreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+      filter {
+        includeTestsMatching("SpringListenerSuppressReceiveSpansTest")
+      }
+      include("**/SpringListenerSuppressReceiveSpansTest.*")
+      jvmArgs("-Dotel.instrumentation.common.v3-preview=true")
+      systemProperty("metadataConfig", "otel.instrumentation.common.v3-preview=true")
+    }
+
   test {
     filter {
       excludeTestsMatching("SpringListenerSuppressReceiveSpansTest")
@@ -98,6 +110,12 @@ tasks {
   }
 
   check {
-    dependsOn(testReceiveSpansDisabled, testMessagingPreview, testJmsDisabled, testBothSemconv)
+    dependsOn(
+      testReceiveSpansDisabled,
+      testMessagingPreview,
+      testJmsDisabled,
+      testBothSemconv,
+      testV3PreviewReceiveSpansDisabled,
+    )
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/build.gradle.kts
@@ -71,6 +71,9 @@ tasks {
       includeTestsMatching("*.testSpringJmsListenerWithJmsDisabled")
     }
     jvmArgs("-Dotel.instrumentation.jms.enabled=false")
+    // receive telemetry is enabled here because the jms instrumentation that would create the
+    // receive operation is disabled, so the process operation has to count the consumed message
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
     systemProperty("testJmsDisabled", "true")
   }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsMessageListenerInstrumentation.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsMessageListenerInstrumentation.java
@@ -16,6 +16,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.jms.JmsReceiveContextHolder;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -55,11 +56,17 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
   public static class MessageListenerAdvice {
 
     public static class AdviceScope {
+      private final Instrumenter<MessageWithDestination, Void> instrumenter;
       private final MessageWithDestination request;
       private final Context context;
       private final Scope scope;
 
-      private AdviceScope(MessageWithDestination request, Context context, Scope scope) {
+      private AdviceScope(
+          Instrumenter<MessageWithDestination, Void> instrumenter,
+          MessageWithDestination request,
+          Context context,
+          Scope scope) {
+        this.instrumenter = instrumenter;
         this.request = request;
         this.context = context;
         this.scope = scope;
@@ -78,17 +85,19 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
             MessageWithDestination.create(
                 JakartaMessageAdapter.create(message), null, JmsSubscriptionNames.get(message));
 
-        if (!listenerInstrumenter().shouldStart(parentContext, request)) {
+        Instrumenter<MessageWithDestination, Void> instrumenter =
+            listenerInstrumenter(request.message().wasReceiveTelemetryRecorded());
+        if (!instrumenter.shouldStart(parentContext, request)) {
           return null;
         }
 
-        Context context = listenerInstrumenter().start(parentContext, request);
-        return new AdviceScope(request, context, context.makeCurrent());
+        Context context = instrumenter.start(parentContext, request);
+        return new AdviceScope(instrumenter, request, context, context.makeCurrent());
       }
 
       public void end(@Nullable Throwable throwable) {
         scope.close();
-        listenerInstrumenter().end(context, request, null, throwable);
+        instrumenter.end(context, request, null, throwable);
       }
     }
 

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsSingletons.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
@@ -17,6 +19,8 @@ public class SpringJmsSingletons {
   public static final boolean RECEIVE_TELEMETRY_ENABLED =
       ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
   private static final Instrumenter<MessageWithDestination, Void> listenerInstrumenter;
+  private static final Instrumenter<MessageWithDestination, Void>
+      listenerInstrumenterWithConsumedMessages;
   private static final Instrumenter<MessageWithDestination, Void> receiveInstrumenter;
 
   static {
@@ -25,12 +29,19 @@ public class SpringJmsSingletons {
             .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
             .setMessagingReceiveTelemetryEnabled(RECEIVE_TELEMETRY_ENABLED);
 
-    listenerInstrumenter = factory.createConsumerProcessInstrumenter(true);
+    listenerInstrumenter = factory.createConsumerProcessInstrumenter(true, false);
+    listenerInstrumenterWithConsumedMessages =
+        emitStableMessagingSemconv()
+            ? factory.createConsumerProcessInstrumenter(true, true)
+            : listenerInstrumenter;
     receiveInstrumenter = factory.createConsumerReceiveInstrumenter();
   }
 
-  public static Instrumenter<MessageWithDestination, Void> listenerInstrumenter() {
-    return listenerInstrumenter;
+  public static Instrumenter<MessageWithDestination, Void> listenerInstrumenter(
+      boolean receiveTelemetryRecorded) {
+    return receiveTelemetryRecorded
+        ? listenerInstrumenter
+        : listenerInstrumenterWithConsumedMessages;
   }
 
   public static Instrumenter<MessageWithDestination, Void> receiveInstrumenter() {

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -12,6 +12,9 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -27,6 +30,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -287,6 +291,28 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
                             subscriptionName(subscriptionName)),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
+
+    if (!emitStableMessagingSemconv()) {
+      assertNoStableMetrics(testing, "io.opentelemetry.jms-3.0");
+      assertNoStableMetrics(testing, "io.opentelemetry.spring-jms-6.0");
+      return;
+    }
+
+    Attributes receiveAttributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION_NAME, "receive")
+            .put(MESSAGING_SYSTEM, "jms")
+            .put(MESSAGING_DESTINATION_NAME, "spring-jms-listener")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
+            .build();
+    assertCounter(
+        testing,
+        "io.opentelemetry.jms-3.0",
+        "messaging.client.consumed.messages",
+        1,
+        receiveAttributes);
+    assertNoMetric(
+        testing, "io.opentelemetry.spring-jms-6.0", "messaging.client.consumed.messages");
   }
 
   @ParameterizedTest

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -510,6 +510,22 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
             trace.hasSpansSatisfyingExactly(
                 span -> assertProcessSpanWithSubscription(span),
                 span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
+
+    // the jms instrumentation that would create the receive operation is disabled, so the process
+    // operation counts the consumed message
+    Attributes processAttributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION_NAME, "process")
+            .put(MESSAGING_SYSTEM, "jms")
+            .put(MESSAGING_DESTINATION_NAME, "spring-jms-listener")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
+            .build();
+    assertCounter(
+        testing,
+        "io.opentelemetry.spring-jms-6.0",
+        "messaging.client.consumed.messages",
+        1,
+        processAttributes);
   }
 
   private static void assertProcessSpanWithSubscription(SpanDataAssert span) {

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
@@ -16,22 +15,18 @@ import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAss
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_SUBSCRIPTION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import org.assertj.core.api.AbstractStringAssert;
 
 class SpringListenerSuppressReceiveSpansTest extends AbstractSpringJmsListenerTest {
-
-  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
-  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
-      stringKey("messaging.destination.subscription.name");
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Override

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringListenerSuppressReceiveSpansTest.java
@@ -5,18 +5,33 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertCounter;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertHistogram;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoMetric;
+import static io.opentelemetry.instrumentation.testing.junit.MessagingMetricsAssertions.assertNoStableMetrics;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_MESSAGE_ID;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import org.assertj.core.api.AbstractStringAssert;
 
 class SpringListenerSuppressReceiveSpansTest extends AbstractSpringJmsListenerTest {
+
+  // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions
+  private static final AttributeKey<String> MESSAGING_DESTINATION_SUBSCRIPTION_NAME =
+      stringKey("messaging.destination.subscription.name");
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Override
@@ -26,24 +41,93 @@ class SpringListenerSuppressReceiveSpansTest extends AbstractSpringJmsListenerTe
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName("spring-jms-listener publish")
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "send spring-jms-listener"
+                                : "spring-jms-listener publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
                             equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "publish"),
+                            equalTo(
+                                MESSAGING_OPERATION,
+                                emitStableMessagingSemconv() ? null : "publish"),
+                            equalTo(
+                                MESSAGING_OPERATION_NAME,
+                                emitStableMessagingSemconv() ? "send" : null),
+                            equalTo(
+                                MESSAGING_OPERATION_TYPE,
+                                emitStableMessagingSemconv() ? "send" : null),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
-                span ->
-                    span.hasName("spring-jms-listener process")
-                        .hasKind(CONSUMER)
-                        .hasParent(trace.getSpan(1))
-                        .hasTotalRecordedLinks(0)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "jms"),
-                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
-                            equalTo(MESSAGING_OPERATION, "process"),
-                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
+                span -> {
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "process spring-jms-listener"
+                              : "spring-jms-listener process")
+                      .hasKind(CONSUMER)
+                      .hasParent(trace.getSpan(1))
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(MESSAGING_SYSTEM, "jms"),
+                          equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                          equalTo(
+                              MESSAGING_OPERATION, emitStableMessagingSemconv() ? null : "process"),
+                          equalTo(
+                              MESSAGING_OPERATION_NAME,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          equalTo(
+                              MESSAGING_OPERATION_TYPE,
+                              emitStableMessagingSemconv() ? "process" : null),
+                          satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                          equalTo(
+                              MESSAGING_DESTINATION_SUBSCRIPTION_NAME,
+                              emitStableMessagingSemconv() ? "durable-subscription" : null));
+                  if (emitStableMessagingSemconv()) {
+                    span.hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()));
+                  } else {
+                    span.hasTotalRecordedLinks(0);
+                  }
+                },
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
+
+    if (!emitStableMessagingSemconv()) {
+      assertNoStableMetrics(testing, "io.opentelemetry.jms-3.0");
+      assertNoStableMetrics(testing, "io.opentelemetry.spring-jms-6.0");
+      return;
+    }
+
+    Attributes sendAttributes =
+        Attributes.of(
+            MESSAGING_OPERATION_NAME,
+            "send",
+            MESSAGING_SYSTEM,
+            "jms",
+            MESSAGING_DESTINATION_NAME,
+            "spring-jms-listener");
+    assertHistogram(
+        testing,
+        "io.opentelemetry.jms-3.0",
+        "messaging.client.operation.duration",
+        sendAttributes.toBuilder().put(MESSAGING_OPERATION_TYPE, "send").build());
+    assertNoMetric(testing, "io.opentelemetry.jms-3.0", "messaging.client.consumed.messages");
+
+    Attributes processAttributes =
+        Attributes.builder()
+            .put(MESSAGING_OPERATION_NAME, "process")
+            .put(MESSAGING_SYSTEM, "jms")
+            .put(MESSAGING_DESTINATION_NAME, "spring-jms-listener")
+            .put(MESSAGING_DESTINATION_SUBSCRIPTION_NAME, "durable-subscription")
+            .build();
+    assertHistogram(
+        testing,
+        "io.opentelemetry.spring-jms-6.0",
+        "messaging.process.duration",
+        processAttributes);
+    assertCounter(
+        testing,
+        "io.opentelemetry.spring-jms-6.0",
+        "messaging.client.consumed.messages",
+        1,
+        processAttributes);
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/MessagingMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/MessagingMetricsAssertions.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.testing.junit;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Assertions for the messaging metrics defined by the v1.43 semantic conventions. */
+public final class MessagingMetricsAssertions {
+
+  private static final Set<String> STABLE_METRICS =
+      unmodifiableSet(
+          new HashSet<>(
+              asList(
+                  "messaging.client.operation.duration",
+                  "messaging.client.sent.messages",
+                  "messaging.client.consumed.messages",
+                  "messaging.process.duration")));
+
+  /** Asserts that the named counter has a single point with the given value and attributes. */
+  public static void assertCounter(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String metricName,
+      long value,
+      Attributes attributes) {
+    testing.waitAndAssertMetrics(
+        instrumentationName,
+        metricName,
+        metrics ->
+            metrics.singleElement().satisfies(metric -> verifyCounter(metric, value, attributes)));
+  }
+
+  /** Asserts that the named histogram has one point per given attribute set. */
+  public static void assertHistogram(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String metricName,
+      Attributes... attributes) {
+    testing.waitAndAssertMetrics(
+        instrumentationName,
+        metricName,
+        metrics ->
+            metrics.singleElement().satisfies(metric -> verifyHistogram(metric, attributes)));
+  }
+
+  /** Asserts that the given instrumentation recorded none of the stable messaging metrics. */
+  public static void assertNoStableMetrics(
+      InstrumentationExtension testing, String instrumentationName) {
+    assertThat(testing.metrics())
+        .noneMatch(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(instrumentationName)
+                    && STABLE_METRICS.contains(metric.getName()));
+  }
+
+  /** Asserts that the given instrumentation did not record the named metric. */
+  public static void assertNoMetric(
+      InstrumentationExtension testing, String instrumentationName, String metricName) {
+    assertThat(testing.metrics())
+        .noneMatch(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(instrumentationName)
+                    && metric.getName().equals(metricName));
+  }
+
+  private static void verifyCounter(MetricData metric, long value, Attributes attributes) {
+    assertThat(metric.getLongSumData().getPoints())
+        .singleElement()
+        .satisfies(
+            point -> {
+              assertThat(point.getValue()).isEqualTo(value);
+              assertThat(point.getAttributes()).isEqualTo(attributes);
+            });
+  }
+
+  private static void verifyHistogram(MetricData metric, Attributes... attributes) {
+    assertThat(metric.getHistogramData().getPoints())
+        .allSatisfy(point -> assertThat(point.getCount()).isEqualTo(1))
+        .extracting(point -> point.getAttributes())
+        .containsExactlyInAnyOrder(attributes);
+  }
+
+  private MessagingMetricsAssertions() {}
+}


### PR DESCRIPTION
Records the v1.43 messaging metrics for JMS: `messaging.client.sent.messages`, `messaging.client.operation.duration`, `messaging.client.consumed.messages`, and `messaging.process.duration`.

The metrics are recorded only under the stable messaging semantic conventions or the v3 preview. Under the legacy conventions, JMS scopes continue to emit no messaging metrics.

`messaging.client.consumed.messages` is recorded exactly once per delivery. Ownership is decided per message at runtime: a receive operation that actually ran for the message records the count, and the process operation records it otherwise.

An application-initiated `MessageConsumer.receive()` therefore owns the count on its receive operation, and native JMS listener delivery, which has no separate receive operation, is counted by its process operation. For Spring JMS listener delivery, receive owns the count when receive telemetry is enabled and the JMS instrumentation is active, and process owns it in every other case.

This leaves the existing receive policy unchanged: `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` remains a non-null boolean defaulting to `false` in every semantic-convention mode, explicit receives remain instrumented when otherwise unrepresented, Spring's suppressed receive path remains suppressed, and empty receives emit no telemetry.
