### PR TITLE
Fix Spring Boot starter breaking actuator metrics endpoint

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistry.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.micrometer.v1_5;
 
+import static java.util.Collections.emptyList;
+
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -21,6 +23,7 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.opentelemetry.api.OpenTelemetry;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
@@ -53,6 +56,7 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
   private final TimeUnit baseTimeUnit;
   private final DistributionStatisticConfigModifier distributionStatisticConfigModifier;
   private final boolean emitMaxGauge;
+  private final boolean metersHiddenFromSearch;
   private final io.opentelemetry.api.metrics.Meter otelMeter;
 
   OpenTelemetryMeterRegistry(
@@ -61,17 +65,33 @@ public final class OpenTelemetryMeterRegistry extends MeterRegistry {
       NamingConvention namingConvention,
       DistributionStatisticConfigModifier distributionStatisticConfigModifier,
       boolean v3Preview,
+      boolean metersHiddenFromSearch,
       io.opentelemetry.api.metrics.Meter otelMeter) {
     super(clock);
     this.bridging = new Bridging(v3Preview);
     this.baseTimeUnit = baseTimeUnit;
     this.distributionStatisticConfigModifier = distributionStatisticConfigModifier;
     this.emitMaxGauge = !v3Preview;
+    this.metersHiddenFromSearch = metersHiddenFromSearch;
     this.otelMeter = otelMeter;
 
     this.config()
         .namingConvention(namingConvention)
         .onMeterRemoved(OpenTelemetryMeterRegistry::onMeterRemoved);
+  }
+
+  /**
+   * Returns the registered meters, or an empty list when the meters are hidden from the search
+   * APIs.
+   *
+   * <p>This registry only forwards metrics to OpenTelemetry and cannot read metric values back, so
+   * hiding the meters lets readers that pick a single registry out of a {@link
+   * io.micrometer.core.instrument.composite.CompositeMeterRegistry} skip this registry and read
+   * from one that is able to report values.
+   */
+  @Override
+  public List<Meter> getMeters() {
+    return metersHiddenFromSearch ? emptyList() : super.getMeters();
   }
 
   @Override

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.metrics.MeterBuilder;
 import io.opentelemetry.instrumentation.api.internal.EmbeddedInstrumentationProperties;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental;
+import io.opentelemetry.instrumentation.micrometer.v1_5.internal.Internal;
 import java.util.concurrent.TimeUnit;
 
 /** A builder of {@link OpenTelemetryMeterRegistry}. */
@@ -30,6 +31,8 @@ public final class OpenTelemetryMeterRegistryBuilder {
   static {
     Experimental.internalSetMicrometerHistogramGaugesEnabled(
         (builder, enabled) -> builder.histogramGaugesEnabled = enabled);
+    Internal.internalSetMetersHiddenFromSearch(
+        (builder, hidden) -> builder.metersHiddenFromSearch = hidden);
   }
 
   private final OpenTelemetry openTelemetry;
@@ -37,6 +40,7 @@ public final class OpenTelemetryMeterRegistryBuilder {
   private TimeUnit baseTimeUnit = SECONDS;
   private boolean prometheusMode = false;
   private boolean histogramGaugesEnabled = false;
+  private boolean metersHiddenFromSearch = false;
 
   OpenTelemetryMeterRegistryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -120,6 +124,7 @@ public final class OpenTelemetryMeterRegistryBuilder {
         namingConvention,
         modifier,
         SemconvStability.v3Preview(openTelemetry),
+        metersHiddenFromSearch,
         meterBuilder.build());
   }
 }

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/internal/Internal.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/internal/Internal.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.micrometer.v1_5.internal;
+
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistryBuilder;
+import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class Internal {
+
+  @Nullable
+  private static volatile BiConsumer<OpenTelemetryMeterRegistryBuilder, Boolean>
+      setMetersHiddenFromSearch;
+
+  /**
+   * Hides the registered meters from the meter registry search APIs, i.e. {@code getMeters()},
+   * {@code find(String)} and {@code get(String)}. Meter registration, {@code
+   * forEachMeter(Consumer)} and meter removal are not affected.
+   *
+   * <p>The OpenTelemetry meter registry only forwards metrics to OpenTelemetry; it cannot read
+   * metric values back, so the meters it returns always measure to nothing. Readers that pick a
+   * single registry out of a {@code CompositeMeterRegistry}, such as Spring Boot Actuator's metrics
+   * endpoint, otherwise have no way of telling that they should read from a different member of the
+   * composite instead.
+   *
+   * <p>Only set this when the registry is part of a composite that has another member capable of
+   * reading metric values, otherwise the metrics become invisible to those readers entirely.
+   *
+   * <p>This is disabled by default, set this to {@code true} to hide the registered meters.
+   */
+  public static void setMetersHiddenFromSearch(
+      OpenTelemetryMeterRegistryBuilder builder, boolean metersHiddenFromSearch) {
+    if (setMetersHiddenFromSearch != null) {
+      setMetersHiddenFromSearch.accept(builder, metersHiddenFromSearch);
+    }
+  }
+
+  public static void internalSetMetersHiddenFromSearch(
+      BiConsumer<OpenTelemetryMeterRegistryBuilder, Boolean> setMetersHiddenFromSearch) {
+    Internal.setMetersHiddenFromSearch = setMetersHiddenFromSearch;
+  }
+
+  private Internal() {}
+}

--- a/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/HiddenMetersTest.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/test/java/io/opentelemetry/instrumentation/micrometer/v1_5/HiddenMetersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.micrometer.v1_5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.micrometer.v1_5.internal.Internal;
+import org.junit.jupiter.api.Test;
+
+class HiddenMetersTest {
+
+  @Test
+  void metersAreVisibleByDefault() {
+    MeterRegistry registry = OpenTelemetryMeterRegistry.create(OpenTelemetry.noop());
+    registry.counter("test.counter").increment();
+
+    assertThat(registry.getMeters()).hasSize(1);
+    assertThat(registry.find("test.counter").counter()).isNotNull();
+  }
+
+  @Test
+  void metersAreHiddenWhenConfigured() {
+    OpenTelemetryMeterRegistryBuilder builder =
+        OpenTelemetryMeterRegistry.builder(OpenTelemetry.noop());
+    Internal.setMetersHiddenFromSearch(builder, true);
+    MeterRegistry registry = builder.build();
+
+    registry.counter("test.counter").increment();
+
+    assertThat(registry.getMeters()).isEmpty();
+    assertThat(registry.find("test.counter").counter()).isNull();
+    assertThatExceptionOfType(MeterNotFoundException.class)
+        .isThrownBy(() -> registry.get("test.counter").counter());
+  }
+
+  @Test
+  void hiddenMetersAreStillRegisteredAndRemovable() {
+    OpenTelemetryMeterRegistryBuilder builder =
+        OpenTelemetryMeterRegistry.builder(OpenTelemetry.noop());
+    Internal.setMetersHiddenFromSearch(builder, true);
+    MeterRegistry registry = builder.build();
+
+    Counter counter = registry.counter("test.counter");
+    // registration is deduplicated even though the meter is hidden from the search apis
+    assertThat(registry.counter("test.counter")).isSameAs(counter);
+
+    registry.forEachMeter(registry::remove);
+    assertThat(registry.counter("test.counter")).isNotSameAs(counter);
+  }
+}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfiguration.java
@@ -8,11 +8,12 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumen
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.ConditionalOnEnabledInstrumentation;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -25,7 +26,14 @@ import org.springframework.context.annotation.Configuration;
  * any time.
  */
 @ConditionalOnEnabledInstrumentation(module = "micrometer", enabledByDefault = false)
-@AutoConfigureAfter({MetricsAutoConfiguration.class, OpenTelemetryAutoConfiguration.class})
+@AutoConfigureAfter({
+  MetricsAutoConfiguration.class,
+  OpenTelemetryAutoConfiguration.class,
+  // configure after the SimpleMeterRegistry has initialized; it is normally the last MeterRegistry
+  // implementation to be configured, as it's used as a fallback
+  // the OTel registry should be added in addition to that fallback and not replace it
+  SimpleMetricsExportAutoConfiguration.class
+})
 @AutoConfigureBefore(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnBean(Clock.class)
 @ConditionalOnClass({
@@ -36,7 +44,8 @@ import org.springframework.context.annotation.Configuration;
 public class MicrometerBridgeAutoConfiguration {
 
   @Bean
-  MeterRegistry otelMeterRegistry(OpenTelemetry openTelemetry, Clock micrometerClock) {
-    return OpenTelemetryMeterRegistry.builder(openTelemetry).setClock(micrometerClock).build();
+  MeterRegistry otelMeterRegistry(
+      OpenTelemetry openTelemetry, Clock micrometerClock, ListableBeanFactory beanFactory) {
+    return OtelMeterRegistryFactory.create(openTelemetry, micrometerClock, beanFactory);
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/OtelMeterRegistryFactory.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/OtelMeterRegistryFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.micrometer;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
+import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistryBuilder;
+import io.opentelemetry.instrumentation.micrometer.v1_5.internal.Internal;
+import org.springframework.beans.factory.ListableBeanFactory;
+
+final class OtelMeterRegistryFactory {
+
+  static MeterRegistry create(
+      OpenTelemetry openTelemetry, Clock micrometerClock, ListableBeanFactory beanFactory) {
+    OpenTelemetryMeterRegistryBuilder builder =
+        OpenTelemetryMeterRegistry.builder(openTelemetry).setClock(micrometerClock);
+    Internal.setMetersHiddenFromSearch(builder, hasOtherMeterRegistry(beanFactory));
+    return builder.build();
+  }
+
+  /**
+   * Returns whether a meter registry other than the OpenTelemetry one is configured, which means
+   * that the OpenTelemetry registry ends up in a composite registry next to it.
+   *
+   * <p>All bean definitions are registered before any of them is instantiated, so this sees the
+   * fallback {@code SimpleMeterRegistry} even though it is contributed by an auto-configuration
+   * that this one is ordered after.
+   */
+  private static boolean hasOtherMeterRegistry(ListableBeanFactory beanFactory) {
+    // the OpenTelemetry registry itself is always one of them
+    return beanFactory.getBeanNamesForType(MeterRegistry.class, false, false).length > 1;
+  }
+
+  private OtelMeterRegistryFactory() {}
+}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/javaSpring4/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeSpringBoot4AutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/javaSpring4/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeSpringBoot4AutoConfiguration.java
@@ -8,15 +8,16 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumen
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
 import io.opentelemetry.instrumentation.spring.autoconfigure.OpenTelemetryAutoConfiguration;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.ConditionalOnEnabledInstrumentation;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,7 +26,14 @@ import org.springframework.context.annotation.Configuration;
  * any time.
  */
 @ConditionalOnEnabledInstrumentation(module = "micrometer", enabledByDefault = false)
-@AutoConfigureAfter({MetricsAutoConfiguration.class, OpenTelemetryAutoConfiguration.class})
+@AutoConfigureAfter({
+  MetricsAutoConfiguration.class,
+  OpenTelemetryAutoConfiguration.class,
+  // configure after the SimpleMeterRegistry has initialized; it is normally the last MeterRegistry
+  // implementation to be configured, as it's used as a fallback
+  // the OTel registry should be added in addition to that fallback and not replace it
+  SimpleMetricsExportAutoConfiguration.class
+})
 @AutoConfigureBefore(CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnBean(Clock.class)
 @ConditionalOnClass({MeterRegistry.class, MetricsAutoConfiguration.class})
@@ -33,7 +41,8 @@ import org.springframework.context.annotation.Configuration;
 public class MicrometerBridgeSpringBoot4AutoConfiguration {
 
   @Bean
-  MeterRegistry otelMeterRegistry(OpenTelemetry openTelemetry, Clock micrometerClock) {
-    return OpenTelemetryMeterRegistry.builder(openTelemetry).setClock(micrometerClock).build();
+  MeterRegistry otelMeterRegistry(
+      OpenTelemetry openTelemetry, Clock micrometerClock, ListableBeanFactory beanFactory) {
+    return OtelMeterRegistryFactory.create(openTelemetry, micrometerClock, beanFactory);
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/testSpring2/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testSpring2/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfigurationTest.java
@@ -5,9 +5,16 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumentation.micrometer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.AbstractMicrometerBridgeAutoConfigurationTest;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 
 class MicrometerBridgeAutoConfigurationTest extends AbstractMicrometerBridgeAutoConfigurationTest {
@@ -23,7 +30,42 @@ class MicrometerBridgeAutoConfigurationTest extends AbstractMicrometerBridgeAuto
   }
 
   @Override
+  protected Class<?> getSimpleMetricsExportAutoConfigurationClass() {
+    return SimpleMetricsExportAutoConfiguration.class;
+  }
+
+  @Override
+  protected Class<?> getCompositeMeterRegistryAutoConfigurationClass() {
+    return CompositeMeterRegistryAutoConfiguration.class;
+  }
+
+  @Override
   protected Class<?> getMeterRegistryClass() {
     return MeterRegistry.class;
+  }
+
+  // repeated because the composite registry keeps its members in an identity hash set, so a reader
+  // that relies on its iteration order only fails intermittently
+  @RepeatedTest(5)
+  void actuatorMetricsEndpointReturnsMeasurements() {
+    actuatorContextRunner(OpenTelemetry.noop())
+        .run(
+            context -> {
+              MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+              meterRegistry.counter("test.counter").increment(2);
+
+              // the return type of MetricsEndpoint.metric() differs between Spring Boot 2 and 3
+              MetricsEndpoint metricsEndpoint = new MetricsEndpoint(meterRegistry);
+              var metric = metricsEndpoint.metric("test.counter", null);
+              assertThat(metric).isNotNull();
+              assertThat(metric.getMeasurements())
+                  .singleElement()
+                  .extracting(MetricsEndpoint.Sample::getValue)
+                  .isEqualTo(2.0);
+
+              // hiding the OTel registry's meters must not hide them from the name listing, which
+              // reads the meters of every composite member
+              assertThat(metricsEndpoint.listNames().getNames()).contains("test.counter");
+            });
   }
 }

--- a/instrumentation/spring/spring-boot-autoconfigure/src/testSpring4/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/testSpring4/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/micrometer/MicrometerBridgeAutoConfigurationTest.java
@@ -8,7 +8,9 @@ package io.opentelemetry.instrumentation.spring.autoconfigure.internal.instrumen
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.instrumentation.spring.autoconfigure.internal.AbstractMicrometerBridgeAutoConfigurationTest;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 
 class MicrometerBridgeAutoConfigurationTest extends AbstractMicrometerBridgeAutoConfigurationTest {
 
@@ -20,6 +22,16 @@ class MicrometerBridgeAutoConfigurationTest extends AbstractMicrometerBridgeAuto
   @Override
   protected Class<?> getMetricsAutoConfigurationClass() {
     return MetricsAutoConfiguration.class;
+  }
+
+  @Override
+  protected Class<?> getSimpleMetricsExportAutoConfigurationClass() {
+    return SimpleMetricsExportAutoConfiguration.class;
+  }
+
+  @Override
+  protected Class<?> getCompositeMeterRegistryAutoConfigurationClass() {
+    return CompositeMeterRegistryAutoConfiguration.class;
   }
 
   @Override

--- a/instrumentation/spring/spring-boot-autoconfigure/testing/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/AbstractMicrometerBridgeAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/testing/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/AbstractMicrometerBridgeAutoConfigurationTest.java
@@ -5,11 +5,18 @@
 
 package io.opentelemetry.instrumentation.spring.autoconfigure.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -20,6 +27,10 @@ public abstract class AbstractMicrometerBridgeAutoConfigurationTest {
   protected abstract AutoConfigurations autoConfigurations();
 
   protected abstract Class<?> getMetricsAutoConfigurationClass();
+
+  protected abstract Class<?> getSimpleMetricsExportAutoConfigurationClass();
+
+  protected abstract Class<?> getCompositeMeterRegistryAutoConfigurationClass();
 
   protected abstract Class<?> getMeterRegistryClass();
 
@@ -68,5 +79,99 @@ public abstract class AbstractMicrometerBridgeAutoConfigurationTest {
         .withBean(Clock.class, () -> Clock.SYSTEM)
         .withPropertyValues("otel.instrumentation.micrometer.enabled=true")
         .run(context -> assertThat(context).hasNotFailed().doesNotHaveBean("otelMeterRegistry"));
+  }
+
+  @Test
+  void keepsFallbackSimpleMeterRegistry() {
+    actuatorContextRunner(OpenTelemetry.noop())
+        .run(context -> assertThat(context).hasSingleBean(SimpleMeterRegistry.class));
+  }
+
+  @Test
+  void keepsMetersVisibleWhenThereIsNoOtherRegistryToReadFrom() {
+    contextRunner
+        .withConfiguration(AutoConfigurations.of(getMetricsAutoConfigurationClass()))
+        .withPropertyValues("otel.instrumentation.micrometer.enabled=true")
+        .run(
+            context -> {
+              // without a fallback registry the OTel registry is the only one, so hiding its meters
+              // would make them unreadable instead of readable from somewhere else
+              MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+              meterRegistry.counter("test.counter").increment();
+
+              assertThat(meterRegistry).isInstanceOf(OpenTelemetryMeterRegistry.class);
+              assertThat(meterRegistry.getMeters()).hasSize(1);
+              assertThat(meterRegistry.find("test.counter").counter()).isNotNull();
+            });
+  }
+
+  // repeated because the composite registry keeps its members in an identity hash set, so a reader
+  // that relies on its iteration order only fails intermittently
+  @RepeatedTest(5)
+  void hidesOpenTelemetryRegistryMetersFromReaders() {
+    actuatorContextRunner(OpenTelemetry.noop())
+        .run(
+            context -> {
+              context.getBean(MeterRegistry.class).counter("test.counter").increment(2);
+
+              MeterRegistry otelMeterRegistry =
+                  context.getBean("otelMeterRegistry", MeterRegistry.class);
+              assertThat(otelMeterRegistry).isInstanceOf(OpenTelemetryMeterRegistry.class);
+              assertThat(otelMeterRegistry.getMeters()).isEmpty();
+              assertThat(otelMeterRegistry.find("test.counter").counter()).isNull();
+
+              assertThat(context.getBean(SimpleMeterRegistry.class).find("test.counter").counter())
+                  .isNotNull();
+            });
+  }
+
+  @Test
+  void exposesMetersAddedByMeterBinders() {
+    actuatorContextRunner(OpenTelemetry.noop())
+        .withBean(MeterBinder.class, () -> registry -> registry.counter("test.bound"))
+        .run(
+            context ->
+                assertThat(context.getBean(MeterRegistry.class).find("test.bound").counter())
+                    .isNotNull());
+  }
+
+  @Test
+  void exportsMetricsToOpenTelemetry() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build();
+
+    actuatorContextRunner(openTelemetry)
+        .run(
+            context -> {
+              context.getBean(MeterRegistry.class).counter("test.counter").increment(2);
+
+              assertThat(metricReader.collectAllMetrics())
+                  .singleElement()
+                  .satisfies(
+                      metric ->
+                          assertThat(metric)
+                              .hasName("test.counter")
+                              .hasDoubleSumSatisfying(
+                                  sum -> sum.hasPointsSatisfying(point -> point.hasValue(2))));
+            });
+  }
+
+  /**
+   * Returns a runner with the bridge enabled and the actuator auto-configurations that an
+   * application relying on the actuator metrics endpoint would have.
+   */
+  protected ApplicationContextRunner actuatorContextRunner(OpenTelemetry openTelemetry) {
+    return new ApplicationContextRunner()
+        .withBean(OpenTelemetry.class, () -> openTelemetry)
+        .withConfiguration(autoConfigurations())
+        .withConfiguration(
+            AutoConfigurations.of(
+                getMetricsAutoConfigurationClass(),
+                getSimpleMetricsExportAutoConfigurationClass(),
+                getCompositeMeterRegistryAutoConfigurationClass()))
+        .withPropertyValues("otel.instrumentation.micrometer.enabled=true");
   }
 }


### PR DESCRIPTION
Enabling the Micrometer bridge in the OpenTelemetry Spring Boot starter (`otel.instrumentation.micrometer.enabled=true`) broke Spring Boot Actuator's metrics endpoint: `/actuator/metrics/<name>` returned no measurements. Fixes #7360.

There were two independent defects.

**The fallback `SimpleMeterRegistry` was suppressed.** Spring Boot's `SimpleMetricsExportAutoConfiguration` is `@ConditionalOnMissingBean(MeterRegistry.class)`, and `MicrometerBridgeAutoConfiguration` was not ordered after it. The OTel registry bean definition was registered first, `SimpleMetricsExportAutoConfiguration` backed off, and no read-capable registry existed at all — `OpenTelemetryMeterRegistry` only writes metrics, it cannot read them back. Adding `SimpleMetricsExportAutoConfiguration` to `@AutoConfigureAfter` lets the fallback registry survive alongside the OTel one.

**Which composite member the endpoint read from was nondeterministic.** `MetricsEndpoint` reads from the first registry in `CompositeMeterRegistry.getRegistries()` that has a matching meter, and the composite stores its members in `Collections.newSetFromMap(new IdentityHashMap<>())`. Identity-hash iteration order varies per JVM run, so even with a second registry present, whether the endpoint read the OTel registry (broken) or the simple registry (working) was a coin flip. `@Order` on the registry bean does not help, because insertion order is irrelevant to an identity hash set.

Rather than reordering the composite, the OTel registry now hides its meters from the registry search APIs. `MetricsEndpoint` resolves meters through `registry.find(name).tags(tags).meters()`, and Micrometer's `Search` reads `registry.getMeters()`, so an empty `getMeters()` makes the endpoint skip the write-only registry and fall through to one that can report values — deterministically, without touching Boot's composite at all.

Hiding is opt-in through a new internal `Internal.setMetersHiddenFromSearch`, following the existing `Experimental` hook pattern, so the default behavior of `OpenTelemetryMeterRegistry` for standalone users is unchanged. It affects only `getMeters()`, `find(String)` and `get(String)`; meter registration, `forEachMeter`, removal and shutdown all go through Micrometer's internal meter map and are unaffected.

The starter only hides meters when another `MeterRegistry` bean is configured. When the OTel registry is the only one, Spring Boot skips the composite entirely and the actuator endpoint reads the OTel registry directly, so hiding would turn "metric with no measurements" into a missing metric and an empty `/actuator/metrics` listing.

Both fixes are applied to the Spring Boot 2/3 and Spring Boot 4 variants of the auto-configuration.

Before, with a counter incremented by 2 through the injected registry: `/actuator/metrics/test.counter` returned no measurements. After: it returns `2.0`, the metric name still appears in `/actuator/metrics`, and the metric is still exported to OpenTelemetry.

The regression tests fail on the unfixed code — `hidesOpenTelemetryRegistryMetersFromReaders` fails all 5 repetitions and `actuatorMetricsEndpointReturnsMeasurements` fails 4 of 5, reproducing the coin flip — and pass with the fix. `testSpring2`, `testSpring4` and the Micrometer library tests were run locally and pass.

One known limitation is out of scope here. `AbstractCompositeMeter` keeps its per-registry child meters in an `IdentityHashMap` and `CompositeCounter.count()` reads `firstChild()`, so reading back through the injected composite (`meterRegistry.get("x").counter().count()`) still picks an arbitrary member and can return `NaN`. That path is independent of `getRegistries()` ordering, so neither this fix nor a composite-reordering fix addresses it; closing it requires the bridge to support reading values back, or an upstream Micrometer change. The actuator endpoint is unaffected, because it reads the member registries' own meters rather than the composite's.