### PR TITLE
Fix build warning about duplicate kotlin module files

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-shadowing.gradle.kts
@@ -19,6 +19,10 @@ tasks.withType<ShadowJar>().configureEach {
   filesMatching("software/amazon/awssdk/global/handlers/**") {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
+  // avoid warning about duplicate kotlin module files being silently dropped
+  filesMatching("META-INF/*.kotlin_module") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   exclude("**/module-info.class")
 

--- a/examples/distro/buildSrc/src/main/kotlin/otel.instrumentation-conventions.gradle.kts
+++ b/examples/distro/buildSrc/src/main/kotlin/otel.instrumentation-conventions.gradle.kts
@@ -30,6 +30,10 @@ tasks.shadowJar {
   filesMatching("META-INF/services/**") {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
+  // avoid warning about duplicate kotlin module files being silently dropped
+  filesMatching("META-INF/*.kotlin_module") {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
 
   archiveFileName.set("agent-testing.jar")
 

--- a/examples/distro/buildSrc/src/main/kotlin/otel.javaagent-shadow-conventions.gradle.kts
+++ b/examples/distro/buildSrc/src/main/kotlin/otel.javaagent-shadow-conventions.gradle.kts
@@ -55,6 +55,10 @@ tasks {
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     exclude("**/module-info.class")
     relocatePackages(this)
 
@@ -94,6 +98,10 @@ tasks {
     mergeServiceFiles("inst/META-INF/services")
     // mergeServiceFiles requires that duplicate strategy is set to include
     filesMatching("inst/META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("inst/META-INF/*.kotlin_module") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
 

--- a/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
+++ b/gradle-plugins/src/main/kotlin/io.opentelemetry.instrumentation.muzzle-check.gradle.kts
@@ -139,6 +139,10 @@ listOf(shadowModule, shadowMuzzleTooling, shadowMuzzleBootstrap).forEach { task 
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     // Merge any AWS SDK service files that may be present (too bad they didn't just use normal
     // service loader...)
     mergeServiceFiles("software/amazon/awssdk/global/handlers")

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent-kotlin/gradle.properties
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent-kotlin/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false

--- a/instrumentation/spring/spring-data/spring-data-3.0/kotlin-testing/gradle.properties
+++ b/instrumentation/spring/spring-data/spring-data-3.0/kotlin-testing/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false

--- a/smoke-tests/images/fake-backend/build.gradle.kts
+++ b/smoke-tests/images/fake-backend/build.gradle.kts
@@ -59,6 +59,11 @@ tasks {
   }
 
   shadowJar {
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
     manifest {
       attributes("Main-Class" to "io.opentelemetry.smoketest.fakebackend.FakeBackendMain")
     }

--- a/testing/dependencies-shaded-for-testing/build.gradle.kts
+++ b/testing/dependencies-shaded-for-testing/build.gradle.kts
@@ -74,6 +74,10 @@ tasks {
     filesMatching("META-INF/services/**") {
       duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
+    // avoid warning about duplicate kotlin module files being silently dropped
+    filesMatching("META-INF/*.kotlin_module") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
     // exclude caffeine shaded in armeria
     if (otelProps.denyUnsafe) {
       exclude("com/linecorp/armeria/internal/shaded/caffeine/**")


### PR DESCRIPTION
> 'META-INF/kotlin-stdlib-jdk7.kotlin_module' is matched by com.github.jengelman.gradle.plugins.shadow.transformers.KotlinModuleMetadataTransformer_Decorated but its DuplicatesStrategy is EXCLUDE — duplicates may be silently dropped before the transformer processes them.
Set it to INCLUDE or WARN to ensure all duplicates are processed by the transformer.
See https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy for more details.


