### PR TITLE
Mark alpha messaging deprecations as removable in the next minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,18 @@
   The Java agent continues to support the system property through its declarative config bridge.
   ([#19180](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19180))
 - Deprecate the `opentelemetry-zipkin-spring-boot-starter` artifact. Use
-  `opentelemetry-spring-boot-starter` with the OTLP exporter instead. It will be removed in 3.0.
+  `opentelemetry-spring-boot-starter` with the OTLP exporter instead.
 - Deprecate `OpenTelemetryMeterRegistryBuilder#setMicrometerHistogramGaugesEnabled(boolean)` in the
   Micrometer 1.5 library in favor of
   `io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled(OpenTelemetryMeterRegistryBuilder, boolean)`.
   Histogram/percentile gauges are experimental compatibility behavior, and this moves the API to the
   standard experimental surface ahead of stabilization. Behavior and the
-  `otel.instrumentation.micrometer.histogram-gauges.enabled` config property are unchanged. The
-  deprecated builder method will be removed in the next release.
+  `otel.instrumentation.micrometer.histogram-gauges.enabled` config property are unchanged.
   ([#19404](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19404))
 - The decaying `<name>.max` gauge that the Micrometer bridge emits alongside the histogram for
-  `Timer` and `DistributionSummary` is deprecated and will be removed in 3.0. The `<name>` /
-  `<name>.max` pair violates the OpenTelemetry metric naming rules, and OpenTelemetry histograms
-  already expose a max. It is no longer emitted when `otel.instrumentation.common.v3-preview` is
-  enabled.
+  `Timer` and `DistributionSummary` is deprecated. The `<name>` / `<name>.max` pair violates the
+  OpenTelemetry metric naming rules, and OpenTelemetry histograms already expose a max. It is no
+  longer emitted when `otel.instrumentation.common.v3-preview` is enabled.
   ([#19397](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19397))
 - Deprecate `MessageOperation` in favor of `MessagingOperationType`.
   ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@
   `otel.instrumentation.micrometer.histogram-gauges.enabled` config property are unchanged.
   ([#19404](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19404))
 - The decaying `<name>.max` gauge that the Micrometer bridge emits alongside the histogram for
-  `Timer` and `DistributionSummary` is deprecated. The `<name>` / `<name>.max` pair violates the
-  OpenTelemetry metric naming rules, and OpenTelemetry histograms already expose a max. It is no
-  longer emitted when `otel.instrumentation.common.v3-preview` is enabled.
+  `Timer` and `DistributionSummary` is deprecated and will be removed in 3.0. The `<name>` /
+  `<name>.max` pair violates the OpenTelemetry metric naming rules, and OpenTelemetry histograms
+  already expose a max. It is no longer emitted when `otel.instrumentation.common.v3-preview` is
+  enabled.
   ([#19397](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19397))
 - Deprecate `MessageOperation` in favor of `MessagingOperationType`.
   ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessageOperation.java
@@ -8,9 +8,9 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 /**
  * Represents an operation that may be used in a messaging system.
  *
- * @deprecated Use {@link MessagingOperationType}. Will be removed in 3.0.
+ * @deprecated Use {@link MessagingOperationType}. May be removed in the next minor release.
  */
-@Deprecated // to be removed in 3.0
+@Deprecated // may be removed in the next minor release
 public enum MessageOperation {
   PUBLISH(MessagingOperationType.SEND),
   RECEIVE(MessagingOperationType.RECEIVE),

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -83,10 +83,10 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   /**
-   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}.
-   *     Will be removed in 3.0.
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}. May
+   *     be removed in the next minor release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return builder(getter, operation).build();
@@ -109,9 +109,9 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
 
   /**
    * @deprecated Use {@link #builder(MessagingAttributesGetter, MessagingOperationType, String)}.
-   *     Will be removed in 3.0.
+   *     May be removed in the next minor release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static <REQUEST, RESPONSE> MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> builder(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter, @Nullable MessageOperation operation) {
     return new MessagingAttributesExtractorBuilder<>(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingConsumerMetrics.java
@@ -81,9 +81,13 @@ public final class MessagingConsumerMetrics implements OperationListener {
   /**
    * Returns metrics for extractors configured with {@link MessageOperation}.
    *
-   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   * <p>In 3.0 this method name will be reused for {@link #getForOperationType()}, which emits
+   * different instruments, so callers must migrate rather than rely on this name continuing to
+   * behave the same way.
+   *
+   * @deprecated Use {@link #getForOperationType()}. May be removed in the next minor release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging consumer", meter -> new MessagingConsumerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingProducerMetrics.java
@@ -71,9 +71,13 @@ public final class MessagingProducerMetrics implements OperationListener {
   /**
    * Returns metrics for extractors configured with {@link MessageOperation}.
    *
-   * @deprecated Use {@link #getForOperationType()}. Will be removed in 3.0.
+   * <p>In 3.0 this method name will be reused for {@link #getForOperationType()}, which emits
+   * different instruments, so callers must migrate rather than rely on this name continuing to
+   * behave the same way.
+   *
+   * @deprecated Use {@link #getForOperationType()}. May be removed in the next minor release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static OperationMetrics get() {
     return OperationMetricsUtil.create(
         "messaging producer", meter -> new MessagingProducerMetrics(meter, Variant.LEGACY));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractor.java
@@ -66,9 +66,10 @@ public final class MessagingSpanKindExtractor {
   }
 
   /**
-   * @deprecated Use {@link #create(MessagingOperationType)}. Will be removed in 3.0.
+   * @deprecated Use {@link #create(MessagingOperationType)}. May be removed in the next minor
+   *     release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static <REQUEST> SpanKindExtractor<REQUEST> create(MessageOperation operation) {
     SpanKind spanKind;
     switch (operation) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractor.java
@@ -34,10 +34,10 @@ public final class MessagingSpanNameExtractor<REQUEST> implements SpanNameExtrac
   }
 
   /**
-   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}.
-   *     Will be removed in 3.0.
+   * @deprecated Use {@link #create(MessagingAttributesGetter, MessagingOperationType, String)}. May
+   *     be removed in the next minor release.
    */
-  @Deprecated // to be removed in 3.0
+  @Deprecated // may be removed in the next minor release
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       MessagingAttributesGetter<REQUEST, ?> getter, MessageOperation operation) {
     MessagingOperationType operationType = operation.type();

--- a/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
+++ b/instrumentation/micrometer/micrometer-1.5/library/src/main/java/io/opentelemetry/instrumentation/micrometer/v1_5/OpenTelemetryMeterRegistryBuilder.java
@@ -85,9 +85,9 @@ public final class OpenTelemetryMeterRegistryBuilder {
    *
    * @deprecated Use {@link
    *     io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental#setMicrometerHistogramGaugesEnabled(OpenTelemetryMeterRegistryBuilder,
-   *     boolean)} instead. This method will be removed in the next release.
+   *     boolean)} instead. This method may be removed in the next minor release.
    */
-  @Deprecated // will be removed in the next release
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public OpenTelemetryMeterRegistryBuilder setMicrometerHistogramGaugesEnabled(
       boolean histogramGaugesEnabled) {


### PR DESCRIPTION
`MessageOperation` and the `MessageOperation`-based factory methods deprecated in #19357 are published only from `-alpha` artifacts, so their removal does not have to wait for a major version. This replaces their 3.0 removal markers with the alpha phrasing:

```java
/**
 * @deprecated Use {@link MessagingOperationType}. May be removed in the next minor release.
 */
@Deprecated // may be removed in the next minor release
```

That covers `MessageOperation` itself plus the `MessageOperation` overloads of `MessagingAttributesExtractor#create` / `#builder`, `MessagingSpanNameExtractor#create`, `MessagingSpanKindExtractor#create`, and `MessagingProducerMetrics#get` / `MessagingConsumerMetrics#get`. `OpenTelemetryMeterRegistryBuilder#setMicrometerHistogramGaugesEnabled` moves to the same wording from "will be removed in the next release".

`MessagingProducerMetrics#get()` and `MessagingConsumerMetrics#get()` also gain a javadoc note that the `get()` name will be reused in 3.0 for `getForOperationType()`, which emits different instruments. Callers need to migrate rather than assume the name keeps behaving the same way.

`getForOperationTypeWithOldMetrics()` in both metrics classes keeps its 3.0 marker. It exists to keep emitting pre-1.43 metric names until 3.0, which is a semconv milestone rather than an alpha API deprecation.

The unreleased CHANGELOG entries for these deprecated Java APIs no longer state removal timing, leaving the javadoc as the single place that says when a deprecated API may go away. The entry for the decaying `<name>.max` gauge keeps its 3.0 removal timing, because emitted telemetry has no javadoc to carry it.
