### PR TITLE
Add messaging metrics for Kafka Connect sink tasks

### DIFF
--- a/instrumentation/kafka/kafka-connect-2.6/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectBatchRecordAttributesTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectBatchRecordAttributesTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -147,6 +148,22 @@ class KafkaConnectBatchRecordAttributesTest {
         .put(MESSAGING_KAFKA_OFFSET, offset)
         .put(MESSAGING_KAFKA_MESSAGE_KEY, key)
         .build();
+  }
+
+  @Test
+  void countsReceiveOwnedRecordsOnRetry() {
+    VirtualField<SinkRecord, Boolean> receiveOwnedField =
+        VirtualField.find(SinkRecord.class, Boolean.class);
+    SinkRecord owned = record("topic", 0, 1, "key");
+    SinkRecord notOwned = record("topic", 0, 2, "key");
+    receiveOwnedField.set(owned, true);
+
+    KafkaConnectTask task = new KafkaConnectTask(asList(owned, notOwned));
+
+    // First put(): the receive-owned record is not counted; the marker is cleared for the retry.
+    assertThat(task.countUnmarkedRecords()).isEqualTo(1);
+    // Retry put(): the marker was cleared, so both records are counted.
+    assertThat(task.countUnmarkedRecords()).isEqualTo(2);
   }
 
   private static SinkRecord record(String topic, int partition, long offset, String key) {

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/build.gradle.kts
@@ -16,3 +16,17 @@ dependencies {
   implementation(project(":instrumentation:kafka:kafka-clients:kafka-clients-common-0.11:library"))
   library("org.apache.kafka:connect-api:2.6.0")
 }
+
+tasks {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testMessagingPreview)
+  }
+}

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectSingletons.java
@@ -6,15 +6,24 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingProcessExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_BATCH_MESSAGE_COUNT;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingProcessMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 
 public class KafkaConnectSingletons {
 
@@ -22,8 +31,36 @@ public class KafkaConnectSingletons {
   private static final String PROCESS_OPERATION_NAME = "process";
   private static final TextMapPropagator propagator =
       GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator();
+  private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
+      ContextKey.named("opentelemetry-kafka-connect-consumed-messages-count");
 
   private static final Instrumenter<KafkaConnectTask, Void> instrumenter;
+  private static final OperationMetrics consumedMessagesMetrics =
+      meter -> {
+        OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
+        return new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            Long consumedMessagesCount = context.get(CONSUMED_MESSAGES_COUNT_KEY);
+            return consumedMessagesCount != null && consumedMessagesCount > 0
+                ? delegate.onStart(context, startAttributes, startNanos)
+                : context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            Long consumedMessagesCount = context.get(CONSUMED_MESSAGES_COUNT_KEY);
+            if (consumedMessagesCount != null && consumedMessagesCount > 0) {
+              delegate.onEnd(
+                  context,
+                  endAttributes.toBuilder()
+                      .put(MESSAGING_BATCH_MESSAGE_COUNT, consumedMessagesCount)
+                      .build(),
+                  endNanos);
+            }
+          }
+        };
+      };
 
   static {
     KafkaConnectBatchProcessSpanLinksExtractor spanLinksExtractor =
@@ -43,7 +80,19 @@ public class KafkaConnectSingletons {
                     MessagingOperationType.PROCESS,
                     PROCESS_OPERATION_NAME))
             .addAttributesExtractor(new KafkaConnectBatchAttributesExtractor())
-            .addSpanLinksExtractor(spanLinksExtractor);
+            .addSpanLinksExtractor(spanLinksExtractor)
+            .addOperationMetrics(MessagingProcessMetrics.get());
+    // The worker task usually polls an instrumented KafkaConsumer, whose receive operation already
+    // owns the consumed message count for records it delivered. This operation counts the
+    // deliveries the receive operation did not own, so every delivery attempt, including failed and
+    // redelivered ones, is counted exactly once per put() invocation.
+    if (emitStableMessagingSemconv()) {
+      builder
+          .addContextCustomizer(
+              (context, request, startAttributes) ->
+                  context.with(CONSUMED_MESSAGES_COUNT_KEY, request.countUnmarkedRecords()))
+          .addOperationMetrics(consumedMessagesMetrics);
+    }
     setMessagingProcessExceptionEventExtractor(builder);
 
     instrumenter =

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
@@ -61,8 +61,8 @@ public class KafkaConnectTask {
   }
 
   // counts the records of this put() invocation that were not already counted by a receive
-  // operation, so that a batch partially owned by receive telemetry counts only the remainder,
-  // and every put() invocation, including failed and redelivered ones, counts its own attempt.
+  // operation, so every put() invocation, including failed and redelivered ones, counts its own
+  // attempt.
   // The marker is cleared after suppressing a record so that a retry of the same put() — which
   // Kafka Connect performs when the task throws a RetriableException — is counted as a new attempt.
   long countUnmarkedRecords() {

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
@@ -64,10 +64,14 @@ public class KafkaConnectTask {
   // counts the records of this put() invocation that were not already counted by a receive
   // operation, so that a batch partially owned by receive telemetry counts only the remainder,
   // and every put() invocation, including failed and redelivered ones, counts its own attempt.
+  // The marker is cleared after suppressing a record so that a retry of the same put() — which
+  // Kafka Connect performs when the task throws a RetriableException — is counted as a new attempt.
   long countUnmarkedRecords() {
     long count = 0;
     for (SinkRecord record : records) {
-      if (!Boolean.TRUE.equals(RECEIVE_OWNED_FIELD.get(record))) {
+      if (Boolean.TRUE.equals(RECEIVE_OWNED_FIELD.get(record))) {
+        RECEIVE_OWNED_FIELD.set(record, null);
+      } else {
         count++;
       }
     }

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
@@ -20,9 +20,8 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 public class KafkaConnectTask {
 
-  // Sink tasks run in a Kafka Connect plugin classloader, which has its own copy of the
-  // instrumentation helper classes. A JDK type is used as the field type so that this
-  // classloader and the worker classloader generate the same VirtualField accessor.
+  // Worker and sink task instrumentation may load helpers through different classloaders.
+  // Use a bootstrap-loaded field type so both sides resolve the same VirtualField accessor.
   private static final VirtualField<SinkRecord, Boolean> RECEIVE_OWNED_FIELD =
       VirtualField.find(SinkRecord.class, Boolean.class);
 

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectTask.java
@@ -7,13 +7,24 @@ package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
 import static java.util.stream.Collectors.toCollection;
 
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 public class KafkaConnectTask {
+
+  // Sink tasks run in a Kafka Connect plugin classloader, which has its own copy of the
+  // instrumentation helper classes. A JDK type is used as the field type so that this
+  // classloader and the worker classloader generate the same VirtualField accessor.
+  private static final VirtualField<SinkRecord, Boolean> RECEIVE_OWNED_FIELD =
+      VirtualField.find(SinkRecord.class, Boolean.class);
 
   private final Collection<SinkRecord> records;
   @Nullable private KafkaConnectBatchRecordAttributes batchRecordAttributes;
@@ -33,6 +44,34 @@ public class KafkaConnectTask {
       batchRecordAttributes = KafkaConnectBatchRecordAttributes.create(records);
     }
     return batchRecordAttributes;
+  }
+
+  // marks the transformed SinkRecord as receive-owned when the source ConsumerRecord was already
+  // counted by a kafka-clients receive operation, so the Connect process operation does not count
+  // the same delivery a second time. target is null when the transform filtered the record.
+  public static void copyReceiveOperation(
+      ConsumerRecord<?, ?> source, @Nullable SinkRecord target) {
+    if (target == null) {
+      return;
+    }
+    KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(source);
+    Context context = consumerContext.getContext();
+    if (context != null && KafkaConsumerContextUtil.hasReceiveOperation(context)) {
+      RECEIVE_OWNED_FIELD.set(target, true);
+    }
+  }
+
+  // counts the records of this put() invocation that were not already counted by a receive
+  // operation, so that a batch partially owned by receive telemetry counts only the remainder,
+  // and every put() invocation, including failed and redelivered ones, counts its own attempt.
+  long countUnmarkedRecords() {
+    long count = 0;
+    for (SinkRecord record : records) {
+      if (!Boolean.TRUE.equals(RECEIVE_OWNED_FIELD.get(record))) {
+        count++;
+      }
+    }
+    return count;
   }
 
   private Set<String> getTopics() {

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/SinkTaskInstrumentation.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/SinkTaskInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6.KafkaConnectSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
@@ -58,6 +59,14 @@ class SinkTaskInstrumentation implements TypeInstrumentation {
 
       @Nullable
       public static AdviceScope start(Collection<SinkRecord> records) {
+        // Kafka Connect calls put() on every worker iteration, including when the preceding poll
+        // returned nothing. An empty batch delivers no message, so under stable/v3 semconv it does
+        // not start a process operation at all, matching kafka-clients, which attaches no process
+        // context to an empty poll. Legacy behavior is preserved: it kept spanning empty batches.
+        if (records.isEmpty() && emitStableMessagingSemconv()) {
+          return null;
+        }
+
         Context parentContext = Context.current();
 
         KafkaConnectTask task = new KafkaConnectTask(records);

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/WorkerSinkTaskInstrumentation.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/WorkerSinkTaskInstrumentation.java
@@ -6,13 +6,17 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.javaagent.bootstrap.kafka.KafkaClientsConsumerProcessTracing;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
  * This instrumentation is responsible for suppressing the underlying Kafka client consumer spans to
@@ -31,6 +35,14 @@ class WorkerSinkTaskInstrumentation implements TypeInstrumentation {
   public void transform(TypeTransformer transformer) {
     // Instrument the execute method which contains the main polling loop
     transformer.applyAdviceToMethod(named("execute"), getClass().getName() + "$ExecuteAdvice");
+    transformer.applyAdviceToMethod(
+        named("convertAndTransformRecord")
+            .and(takesArgument(0, named("org.apache.kafka.clients.consumer.ConsumerRecord"))),
+        getClass().getName() + "$ConvertAndTransformRecordArgumentZeroAdvice");
+    transformer.applyAdviceToMethod(
+        named("convertAndTransformRecord")
+            .and(takesArgument(1, named("org.apache.kafka.clients.consumer.ConsumerRecord"))),
+        getClass().getName() + "$ConvertAndTransformRecordArgumentOneAdvice");
   }
 
   // This advice suppresses the CONSUMER spans created by the kafka-clients instrumentation
@@ -45,6 +57,28 @@ class WorkerSinkTaskInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.Enter boolean previousValue) {
       KafkaClientsConsumerProcessTracing.setWrappingEnabled(previousValue);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConvertAndTransformRecordArgumentZeroAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Argument(0) ConsumerRecord<?, ?> source,
+        @Advice.Return @Nullable SinkRecord transformedRecord) {
+      KafkaConnectTask.copyReceiveOperation(source, transformedRecord);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConvertAndTransformRecordArgumentOneAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Argument(1) ConsumerRecord<?, ?> source,
+        @Advice.Return @Nullable SinkRecord transformedRecord) {
+      KafkaConnectTask.copyReceiveOperation(source, transformedRecord);
     }
   }
 }

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
@@ -5,27 +5,14 @@
 
 package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
 
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertConsumedMessagesMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
-import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import java.util.Collection;
 import java.util.Map;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
@@ -34,8 +21,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * Verifies that the Connect process operation counts {@code messaging.client.consumed.messages}
- * once per delivery attempt, including failed and redelivered attempts, while not double-counting
- * deliveries that a kafka-clients receive operation already owns.
+ * once per delivery attempt, including failed and redelivered attempts.
  */
 class KafkaConnectConsumedMessagesTest {
 
@@ -68,73 +54,8 @@ class KafkaConnectConsumedMessagesTest {
     assertTotalConsumedMessages(testing, INSTRUMENTATION_NAME, 2);
   }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  void receiveOwnedRecordIsNotCountedAgainByProcessOperation() {
-    String receiveInstrumentationName = "test-kafka-connect-receive-owned";
-    Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter =
-        new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), receiveInstrumentationName)
-            .setMessagingReceiveTelemetryEnabled(true)
-            .createConsumerReceiveInstrumenter();
-    Consumer<String, String> consumer = mock(Consumer.class);
-    receive(receiveInstrumenter, consumer, "receive-owned-topic", 0, 10);
-    SinkRecord target = sinkRecord("receive-owned-topic", 0, 10);
-    markReceiveOwned(target);
-
-    new RetryingSinkTask(0).put(singletonList(target));
-
-    // the receive operation already reported this delivery, so the process operation records its
-    // own duration but must not add a second consumed-message count
-    assertProcessMetrics(testing, INSTRUMENTATION_NAME, "receive-owned-topic", null, "0", 1, null);
-    assertConsumedMessagesMetrics(
-        testing, receiveInstrumentationName, "receive-owned-topic", null, "0", 1, null);
-  }
-
-  // Test classes are not rewritten to use the javaagent's field-backed VirtualField, so a
-  // SinkRecord created directly in a test cannot be marked receive-owned through
-  // KafkaConnectTask.copyReceiveOperation the way the real convertAndTransformRecord advice does:
-  // the advice class is injected as an agent helper and reads the ConsumerRecord's context through
-  // a shaded copy of the propagation classes, which a plain test class does not share. Instead,
-  // reach the generated accessor that the agent weaves directly onto SinkRecord for the
-  // VirtualField<SinkRecord, Boolean> declared in KafkaConnectTask, and set it the same way the
-  // real accessor would.
-  private static void markReceiveOwned(SinkRecord sinkRecord) {
-    String fieldSuffix =
-        SinkRecord.class.getName().replace('.', '$')
-            + "$"
-            + Boolean.class.getName().replace('.', '$');
-    try {
-      Class<?> accessor =
-          Class.forName(
-              "io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessor$" + fieldSuffix,
-              false,
-              SinkRecord.class.getClassLoader());
-      accessor
-          .getMethod("__set__opentelemetryVirtualField$" + fieldSuffix, Object.class)
-          .invoke(sinkRecord, true);
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Could not mark the record as receive-owned", e);
-    }
-  }
-
   private static SinkRecord sinkRecord(String topic, int partition, long offset) {
     return new SinkRecord(topic, partition, null, null, null, null, offset);
-  }
-
-  private static void receive(
-      Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter,
-      Consumer<String, String> consumer,
-      String topic,
-      int partition,
-      long offset) {
-    ConsumerRecord<String, String> source =
-        new ConsumerRecord<>(topic, partition, offset, "key", "value");
-    ConsumerRecords<String, String> records =
-        new ConsumerRecords<>(
-            singletonMap(new TopicPartition(topic, partition), singletonList(source)));
-    KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
-    Context receiveContext = receiveInstrumenter.start(Context.root(), request);
-    receiveInstrumenter.end(receiveContext, request, null, null);
   }
 
   private static class RetryingSinkTask extends SinkTask {

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMess
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -89,27 +88,6 @@ class KafkaConnectConsumedMessagesTest {
     assertProcessMetrics(testing, INSTRUMENTATION_NAME, "receive-owned-topic", null, "0", 1, null);
     assertConsumedMessagesMetrics(
         testing, receiveInstrumentationName, "receive-owned-topic", null, "0", 1, null);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void partiallyReceiveOwnedBatchCountsOnlyTheUnmarkedRecords() {
-    String receiveInstrumentationName = "test-kafka-connect-receive-partial";
-    Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter =
-        new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), receiveInstrumentationName)
-            .setMessagingReceiveTelemetryEnabled(true)
-            .createConsumerReceiveInstrumenter();
-    Consumer<String, String> consumer = mock(Consumer.class);
-    receive(receiveInstrumenter, consumer, "partial-batch-topic", 0, 20);
-    SinkRecord receiveOwnedTarget = sinkRecord("partial-batch-topic", 0, 20);
-    markReceiveOwned(receiveOwnedTarget);
-    SinkRecord plainRecord = sinkRecord("partial-batch-topic", 0, 21);
-
-    new RetryingSinkTask(0).put(asList(receiveOwnedTarget, plainRecord));
-
-    // only the record that was not already owned by the receive operation is counted here
-    assertProcessMetricsWithConsumedMessages(
-        testing, INSTRUMENTATION_NAME, "partial-batch-topic", null, "0", 1, 1, null);
   }
 
   // Test classes are not rewritten to use the javaagent's field-backed VirtualField, so a

--- a/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaconnect/v2_6/KafkaConnectConsumedMessagesTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.kafkaconnect.v2_6;
+
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertConsumedMessagesMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import java.util.Collection;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Verifies that the Connect process operation counts {@code messaging.client.consumed.messages}
+ * once per delivery attempt, including failed and redelivered attempts, while not double-counting
+ * deliveries that a kafka-clients receive operation already owns.
+ */
+class KafkaConnectConsumedMessagesTest {
+
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.kafka-connect-2.6";
+
+  @RegisterExtension
+  static final AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Test
+  void failedAttemptAndSuccessfulRetryAreBothCounted() {
+    RetryingSinkTask task = new RetryingSinkTask(1);
+    SinkRecord record = sinkRecord("failed-retry-topic", 0, 10);
+
+    assertThatThrownBy(() -> task.put(singletonList(record)))
+        .isInstanceOf(RetriableException.class);
+    task.put(singletonList(record));
+
+    assertProcessMetricsWithConsumedMessages(
+        testing,
+        INSTRUMENTATION_NAME,
+        "failed-retry-topic",
+        null,
+        "0",
+        1,
+        1,
+        RetriableException.class.getName());
+    assertProcessMetricsWithConsumedMessages(
+        testing, INSTRUMENTATION_NAME, "failed-retry-topic", null, "0", 1, 1, null);
+    // both the failed attempt and its retry deliver the record, so both must be counted
+    assertTotalConsumedMessages(testing, INSTRUMENTATION_NAME, 2);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void receiveOwnedRecordIsNotCountedAgainByProcessOperation() {
+    String receiveInstrumentationName = "test-kafka-connect-receive-owned";
+    Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter =
+        new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), receiveInstrumentationName)
+            .setMessagingReceiveTelemetryEnabled(true)
+            .createConsumerReceiveInstrumenter();
+    Consumer<String, String> consumer = mock(Consumer.class);
+    receive(receiveInstrumenter, consumer, "receive-owned-topic", 0, 10);
+    SinkRecord target = sinkRecord("receive-owned-topic", 0, 10);
+    markReceiveOwned(target);
+
+    new RetryingSinkTask(0).put(singletonList(target));
+
+    // the receive operation already reported this delivery, so the process operation records its
+    // own duration but must not add a second consumed-message count
+    assertProcessMetrics(testing, INSTRUMENTATION_NAME, "receive-owned-topic", null, "0", 1, null);
+    assertConsumedMessagesMetrics(
+        testing, receiveInstrumentationName, "receive-owned-topic", null, "0", 1, null);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void partiallyReceiveOwnedBatchCountsOnlyTheUnmarkedRecords() {
+    String receiveInstrumentationName = "test-kafka-connect-receive-partial";
+    Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter =
+        new KafkaInstrumenterFactory(GlobalOpenTelemetry.get(), receiveInstrumentationName)
+            .setMessagingReceiveTelemetryEnabled(true)
+            .createConsumerReceiveInstrumenter();
+    Consumer<String, String> consumer = mock(Consumer.class);
+    receive(receiveInstrumenter, consumer, "partial-batch-topic", 0, 20);
+    SinkRecord receiveOwnedTarget = sinkRecord("partial-batch-topic", 0, 20);
+    markReceiveOwned(receiveOwnedTarget);
+    SinkRecord plainRecord = sinkRecord("partial-batch-topic", 0, 21);
+
+    new RetryingSinkTask(0).put(asList(receiveOwnedTarget, plainRecord));
+
+    // only the record that was not already owned by the receive operation is counted here
+    assertProcessMetricsWithConsumedMessages(
+        testing, INSTRUMENTATION_NAME, "partial-batch-topic", null, "0", 1, 1, null);
+  }
+
+  // Test classes are not rewritten to use the javaagent's field-backed VirtualField, so a
+  // SinkRecord created directly in a test cannot be marked receive-owned through
+  // KafkaConnectTask.copyReceiveOperation the way the real convertAndTransformRecord advice does:
+  // the advice class is injected as an agent helper and reads the ConsumerRecord's context through
+  // a shaded copy of the propagation classes, which a plain test class does not share. Instead,
+  // reach the generated accessor that the agent weaves directly onto SinkRecord for the
+  // VirtualField<SinkRecord, Boolean> declared in KafkaConnectTask, and set it the same way the
+  // real accessor would.
+  private static void markReceiveOwned(SinkRecord sinkRecord) {
+    String fieldSuffix =
+        SinkRecord.class.getName().replace('.', '$')
+            + "$"
+            + Boolean.class.getName().replace('.', '$');
+    try {
+      Class<?> accessor =
+          Class.forName(
+              "io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessor$" + fieldSuffix,
+              false,
+              SinkRecord.class.getClassLoader());
+      accessor
+          .getMethod("__set__opentelemetryVirtualField$" + fieldSuffix, Object.class)
+          .invoke(sinkRecord, true);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Could not mark the record as receive-owned", e);
+    }
+  }
+
+  private static SinkRecord sinkRecord(String topic, int partition, long offset) {
+    return new SinkRecord(topic, partition, null, null, null, null, offset);
+  }
+
+  private static void receive(
+      Instrumenter<KafkaReceiveRequest, Void> receiveInstrumenter,
+      Consumer<String, String> consumer,
+      String topic,
+      int partition,
+      long offset) {
+    ConsumerRecord<String, String> source =
+        new ConsumerRecord<>(topic, partition, offset, "key", "value");
+    ConsumerRecords<String, String> records =
+        new ConsumerRecords<>(
+            singletonMap(new TopicPartition(topic, partition), singletonList(source)));
+    KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
+    Context receiveContext = receiveInstrumenter.start(Context.root(), request);
+    receiveInstrumenter.end(receiveContext, request, null, null);
+  }
+
+  private static class RetryingSinkTask extends SinkTask {
+    private final int failures;
+    private int attempts;
+
+    RetryingSinkTask(int failures) {
+      this.failures = failures;
+    }
+
+    @Override
+    public String version() {
+      return "test";
+    }
+
+    @Override
+    public void start(Map<String, String> properties) {}
+
+    @Override
+    public void put(Collection<SinkRecord> records) {
+      if (attempts++ < failures) {
+        throw new RetriableException("retry");
+      }
+    }
+
+    @Override
+    public void stop() {}
+  }
+}

--- a/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
@@ -57,7 +57,6 @@ tasks {
       filter {
         includeTestsMatching("io.opentelemetry.instrumentation.kafkaconnect.v2_6.MongoKafkaConnectSinkTaskTest.testSingleMessage")
       }
-      include("**/MongoKafkaConnectSinkTaskTest.*")
       jvmArgs("-Dotel.semconv-stability.preview=messaging")
       jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
       systemProperty(

--- a/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/build.gradle.kts
@@ -50,6 +50,23 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testMessagingPreviewReceiveTelemetry =
+    register<Test>("testMessagingPreviewReceiveTelemetry") {
+      testClassesDirs = sourceSets.test.get().output.classesDirs
+      classpath = sourceSets.test.get().runtimeClasspath
+      filter {
+        includeTestsMatching("io.opentelemetry.instrumentation.kafkaconnect.v2_6.MongoKafkaConnectSinkTaskTest.testSingleMessage")
+      }
+      include("**/MongoKafkaConnectSinkTaskTest.*")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+      systemProperty(
+        "metadataConfig",
+        "otel.semconv-stability.preview=messaging," +
+          "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true"
+      )
+    }
+
   val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -58,6 +75,11 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testMessagingPreview, testBothSemconv)
+    dependsOn(
+      testStableSemconv,
+      testMessagingPreview,
+      testMessagingPreviewReceiveTelemetry,
+      testBothSemconv
+    )
   }
 }

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
@@ -483,10 +483,13 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
             .withEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1")
             .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10ms")
-            // the fake backend accumulates metric payloads instead of replacing them, so a longer
-            // interval keeps each test run's assertions looking at a small, predictable number of
-            // exports
-            .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "10000")
+            // The fake backend can clear retained OTLP payloads between tests, but it cannot reset
+            // metric state in the separately running Java agent. Unlike the regular in-process
+            // Java agent test harness, which can and frequently does reset captured telemetry and
+            // metric state, cumulative exports can re-emit measurements from earlier tests. Delta
+            // temporality makes clearing the backend meaningful.
+            .withEnv("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "delta")
+            .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "1000")
             .withEnv(
                 "OTEL_SEMCONV_STABILITY_OPT_IN",
                 emitStableMessagingSemconv()

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
@@ -7,6 +7,9 @@ package io.opentelemetry.instrumentation.kafkaconnect.v2_6;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.groupTraces;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -188,6 +191,10 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
                   trace ->
                       trace.stream()
                           .anyMatch(span -> span.getName().contains("kafka-connect-status")));
+              // Kafka Connect polls its own REST API on a schedule that is not deterministic
+              // relative to the test, so these traces are not relevant to the assertions here.
+              traces.removeIf(
+                  trace -> trace.size() == 1 && trace.get(0).getName().equals("GET /connectors"));
               TracesAssert.assertThat(traces).hasTracesSatisfyingExactly(asList(assertions));
             });
   }
@@ -470,13 +477,16 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
             // Disable test exporter and force OTLP exporter
             .withEnv("OTEL_TESTING_EXPORTER_ENABLED", "false")
             .withEnv("OTEL_TRACES_EXPORTER", "otlp")
-            .withEnv("OTEL_METRICS_EXPORTER", "none")
+            .withEnv("OTEL_METRICS_EXPORTER", "otlp")
             .withEnv("OTEL_LOGS_EXPORTER", "none")
             .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://" + BACKEND_ALIAS + ":" + BACKEND_PORT)
             .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
             .withEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1")
             .withEnv("OTEL_BSP_SCHEDULE_DELAY", "10ms")
-            .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "1000")
+            // the fake backend accumulates metric payloads instead of replacing them, so a longer
+            // interval keeps each test run's assertions looking at a small, predictable number of
+            // exports
+            .withEnv("OTEL_METRIC_EXPORT_INTERVAL", "10000")
             .withEnv(
                 "OTEL_SEMCONV_STABILITY_OPT_IN",
                 emitStableMessagingSemconv()
@@ -516,6 +526,8 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
     StringBuilder options =
         new StringBuilder("-javaagent:/opentelemetry-javaagent.jar -Dotel.javaagent.debug=true");
     appendSystemProperty(options, "otel.semconv-stability.preview");
+    appendSystemProperty(
+        options, "otel.instrumentation.messaging.experimental.receive-telemetry.enabled");
     return options.toString();
   }
 
@@ -523,6 +535,37 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
     String value = System.getProperty(propertyName);
     if (value != null) {
       options.append(" -D").append(propertyName).append('=').append(value);
+    }
+  }
+
+  // whether the kafka-clients receive operation is enabled for the consumer that Kafka Connect
+  // uses internally: when it is, that receive operation owns the consumed-messages count for
+  // each delivery, and the Connect process operation must not count it again.
+  protected static boolean isReceiveTelemetryEnabled() {
+    return Boolean.getBoolean(
+        "otel.instrumentation.messaging.experimental.receive-telemetry.enabled");
+  }
+
+  // asserts the messaging metrics for a single-message delivery through the given destination,
+  // covering both the default configuration, where the Connect process operation is the only
+  // operation that observes the delivery, and the receive-telemetry-enabled configuration, where
+  // the kafka-clients receive operation on the sink connector's own consumer owns the count.
+  protected void assertConnectMessagingMetrics(String destination) {
+    if (isReceiveTelemetryEnabled()) {
+      assertProcessMetrics(
+          testing, "io.opentelemetry.kafka-connect-2.6", destination, null, "0", 1, null);
+      assertReceiveMetrics(
+          testing,
+          "io.opentelemetry.kafka-clients-0.11",
+          destination,
+          "connect-" + getConnectorName(),
+          "0",
+          1,
+          1,
+          null);
+    } else {
+      assertProcessMetricsWithConsumedMessages(
+          testing, "io.opentelemetry.kafka-connect-2.6", destination, null, "0", 1, 1, null);
     }
   }
 

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/MongoKafkaConnectSinkTaskTest.java
@@ -146,13 +146,9 @@ class MongoKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
                                 ? "update " + COLLECTION_NAME
                                 : "update " + DATABASE_NAME + "." + COLLECTION_NAME)
                         .hasKind(SpanKind.CLIENT)
-                        .hasParent(trace.getSpan(0))),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET /connectors").hasKind(SpanKind.SERVER).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET /connectors").hasKind(SpanKind.SERVER).hasNoParent()));
+                        .hasParent(trace.getSpan(0))));
+
+    assertConnectMessagingMetrics(testTopicName);
   }
 
   @Test

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/PostgresKafkaConnectSinkTaskTest.java
@@ -178,13 +178,9 @@ class PostgresKafkaConnectSinkTaskTest extends KafkaConnectSinkTaskBaseTest {
                               : "INSERT " + DATABASE_NAME + "." + DB_TABLE_PERSON)
                       .hasKind(SpanKind.CLIENT)
                       .hasParent(trace.getSpan(0)));
-        },
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET /connectors").hasKind(SpanKind.SERVER).hasNoParent()),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET /connectors").hasKind(SpanKind.SERVER).hasNoParent()));
+        });
+
+    assertConnectMessagingMetrics(testTopicName);
   }
 
   @Test


### PR DESCRIPTION
Kafka Connect sink tasks report `messaging.process.duration` and `messaging.client.consumed.messages` under the stable messaging conventions when `-Dotel.semconv-stability.preview=messaging` is set.

When Kafka client receive telemetry is enabled, the receive operation reports consumed messages and the Connect process operation reports only duration. This prevents double counting.

Retries count as separate delivery attempts. Empty `put()` calls do not emit process telemetry under stable conventions, while legacy behavior remains unchanged.