### PR TITLE
Sort otel meter registry last via getRegistries advice

### DIFF
--- a/instrumentation/micrometer/micrometer-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/MicrometerSingletons.java
+++ b/instrumentation/micrometer/micrometer-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/MicrometerSingletons.java
@@ -67,6 +67,16 @@ public class MicrometerSingletons {
       public boolean contains(Object object) {
         return registries.contains(object);
       }
+
+      @Override
+      public boolean equals(Object object) {
+        return registries.equals(object);
+      }
+
+      @Override
+      public int hashCode() {
+        return registries.hashCode();
+      }
     };
   }
 

--- a/instrumentation/micrometer/micrometer-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/MicrometerSingletons.java
+++ b/instrumentation/micrometer/micrometer-1.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/micrometer/v1_5/MicrometerSingletons.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.micrometer.v1_5;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.Comparator.comparingInt;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
@@ -13,8 +16,12 @@ import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegist
 import io.opentelemetry.instrumentation.micrometer.v1_5.OpenTelemetryMeterRegistryBuilder;
 import io.opentelemetry.instrumentation.micrometer.v1_5.internal.Experimental;
 import io.opentelemetry.instrumentation.micrometer.v1_5.internal.OpenTelemetryInstrument;
+import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 public class MicrometerSingletons {
@@ -35,6 +42,32 @@ public class MicrometerSingletons {
 
   public static MeterRegistry meterRegistry() {
     return meterRegistry;
+  }
+
+  // called from CompositeMeterRegistryInstrumentation
+  public static Set<MeterRegistry> sortOtelMeterRegistryLast(Set<MeterRegistry> registries) {
+    // a view instead of a copy, so that it stays live and keeps the composite's identity-based
+    // membership, same as the set that micrometer returns
+    return new AbstractSet<MeterRegistry>() {
+      @Override
+      public Iterator<MeterRegistry> iterator() {
+        List<MeterRegistry> sorted = new ArrayList<>(registries);
+        // sort otel registry last since it doesn't support reading metric values
+        // and the actuator endpoint reads metrics from the first registry
+        sorted.sort(comparingInt(registry -> registry == meterRegistry ? 1 : 0));
+        return unmodifiableList(sorted).iterator();
+      }
+
+      @Override
+      public int size() {
+        return registries.size();
+      }
+
+      @Override
+      public boolean contains(Object object) {
+        return registries.contains(object);
+      }
+    };
   }
 
   // called from code generated in AbstractCompositeMeterInstrumentation

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/CompositeMeterRegistryInstrumentation.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/CompositeMeterRegistryInstrumentation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.spring.boot.actuator.autoconfigure.v2_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.micrometer.v1_5.MicrometerSingletons;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class CompositeMeterRegistryInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("io.micrometer.core.instrument.composite.CompositeMeterRegistry");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getRegistries").and(takesNoArguments()),
+        getClass().getName() + "$GetRegistriesAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class GetRegistriesAdvice {
+
+    @AssignReturned.ToReturned
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static Set<MeterRegistry> onExit(@Advice.Return Set<MeterRegistry> registries) {
+      return MicrometerSingletons.sortOtelMeterRegistryLast(registries);
+    }
+  }
+}

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/OpenTelemetryMeterRegistryAutoConfiguration.java
@@ -5,18 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.boot.actuator.autoconfigure.v2_0;
 
-import static java.util.Collections.singletonList;
-
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.opentelemetry.javaagent.instrumentation.micrometer.v1_5.MicrometerSingletons;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -46,32 +37,5 @@ public class OpenTelemetryMeterRegistryAutoConfiguration {
   @Bean
   public MeterRegistry otelMeterRegistry() {
     return MicrometerSingletons.meterRegistry();
-  }
-
-  @Bean
-  // static to avoid "is not eligible for getting processed by all BeanPostProcessors" warning
-  static BeanPostProcessor postProcessCompositeMeterRegistry() {
-    return new BeanPostProcessor() {
-      @Override
-      public Object postProcessAfterInitialization(Object bean, String beanName) {
-        if (bean instanceof CompositeMeterRegistry) {
-          CompositeMeterRegistry original = (CompositeMeterRegistry) bean;
-          List<MeterRegistry> list = new ArrayList<>(original.getRegistries());
-          // sort otel registry last since it doesn't support reading metric values
-          // and the actuator endpoint reads metrics from the first registry
-          list.sort(
-              Comparator.comparingInt(
-                  value -> value == MicrometerSingletons.meterRegistry() ? 1 : 0));
-          Set<MeterRegistry> registries = new LinkedHashSet<>(list);
-          return new CompositeMeterRegistry(original.config().clock(), singletonList(original)) {
-            @Override
-            public Set<MeterRegistry> getRegistries() {
-              return registries;
-            }
-          };
-        }
-        return bean;
-      }
-    };
   }
 }

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/SpringBootActuatorInstrumentationModule.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/SpringBootActuatorInstrumentationModule.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.spring.boot.actuator.autoconfigure.v2_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
@@ -51,7 +52,9 @@ public class SpringBootActuatorInstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new AutoConfigurationImportSelectorInstrumentation());
+    return asList(
+        new AutoConfigurationImportSelectorInstrumentation(),
+        new CompositeMeterRegistryInstrumentation());
   }
 
   @Override

--- a/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/ActuatorTest.java
+++ b/instrumentation/spring/spring-boot-actuator-autoconfigure-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/boot/actuator/autoconfigure/v2_0/ActuatorTest.java
@@ -9,8 +9,10 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -55,13 +57,48 @@ class ActuatorTest {
                                             equalTo(stringKey("tag"), "value")))));
 
     MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+    // the composite registry bean must be the one spring created, not a wrapper; beans that were
+    // injected with the original composite would not see the wrapper, and its registry list would
+    // be frozen at the time it was created
     assertThat(meterRegistry).isInstanceOf(CompositeMeterRegistry.class);
+    assertThat(meterRegistry.getClass().getName()).doesNotStartWith("io.opentelemetry.");
 
-    Set<MeterRegistry> registries = ((CompositeMeterRegistry) meterRegistry).getRegistries();
+    CompositeMeterRegistry composite = (CompositeMeterRegistry) meterRegistry;
+    Set<MeterRegistry> registries = composite.getRegistries();
+    assertOtelMeterRegistryIsLast(registries);
+
+    // the actuator metrics endpoint reads from the first registry that has a matching meter, so
+    // that registry has to be able to report the value
+    Counter counter = findFirstMatchingCounter(composite);
+    assertThat(counter).isNotNull();
+    assertThat(counter.count()).isEqualTo(1);
+
+    // the returned set is a live view of the composite, same as micrometer's
+    int registryCount = registries.size();
+    SimpleMeterRegistry added = new SimpleMeterRegistry();
+    composite.add(added);
+    assertThat(registries).hasSize(registryCount + 1);
+    assertOtelMeterRegistryIsLast(registries);
+
+    composite.remove(added);
+    assertThat(registries).hasSize(registryCount);
+  }
+
+  private static void assertOtelMeterRegistryIsLast(Set<MeterRegistry> registries) {
     ArrayList<MeterRegistry> list = new ArrayList<>(registries);
 
     assertThat(list)
         .extracting(registry -> registry.getClass().getSimpleName())
         .endsWith("OpenTelemetryMeterRegistry");
+  }
+
+  private static Counter findFirstMatchingCounter(CompositeMeterRegistry composite) {
+    for (MeterRegistry registry : composite.getRegistries()) {
+      Counter counter = registry.find("test-counter").counter();
+      if (counter != null) {
+        return counter;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
The javaagent registers its `OpenTelemetryMeterRegistry` into Spring Boot's `CompositeMeterRegistry`, and that registry can't read metric values back. Since the actuator metrics endpoint reads from the first registry that has a matching meter, the otel registry has to be sorted last or the endpoint reports zeros. Today that's done by a `BeanPostProcessor` that replaces the composite bean with an anonymous subclass wrapping the original and overriding `getRegistries()` to return a pre-sorted set. This replaces that wrapper with byte code advice on `CompositeMeterRegistry.getRegistries()` itself.

The behavior the wrapper was there for is unchanged — the otel registry still ends up last, which is what #12719 was about — but it is now computed on each read rather than captured once during bean post-processing.

Dropping the wrapper also removes two structural oddities it introduced. The bean handed to the application was no longer the composite Spring created, so beans injected with the original composite (and anything holding a reference from before post-processing) saw a different object than `context.getBean(MeterRegistry.class)` returned. And because the wrapper's `getRegistries()` returned a set captured at startup, a registry added to the composite later was invisible through the bean, while `getRegistries()` reported registries that weren't actually members of the wrapper.

The advice lives in the spring-boot-actuator-autoconfigure module rather than the micrometer module because that module can be enabled on its own, and the sort helper sits next to `wrapIterator` in `MicrometerSingletons`, which the existing `AbstractCompositeMeterInstrumentation` uses for the same purpose at the meter level.
