### PR TITLE
Increase gradle daemon heap in build job from 3g to 4g

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Increase gradle daemon heap size
         run: |
-          sed -i "s/org.gradle.jvmargs=/org.gradle.jvmargs=-Xmx3g /" gradle.properties
+          sed -i "s/org.gradle.jvmargs=/org.gradle.jvmargs=-Xmx4g /" gradle.properties
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0


### PR DESCRIPTION
The `common / build` job has been running out of memory and taking 2–3 hours before failing, e.g. [run 31523163208](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/31523163208/job/93942063529?pr=19496) and [run 31549987874](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/31549987874/job/93970634725?pr=19519). The OOM is in the Gradle daemon JVM (not test workers — tests are skipped via `-PskipTests=true`), and it always surfaces inside a `compile*Java` task:

```
Execution failed for task ':instrumentation:hibernate:hibernate-4.0:javaagent:compileVersion5TestJava'
> Java heap space
BUILD FAILED in 2h 56m 22s
3946 actionable tasks: 3881 executed, 65 from cache
```

This bumps the daemon heap for that job from `-Xmx3g` to `-Xmx4g`.

## This is not a Gradle 9.7.0 regression

I ran a controlled A/B — identical full builds, `-Xmx3g`, `-XX:+HeapDumpOnOutOfMemoryError`, cold cache, one on 9.7.0 and one on 9.6.0. **Both OOM'd**, and 9.6.0 died *faster*:

| | 9.7.0 | 9.6.0 |
| --- | --- | --- |
| Heap saturated at | t+18 min | **t+13 min** |
| Full GCs | 4,279 | 2,619 |
| Wall clock in GC | **83%** | 78% |
| Live set after 1st Full GC | 2,617 MB | 2,247 MB |
| Live set at death | 3,068 MB | 3,068 MB |

CI history agrees: identical OOMs occurred on 9.6.1 on Aug 2 (run `30762462028`) and Aug 3 (run `30776396457`), before the Aug 7 upgrade to 9.7.0. The `>100 min` build rate was 3.7% on 9.6.1 (Aug 1–7) vs 2.9% on 9.7.0 (Aug 8–12) — statistically indistinguishable.

The 3 GB ceiling was already marginal; the build simply outgrew it. Note the daemon spent 83% of wall clock in GC, which is why these builds stretch to ~3 hours instead of failing fast.

## No single leak explains it — the whole build model is retained

Full breakdown of the 3,016 MB live set (Eclipse MAT, dominator tree over the 9.7.0 heap dump):

| Subsystem | Retained | % |
| --- | --- | --- |
| Dependency/module metadata (`InMemoryModuleMetadataCache` 154 MB; 863,056 `MavenDependencyDescriptor` = 224 MB) | 761 MB | 25% |
| Guava caches (javaCompile analysis) | 660 MB | 22% |
| Project/task/configuration model (2,061 `DefaultProject_Decorated`, 11,472 `LocalTaskNode`, 15,368 `Configuration`) | 651 MB | 22% |
| VFS / snapshots / `CachingPatternSpecFactory` (124 MB) | 251 MB | 8% |
| Strings + `StringInterner` (40 MB) | 193 MB | 6% |
| Develocity plugin | 110 MB | 4% |
| 1,081 open `ZipFile$Source` | 82 MB | 3% |

Two things worth flagging to Gradle: **2,061 `DefaultProject_Decorated` for 1,028 declared project paths** (~2× the model retained), and **618 `PoolingHttpClientConnectionManager` instances holding 72 MB**.

The largest single suspect is the incremental-compile analysis cache — MAT on the 9.6.0 dump names it directly:

> Thread `Cache worker for Java compile cache (/home/runner/.gradle/caches/9.6.0/javaCompile)` has a reference to `DefaultCacheCoordinator` … on the shortest path to `LocalCache$Segment[4]`, which occupies 337,487,000 (10.67%) bytes.

Inside those Guava caches: **1,039,253 `DependentsSet$DefaultDependentsSet`** (≥149 MB), 2,334,214 `ImmutableMapEntry` (≥177 MB), 633,245 `RegularImmutableSet` (≥117 MB). This is the same family as gradle/gradle#37753, but `ClassSetAnalysisData` itself is now only 8.8 MB / 70 objects, so gradle/gradle#37845 did hold — what remains is the in-memory layer over `caches/<ver>/javaCompile` accumulating one analysis per distinct classpath entry across 2,704 `JavaCompile` tasks.

## Trigger and amplifier

The OOM only fires on a **cold Gradle User Home**. Warm builds finish in 13–14 min with ~1,900–3,340 tasks from cache; cold builds execute ~3,900 and die. The failing job logged `Gradle User Home cache not found. Will initialize empty.` and `3946 actionable tasks: 3881 executed, 65 from cache`.

Why cold builds got common around Aug 1: **the repo's Actions cache is at 8.1 GB of the 10 GB limit across 34 entries**, with single `gradle-dependencies-v2` entries at 2.88 GB and 2.45 GB. There is **no `gradle-home-v2|Linux-X64|build[…]` entry at all** — it's evicted by LRU as fast as it's written. PR volume roughly doubled in August, accelerating eviction.

So this bump treats the symptom. The durable fixes are reducing cache pressure so `build` gets warm caches again, and the `javaCompile` cache growth on the Gradle side.

## Why 4g and not more

`ubuntu-latest` on a public repo is [4 CPU / 16 GB RAM](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories), confirmed by the runner itself (`[gc,init] CPUs: 4 total, 4 available` / `Memory: 15989M`). At OOM the daemon's RSS was ~4–4.5 GB (3,072 MB committed heap + 397 MB committed metaspace + 309 threads + code cache + G1 structures), and no worker daemons were forked — `JavaCompile` ran in-process, so the daemon is the only large JVM. 4g leaves comfortable room for the OS and page cache on a build that opens 1,081 zip files.