### PR TITLE
Disable the local build cache on the build that writes the remote build cache

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -230,6 +230,8 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: ${{ inputs.cache-read-only }}
+          gradle-home-cache-excludes: >-
+            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && 'caches/build-cache-1' || '' }}
 
       - name: Build
         env:

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -231,7 +231,7 @@ jobs:
         with:
           cache-read-only: ${{ inputs.cache-read-only }}
           gradle-home-cache-excludes: >-
-            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && 'caches/build-cache-1' || '' }}
+            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && 'caches/build-cache-1' || '' }}
 
       - name: Build
         env:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -71,6 +71,7 @@ dependencyResolutionManagement {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
+val isRemoteBuildCacheWriter = isCI && develocityAccessKey.isNotEmpty()
 
 develocity {
   if (develocityAccessKey.isNotEmpty()) {
@@ -106,9 +107,16 @@ develocity {
 }
 
 buildCache {
+  // a task loaded from the local build cache is never pushed to the remote build cache, so on the
+  // build that writes the remote cache the local cache is disabled, otherwise everything that
+  // doesn't change is served locally, never re-executed, and so never reaches the remote cache
+  local {
+    isEnabled = !isRemoteBuildCacheWriter
+  }
+
   remote(develocity.buildCache) {
     server = develocityServer
-    isPush = isCI && develocityAccessKey.isNotEmpty()
+    isPush = isRemoteBuildCacheWriter
   }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -71,7 +71,9 @@ dependencyResolutionManagement {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
-val isRemoteBuildCacheWriter = isCI && develocityAccessKey.isNotEmpty()
+val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
+val shouldDisableLocalBuildCache =
+  isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 develocity {
   if (develocityAccessKey.isNotEmpty()) {
@@ -107,16 +109,16 @@ develocity {
 }
 
 buildCache {
-  // a task loaded from the local build cache is never pushed to the remote build cache, so on the
-  // build that writes the remote cache the local cache is disabled, otherwise everything that
-  // doesn't change is served locally, never re-executed, and so never reaches the remote cache
+  // a task loaded from the local build cache is never pushed to the remote build cache, so on main
+  // builds that write the remote cache the local cache is disabled, otherwise everything that
+  // doesn't change is served locally, never re-executed, and never reaches the remote cache
   local {
-    isEnabled = !isRemoteBuildCacheWriter
+    isEnabled = !shouldDisableLocalBuildCache
   }
 
   remote(develocity.buildCache) {
     server = develocityServer
-    isPush = isRemoteBuildCacheWriter
+    isPush = isRemoteBuildCachePushEnabled
   }
 }
 


### PR DESCRIPTION
Disables the local build cache on `main` builds that write the Develocity remote build cache, so those builds push every task they execute and the remote cache converges on complete.

Today a `common / build` job that misses the GitHub Actions cache gets almost nothing from the build cache:

| build | where hits come from | from cache |
| --- | --- | --- |
| Actions cache restored | local `build-cache-1` | 3,350 of 5,110 |
| Actions cache evicted | Develocity remote | 65 of 3,946 |

Those cold builds are what has been running the Gradle daemon out of memory.

The remote cache itself is fine. I verified anonymous read with a probe job that disabled the Actions cache entirely, so `build-cache-1` did not exist and every hit had to come from Develocity — all 27 cacheable tasks came back `FROM-CACHE`. The remote is just missing almost everything.

That's because **a task loaded from the local build cache is never pushed to the remote** — Gradle only stores results it actually executed. `main` restores its own warm `build-cache-1` from the Actions cache, so it only pushes the churn from that commit. Everything stable was stored locally once and has never been re-executed on `main` since, so it has never reached Develocity.

The cache-writing job also excludes `caches/build-cache-1` from its Gradle User Home snapshot, which helps the 10 GB Actions cache limit.

The local-cache disablement is scoped to `GITHUB_REF_NAME=main`, covering `main` pushes and daily builds. Release branches continue to push to the remote cache but retain their local cache. PRs and local developer builds are unchanged.

## What to check after this is merged

CI on this PR only proves it still compiles — PRs have no access key, so the new branch is never taken here.

- **The Develocity cache node's size and retention.** If the node is small, pushing everything could just move the thrashing there. This is the one thing I couldn't check from outside.
- **The first few `main` builds will be slower** and network-bound, since they push everything they execute instead of reading locally. This should settle.
- **Then confirm the remote is actually filling up:** re-run the probe (a job with `cache-disabled: true` on a branch, so hits can only be remote) and check that it covers far more than the 27 tasks it hit before.
- **The real test** is a PR whose `common / build` misses the Actions cache. `from cache` should now be in the thousands rather than 65, and the daemon should stay well under its heap limit.