### PR TITLE
Only write the GitHub Actions cache from the common build job

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -510,7 +510,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Build
         run: ./gradlew build ${{ inputs.no-build-cache && '--no-build-cache' || '' }}

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build and publish artifact snapshots
         env:

--- a/.github/workflows/reusable-muzzle.yml
+++ b/.github/workflows/reusable-muzzle.yml
@@ -6,6 +6,7 @@ on:
       cache-read-only:
         type: boolean
         required: false
+        default: true
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-test-latest-deps.yml
+++ b/.github/workflows/reusable-test-latest-deps.yml
@@ -6,6 +6,7 @@ on:
       cache-read-only:
         type: boolean
         required: false
+        default: true
       no-build-cache:
         type: boolean
         required: false


### PR DESCRIPTION
Every push to `main` writes ten separate multi-GB dependency cache entries, each its own copy of `~/.gradle/caches/modules-2/files-2.1/` under a distinct content hash, so they never dedupe. From run [31600792706](https://github.com/open-telemetry/opentelemetry-java-instrumentation/actions/runs/31600792706):

| job | entries saved |
| --- | --- |
| `test-latest-deps / testLatestDeps0-3` | 4 |
| `muzzle / muzzle1-4` | 4 |
| `common / build` | 1 |
| `common / gradle-plugins` | 1 |

That left 19.2 GB in five surviving `gradle-dependencies-v2` entries, all written within 11 minutes. The repo cache limit is 10 GB and can't be raised, so one main push overruns the budget and LRU evicts `gradle-home-v2|Linux-X64|build[…]`, which every PR's `common / build` restores:

| Gradle User Home | actionable tasks | from cache |
| --- | --- | --- |
| restored | 5,110 | 3,350 (66%) |
| not found | 3,946 | 65 (1.6%) |

Those cold builds are what has been running the Gradle daemon out of memory.

The fix is what the action's [docs](https://github.com/gradle/actions/blob/v6.3.0/docs/setup-gradle.md#select-which-jobs-should-write-to-the-cache) recommend here: make `common / build` the only writer. It's unchanged — it still follows `inputs.cache-read-only`, unset on `main` (writes) and `true` from `reusable-pr-build.yml` (reads). The two reusable workflows get `default: true` on their existing input, so no call site changes and no caller anywhere passes `false`. `build-daily.yml`'s `publish-snapshots` step had no setting at all, so it was writing too.

Tradeoff: muzzle and `test-latest-deps` need dependencies beyond `common / build`'s entry and will re-download them. But they're already paying the save cost for nothing, since their entries are evicted within minutes.

Expected steady state is ~4.4 GB, and `gradle-home-v2|Linux-X64|build[…]` should stop disappearing between runs.