### PR TITLE
Scrub secrets from sun.java.command and multi-line property values

### DIFF
--- a/instrumentation/resources/library/build.gradle.kts
+++ b/instrumentation/resources/library/build.gradle.kts
@@ -89,6 +89,7 @@ tasks {
     // use the final jar instead of directories with built classes to test the mrjar functionality
     classpath = project.files(jar) + classpath
     systemProperty("testSecret", "test")
+    systemProperty("testMultilineSecret", "test\nleaked")
     systemProperty("testPassword", "test")
     systemProperty("testNotRedacted", "test")
   }

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -38,6 +38,8 @@ public final class ProcessResource {
   // scrub values for system properties containing "secret" or "password" in the name
   private static final Pattern SCRUB_PATTERN =
       Pattern.compile("(-D.*(password|secret).*=).*", Pattern.CASE_INSENSITIVE);
+  private static final Pattern SCRUB_COMMAND_LINE_PATTERN =
+      Pattern.compile("(-D[^\\s=]*(password|secret)[^\\s=]*=).*", Pattern.CASE_INSENSITIVE);
 
   @Deprecated // to be removed in 3.0
   private static final Resource INSTANCE = create(true);
@@ -150,15 +152,8 @@ public final class ProcessResource {
   }
 
   private static String scrubCommandLine(String commandLine) {
-    String[] arguments = commandLine.split(" ", -1);
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i < arguments.length; i++) {
-      if (i > 0) {
-        result.append(' ');
-      }
-      result.append(scrub(arguments[i]));
-    }
-    return result.toString();
+    // Argument boundaries have been lost, so redact the remainder to avoid exposing continuations.
+    return SCRUB_COMMAND_LINE_PATTERN.matcher(commandLine).replaceFirst("$1***");
   }
 
   private static String scrub(String argument) {

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -38,9 +38,11 @@ public final class ProcessResource {
   // scrub values for system properties containing "secret" or "password" in the name
   private static final Pattern SCRUB_PATTERN =
       Pattern.compile("(-D.*(password|secret).*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+  // same as above, except that the property name cannot span "=", since argument boundaries have
+  // been lost in the flattened command line
   private static final Pattern SCRUB_COMMAND_LINE_PATTERN =
       Pattern.compile(
-          "(-D[^\\s=]*(password|secret)[^\\s=]*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+          "(-D[^=]*(password|secret)[^=]*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
   @Deprecated // to be removed in 3.0
   private static final Resource INSTANCE = create(true);

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -39,7 +39,8 @@ public final class ProcessResource {
   private static final Pattern SCRUB_PATTERN =
       Pattern.compile("(-D.*(password|secret).*=).*", Pattern.CASE_INSENSITIVE);
   private static final Pattern SCRUB_COMMAND_LINE_PATTERN =
-      Pattern.compile("(-D[^\\s=]*(password|secret)[^\\s=]*=).*", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "(-D[^\\s=]*(password|secret)[^\\s=]*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
   @Deprecated // to be removed in 3.0
   private static final Resource INSTANCE = create(true);

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -143,10 +143,22 @@ public final class ProcessResource {
         if (JAR_FILE_PATTERN.matcher(javaCommand).matches()) {
           commandLine.append(" -jar");
         }
-        commandLine.append(' ').append(javaCommand);
+        commandLine.append(' ').append(scrubCommandLine(javaCommand));
       }
       attributes.put(PROCESS_COMMAND_LINE, commandLine.toString());
     }
+  }
+
+  private static String scrubCommandLine(String commandLine) {
+    String[] arguments = commandLine.split(" ", -1);
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < arguments.length; i++) {
+      if (i > 0) {
+        result.append(' ');
+      }
+      result.append(scrub(arguments[i]));
+    }
+    return result.toString();
   }
 
   private static String scrub(String argument) {

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/ProcessResource.java
@@ -37,7 +37,7 @@ public final class ProcessResource {
       Pattern.compile("^\\S+\\.(jar|war)", Pattern.CASE_INSENSITIVE);
   // scrub values for system properties containing "secret" or "password" in the name
   private static final Pattern SCRUB_PATTERN =
-      Pattern.compile("(-D.*(password|secret).*=).*", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("(-D.*(password|secret).*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
   private static final Pattern SCRUB_COMMAND_LINE_PATTERN =
       Pattern.compile(
           "(-D[^\\s=]*(password|secret)[^\\s=]*=).*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -46,6 +46,7 @@ class ProcessResourceTest {
   }
 
   @Test
+  @SetSystemProperty(key = "sun.java.command", value = "app.jar -DappSecret=abc --other=test")
   void commandAttributesEnabled() {
     Resource resource = ProcessResource.create(true);
     Attributes attributes = resource.getAttributes();
@@ -55,7 +56,8 @@ class ProcessResourceTest {
           .contains(attributes.get(PROCESS_EXECUTABLE_PATH))
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
-          .contains("-DtestNotRedacted=test");
+          .contains("-DtestNotRedacted=test")
+          .contains("app.jar -DappSecret=*** --other=test");
     } else {
       assertThat(attributes.get(PROCESS_COMMAND_ARGS))
           .contains(attributes.get(PROCESS_EXECUTABLE_PATH))

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -46,7 +46,7 @@ class ProcessResourceTest {
   }
 
   @Test
-  @SetSystemProperty(key = "sun.java.command", value = "app.jar -DappSecret=abc --other=test")
+  @SetSystemProperty(key = "sun.java.command", value = "app.jar -DappSecret=abc def --other=test")
   void commandAttributesEnabled() {
     Resource resource = ProcessResource.create(true);
     Attributes attributes = resource.getAttributes();
@@ -57,7 +57,7 @@ class ProcessResourceTest {
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
           .contains("-DtestNotRedacted=test")
-          .contains("app.jar -DappSecret=*** --other=test");
+          .endsWith(" app.jar -DappSecret=***");
     } else {
       assertThat(attributes.get(PROCESS_COMMAND_ARGS))
           .contains(attributes.get(PROCESS_EXECUTABLE_PATH))

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -56,6 +56,8 @@ class ProcessResourceTest {
           .contains(attributes.get(PROCESS_EXECUTABLE_PATH))
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
+          .contains("-DtestMultilineSecret=***")
+          .doesNotContain("leaked")
           .contains("-DtestNotRedacted=test")
           .endsWith(" app.jar -DappSecret=***");
     } else {
@@ -63,6 +65,7 @@ class ProcessResourceTest {
           .contains(attributes.get(PROCESS_EXECUTABLE_PATH))
           .contains("-DtestSecret=***")
           .contains("-DtestPassword=***")
+          .contains("-DtestMultilineSecret=***")
           .contains("-DtestNotRedacted=test");
     }
   }

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PR
 import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_EXECUTABLE_PATH;
 import static io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes.PROCESS_PID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
@@ -68,6 +69,17 @@ class ProcessResourceTest {
           .contains("-DtestMultilineSecret=***")
           .contains("-DtestNotRedacted=test");
     }
+  }
+
+  @Test
+  @SetSystemProperty(key = "sun.java.command", value = "app.jar -Dmy secret=abc --other=test")
+  void commandLineScrubsPropertyNameContainingSpaces() {
+    assumeTrue(isJava8() || IS_WINDOWS);
+
+    Resource resource = ProcessResource.create(true);
+    Attributes attributes = resource.getAttributes();
+
+    assertThat(attributes.get(PROCESS_COMMAND_LINE)).endsWith(" app.jar -Dmy secret=***");
   }
 
   private static void assertResource(boolean windows) {

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ProcessResourceTest.java
@@ -46,7 +46,7 @@ class ProcessResourceTest {
   }
 
   @Test
-  @SetSystemProperty(key = "sun.java.command", value = "app.jar -DappSecret=abc def --other=test")
+  @SetSystemProperty(key = "sun.java.command", value = "app.jar -DappSecret=abc\ndef --other=test")
   void commandAttributesEnabled() {
     Resource resource = ProcessResource.create(true);
     Attributes attributes = resource.getAttributes();


### PR DESCRIPTION
The `process.command_line` resource attribute derived from `sun.java.command` is now scrubbed, so sensitive `-D` application arguments are no longer exported unchanged on Java 8, Windows, and other paths where the structured process argument array is unavailable.

Scrubbing now also covers property values that span multiple lines. Previously a value such as `-DappSecret=abc\ndef` was only partially redacted, leaking everything after the first newline into `process.command_args` as well.

Because `sun.java.command` is a single string that does not preserve argument boundaries, its scrubber redacts the entire remainder of the string after a sensitive property assignment rather than risk exposing a space-containing continuation.