### PR TITLE
fix unit for jetty.thread.queue.size metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ⚠️ Breaking changes to non-stable APIs
+
+- `jetty.thread.queue.size` Jetty JMX metric unit has been changed from `{thread}` to `{job}`.
+
 ### 🚫 Deprecations
 
 - For library instrumentation users, deprecate configuring span suppression using the

--- a/instrumentation/jmx-metrics/library/jetty.md
+++ b/instrumentation/jmx-metrics/library/jetty.md
@@ -17,7 +17,7 @@ Those metrics require the following Jetty modules to be enabled : `jmx`, `http`,
 | jetty.thread.limit      | UpDownCounter | {thread}    |               | The maximum number of threads in the pool |
 | jetty.thread.busy.count | UpDownCounter | {thread}    |               | The current number of busy threads        |
 | jetty.thread.idle.count | UpDownCounter | {thread}    |               | The current number of idle threads        |
-| jetty.thread.queue.size | UpDownCounter | {thread}    |               | The current job queue size                |
+| jetty.thread.queue.size | UpDownCounter | {job}       |               | The current job queue size                |
 | jetty.io.select.count   | Counter       | {operation} |               | The number of select calls                |
 | jetty.session.count     | UpDownCounter | {session}   | jetty.context | Current number of active sessions         |
 
@@ -33,7 +33,7 @@ Those metrics require the following Jetty modules to be enabled : `jmx`, `http` 
 | jetty.thread.limit          | UpDownCounter | {thread}    |               | The maximum number of threads in the pool |
 | jetty.thread.busy.count     | UpDownCounter | {thread}    |               | The current number of busy threads        |
 | jetty.thread.idle.count     | UpDownCounter | {thread}    |               | The current number of idle threads        |
-| jetty.thread.queue.size     | UpDownCounter | {thread}    |               | The current job queue size                |
+| jetty.thread.queue.size     | UpDownCounter | {job}       |               | The current job queue size                |
 | jetty.io.select.count       | Counter       | {operation} |               | The number of select calls                |
 | jetty.session.created.count | Counter       | {session}   | jetty.context | The total number of created sessions      |
 | jetty.session.duration.sum  | Counter       | {session}   | jetty.context | The cumulated session duration            |

--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/jetty.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/jetty.yaml
@@ -32,6 +32,7 @@ rules:
       queueSize:
         metric: queue.size
         desc: The current job queue size
+        unit: "{job}"
 
   - bean: org.eclipse.jetty.io:context=*,type=managedselector,id=*
     mapping:

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/JettyTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/JettyTest.java
@@ -109,7 +109,7 @@ class JettyTest extends TargetSystemTest {
                     metric
                         .isUpDownCounter()
                         .hasDescription("The current job queue size")
-                        .hasUnit("{thread}")
+                        .hasUnit("{job}")
                         .hasDataPointsWithoutAttributes())
             .add(
                 "jetty.select.count",


### PR DESCRIPTION
Breaking change: modify `jetty.thread.queue.size` unit from `{thread}` to `{job}` as it represents a number of jobs/tasks rather than an actual number of threads.

This is only a breaking change if the consumer is relying on the metric unit, the name and value of the metric remains untouched.

### Migration notes
- `jetty.thread.queue.size` metric has been changed from `{thread}` to `{job}`, consumers must adapt accordingly if they rely on the metric unit.