### PR TITLE
fix activemq.destination.temp.utilization JMX metric value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ⚠️ Breaking changes to non-stable APIs
+
+- Normalize the value of `activemq.destination.temp.utilization` JMX Metric for ActiveMQ to be between 0 and 1 instead of between 0 and 100. 
+
 ### 🚫 Deprecations
 
 - For library instrumentation users, deprecate configuring span suppression using the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ⚠️ Breaking changes to non-stable APIs
 
-- Normalize the value of `activemq.destination.temp.utilization` JMX Metric for ActiveMQ to be between 0 and 1 instead of between 0 and 100. 
+- Normalize the value of `activemq.destination.temp.utilization` JMX Metric for ActiveMQ to be between 0 and 1 (inclusive) instead of between 0 and 100 (inclusive).
 
 ### 🚫 Deprecations
 

--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/activemq.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/activemq.yaml
@@ -40,7 +40,7 @@ rules:
         sourceUnit: "%"
         unit: "1"
         type: gauge
-        desc: The percentage of non-persistent storage used by this destination
+        desc: The fraction of non-persistent storage used by this destination
       # activemq.destination.temp.limit
       TempUsageLimit:
         metric: destination.temp.limit
@@ -97,7 +97,7 @@ rules:
         type: gauge
         sourceUnit: "%"
         unit: "1"
-        desc: The percentage of broker memory used
+        desc: The fraction of broker memory used
       # activemq.memory.limit
       MemoryLimit:
         metric: memory.limit
@@ -110,7 +110,7 @@ rules:
         type: gauge
         sourceUnit: "%"
         unit: "1"
-        desc: The percentage of broker persistent storage used
+        desc: The fraction of broker persistent storage used
       # activemq.store.limit
       StoreLimit:
         metric: store.limit
@@ -123,7 +123,7 @@ rules:
         type: gauge
         sourceUnit: "%"
         unit: "1"
-        desc: The percentage of broker non-persistent storage used
+        desc: The fraction of broker non-persistent storage used
       # activemq.temp.limit
       TempLimit:
         metric: temp.limit

--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/activemq.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/activemq.yaml
@@ -37,6 +37,7 @@ rules:
       # activemq.destination.temp.utilization
       TempUsagePercentUsage:
         metric: destination.temp.utilization
+        sourceUnit: "%"
         unit: "1"
         type: gauge
         desc: The percentage of non-persistent storage used by this destination

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/ActiveMqTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/ActiveMqTest.java
@@ -147,7 +147,7 @@ class ActiveMqTest extends TargetSystemTest {
                     .hasUnit("1")
                     .hasDataPointsWithAttributes(topicAttributes)
                     .hasDescription(
-                        "The percentage of non-persistent storage used by this destination"))
+                        "The fraction of non-persistent storage used by this destination"))
         .add(
             "activemq.destination.temp.limit",
             metric ->
@@ -173,7 +173,7 @@ class ActiveMqTest extends TargetSystemTest {
                     .isGauge()
                     .hasUnit("1")
                     .hasDataPointsWithAttributes(brokerAttributes)
-                    .hasDescription("The percentage of broker memory used"))
+                    .hasDescription("The fraction of broker memory used"))
         .add(
             "activemq.memory.limit",
             metric ->
@@ -189,7 +189,7 @@ class ActiveMqTest extends TargetSystemTest {
                     .isGauge()
                     .hasUnit("1")
                     .hasDataPointsWithAttributes(brokerAttributes)
-                    .hasDescription("The percentage of broker persistent storage used"))
+                    .hasDescription("The fraction of broker persistent storage used"))
         .add(
             "activemq.store.limit",
             metric ->
@@ -205,7 +205,7 @@ class ActiveMqTest extends TargetSystemTest {
                     .isGauge()
                     .hasUnit("1")
                     .hasDataPointsWithAttributes(brokerAttributes)
-                    .hasDescription("The percentage of broker non-persistent storage used"))
+                    .hasDescription("The fraction of broker non-persistent storage used"))
         .add(
             "activemq.temp.limit",
             metric ->


### PR DESCRIPTION
The `activemq.destination.temp.utilization` value is currently captured as a value between 0 and 100, for consistency with other activemq metrics we should normalize it to a fraction between 0 and 1.0.

### Migration notes

- `activemq.destination.temp.utilization` was previously captured with a value between 0 and 100 (inclusive)
- `activemq.destination.temp.utilization` is now being captured as a fraction with value between 0 and 1.0 (inclusive)
- any existing usage relying on the absolute value to be between 0 and 100 should thus be adapted to accommodate the new value between 0 and 1.0.