### PR TITLE
Handle IPv6 addresses in HTTP Host headers

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/internal/HostAddressAndPortExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/internal/HostAddressAndPortExtractor.java
@@ -32,6 +32,18 @@ public final class HostAddressAndPortExtractor<REQUEST>
       return;
     }
 
+    if (host.startsWith("[")) {
+      int ipv6End = host.indexOf(']');
+      if (ipv6End == -1) {
+        return;
+      }
+      sink.setAddress(host.substring(1, ipv6End));
+      if (ipv6End + 1 < host.length() && host.charAt(ipv6End + 1) == ':') {
+        setPort(sink, host, ipv6End + 2, host.length());
+      }
+      return;
+    }
+
     int hostHeaderSeparator = host.indexOf(':');
     if (hostHeaderSeparator == -1) {
       sink.setAddress(host);

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/internal/HostAddressAndPortExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/semconv/http/internal/HostAddressAndPortExtractorTest.java
@@ -69,4 +69,26 @@ class HostAddressAndPortExtractorTest {
     verify(sink).setPort(42);
     verifyNoMoreInteractions(sink);
   }
+
+  @Test
+  void ipv6Host() {
+    when(getter.getHttpRequestHeader(REQUEST, "host")).thenReturn(singletonList("[2001:db8::1]"));
+
+    underTest.extract(sink, REQUEST);
+
+    verify(sink).setAddress("2001:db8::1");
+    verifyNoMoreInteractions(sink);
+  }
+
+  @Test
+  void ipv6HostAndPort() {
+    when(getter.getHttpRequestHeader(REQUEST, "host"))
+        .thenReturn(singletonList("[2001:db8::1]:42"));
+
+    underTest.extract(sink, REQUEST);
+
+    verify(sink).setAddress("2001:db8::1");
+    verify(sink).setPort(42);
+    verifyNoMoreInteractions(sink);
+  }
 }


### PR DESCRIPTION
Fixes #15158.

When the HTTP client server address is unavailable, peer-service extraction falls back to the `Host` header. `HostAddressAndPortExtractor` previously split at the first colon, so a standard bracketed IPv6 authority such as `[2001:db8::1]:42` was truncated to `[2001`.

This change parses the bracketed IPv6 address before its optional port while leaving the existing hostname and IPv4 paths unchanged. Regression tests cover IPv6 authorities both with and without a port.

Reproduction before the fix:
- `HostAddressAndPortExtractorTest` ran 6 tests with 2 failures.
- Both IPv6 cases expected `2001:db8::1` but received `[2001`.

Validation:
- `./gradlew :instrumentation-api:test --tests io.opentelemetry.instrumentation.api.semconv.http.internal.HostAddressAndPortExtractorTest --rerun`
- `./gradlew :instrumentation-api:check :instrumentation-api:spotlessCheck --rerun`
- `git diff --check`