### PR TITLE
Fix SOFA RPC custom async callback completion

### DIFF
--- a/instrumentation/sofa-rpc-5.4/javaagent/build.gradle.kts
+++ b/instrumentation/sofa-rpc-5.4/javaagent/build.gradle.kts
@@ -21,6 +21,7 @@ testing {
   suites {
     register<JvmTestSuite>("testSofaRpc") {
       dependencies {
+        implementation(project(":instrumentation:sofa-rpc-5.4:library"))
         implementation(project(":instrumentation:sofa-rpc-5.4:testing"))
         implementation("com.alipay.sofa:sofa-rpc-all:${baseVersion("5.4.0").orLatest()}")
       }

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
@@ -35,6 +35,6 @@ public class OpenTelemetryClientFilter extends Filter {
   @SuppressWarnings("rawtypes")
   public void onAsyncResponse(
       ConsumerConfig config, SofaRequest request, SofaResponse response, Throwable exception) {
-    clientFilter().onAsyncResponse(config, request, response, exception);
+    delegate.onAsyncResponse(config, request, response, exception);
   }
 }

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
@@ -38,11 +38,6 @@ public class OpenTelemetryClientFilter extends Filter {
     completeAsyncResponse(config, request, response, exception);
   }
 
-  /**
-   * Internal Java agent extension hook that completes telemetry for an asynchronous client request
-   * whose transport does not invoke the standard SOFA RPC async filter callback. This method is not
-   * a stable public API. Calling it more than once, or after the standard callback, has no effect.
-   */
   public static void completeAsyncResponse(
       ConsumerConfig<?> config, SofaRequest request, SofaResponse response, Throwable exception) {
     clientFilter().onAsyncResponse(config, request, response, exception);

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
@@ -35,6 +35,16 @@ public class OpenTelemetryClientFilter extends Filter {
   @SuppressWarnings("rawtypes")
   public void onAsyncResponse(
       ConsumerConfig config, SofaRequest request, SofaResponse response, Throwable exception) {
-    delegate.onAsyncResponse(config, request, response, exception);
+    completeAsyncResponse(config, request, response, exception);
+  }
+
+  /**
+   * Internal Java agent extension hook that completes telemetry for an asynchronous client request
+   * whose transport does not invoke the standard SOFA RPC async filter callback. This method is not
+   * a stable public API. Calling it more than once, or after the standard callback, has no effect.
+   */
+  public static void completeAsyncResponse(
+      ConsumerConfig<?> config, SofaRequest request, SofaResponse response, Throwable exception) {
+    clientFilter().onAsyncResponse(config, request, response, exception);
   }
 }

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/OpenTelemetryClientFilter.java
@@ -35,11 +35,6 @@ public class OpenTelemetryClientFilter extends Filter {
   @SuppressWarnings("rawtypes")
   public void onAsyncResponse(
       ConsumerConfig config, SofaRequest request, SofaResponse response, Throwable exception) {
-    completeAsyncResponse(config, request, response, exception);
-  }
-
-  public static void completeAsyncResponse(
-      ConsumerConfig<?> config, SofaRequest request, SofaResponse response, Throwable exception) {
     clientFilter().onAsyncResponse(config, request, response, exception);
   }
 }

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
@@ -17,10 +17,10 @@ import com.alipay.sofa.rpc.filter.Filter;
 import com.alipay.sofa.rpc.filter.FilterInvoker;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.sofarpc.v5_4.AbstractSofaRpcTest;
+import io.opentelemetry.instrumentation.sofarpc.v5_4.SofaRpcTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -52,26 +52,26 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
   }
 
   @Test
-  void staticAsyncCompletionProducesSpanAndMetric() throws Exception {
-    AsyncTestCall call = startAsyncTestCall("staticOnlySuccess", "ok");
+  void publicApiAsyncCompletionProducesSpanAndMetric() throws Exception {
+    AsyncTestCall call = startAsyncTestCall("publicApiOnlySuccess", "ok");
 
-    call.completeStatically(null);
+    call.completeThroughPublicApi(null);
 
-    assertSingleAsyncClientSpanAndMetric("staticOnlySuccess", false);
+    assertSingleAsyncClientSpanAndMetric("publicApiOnlySuccess", false);
   }
 
   @Test
-  void staticAsyncExceptionProducesSpanAndMetric() throws Exception {
+  void publicApiAsyncExceptionProducesSpanAndMetric() throws Exception {
     IllegalStateException callbackError = new IllegalStateException("callback failed");
-    AsyncTestCall call = startAsyncTestCall("staticOnlyException", null);
+    AsyncTestCall call = startAsyncTestCall("publicApiOnlyException", null);
 
-    call.completeStatically(callbackError);
+    call.completeThroughPublicApi(callbackError);
 
-    assertSingleAsyncClientSpanAndMetric("staticOnlyException", true);
+    assertSingleAsyncClientSpanAndMetric("publicApiOnlyException", true);
   }
 
   @Test
-  void standardAndStaticAsyncCompletionEndOnlyOnce() throws Exception {
+  void standardAndPublicApiAsyncCompletionEndOnlyOnce() throws Exception {
     AsyncTestCall call = startAsyncTestCall("completeOnce", "ok");
 
     ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -86,19 +86,19 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
                 call.filter.onAsyncResponse(call.consumerConfig, call.request, call.response, null);
                 return null;
               });
-      Future<?> staticCompletion =
+      Future<?> publicApiCompletion =
           executor.submit(
               () -> {
                 ready.countDown();
                 start.await();
-                call.completeStatically(null);
+                call.completeThroughPublicApi(null);
                 return null;
               });
 
       ready.await();
       start.countDown();
       standardCompletion.get();
-      staticCompletion.get();
+      publicApiCompletion.get();
     } finally {
       executor.shutdownNow();
     }
@@ -107,11 +107,8 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
   }
 
   @Test
-  void staticCompletionWithoutAsyncStateIsNoOp() throws Exception {
-    Method completeAsyncResponse = getStaticCompletionMethod();
-
-    completeAsyncResponse.invoke(
-        null, new ConsumerConfig<>(), new SofaRequest(), new SofaResponse(), null);
+  void publicApiCompletionWithoutAsyncStateIsNoOp() {
+    SofaRpcTelemetry.completeAsyncResponse(new SofaRequest(), new SofaResponse(), null);
 
     assertThat(testing.spans()).isEmpty();
   }
@@ -138,18 +135,7 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
     FilterInvoker invoker = new FilterInvoker(terminalFilter, null, consumerConfig);
 
     runWithSpan("parent", () -> filter.invoke(invoker, request));
-    return new AsyncTestCall(
-        filter, getStaticCompletionMethod(), consumerConfig, request, response);
-  }
-
-  private static Method getStaticCompletionMethod() throws Exception {
-    return getClientFilterClass()
-        .getMethod(
-            "completeAsyncResponse",
-            ConsumerConfig.class,
-            SofaRequest.class,
-            SofaResponse.class,
-            Throwable.class);
+    return new AsyncTestCall(filter, consumerConfig, request, response);
   }
 
   private static Class<?> getClientFilterClass() throws Exception {
@@ -188,26 +174,23 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
   private static final class AsyncTestCall {
 
     private final Filter filter;
-    private final Method completeAsyncResponse;
     private final ConsumerConfig<Object> consumerConfig;
     private final SofaRequest request;
     private final SofaResponse response;
 
     private AsyncTestCall(
         Filter filter,
-        Method completeAsyncResponse,
         ConsumerConfig<Object> consumerConfig,
         SofaRequest request,
         SofaResponse response) {
       this.filter = filter;
-      this.completeAsyncResponse = completeAsyncResponse;
       this.consumerConfig = consumerConfig;
       this.request = request;
       this.response = response;
     }
 
-    private void completeStatically(Throwable exception) throws Exception {
-      completeAsyncResponse.invoke(null, consumerConfig, request, response, exception);
+    private void completeThroughPublicApi(Throwable exception) {
+      SofaRpcTelemetry.completeAsyncResponse(request, response, exception);
     }
   }
 

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.sofarpc.v5_4;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -113,6 +112,8 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
 
     completeAsyncResponse.invoke(
         null, new ConsumerConfig<>(), new SofaRequest(), new SofaResponse(), null);
+
+    assertThat(testing.spans()).isEmpty();
   }
 
   private static AsyncTestCall startAsyncTestCall(String methodName, Object appResponse)
@@ -172,18 +173,16 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
                 }));
 
     String metricName = emitStableRpcSemconv() ? "rpc.client.call.duration" : "rpc.client.duration";
-    if (emitOldRpcSemconv() || emitStableRpcSemconv()) {
-      testing.waitAndAssertMetrics(
-          "io.opentelemetry.sofa-rpc-5.4",
-          metricName,
-          metrics ->
-              metrics.anySatisfy(
-                  metric ->
-                      assertThat(metric)
-                          .hasHistogramSatisfying(
-                              histogram ->
-                                  histogram.hasPointsSatisfying(point -> point.hasCount(1)))));
-    }
+    testing.waitAndAssertMetrics(
+        "io.opentelemetry.sofa-rpc-5.4",
+        metricName,
+        metrics ->
+            metrics.anySatisfy(
+                metric ->
+                    assertThat(metric)
+                        .hasHistogramSatisfying(
+                            histogram ->
+                                histogram.hasPointsSatisfying(point -> point.hasCount(1)))));
   }
 
   private static final class AsyncTestCall {

--- a/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
+++ b/instrumentation/sofa-rpc-5.4/javaagent/src/testSofaRpc/java/io/opentelemetry/javaagent/instrumentation/sofarpc/v5_4/SofaRpcAgentTest.java
@@ -5,12 +5,34 @@
 
 package io.opentelemetry.javaagent.instrumentation.sofarpc.v5_4;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
+import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.filter.Filter;
+import com.alipay.sofa.rpc.filter.FilterInvoker;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.sofarpc.v5_4.AbstractSofaRpcTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class SofaRpcAgentTest extends AbstractSofaRpcTest {
+
+  private static final String CLIENT_FILTER_CLASS_NAME =
+      "io.opentelemetry.javaagent.instrumentation.sofarpc.v5_4.OpenTelemetryClientFilter";
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -29,4 +51,166 @@ class SofaRpcAgentTest extends AbstractSofaRpcTest {
   protected String genericMethodName() {
     return "$invoke";
   }
+
+  @Test
+  void staticAsyncCompletionProducesSpanAndMetric() throws Exception {
+    AsyncTestCall call = startAsyncTestCall("staticOnlySuccess", "ok");
+
+    call.completeStatically(null);
+
+    assertSingleAsyncClientSpanAndMetric("staticOnlySuccess", false);
+  }
+
+  @Test
+  void staticAsyncExceptionProducesSpanAndMetric() throws Exception {
+    IllegalStateException callbackError = new IllegalStateException("callback failed");
+    AsyncTestCall call = startAsyncTestCall("staticOnlyException", null);
+
+    call.completeStatically(callbackError);
+
+    assertSingleAsyncClientSpanAndMetric("staticOnlyException", true);
+  }
+
+  @Test
+  void standardAndStaticAsyncCompletionEndOnlyOnce() throws Exception {
+    AsyncTestCall call = startAsyncTestCall("completeOnce", "ok");
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      Future<?> standardCompletion =
+          executor.submit(
+              () -> {
+                ready.countDown();
+                start.await();
+                call.filter.onAsyncResponse(call.consumerConfig, call.request, call.response, null);
+                return null;
+              });
+      Future<?> staticCompletion =
+          executor.submit(
+              () -> {
+                ready.countDown();
+                start.await();
+                call.completeStatically(null);
+                return null;
+              });
+
+      ready.await();
+      start.countDown();
+      standardCompletion.get();
+      staticCompletion.get();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertSingleAsyncClientSpanAndMetric("completeOnce", false);
+  }
+
+  @Test
+  void staticCompletionWithoutAsyncStateIsNoOp() throws Exception {
+    Method completeAsyncResponse = getStaticCompletionMethod();
+
+    completeAsyncResponse.invoke(
+        null, new ConsumerConfig<>(), new SofaRequest(), new SofaResponse(), null);
+  }
+
+  private static AsyncTestCall startAsyncTestCall(String methodName, Object appResponse)
+      throws Exception {
+    Class<?> filterClass = getClientFilterClass();
+    Filter filter = (Filter) filterClass.getConstructor().newInstance();
+    ConsumerConfig<Object> consumerConfig = new ConsumerConfig<>();
+    consumerConfig.setInterfaceId(AsyncService.class.getName());
+    SofaRequest request = new SofaRequest();
+    request.setInterfaceName("test.AsyncService");
+    request.setMethodName(methodName);
+    request.setInvokeType(RpcConstants.INVOKER_TYPE_FUTURE);
+    SofaResponse response = new SofaResponse();
+    response.setAppResponse(appResponse);
+    Filter terminalFilter =
+        new Filter() {
+          @Override
+          public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) {
+            return response;
+          }
+        };
+    FilterInvoker invoker = new FilterInvoker(terminalFilter, null, consumerConfig);
+
+    runWithSpan("parent", () -> filter.invoke(invoker, request));
+    return new AsyncTestCall(
+        filter, getStaticCompletionMethod(), consumerConfig, request, response);
+  }
+
+  private static Method getStaticCompletionMethod() throws Exception {
+    return getClientFilterClass()
+        .getMethod(
+            "completeAsyncResponse",
+            ConsumerConfig.class,
+            SofaRequest.class,
+            SofaResponse.class,
+            Throwable.class);
+  }
+
+  private static Class<?> getClientFilterClass() throws Exception {
+    // Loading ExtensionLoader triggers the agent's helper and resource injection for SOFA RPC.
+    Class.forName("com.alipay.sofa.rpc.ext.ExtensionLoader");
+    return Class.forName(CLIENT_FILTER_CLASS_NAME);
+  }
+
+  private static void assertSingleAsyncClientSpanAndMetric(String methodName, boolean error) {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span -> {
+                  span.hasName("test.AsyncService/" + methodName)
+                      .hasKind(SpanKind.CLIENT)
+                      .hasParent(trace.getSpan(0));
+                  if (error) {
+                    span.hasStatus(StatusData.error());
+                  }
+                }));
+
+    String metricName = emitStableRpcSemconv() ? "rpc.client.call.duration" : "rpc.client.duration";
+    if (emitOldRpcSemconv() || emitStableRpcSemconv()) {
+      testing.waitAndAssertMetrics(
+          "io.opentelemetry.sofa-rpc-5.4",
+          metricName,
+          metrics ->
+              metrics.anySatisfy(
+                  metric ->
+                      assertThat(metric)
+                          .hasHistogramSatisfying(
+                              histogram ->
+                                  histogram.hasPointsSatisfying(point -> point.hasCount(1)))));
+    }
+  }
+
+  private static final class AsyncTestCall {
+
+    private final Filter filter;
+    private final Method completeAsyncResponse;
+    private final ConsumerConfig<Object> consumerConfig;
+    private final SofaRequest request;
+    private final SofaResponse response;
+
+    private AsyncTestCall(
+        Filter filter,
+        Method completeAsyncResponse,
+        ConsumerConfig<Object> consumerConfig,
+        SofaRequest request,
+        SofaResponse response) {
+      this.filter = filter;
+      this.completeAsyncResponse = completeAsyncResponse;
+      this.consumerConfig = consumerConfig;
+      this.request = request;
+      this.response = response;
+    }
+
+    private void completeStatically(Throwable exception) throws Exception {
+      completeAsyncResponse.invoke(null, consumerConfig, request, response, exception);
+    }
+  }
+
+  private interface AsyncService {}
 }

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcRequest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcRequest.java
@@ -22,6 +22,14 @@ public abstract class SofaRpcRequest {
     InetSocketAddress localAddress = context != null ? context.getLocalAddress() : null;
     ProviderInfo providerInfo = context != null ? context.getProviderInfo() : null;
 
+    return create(request, remoteAddress, localAddress, providerInfo);
+  }
+
+  static SofaRpcRequest create(
+      SofaRequest request,
+      @Nullable InetSocketAddress remoteAddress,
+      @Nullable InetSocketAddress localAddress,
+      @Nullable ProviderInfo providerInfo) {
     return new AutoValue_SofaRpcRequest(request, remoteAddress, localAddress, providerInfo);
   }
 

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
@@ -19,6 +19,8 @@ public final class SofaRpcTelemetry {
 
   private static final String CLIENT_FILTER_NAME = "openTelemetryClient";
 
+  @Nullable private static volatile Filter cachedClientFilter;
+
   private final Instrumenter<SofaRpcRequest, SofaResponse> serverInstrumenter;
   private final Instrumenter<SofaRpcRequest, SofaResponse> clientInstrumenter;
 
@@ -51,13 +53,35 @@ public final class SofaRpcTelemetry {
    */
   public static void completeAsyncResponse(
       SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
-    ExtensionLoader<Filter> loader = ExtensionLoaderFactory.getExtensionLoader(Filter.class);
-    if (loader.getExtensionClass(CLIENT_FILTER_NAME) == null) {
+    Filter filter = getClientFilter();
+    if (filter == null) {
       TracingFilter.completeAsyncRequest(request, response, exception);
       return;
     }
-    Filter filter = loader.getExtension(CLIENT_FILTER_NAME);
     filter.onAsyncResponse(null, request, response, exception);
+  }
+
+  @Nullable
+  private static Filter getClientFilter() {
+    Filter cachedFilter = cachedClientFilter;
+    if (cachedFilter != null) {
+      return cachedFilter;
+    }
+
+    synchronized (SofaRpcTelemetry.class) {
+      cachedFilter = cachedClientFilter;
+      if (cachedFilter != null) {
+        return cachedFilter;
+      }
+
+      ExtensionLoader<Filter> loader = ExtensionLoaderFactory.getExtensionLoader(Filter.class);
+      if (loader.getExtensionClass(CLIENT_FILTER_NAME) == null) {
+        return null;
+      }
+      cachedFilter = loader.getExtension(CLIENT_FILTER_NAME);
+      cachedClientFilter = cachedFilter;
+      return cachedFilter;
+    }
   }
 
   /**

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
@@ -34,6 +34,13 @@ public final class SofaRpcTelemetry {
     return new SofaRpcTelemetryBuilder(openTelemetry);
   }
 
+  SofaRpcTelemetry(
+      Instrumenter<SofaRpcRequest, SofaResponse> serverInstrumenter,
+      Instrumenter<SofaRpcRequest, SofaResponse> clientInstrumenter) {
+    this.serverInstrumenter = serverInstrumenter;
+    this.clientInstrumenter = clientInstrumenter;
+  }
+
   /**
    * Completes telemetry for an asynchronous client request when a custom transport bypasses the
    * standard SOFARPC callback path.
@@ -46,17 +53,11 @@ public final class SofaRpcTelemetry {
       SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
     ExtensionLoader<Filter> loader = ExtensionLoaderFactory.getExtensionLoader(Filter.class);
     if (loader.getExtensionClass(CLIENT_FILTER_NAME) == null) {
+      TracingFilter.completeAsyncRequest(request, response, exception);
       return;
     }
     Filter filter = loader.getExtension(CLIENT_FILTER_NAME);
     filter.onAsyncResponse(null, request, response, exception);
-  }
-
-  SofaRpcTelemetry(
-      Instrumenter<SofaRpcRequest, SofaResponse> serverInstrumenter,
-      Instrumenter<SofaRpcRequest, SofaResponse> clientInstrumenter) {
-    this.serverInstrumenter = serverInstrumenter;
-    this.clientInstrumenter = clientInstrumenter;
   }
 
   /**

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/SofaRpcTelemetry.java
@@ -5,13 +5,19 @@
 
 package io.opentelemetry.instrumentation.sofarpc.v5_4;
 
+import com.alipay.sofa.rpc.core.request.SofaRequest;
 import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.ext.ExtensionLoader;
+import com.alipay.sofa.rpc.ext.ExtensionLoaderFactory;
 import com.alipay.sofa.rpc.filter.Filter;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import javax.annotation.Nullable;
 
 /** Entrypoint for instrumenting SOFARPC clients or servers. */
 public final class SofaRpcTelemetry {
+
+  private static final String CLIENT_FILTER_NAME = "openTelemetryClient";
 
   private final Instrumenter<SofaRpcRequest, SofaResponse> serverInstrumenter;
   private final Instrumenter<SofaRpcRequest, SofaResponse> clientInstrumenter;
@@ -26,6 +32,24 @@ public final class SofaRpcTelemetry {
    */
   public static SofaRpcTelemetryBuilder builder(OpenTelemetry openTelemetry) {
     return new SofaRpcTelemetryBuilder(openTelemetry);
+  }
+
+  /**
+   * Completes telemetry for an asynchronous client request when a custom transport bypasses the
+   * standard SOFARPC callback path.
+   *
+   * <p>This method must be called with the same {@link SofaRequest} instance that was passed to the
+   * client filter. It safely does nothing when the request has no pending asynchronous telemetry or
+   * has already been completed.
+   */
+  public static void completeAsyncResponse(
+      SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
+    ExtensionLoader<Filter> loader = ExtensionLoaderFactory.getExtensionLoader(Filter.class);
+    if (loader.getExtensionClass(CLIENT_FILTER_NAME) == null) {
+      return;
+    }
+    Filter filter = loader.getExtension(CLIENT_FILTER_NAME);
+    filter.onAsyncResponse(null, request, response, exception);
   }
 
   SofaRpcTelemetry(

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -134,7 +134,7 @@ final class TracingFilter extends Filter {
   // Completes an asynchronous request at most once across transport failures, standard filter
   // callbacks, and custom completion callbacks.
   static void completeAsyncRequest(
-      SofaRequest request, SofaResponse response, Throwable exception) {
+      SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
     AsyncState asyncState = ASYNC_STATE_FIELD.get(request);
     if (asyncState == null || !asyncState.tryComplete()) {
       return;
@@ -169,7 +169,8 @@ final class TracingFilter extends Filter {
       return completed.compareAndSet(false, true);
     }
 
-    private void end(SofaRequest request, SofaResponse response, Throwable error) {
+    private void end(
+        SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable error) {
       SofaRpcRequest endRequest =
           SofaRpcRequest.create(request, remoteAddress, localAddress, providerInfo);
       instrumenter.end(context, endRequest, response, error);

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -133,7 +133,7 @@ final class TracingFilter extends Filter {
 
   // Completes an asynchronous request at most once across transport failures, standard filter
   // callbacks, and custom completion callbacks.
-  private static void completeAsyncRequest(
+  static void completeAsyncRequest(
       SofaRequest request, SofaResponse response, Throwable exception) {
     AsyncState asyncState = ASYNC_STATE_FIELD.get(request);
     if (asyncState == null || !asyncState.tryComplete()) {

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -19,13 +19,15 @@ import com.alipay.sofa.rpc.filter.FilterInvoker;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 final class TracingFilter extends Filter {
 
-  private static final String ASYNC_STATE_KEY = "otel.async.state";
+  private static final VirtualField<SofaRequest, AsyncState> ASYNC_STATE_FIELD =
+      VirtualField.find(SofaRequest.class, AsyncState.class);
 
   private final Instrumenter<SofaRpcRequest, SofaResponse> instrumenter;
   private final boolean isClientSide;
@@ -50,8 +52,7 @@ final class TracingFilter extends Filter {
     Context context = instrumenter.start(parentContext, sofaRpcRequest);
     boolean isAsync = isClientSide && request.isAsync();
     if (isAsync) {
-      request.addRequestProp(
-          ASYNC_STATE_KEY, new AsyncState(instrumenter, context, sofaRpcRequest));
+      ASYNC_STATE_FIELD.set(request, new AsyncState(instrumenter, context, sofaRpcRequest));
     }
 
     SofaResponse response;
@@ -134,15 +135,11 @@ final class TracingFilter extends Filter {
   // callbacks, and custom completion callbacks.
   static void completeAsyncRequest(
       SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
-    Object asyncStateValue = request.getRequestProp(ASYNC_STATE_KEY);
-    if (!(asyncStateValue instanceof AsyncState)) {
+    AsyncState asyncState = ASYNC_STATE_FIELD.get(request);
+    if (asyncState == null || !asyncState.tryComplete()) {
       return;
     }
-    AsyncState asyncState = (AsyncState) asyncStateValue;
-    if (!asyncState.tryComplete()) {
-      return;
-    }
-    request.removeRequestProp(ASYNC_STATE_KEY);
+    ASYNC_STATE_FIELD.set(request, null);
 
     Throwable error = exception != null ? exception : extractException(response);
     asyncState.end(request, response, error);

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -19,15 +19,13 @@ import com.alipay.sofa.rpc.filter.FilterInvoker;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 final class TracingFilter extends Filter {
 
-  private static final VirtualField<SofaRequest, AsyncState> ASYNC_STATE_FIELD =
-      VirtualField.find(SofaRequest.class, AsyncState.class);
+  private static final String ASYNC_STATE_KEY = "otel.async.state";
 
   private final Instrumenter<SofaRpcRequest, SofaResponse> instrumenter;
   private final boolean isClientSide;
@@ -52,7 +50,8 @@ final class TracingFilter extends Filter {
     Context context = instrumenter.start(parentContext, sofaRpcRequest);
     boolean isAsync = isClientSide && request.isAsync();
     if (isAsync) {
-      ASYNC_STATE_FIELD.set(request, new AsyncState(instrumenter, context, sofaRpcRequest));
+      request.addRequestProp(
+          ASYNC_STATE_KEY, new AsyncState(instrumenter, context, sofaRpcRequest));
     }
 
     SofaResponse response;
@@ -135,11 +134,15 @@ final class TracingFilter extends Filter {
   // callbacks, and custom completion callbacks.
   static void completeAsyncRequest(
       SofaRequest request, @Nullable SofaResponse response, @Nullable Throwable exception) {
-    AsyncState asyncState = ASYNC_STATE_FIELD.get(request);
-    if (asyncState == null || !asyncState.tryComplete()) {
+    Object asyncStateValue = request.getRequestProp(ASYNC_STATE_KEY);
+    if (!(asyncStateValue instanceof AsyncState)) {
       return;
     }
-    ASYNC_STATE_FIELD.set(request, null);
+    AsyncState asyncState = (AsyncState) asyncStateValue;
+    if (!asyncState.tryComplete()) {
+      return;
+    }
+    request.removeRequestProp(ASYNC_STATE_KEY);
 
     Throwable error = exception != null ? exception : extractException(response);
     asyncState.end(request, response, error);

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -131,6 +131,8 @@ final class TracingFilter extends Filter {
     completeAsyncRequest(request, response, exception);
   }
 
+  // Completes an asynchronous request at most once across transport failures, standard filter
+  // callbacks, and custom completion callbacks.
   private static void completeAsyncRequest(
       SofaRequest request, SofaResponse response, Throwable exception) {
     AsyncState asyncState = ASYNC_STATE_FIELD.get(request);

--- a/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/main/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.sofarpc.v5_4;
 
 import static com.alipay.sofa.rpc.core.exception.RpcErrorType.SERVER_UNDECLARED_ERROR;
 
+import com.alipay.sofa.rpc.client.ProviderInfo;
 import com.alipay.sofa.rpc.common.RemotingConstants;
 import com.alipay.sofa.rpc.config.AbstractInterfaceConfig;
 import com.alipay.sofa.rpc.config.ConsumerConfig;
@@ -18,11 +19,15 @@ import com.alipay.sofa.rpc.filter.FilterInvoker;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
 final class TracingFilter extends Filter {
 
-  private static final String OTEL_CONTEXT_KEY = "otel.context";
-  private static final String OTEL_REQUEST_KEY = "otel.request";
+  private static final VirtualField<SofaRequest, AsyncState> ASYNC_STATE_FIELD =
+      VirtualField.find(SofaRequest.class, AsyncState.class);
 
   private final Instrumenter<SofaRpcRequest, SofaResponse> instrumenter;
   private final boolean isClientSide;
@@ -45,22 +50,24 @@ final class TracingFilter extends Filter {
       return invoker.invoke(request);
     }
     Context context = instrumenter.start(parentContext, sofaRpcRequest);
+    boolean isAsync = isClientSide && request.isAsync();
+    if (isAsync) {
+      ASYNC_STATE_FIELD.set(request, new AsyncState(instrumenter, context, sofaRpcRequest));
+    }
 
     SofaResponse response;
-    boolean isSynchronous = true;
     try (Scope ignored = context.makeCurrent()) {
       response = invoker.invoke(request);
-      if (isClientSide && request.isAsync()) {
-        isSynchronous = false;
-        request.addRequestProp(OTEL_CONTEXT_KEY, context);
-        request.addRequestProp(OTEL_REQUEST_KEY, sofaRpcRequest);
-      }
     } catch (Throwable t) {
-      instrumenter.end(context, sofaRpcRequest, null, t);
+      if (isAsync) {
+        completeAsyncRequest(request, null, t);
+      } else {
+        instrumenter.end(context, sofaRpcRequest, null, t);
+      }
       throw t;
     }
 
-    if (isSynchronous) {
+    if (!isAsync) {
       Throwable exception = extractException(response);
       instrumenter.end(context, sofaRpcRequest, response, exception);
     }
@@ -121,12 +128,49 @@ final class TracingFilter extends Filter {
     if (!isClientSide) {
       return;
     }
-    Context context = (Context) request.getRequestProp(OTEL_CONTEXT_KEY);
-    SofaRpcRequest sofaRpcRequest = (SofaRpcRequest) request.getRequestProp(OTEL_REQUEST_KEY);
-    if (context == null || sofaRpcRequest == null) {
+    completeAsyncRequest(request, response, exception);
+  }
+
+  private static void completeAsyncRequest(
+      SofaRequest request, SofaResponse response, Throwable exception) {
+    AsyncState asyncState = ASYNC_STATE_FIELD.get(request);
+    if (asyncState == null || !asyncState.tryComplete()) {
       return;
     }
+    ASYNC_STATE_FIELD.set(request, null);
+
     Throwable error = exception != null ? exception : extractException(response);
-    instrumenter.end(context, sofaRpcRequest, response, error);
+    asyncState.end(request, response, error);
+  }
+
+  private static final class AsyncState {
+
+    private final Instrumenter<SofaRpcRequest, SofaResponse> instrumenter;
+    private final Context context;
+    @Nullable private final InetSocketAddress remoteAddress;
+    @Nullable private final InetSocketAddress localAddress;
+    @Nullable private final ProviderInfo providerInfo;
+    private final AtomicBoolean completed = new AtomicBoolean();
+
+    private AsyncState(
+        Instrumenter<SofaRpcRequest, SofaResponse> instrumenter,
+        Context context,
+        SofaRpcRequest request) {
+      this.instrumenter = instrumenter;
+      this.context = context;
+      remoteAddress = request.remoteAddress();
+      localAddress = request.localAddress();
+      providerInfo = request.providerInfo();
+    }
+
+    private boolean tryComplete() {
+      return completed.compareAndSet(false, true);
+    }
+
+    private void end(SofaRequest request, SofaResponse response, Throwable error) {
+      SofaRpcRequest endRequest =
+          SofaRpcRequest.create(request, remoteAddress, localAddress, providerInfo);
+      instrumenter.end(context, endRequest, response, error);
+    }
   }
 }

--- a/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
@@ -84,7 +84,7 @@ class TracingFilterTest {
     assertThat(endRequestCaptor.getValue())
         .isNotSameAs(startRequestCaptor.getValue())
         .isEqualTo(startRequestCaptor.getValue());
-    assertThat(request.getRequestProps()).isNull();
+    assertThat(request.getRequestProps()).isEmpty();
   }
 
   @Test
@@ -118,7 +118,7 @@ class TracingFilterTest {
     }
 
     verify(instrumenter, times(1)).end(any(), any(), any(), any());
-    assertThat(request.getRequestProps()).isNull();
+    assertThat(request.getRequestProps()).isEmpty();
   }
 
   @Test
@@ -146,7 +146,7 @@ class TracingFilterTest {
     filter.invoke(new FilterInvoker(callbackBeforeReturnFilter, null, consumerConfig), request);
 
     verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
-    assertThat(request.getRequestProps()).isNull();
+    assertThat(request.getRequestProps()).isEmpty();
   }
 
   @Test
@@ -170,7 +170,7 @@ class TracingFilterTest {
         .isSameAs(invokeFailure);
 
     verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
-    assertThat(request.getRequestProps()).isNull();
+    assertThat(request.getRequestProps()).isEmpty();
   }
 
   @Test
@@ -192,11 +192,11 @@ class TracingFilterTest {
     filter.onAsyncResponse(consumerConfig, request, response, null);
 
     verify(instrumenter, times(1)).end(any(), any(), isNull(), same(invokeFailure));
-    assertThat(request.getRequestProps()).isNull();
+    assertThat(request.getRequestProps()).isEmpty();
   }
 
   @Test
-  void asyncStateDoesNotModifyRequestProperties() {
+  void asyncStateIsRemovedFromRequestPropertiesAfterCompletion() {
     request.addRequestProp("existing", "value");
 
     startAsyncRequest();

--- a/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
@@ -122,6 +122,15 @@ class TracingFilterTest {
   }
 
   @Test
+  void publicApiCompletionFallsBackToLibraryFilter() {
+    startAsyncRequest();
+
+    SofaRpcTelemetry.completeAsyncResponse(request, response, null);
+
+    verify(instrumenter, times(1)).end(eq(Context.root()), any(), same(response), isNull());
+  }
+
+  @Test
   void callbackBeforeInvokeReturnsCompletesRequest() {
     when(instrumenter.shouldStart(any(), any())).thenReturn(true);
     when(instrumenter.start(any(), any())).thenReturn(Context.root());

--- a/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
@@ -84,7 +84,7 @@ class TracingFilterTest {
     assertThat(endRequestCaptor.getValue())
         .isNotSameAs(startRequestCaptor.getValue())
         .isEqualTo(startRequestCaptor.getValue());
-    assertThat(request.getRequestProps()).isEmpty();
+    assertThat(request.getRequestProps()).isNull();
   }
 
   @Test
@@ -118,7 +118,7 @@ class TracingFilterTest {
     }
 
     verify(instrumenter, times(1)).end(any(), any(), any(), any());
-    assertThat(request.getRequestProps()).isEmpty();
+    assertThat(request.getRequestProps()).isNull();
   }
 
   @Test
@@ -146,7 +146,7 @@ class TracingFilterTest {
     filter.invoke(new FilterInvoker(callbackBeforeReturnFilter, null, consumerConfig), request);
 
     verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
-    assertThat(request.getRequestProps()).isEmpty();
+    assertThat(request.getRequestProps()).isNull();
   }
 
   @Test
@@ -170,7 +170,7 @@ class TracingFilterTest {
         .isSameAs(invokeFailure);
 
     verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
-    assertThat(request.getRequestProps()).isEmpty();
+    assertThat(request.getRequestProps()).isNull();
   }
 
   @Test
@@ -192,11 +192,11 @@ class TracingFilterTest {
     filter.onAsyncResponse(consumerConfig, request, response, null);
 
     verify(instrumenter, times(1)).end(any(), any(), isNull(), same(invokeFailure));
-    assertThat(request.getRequestProps()).isEmpty();
+    assertThat(request.getRequestProps()).isNull();
   }
 
   @Test
-  void asyncStateIsRemovedFromRequestPropertiesAfterCompletion() {
+  void asyncStateDoesNotModifyRequestProperties() {
     request.addRequestProp("existing", "value");
 
     startAsyncRequest();

--- a/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
@@ -55,6 +55,7 @@ class TracingFilterTest {
   void setUp() {
     filter = new TracingFilter(instrumenter, true);
     consumerConfig = new ConsumerConfig<>();
+    consumerConfig.setInterfaceId(Runnable.class.getName());
     request = new SofaRequest().setInvokeType(RpcConstants.INVOKER_TYPE_FUTURE);
     response = new SofaResponse();
     Filter terminalFilter =

--- a/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
+++ b/instrumentation/sofa-rpc-5.4/library/src/test/java/io/opentelemetry/instrumentation/sofarpc/v5_4/TracingFilterTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.sofarpc.v5_4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.filter.Filter;
+import com.alipay.sofa.rpc.filter.FilterInvoker;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.test.utils.GcUtils;
+import java.lang.ref.WeakReference;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TracingFilterTest {
+
+  @Mock private Instrumenter<SofaRpcRequest, SofaResponse> instrumenter;
+
+  private ConsumerConfig<?> consumerConfig;
+  private SofaRequest request;
+  private SofaResponse response;
+  private FilterInvoker invoker;
+  private TracingFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    filter = new TracingFilter(instrumenter, true);
+    consumerConfig = new ConsumerConfig<>();
+    request = new SofaRequest().setInvokeType(RpcConstants.INVOKER_TYPE_FUTURE);
+    response = new SofaResponse();
+    Filter terminalFilter =
+        new Filter() {
+          @Override
+          public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) {
+            return response;
+          }
+        };
+    invoker = new FilterInvoker(terminalFilter, null, consumerConfig);
+  }
+
+  @Test
+  void completesAsyncRequestOnlyOnce() {
+    startAsyncRequest();
+
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    ArgumentCaptor<SofaRpcRequest> startRequestCaptor =
+        ArgumentCaptor.forClass(SofaRpcRequest.class);
+    verify(instrumenter).start(any(), startRequestCaptor.capture());
+    ArgumentCaptor<SofaRpcRequest> endRequestCaptor = ArgumentCaptor.forClass(SofaRpcRequest.class);
+    verify(instrumenter)
+        .end(eq(Context.root()), endRequestCaptor.capture(), same(response), isNull());
+    assertThat(endRequestCaptor.getValue())
+        .isNotSameAs(startRequestCaptor.getValue())
+        .isEqualTo(startRequestCaptor.getValue());
+    assertThat(request.getRequestProps()).isNull();
+  }
+
+  @Test
+  void concurrentCompletionsEndOnlyOnce() throws Exception {
+    startAsyncRequest();
+
+    int completionCount = 16;
+    ExecutorService executor = Executors.newFixedThreadPool(completionCount);
+    CountDownLatch ready = new CountDownLatch(completionCount);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      Future<?>[] futures = new Future<?>[completionCount];
+      for (int i = 0; i < completionCount; i++) {
+        futures[i] =
+            executor.submit(
+                () -> {
+                  ready.countDown();
+                  start.await();
+                  filter.onAsyncResponse(consumerConfig, request, response, null);
+                  return null;
+                });
+      }
+
+      ready.await();
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    verify(instrumenter, times(1)).end(any(), any(), any(), any());
+    assertThat(request.getRequestProps()).isNull();
+  }
+
+  @Test
+  void callbackBeforeInvokeReturnsCompletesRequest() {
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+    Filter callbackBeforeReturnFilter =
+        new Filter() {
+          @Override
+          public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) {
+            filter.onAsyncResponse(consumerConfig, request, response, null);
+            return response;
+          }
+        };
+
+    filter.invoke(new FilterInvoker(callbackBeforeReturnFilter, null, consumerConfig), request);
+
+    verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
+    assertThat(request.getRequestProps()).isNull();
+  }
+
+  @Test
+  void callbackCompletionAndLaterInvokeFailureEndOnlyOnce() {
+    IllegalStateException invokeFailure = new IllegalStateException("invoke failed");
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+    Filter callbackThenFailureFilter =
+        new Filter() {
+          @Override
+          public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) {
+            filter.onAsyncResponse(consumerConfig, request, response, null);
+            throw invokeFailure;
+          }
+        };
+
+    assertThatThrownBy(
+            () ->
+                filter.invoke(
+                    new FilterInvoker(callbackThenFailureFilter, null, consumerConfig), request))
+        .isSameAs(invokeFailure);
+
+    verify(instrumenter, times(1)).end(any(), any(), same(response), isNull());
+    assertThat(request.getRequestProps()).isNull();
+  }
+
+  @Test
+  void invokeFailureAndLaterCallbackEndOnlyOnce() {
+    IllegalStateException invokeFailure = new IllegalStateException("invoke failed");
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+    Filter failureFilter =
+        new Filter() {
+          @Override
+          public SofaResponse invoke(FilterInvoker invoker, SofaRequest request) {
+            throw invokeFailure;
+          }
+        };
+
+    assertThatThrownBy(
+            () -> filter.invoke(new FilterInvoker(failureFilter, null, consumerConfig), request))
+        .isSameAs(invokeFailure);
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    verify(instrumenter, times(1)).end(any(), any(), isNull(), same(invokeFailure));
+    assertThat(request.getRequestProps()).isNull();
+  }
+
+  @Test
+  void asyncStateDoesNotModifyRequestProperties() {
+    request.addRequestProp("existing", "value");
+
+    startAsyncRequest();
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    assertThat(request.getRequestProps())
+        .containsOnlyKeys("existing")
+        .containsEntry("existing", "value");
+  }
+
+  @Test
+  void asyncStateDoesNotRetainRequestCarrier() throws Exception {
+    WeakReference<SofaRequest> requestReference = startUncompletedAsyncRequest();
+
+    GcUtils.awaitGc(requestReference, Duration.ofSeconds(10));
+  }
+
+  @Test
+  void explicitCallbackErrorWinsOverResponseError() {
+    IllegalStateException callbackError = new IllegalStateException("callback failed");
+    response.setAppResponse(new IllegalArgumentException("application failed"));
+    startAsyncRequest();
+
+    filter.onAsyncResponse(consumerConfig, request, response, callbackError);
+
+    verify(instrumenter).end(any(), any(), any(), same(callbackError));
+  }
+
+  @Test
+  void extractsApplicationError() {
+    IllegalArgumentException applicationError = new IllegalArgumentException("application failed");
+    response.setAppResponse(applicationError);
+    startAsyncRequest();
+
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    verify(instrumenter).end(any(), any(), any(), same(applicationError));
+  }
+
+  @Test
+  void completionAfterSynchronousRequestIsNoOp() {
+    request.setInvokeType(RpcConstants.INVOKER_TYPE_SYNC);
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+
+    filter.invoke(invoker, request);
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    verify(instrumenter, times(1)).end(any(), any(), any(), any());
+  }
+
+  @Test
+  void localRequestAndCompletionAreNoOp() {
+    consumerConfig.setInJVM(true);
+
+    filter.invoke(invoker, request);
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    verifyNoInteractions(instrumenter);
+  }
+
+  @Test
+  void completionWithoutAsyncStateIsNoOp() {
+    filter.onAsyncResponse(consumerConfig, request, response, null);
+
+    verifyNoInteractions(instrumenter);
+  }
+
+  private void startAsyncRequest() {
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+    filter.invoke(invoker, request);
+  }
+
+  private WeakReference<SofaRequest> startUncompletedAsyncRequest() throws Exception {
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(Context.root());
+    AtomicReference<WeakReference<SofaRequest>> requestReference = new AtomicReference<>();
+    Thread requestThread =
+        new Thread(
+            () -> {
+              SofaRequest uncompletedRequest =
+                  new SofaRequest().setInvokeType(RpcConstants.INVOKER_TYPE_FUTURE);
+              filter.invoke(invoker, uncompletedRequest);
+              requestReference.set(new WeakReference<>(uncompletedRequest));
+            });
+    requestThread.start();
+    requestThread.join();
+    reset((Object) instrumenter);
+    return requestReference.get();
+  }
+}


### PR DESCRIPTION
Addresses #19509.

## Summary

- store SOFA RPC asynchronous client state before invoking the transport, so an early callback cannot race ahead of state registration
- expose a strongly typed completion facade from the published SOFA RPC library API for custom asynchronous transports
- route the public facade through the registered OpenTelemetry client filter, so Java agent and library-autoconfigure users share the same exactly-once completion path
- clear the request-associated virtual field on completion without modifying SOFA RPC request properties

## Motivation

The SOFA RPC client filter currently relies on `FilterChain.onAsyncResponse(...)` to end asynchronous client spans. A custom transport can own a future-completion callback outside that chain, leaving the span open. A callback may also run before `invoke(...)` returns, so registering state after transport invocation introduces a second race.

This change stores detached asynchronous state in a `VirtualField` before transport invocation. Custom transport code can compile against the published SOFA RPC library and call `SofaRpcTelemetry.completeAsyncResponse(...)` with the original request and its response or error. The facade resolves the registered `openTelemetryClient` SOFA RPC filter and invokes only its asynchronous completion path, avoiding reflection and dependencies on internal javaagent artifacts.

`SofaRequest.requestProps` cannot hold the state: in the SOFA Bolt future path it is serialized, and storing the non-serializable tracing state there causes a `SerializationException`.

## API scope

`SofaRpcTelemetry.completeAsyncResponse(...)` is a public API in the published SOFA RPC library. It does not automatically instrument custom transports; the callback must call it using the original `SofaRequest`.

When the OpenTelemetry SOFA RPC client filter is not registered, or the request has no pending asynchronous telemetry, the method safely no-ops. Standard filter callbacks, custom completion calls, invocation failures, and concurrent duplicate callbacks all converge on the same idempotent completion state.

## Compatibility

- no reflection in production code
- no dependency on `io.opentelemetry.javaagent.instrumentation.*` from application code
- no changes to SOFA RPC request properties, wire serialization, configuration, metadata, or semantic conventions
- missing state, synchronous calls, local calls, unsampled calls, and duplicate completion safely no-op

## Tests

Passing locally:

- `./gradlew :instrumentation:sofa-rpc-5.4:library:check :instrumentation:sofa-rpc-5.4:library-autoconfigure:check :instrumentation:sofa-rpc-5.4:javaagent:check`
- `./gradlew spotlessCheck`

Coverage includes direct compilation and invocation of the published API, successful and exceptional completion, callback-before-return, invocation failure races, concurrent duplicate completion, standard-versus-public completion races, exactly-once spans and metrics, missing-state no-op behavior, request-property isolation, and cache-backed `VirtualField` carrier retention.