### PR TITLE
Model Pulsar destination name without the partition suffix

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/build.gradle.kts
@@ -4,4 +4,18 @@ plugins {
 
 dependencies {
   testImplementation(project(":instrumentation:pulsar:pulsar-2.8:javaagent"))
+  testImplementation(project(":instrumentation-api"))
+  testImplementation("org.apache.pulsar:pulsar-client:2.8.0")
+}
+
+tasks {
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testMessagingPreview)
+  }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
@@ -59,6 +59,26 @@ class PulsarRequestDestinationTest {
   }
 
   @Test
+  void keepsTopicNameThatOnlyContainsThePartitionSuffix() {
+    // pulsar 2.8 reads the partition index from the last '-' rather than from the last partition
+    // suffix, so it reports this non-partitioned topic as partition 7; the destination name must
+    // not be rewritten based on that
+    String topic = TOPIC + "-partition-key-7";
+    PulsarRequest request = request(message(topic));
+
+    assertThat(request.getDestination()).isEqualTo(topic);
+  }
+
+  @Test
+  void keepsTopicNameWhosePartitionSuffixIsNotTheIndex() {
+    // pulsar 2.9+ rejects a zero padded partition suffix, pulsar 2.8 reads it as partition 1
+    String topic = TOPIC + "-partition-01";
+    PulsarRequest request = request(message(topic));
+
+    assertThat(request.getDestination()).isEqualTo(topic);
+  }
+
+  @Test
   void separatesPartitionFromBatchDestinationName() {
     String partitionTopic = TOPIC + "-partition-0";
     PulsarBatchRequest request = batchRequest(message(partitionTopic), message(partitionTopic));
@@ -74,6 +94,15 @@ class PulsarRequestDestinationTest {
         batchRequest(message(TOPIC + "-partition-0"), message(TOPIC + "-partition-1"));
 
     assertThat(request.getDestination()).isEqualTo(TOPIC);
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  @Test
+  void keepsBatchTopicNameThatIsNotFullyQualifiedWhenBatchSpansMultiplePartitions() {
+    PulsarBatchRequest request =
+        batchRequest(message("test-partition-0"), message("test-partition-1"));
+
+    assertThat(request.getDestination()).isEqualTo("test");
     assertThat(request.getDestinationPartitionId()).isNull();
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
@@ -42,6 +42,23 @@ class PulsarRequestDestinationTest {
   }
 
   @Test
+  void keepsTopicNameThatIsNotFullyQualified() {
+    PulsarRequest request = request(message("test"));
+
+    assertThat(request.getDestination()).isEqualTo("test");
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  @Test
+  void keepsTopicNameThatIsNotFullyQualifiedWhenSeparatingPartition() {
+    PulsarRequest request = request(message("test-partition-1"));
+
+    assertThat(request.getDestination())
+        .isEqualTo(emitStableMessagingSemconv() ? "test" : "test-partition-1");
+    assertThat(request.getDestinationPartitionId()).isEqualTo("1");
+  }
+
+  @Test
   void separatesPartitionFromBatchDestinationName() {
     String partitionTopic = TOPIC + "-partition-0";
     PulsarBatchRequest request = batchRequest(message(partitionTopic), message(partitionTopic));

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
@@ -67,6 +67,7 @@ class PulsarRequestDestinationTest {
     PulsarRequest request = request(message(topic));
 
     assertThat(request.getDestination()).isEqualTo(topic);
+    assertThat(request.getDestinationPartitionId()).isNull();
   }
 
   @Test
@@ -76,6 +77,17 @@ class PulsarRequestDestinationTest {
     PulsarRequest request = request(message(topic));
 
     assertThat(request.getDestination()).isEqualTo(topic);
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  @Test
+  void keepsTopicNameWithoutPartitionSuffix() {
+    // pulsar 2.8 reads the partition index from the last '-' even without a partition suffix
+    String topic = TOPIC + "-1";
+    PulsarRequest request = request(message(topic));
+
+    assertThat(request.getDestination()).isEqualTo(topic);
+    assertThat(request.getDestinationPartitionId()).isNull();
   }
 
   @Test

--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Messages;
+import org.junit.jupiter.api.Test;
+
+class PulsarRequestDestinationTest {
+
+  private static final String TOPIC = "persistent://public/default/test";
+
+  @Test
+  void keepsNonPartitionedTopicName() {
+    PulsarRequest request = request(message(TOPIC));
+
+    assertThat(request.getDestination()).isEqualTo(TOPIC);
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  @Test
+  void separatesPartitionFromDestinationName() {
+    String partitionTopic = TOPIC + "-partition-1";
+    PulsarRequest request = request(message(partitionTopic));
+
+    // the stable semantic conventions record the partition in messaging.destination.partition.id,
+    // which is only unique within the destination name, so the destination name must not embed it
+    assertThat(request.getDestination())
+        .isEqualTo(emitStableMessagingSemconv() ? TOPIC : partitionTopic);
+    assertThat(request.getDestinationPartitionId()).isEqualTo("1");
+  }
+
+  @Test
+  void separatesPartitionFromBatchDestinationName() {
+    String partitionTopic = TOPIC + "-partition-0";
+    PulsarBatchRequest request = batchRequest(message(partitionTopic), message(partitionTopic));
+
+    assertThat(request.getDestination())
+        .isEqualTo(emitStableMessagingSemconv() ? TOPIC : partitionTopic);
+    assertThat(request.getDestinationPartitionId()).isEqualTo("0");
+  }
+
+  @Test
+  void hasNoPartitionWhenBatchSpansMultiplePartitions() {
+    PulsarBatchRequest request =
+        batchRequest(message(TOPIC + "-partition-0"), message(TOPIC + "-partition-1"));
+
+    assertThat(request.getDestination()).isEqualTo(TOPIC);
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  private static Message<?> message(String topic) {
+    Message<?> message = mock(Message.class);
+    when(message.getTopicName()).thenReturn(topic);
+    return message;
+  }
+
+  private static PulsarRequest request(Message<?> message) {
+    return PulsarRequest.create(message, null, "subscription");
+  }
+
+  private static PulsarBatchRequest batchRequest(Message<?>... messages) {
+    List<Message<?>> messageList = asList(messages);
+    @SuppressWarnings("unchecked")
+    Messages<Object> batch = mock(Messages.class);
+    when(batch.iterator()).thenAnswer(invocation -> messageList.iterator());
+    @SuppressWarnings("unchecked")
+    Consumer<Object> consumer = mock(Consumer.class);
+    when(consumer.getSubscription()).thenReturn("subscription");
+    return PulsarBatchRequest.create(batch, null, consumer);
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
@@ -44,18 +44,8 @@ public class BasePulsarRequest {
    * does not have one.
    */
   static String stripPartitionSuffix(String topicName) {
-    int partitionIndex = TopicName.getPartitionIndex(topicName);
-    if (partitionIndex == -1) {
-      return topicName;
-    }
-    int suffixIndex = topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
-    // pulsar 2.8 reads the partition index from the last '-' instead of from the last
-    // "-partition-", so it reports e.g. "my-topic-partition-key-1" as partition 1, and it accepts a
-    // zero padded suffix that pulsar 2.9+ rejects; only strip a suffix that is exactly the
-    // partition index, otherwise the topic name would lose more than the partition
-    if (!topicName
-        .substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length())
-        .equals(String.valueOf(partitionIndex))) {
+    int suffixIndex = partitionSuffixIndex(topicName);
+    if (suffixIndex == -1) {
       return topicName;
     }
     // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is
@@ -66,8 +56,29 @@ public class BasePulsarRequest {
   /** Returns the value to use for {@code messaging.destination.partition.id}. */
   @Nullable
   static String destinationPartitionId(String topicName) {
+    int suffixIndex = partitionSuffixIndex(topicName);
+    return suffixIndex == -1
+        ? null
+        : topicName.substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length());
+  }
+
+  private static int partitionSuffixIndex(String topicName) {
     int partitionIndex = TopicName.getPartitionIndex(topicName);
-    return partitionIndex == -1 ? null : String.valueOf(partitionIndex);
+    if (partitionIndex == -1) {
+      return -1;
+    }
+    int suffixIndex = topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    // pulsar 2.8 reads the partition index from the last '-' instead of from the last
+    // "-partition-", so it reports e.g. "my-topic-partition-key-1" as partition 1, and it accepts a
+    // zero padded suffix that pulsar 2.9+ rejects; only recognize a suffix that is exactly the
+    // partition index
+    if (suffixIndex == -1
+        || !topicName
+            .substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length())
+            .equals(String.valueOf(partitionIndex))) {
+      return -1;
+    }
+    return suffixIndex;
   }
 
   public String getDestination() {

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
@@ -33,12 +33,34 @@ public class BasePulsarRequest {
    * embed the {@code -partition-N} suffix.
    */
   static String destination(String topicName) {
-    if (!emitStableMessagingSemconv() || TopicName.getPartitionIndex(topicName) == -1) {
+    if (!emitStableMessagingSemconv()) {
+      return topicName;
+    }
+    return stripPartitionSuffix(topicName);
+  }
+
+  /**
+   * Returns {@code topicName} without its {@code -partition-N} suffix, or {@code topicName} when it
+   * does not have one.
+   */
+  static String stripPartitionSuffix(String topicName) {
+    int partitionIndex = TopicName.getPartitionIndex(topicName);
+    if (partitionIndex == -1) {
+      return topicName;
+    }
+    int suffixIndex = topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    // pulsar 2.8 reads the partition index from the last '-' instead of from the last
+    // "-partition-", so it reports e.g. "my-topic-partition-key-1" as partition 1, and it accepts a
+    // zero padded suffix that pulsar 2.9+ rejects; only strip a suffix that is exactly the
+    // partition index, otherwise the topic name would lose more than the partition
+    if (!topicName
+        .substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length())
+        .equals(String.valueOf(partitionIndex))) {
       return topicName;
     }
     // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is
     // not fully qualified, e.g. "my-topic" to "persistent://public/default/my-topic"
-    return topicName.substring(0, topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX));
+    return topicName.substring(0, suffixIndex);
   }
 
   /** Returns the value to use for {@code messaging.destination.partition.id}. */

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
@@ -5,24 +5,53 @@
 
 package io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.telemetry;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+
 import io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.UrlParser.UrlData;
 import javax.annotation.Nullable;
+import org.apache.pulsar.common.naming.TopicName;
 
 public class BasePulsarRequest {
 
   private final String destination;
+  @Nullable private final String destinationPartitionId;
   @Nullable private final UrlData urlData;
   @Nullable private final String subscription;
 
   protected BasePulsarRequest(
-      String destination, @Nullable UrlData urlData, @Nullable String subscription) {
-    this.destination = destination;
+      String topicName, @Nullable UrlData urlData, @Nullable String subscription) {
+    this.destination = destination(topicName);
+    this.destinationPartitionId = destinationPartitionId(topicName);
     this.urlData = urlData;
     this.subscription = subscription;
   }
 
+  /**
+   * Returns the value to use for {@code messaging.destination.name}. The stable messaging semantic
+   * conventions model the partition separately, in {@code messaging.destination.partition.id},
+   * which is defined as being unique within the destination name, so the destination name must not
+   * embed the {@code -partition-N} suffix.
+   */
+  static String destination(String topicName) {
+    return emitStableMessagingSemconv()
+        ? TopicName.get(topicName).getPartitionedTopicName()
+        : topicName;
+  }
+
+  /** Returns the value to use for {@code messaging.destination.partition.id}. */
+  @Nullable
+  static String destinationPartitionId(String topicName) {
+    int partitionIndex = TopicName.getPartitionIndex(topicName);
+    return partitionIndex == -1 ? null : String.valueOf(partitionIndex);
+  }
+
   public String getDestination() {
     return destination;
+  }
+
+  @Nullable
+  public String getDestinationPartitionId() {
+    return destinationPartitionId;
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
@@ -33,9 +33,12 @@ public class BasePulsarRequest {
    * embed the {@code -partition-N} suffix.
    */
   static String destination(String topicName) {
-    return emitStableMessagingSemconv()
-        ? TopicName.get(topicName).getPartitionedTopicName()
-        : topicName;
+    if (!emitStableMessagingSemconv() || TopicName.getPartitionIndex(topicName) == -1) {
+      return topicName;
+    }
+    // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is
+    // not fully qualified, e.g. "my-topic" to "persistent://public/default/my-topic"
+    return topicName.substring(0, topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX));
   }
 
   /** Returns the value to use for {@code messaging.destination.partition.id}. */

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchMessagingAttributesGetter.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.common.naming.TopicName;
 
 final class PulsarBatchMessagingAttributesGetter
     implements MessagingAttributesGetter<PulsarBatchRequest, Void> {
@@ -88,11 +87,7 @@ final class PulsarBatchMessagingAttributesGetter
   @Nullable
   @Override
   public String getDestinationPartitionId(PulsarBatchRequest request) {
-    int partitionIndex = TopicName.getPartitionIndex(request.getDestination());
-    if (partitionIndex == -1) {
-      return null;
-    }
-    return String.valueOf(partitionIndex);
+    return request.getDestinationPartitionId();
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
@@ -12,7 +12,6 @@ import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
-import org.apache.pulsar.common.naming.TopicName;
 
 public class PulsarBatchRequest extends BasePulsarRequest {
   private final Messages<?> messages;
@@ -42,7 +41,7 @@ public class PulsarBatchRequest extends BasePulsarRequest {
         // this is a partitioned topic
         // persistent://public/default/test-partition-0 persistent://public/default/test-partition-1
         // return persistent://public/default/test
-        return TopicName.get(topicName).getPartitionedTopicName();
+        return stripPartitionSuffix(topicName);
       }
     }
     return topicName;

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
@@ -25,10 +25,10 @@ public class PulsarBatchRequest extends BasePulsarRequest {
 
   private PulsarBatchRequest(
       Messages<?> messages,
-      String destination,
+      String topicName,
       @Nullable UrlData urlData,
       @Nullable String subscription) {
-    super(destination, urlData, subscription);
+    super(topicName, urlData, subscription);
     this.messages = messages;
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarMessagingAttributesGetter.java
@@ -12,7 +12,6 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.Messagin
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.apache.pulsar.common.naming.TopicName;
 
 final class PulsarMessagingAttributesGetter
     implements MessagingAttributesGetter<PulsarRequest, Void> {
@@ -82,11 +81,7 @@ final class PulsarMessagingAttributesGetter
   @Nullable
   @Override
   public String getDestinationPartitionId(PulsarRequest request) {
-    int partitionIndex = TopicName.getPartitionIndex(request.getDestination());
-    if (partitionIndex == -1) {
-      return null;
-    }
-    return String.valueOf(partitionIndex);
+    return request.getDestinationPartitionId();
   }
 
   @Nullable

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequest.java
@@ -37,10 +37,10 @@ public class PulsarRequest extends BasePulsarRequest {
 
   private PulsarRequest(
       Message<?> message,
-      String destination,
+      String topicName,
       @Nullable UrlData urlData,
       @Nullable String subscription) {
-    super(destination, urlData, subscription);
+    super(topicName, urlData, subscription);
     this.message = message;
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -417,10 +417,8 @@ abstract class AbstractPulsarClientTest {
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
-    int partitionIndex = TopicName.getPartitionIndex(destination);
-    if (partitionIndex != -1) {
-      assertions.add(equalTo(MESSAGING_DESTINATION_PARTITION_ID, String.valueOf(partitionIndex)));
-    }
+    assertions.add(
+        equalTo(MESSAGING_DESTINATION_PARTITION_ID, destinationPartitionId(destination)));
     return assertions;
   }
 
@@ -456,10 +454,8 @@ abstract class AbstractPulsarClientTest {
     if (isBatch) {
       assertions.add(satisfies(MESSAGING_BATCH_MESSAGE_COUNT, AbstractLongAssert::isPositive));
     }
-    int partitionIndex = TopicName.getPartitionIndex(destination);
-    if (partitionIndex != -1) {
-      assertions.add(equalTo(MESSAGING_DESTINATION_PARTITION_ID, String.valueOf(partitionIndex)));
-    }
+    assertions.add(
+        equalTo(MESSAGING_DESTINATION_PARTITION_ID, destinationPartitionId(destination)));
     return assertions;
   }
 
@@ -480,10 +476,8 @@ abstract class AbstractPulsarClientTest {
     if (testHeaders) {
       assertions.add(equalTo(headerAttributeKey("Test-Message-Header"), singletonList("test")));
     }
-    int partitionIndex = TopicName.getPartitionIndex(destination);
-    if (partitionIndex != -1) {
-      assertions.add(equalTo(MESSAGING_DESTINATION_PARTITION_ID, String.valueOf(partitionIndex)));
-    }
+    assertions.add(
+        equalTo(MESSAGING_DESTINATION_PARTITION_ID, destinationPartitionId(destination)));
     return assertions;
   }
 
@@ -495,8 +489,30 @@ abstract class AbstractPulsarClientTest {
     if (!emitStableMessagingSemconv()) {
       return topic;
     }
-    int suffixIndex = topic.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    int suffixIndex = partitionSuffixIndex(topic);
     return suffixIndex == -1 ? topic : topic.substring(0, suffixIndex);
+  }
+
+  private static String destinationPartitionId(String topic) {
+    int suffixIndex = partitionSuffixIndex(topic);
+    return suffixIndex == -1
+        ? null
+        : topic.substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length());
+  }
+
+  private static int partitionSuffixIndex(String topic) {
+    int partitionIndex = TopicName.getPartitionIndex(topic);
+    if (partitionIndex == -1) {
+      return -1;
+    }
+    int suffixIndex = topic.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    if (suffixIndex == -1
+        || !topic
+            .substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length())
+            .equals(String.valueOf(partitionIndex))) {
+      return -1;
+    }
+    return suffixIndex;
   }
 
   // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -489,8 +489,14 @@ abstract class AbstractPulsarClientTest {
 
   // the stable semantic conventions record the partition in messaging.destination.partition.id, so
   // the destination name does not include the "-partition-N" suffix there
+  // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is not
+  // fully qualified, which is not what the instrumentation does
   static String destinationName(String topic) {
-    return emitStableMessagingSemconv() ? TopicName.get(topic).getPartitionedTopicName() : topic;
+    if (!emitStableMessagingSemconv()) {
+      return topic;
+    }
+    int suffixIndex = topic.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    return suffixIndex == -1 ? topic : topic.substring(0, suffixIndex);
   }
 
   // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -407,7 +407,7 @@ abstract class AbstractPulsarClientTest {
                 equalTo(MESSAGING_SYSTEM, "pulsar"),
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
-                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                equalTo(MESSAGING_DESTINATION_NAME, destinationName(destination)),
                 oldOperation("publish"),
                 operationName("send"),
                 operationType("send"),
@@ -443,7 +443,7 @@ abstract class AbstractPulsarClientTest {
                 equalTo(MESSAGING_SYSTEM, "pulsar"),
                 equalTo(SERVER_ADDRESS, brokerHost),
                 equalTo(SERVER_PORT, brokerPort),
-                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                equalTo(MESSAGING_DESTINATION_NAME, destinationName(destination)),
                 oldOperation("receive"),
                 operationName("receive"),
                 operationType("receive"),
@@ -470,7 +470,7 @@ abstract class AbstractPulsarClientTest {
         new ArrayList<>(
             asList(
                 equalTo(MESSAGING_SYSTEM, "pulsar"),
-                equalTo(MESSAGING_DESTINATION_NAME, destination),
+                equalTo(MESSAGING_DESTINATION_NAME, destinationName(destination)),
                 oldOperation("process"),
                 operationName("process"),
                 operationType("process"),
@@ -485,6 +485,12 @@ abstract class AbstractPulsarClientTest {
       assertions.add(equalTo(MESSAGING_DESTINATION_PARTITION_ID, String.valueOf(partitionIndex)));
     }
     return assertions;
+  }
+
+  // the stable semantic conventions record the partition in messaging.destination.partition.id, so
+  // the destination name does not include the "-partition-N" suffix there
+  static String destinationName(String topic) {
+    return emitStableMessagingSemconv() ? TopicName.get(topic).getPartitionedTopicName() : topic;
   }
 
   // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientSuppressReceiveSpansTest.java
@@ -441,7 +441,7 @@ class PulsarClientSuppressReceiveSpansTest extends AbstractPulsarClientTest {
     // the old semantic conventions used "publish" where the stable ones use "send"
     String oldOperation = operationName.equals("send") ? "publish" : operationName;
     return emitStableMessagingSemconv()
-        ? operationName + " " + destination
+        ? operationName + " " + destinationName(destination)
         : destination + " " + oldOperation;
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -766,13 +766,13 @@ class PulsarClientTest extends AbstractPulsarClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("send " + partitionTopic)
+                    span.hasName("send " + topic)
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             sendAttributes(partitionTopic, msgId.toString(), false)),
                 span ->
-                    span.hasName("process " + partitionTopic)
+                    span.hasName("process " + topic)
                         .hasKind(SpanKind.CONSUMER)
                         .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(
@@ -782,7 +782,7 @@ class PulsarClientTest extends AbstractPulsarClientTest {
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span ->
-                      span.hasName("receive " + partitionTopic)
+                      span.hasName("receive " + topic)
                           .hasKind(SpanKind.CLIENT)
                           .hasNoParent()
                           .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))


### PR DESCRIPTION
Pulsar records `messaging.destination.name` as the topic name verbatim, so a span for a partitioned topic reports the partition twice, once embedded in the destination name and once in `messaging.destination.partition.id`:

```
# before
messaging.destination.name         = persistent://public/default/test-partition-0
messaging.destination.partition.id = 0

# after
messaging.destination.name         = persistent://public/default/test
messaging.destination.partition.id = 0
```

The registry defines `messaging.destination.partition.id` as "the identifier of the partition messages are sent to or received from, unique within the `messaging.destination.name`". Being unique *within* the destination name means the destination name identifies the topic and the partition id identifies the partition within it, so a destination name that already embeds the partition leaves the two attributes describing the same thing at different granularities.

Kafka is the in-repo precedent that already models this correctly: `KafkaReceiveAttributesGetter.getDestination` returns `TopicPartition::topic` with no partition, and `KafkaConsumerAttributesExtractor` emits `messaging.destination.partition.id` separately. Pulsar was the only instrumentation getting this wrong.

Under the stable messaging semantic conventions the Pulsar destination name is now the partitioned topic name, for producer send, single message receive, process, and batch receive alike. Legacy output is unchanged: when `otel.semconv-stability.opt-in` selects neither `messaging` nor `messaging/dup` and `otel.instrumentation.common.v3-preview` is absent or `false`, destination names keep their partition suffix exactly as before.

### Span names

Because messaging span names are built from the destination name, this also removes the `-partition-N` suffix from stable-semconv span names:

```
# before
receive persistent://public/default/test-partition-0

# after
receive persistent://public/default/test
```

That lowers span name cardinality from one name per partition to one per topic, and again matches what Kafka already produces. Legacy span names are unaffected.

Part of #19254.