### PR TITLE
Fix metadata validation job writing to the GitHub Actions cache from PRs

### DIFF
--- a/.github/workflows/metadata-validation.yml
+++ b/.github/workflows/metadata-validation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Run documentation analyzer
         run: ./gradlew :instrumentation-docs:runAnalysis


### PR DESCRIPTION
`metadata-validation.yml` is triggered by `pull_request`, but its `validate` job configures `setup-gradle` with `cache-read-only: ${{ inputs.cache-read-only }}`. The `inputs` context only exists for `workflow_call` and `workflow_dispatch`, so on a `pull_request` event it evaluates to an empty string, which is falsy — meaning the job **writes** to the GitHub Actions cache. Every other `pull_request`-triggered workflow here hardcodes `true`, and `codeql.yml` uses `${{ github.event_name == 'pull_request' }}`.

The `validate` job on #19277 saved 3.28 GB of the repository's 8.76 GB of cache, all on `refs/pull/*`, including a 2.7 GB `gradle-dependencies-v2` entry ([job log](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/31599371406/job/94122643172)).

A `refs/pull/*` entry is readable only from that same PR, so it can never produce a hit anywhere else — but it still counts against the repo-wide 10 GB limit and evicts `refs/heads/main` entries by LRU. The casualty is `gradle-home-v2|Linux-X64|build[…]`, which every PR's `common / build` job restores. Without it, the job logs `Gradle User Home cache not found. Will initialize empty.` and executes roughly twice the tasks:

| Gradle User Home | actionable tasks | from cache |
| --- | --- | --- |
| restored | 5,110 | 3,350 (66%) |
| not found | 3,946 | 65 (1.6%) |

Those cold builds are what has been running the Gradle daemon out of memory. #19529 raised the heap so they survive; this addresses the trigger so they become rare.