### PR TITLE
Add an internal path that records a messaging pull without a receive span

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingReceiveTelemetry.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingReceiveTelemetry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
+import io.opentelemetry.instrumentation.api.internal.Timer;
+import javax.annotation.Nullable;
+
+/**
+ * Records a messaging pull operation, creating a receive span for it only when it is eligible for
+ * one.
+ *
+ * <p>Metrics are recorded either way. Whether a span is created is decided by the caller, which
+ * combines the receive spans setting with whether the pull was initiated by the application: a span
+ * is eligible when receive spans are enabled and either the pull was application-initiated or it
+ * returned at least one message.
+ *
+ * <p>An application-initiated pull is a call the user made, so it is worth a span whether or not it
+ * returned messages. An internal listener polling loop is not, so it only gets a span when the poll
+ * actually produced something to correlate to.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class MessagingReceiveTelemetry {
+
+  /**
+   * Records the pull operation described by {@code request} against {@code instrumenter}, using
+   * {@code timer} for the start and end timestamps.
+   *
+   * @return the receive context when a receive span was created, {@code null} otherwise. Callers
+   *     that parent process spans under the receive span should link to the producer instead when
+   *     this returns {@code null}.
+   */
+  @Nullable
+  public static <REQUEST, RESPONSE> Context record(
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context parentContext,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error,
+      Timer timer,
+      boolean spanEligible) {
+    if (!instrumenter.shouldStart(parentContext, request)) {
+      return null;
+    }
+    if (!spanEligible) {
+      InstrumenterUtil.startAndEndWithoutSpan(
+          instrumenter, parentContext, request, response, error, timer.startTime(), timer.now());
+      return null;
+    }
+    return InstrumenterUtil.startAndEnd(
+        instrumenter, parentContext, request, response, error, timer.startTime(), timer.now());
+  }
+
+  private MessagingReceiveTelemetry() {}
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingReceiveTelemetryTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingReceiveTelemetryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
+
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MessagingReceiveTelemetryTest {
+
+  @RegisterExtension static final OpenTelemetryExtension testing = OpenTelemetryExtension.create();
+
+  private static final Instrumenter<String, String> instrumenter =
+      Instrumenter.<String, String>builder(
+              testing.getOpenTelemetry(), "test", request -> "receive " + request)
+          .buildInstrumenter(request -> SpanKind.CONSUMER);
+
+  @Test
+  void spanEligibleCreatesReceiveSpanAndReturnsItsContext() {
+    Timer timer = Timer.start();
+
+    Context receiveContext =
+        MessagingReceiveTelemetry.record(
+            instrumenter, Context.root(), "queue", null, null, timer, /* spanEligible= */ true);
+
+    assertThat(receiveContext).isNotNull();
+    List<SpanData> spans = testing.getSpans();
+    assertThat(spans).hasSize(1);
+    assertThat(spans.get(0)).hasName("receive queue").hasKind(SpanKind.CONSUMER);
+  }
+
+  @Test
+  void spanIneligibleRecordsNoSpanAndReturnsNull() {
+    Timer timer = Timer.start();
+
+    Context receiveContext =
+        MessagingReceiveTelemetry.record(
+            instrumenter, Context.root(), "queue", null, null, timer, /* spanEligible= */ false);
+
+    assertThat(receiveContext).isNull();
+    assertThat(testing.getSpans()).isEmpty();
+  }
+
+  @Test
+  void disabledInstrumenterRecordsNothing() {
+    Instrumenter<String, String> disabled =
+        Instrumenter.<String, String>builder(
+                testing.getOpenTelemetry(), "test", request -> "receive " + request)
+            .setEnabled(false)
+            .buildInstrumenter(request -> SpanKind.CONSUMER);
+
+    assertThat(
+            MessagingReceiveTelemetry.record(
+                disabled, Context.root(), "queue", null, null, Timer.start(), false))
+        .isNull();
+    assertThat(
+            MessagingReceiveTelemetry.record(
+                disabled, Context.root(), "queue", null, null, Timer.start(), true))
+        .isNull();
+    assertThat(testing.getSpans()).isEmpty();
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/Instrumenter.java
@@ -158,7 +158,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
    * object of this operation.
    */
   public Context start(Context parentContext, REQUEST request) {
-    return doStart(parentContext, request, null);
+    return doStart(parentContext, request, null, /* recordSpan= */ true);
   }
 
   /**
@@ -173,7 +173,7 @@ public class Instrumenter<REQUEST, RESPONSE> {
    */
   public void end(
       Context context, REQUEST request, @Nullable RESPONSE response, @Nullable Throwable error) {
-    doEnd(context, request, response, error, null);
+    doEnd(context, request, response, error, null, /* recordSpan= */ true);
   }
 
   /** Internal method for creating spans with given start/end timestamps. */
@@ -184,31 +184,57 @@ public class Instrumenter<REQUEST, RESPONSE> {
       @Nullable Throwable error,
       Instant startTime,
       Instant endTime) {
-    Context context = doStart(parentContext, request, startTime);
-    doEnd(context, request, response, error, endTime);
+    Context context = doStart(parentContext, request, startTime, /* recordSpan= */ true);
+    doEnd(context, request, response, error, endTime, /* recordSpan= */ true);
     return context;
   }
 
-  private Context doStart(Context parentContext, REQUEST request, @Nullable Instant startTime) {
+  /**
+   * Internal method for recording an operation with given start/end timestamps without creating a
+   * span for it.
+   *
+   * <p>Operation listeners, and therefore metrics, are invoked exactly as they are for a recorded
+   * operation, and exception logs are emitted as usual. No context is returned because the
+   * resulting context must not be used for parenting: as far as tracing is concerned this operation
+   * did not happen.
+   */
+  void startAndEndWithoutSpan(
+      Context parentContext,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error,
+      Instant startTime,
+      Instant endTime) {
+    Context context = doStart(parentContext, request, startTime, /* recordSpan= */ false);
+    doEnd(context, request, response, error, endTime, /* recordSpan= */ false);
+  }
+
+  private Context doStart(
+      Context parentContext, REQUEST request, @Nullable Instant startTime, boolean recordSpan) {
     try {
-      return doStartImpl(parentContext, request, startTime);
+      return doStartImpl(parentContext, request, startTime, recordSpan);
     } finally {
       InstrumenterContext.reset();
     }
   }
 
-  private Context doStartImpl(Context parentContext, REQUEST request, @Nullable Instant startTime) {
+  private Context doStartImpl(
+      Context parentContext, REQUEST request, @Nullable Instant startTime, boolean recordSpan) {
     SpanKind spanKind = spanKindExtractor.extract(request);
     SpanBuilder spanBuilder =
-        tracer.spanBuilder(spanNameExtractor.extract(request)).setSpanKind(spanKind);
+        recordSpan
+            ? tracer.spanBuilder(spanNameExtractor.extract(request)).setSpanKind(spanKind)
+            : null;
 
-    if (startTime != null) {
-      spanBuilder.setStartTimestamp(startTime);
-    }
+    if (spanBuilder != null) {
+      if (startTime != null) {
+        spanBuilder.setStartTimestamp(startTime);
+      }
 
-    SpanLinksBuilder spanLinksBuilder = new SpanLinksBuilderImpl(spanBuilder);
-    for (SpanLinksExtractor<? super REQUEST> spanLinksExtractor : spanLinksExtractors) {
-      spanLinksExtractor.extract(spanLinksBuilder, parentContext, request);
+      SpanLinksBuilder spanLinksBuilder = new SpanLinksBuilderImpl(spanBuilder);
+      for (SpanLinksExtractor<? super REQUEST> spanLinksExtractor : spanLinksExtractors) {
+        spanLinksExtractor.extract(spanLinksBuilder, parentContext, request);
+      }
     }
 
     UnsafeAttributes attributes = new UnsafeAttributes();
@@ -227,9 +253,12 @@ public class Instrumenter<REQUEST, RESPONSE> {
     boolean localRoot = LocalRootSpan.isLocalRoot(parentContext);
     boolean hasLocalRoot = LocalRootSpan.fromContextOrNull(context) != null;
 
-    spanBuilder.setAllAttributes(attributes);
-    Span span = spanBuilder.setParent(context).startSpan();
-    context = context.with(span);
+    Span span = null;
+    if (spanBuilder != null) {
+      spanBuilder.setAllAttributes(attributes);
+      span = spanBuilder.setParent(context).startSpan();
+      context = context.with(span);
+    }
 
     if (operationListeners.length != 0) {
       if (operationListenerAttributesExtractors.length != 0) {
@@ -259,6 +288,10 @@ public class Instrumenter<REQUEST, RESPONSE> {
       context = context.with(START_OPERATION_LISTENERS, operationListeners);
     }
 
+    if (span == null) {
+      return context;
+    }
+
     if (localRoot) {
       context = LocalRootSpan.store(context, span);
     }
@@ -274,8 +307,11 @@ public class Instrumenter<REQUEST, RESPONSE> {
       REQUEST request,
       @Nullable RESPONSE response,
       @Nullable Throwable error,
-      @Nullable Instant endTime) {
-    Span span = Span.fromContext(context);
+      @Nullable Instant endTime,
+      boolean recordSpan) {
+    // when the operation is recorded without a span, all span mutations below are no-ops on the
+    // invalid span; reading the span from the context would incorrectly mutate the parent span
+    Span span = recordSpan ? Span.fromContext(context) : Span.getInvalid();
 
     if (error != null) {
       error = errorCauseExtractor.extract(error);
@@ -380,6 +416,19 @@ public class Instrumenter<REQUEST, RESPONSE> {
               Instant startTime,
               Instant endTime) {
             return instrumenter.startAndEnd(
+                parentContext, request, response, error, startTime, endTime);
+          }
+
+          @Override
+          public <RQ, RS> void startAndEndWithoutSpan(
+              Instrumenter<RQ, RS> instrumenter,
+              Context parentContext,
+              RQ request,
+              @Nullable RS response,
+              @Nullable Throwable error,
+              Instant startTime,
+              Instant endTime) {
+            instrumenter.startAndEndWithoutSpan(
                 parentContext, request, response, error, startTime, endTime);
           }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterAccess.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterAccess.java
@@ -26,6 +26,15 @@ public interface InstrumenterAccess {
       Instant startTime,
       Instant endTime);
 
+  <REQUEST, RESPONSE> void startAndEndWithoutSpan(
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context parentContext,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error,
+      Instant startTime,
+      Instant endTime);
+
   <REQUEST, RESPONSE> Context suppressSpan(
       Instrumenter<REQUEST, RESPONSE> instrumenter, Context parentContext, REQUEST request);
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/InstrumenterUtil.java
@@ -55,6 +55,27 @@ public final class InstrumenterUtil {
         instrumenter, parentContext, request, response, error, startTime, endTime);
   }
 
+  /**
+   * Records an operation with the given start/end timestamps without creating a span for it.
+   *
+   * <p>Operation listeners, and therefore metrics, are invoked exactly as they are by {@link
+   * #startAndEnd}, and exception logs are emitted as usual. No context is returned because the
+   * resulting context must not be used for parenting: as far as tracing is concerned this operation
+   * did not happen.
+   */
+  public static <REQUEST, RESPONSE> void startAndEndWithoutSpan(
+      Instrumenter<REQUEST, RESPONSE> instrumenter,
+      Context parentContext,
+      REQUEST request,
+      @Nullable RESPONSE response,
+      @Nullable Throwable error,
+      Instant startTime,
+      Instant endTime) {
+    // instrumenterAccess is guaranteed to be non-null here
+    instrumenterAccess.startAndEndWithoutSpan(
+        instrumenter, parentContext, request, response, error, startTime, endTime);
+  }
+
   public static <REQUEST, RESPONSE> Context suppressSpan(
       Instrumenter<REQUEST, RESPONSE> instrumenter, Context parentContext, REQUEST request) {
     return instrumenterAccess.suppressSpan(instrumenter, parentContext, request);

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -960,6 +960,173 @@ class InstrumenterTest {
     assertThatSpanKeyWasStored(SpanKey.HTTP_CLIENT, context);
   }
 
+  @Test
+  void startAndEndWithoutSpan_recordsOperationListenerButNoSpan() {
+    AtomicReference<Attributes> startAttributes = new AtomicReference<>();
+    AtomicReference<Attributes> endAttributes = new AtomicReference<>();
+    AtomicReference<Long> startNanos = new AtomicReference<>();
+    AtomicReference<Long> endNanos = new AtomicReference<>();
+
+    OperationListener operationListener =
+        new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes attributes, long nanos) {
+            startAttributes.set(attributes);
+            startNanos.set(nanos);
+            return context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes attributes, long nanos) {
+            endAttributes.set(attributes);
+            endNanos.set(nanos);
+          }
+        };
+
+    InstrumenterBuilder<Map<String, String>, Map<String, String>> builder =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(operationListener)
+            .addAttributesExtractor(new AttributesExtractor1());
+    Experimental.addOperationListenerAttributesExtractor(builder, new AttributesExtractor2());
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
+        builder.buildInstrumenter();
+
+    InstrumenterUtil.startAndEndWithoutSpan(
+        instrumenter,
+        Context.root(),
+        REQUEST,
+        RESPONSE,
+        null,
+        Instant.ofEpochSecond(100),
+        Instant.ofEpochSecond(123, 456));
+
+    assertThat(otelTesting.getSpans()).isEmpty();
+
+    // attributes from both the regular and the operation listener only extractors are visible
+    assertThat(startAttributes.get())
+        .containsEntry(stringKey("req1"), "req1_value")
+        .containsEntry(stringKey("req3"), "req3_value");
+    assertThat(endAttributes.get())
+        .containsEntry(stringKey("resp1"), "resp1_value")
+        .containsEntry(stringKey("resp3"), "resp3_value");
+    assertThat(startNanos.get()).isEqualTo(100_000_000_000L);
+    assertThat(endNanos.get()).isEqualTo(123_000_000_456L);
+  }
+
+  @Test
+  void startAndEndWithoutSpan_doesNotModifyParentSpan() {
+    Instrumenter<Map<String, String>, Map<String, String>> parentInstrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "parent")
+            .buildInstrumenter();
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addAttributesExtractor(new AttributesExtractor1())
+            .buildInstrumenter();
+
+    Context parentContext = parentInstrumenter.start(Context.root(), REQUEST);
+    InstrumenterUtil.startAndEndWithoutSpan(
+        instrumenter,
+        parentContext,
+        REQUEST,
+        RESPONSE,
+        new IllegalStateException("test"),
+        Instant.ofEpochSecond(100),
+        Instant.ofEpochSecond(123));
+    parentInstrumenter.end(parentContext, REQUEST, RESPONSE, null);
+
+    otelTesting
+        .assertTraces()
+        .hasTracesSatisfyingExactly(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName("parent")
+                            .hasStatus(StatusData.unset())
+                            .hasAttributes(Attributes.empty())
+                            .hasEventsSatisfyingExactly()));
+  }
+
+  @Test
+  void startAndEndWithoutSpan_emitsExceptionLog() {
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .buildInstrumenter();
+
+    InstrumenterUtil.startAndEndWithoutSpan(
+        instrumenter,
+        Context.root(),
+        REQUEST,
+        RESPONSE,
+        new IllegalStateException("test"),
+        Instant.ofEpochSecond(100),
+        Instant.ofEpochSecond(123, 456));
+
+    assertThat(otelTesting.getSpans()).isEmpty();
+
+    if (emitExceptionAsLogs()) {
+      List<LogRecordData> logs = otelTesting.getLogRecords();
+      assertThat(logs).hasSize(1);
+      assertThat(logs.get(0)).hasSeverity(Severity.WARN).hasEventName("exception");
+      assertThat(logs.get(0).getTimestampEpochNanos()).isEqualTo(123_000_000_456L);
+    }
+  }
+
+  @Test
+  void startAndEndWithoutSpan_honorsSuppression() {
+    RecordingOperationListener listener = new RecordingOperationListener();
+
+    when(((SpanKeyProvider) mockHttpClientAttributes).internalGetSpanKey())
+        .thenReturn(SpanKey.HTTP_CLIENT);
+
+    Instrumenter<Map<String, String>, Map<String, String>> outerInstrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "outer")
+            .addAttributesExtractor(mockHttpClientAttributes)
+            .buildClientInstrumenter(Map::put);
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
+        Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                otelTesting.getOpenTelemetry(), "test", unused -> "span")
+            .addOperationListener(listener)
+            .addAttributesExtractor(mockHttpClientAttributes)
+            .buildClientInstrumenter(Map::put);
+
+    Context outerContext = outerInstrumenter.start(Context.root(), new HashMap<>(REQUEST));
+
+    // the outer client instrumentation already covers this operation, so it must not be recorded
+    // again, otherwise its metrics would be double counted
+    assertThat(instrumenter.shouldStart(outerContext, REQUEST)).isFalse();
+    assertThat(listener.started).isFalse();
+  }
+
+  @Test
+  void startAndEndWithoutSpan_propagatedOperationListeners() {
+    RecordingOperationListener listener = new RecordingOperationListener();
+
+    Instrumenter<Map<String, String>, Map<String, String>> instrumenter =
+        InstrumenterUtil.propagateOperationListenersToOnEnd(
+                Instrumenter.<Map<String, String>, Map<String, String>>builder(
+                        otelTesting.getOpenTelemetry(), "test", unused -> "span")
+                    .addOperationListener(listener))
+            .buildInstrumenter();
+
+    InstrumenterUtil.startAndEndWithoutSpan(
+        instrumenter,
+        Context.root(),
+        REQUEST,
+        RESPONSE,
+        null,
+        Instant.ofEpochSecond(100),
+        Instant.ofEpochSecond(123));
+
+    assertThat(otelTesting.getSpans()).isEmpty();
+    assertThat(listener.started).isTrue();
+    assertThat(listener.ended).isTrue();
+  }
+
   private static void assertThatSpanKeyWasStored(SpanKey spanKey, Context context) {
     Span span = Span.fromContext(context);
     assertThat(span).isNotNull();

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/InstrumenterTest.java
@@ -1045,7 +1045,7 @@ class InstrumenterTest {
                     span ->
                         span.hasName("parent")
                             .hasStatus(StatusData.unset())
-                            .hasAttributes(Attributes.empty())
+                            .hasTotalAttributeCount(0)
                             .hasEventsSatisfyingExactly()));
   }
 


### PR DESCRIPTION
`Instrumenter` creates a span before running its operation listeners and ends it afterwards, and the only way to stop the span is `setEnabled(false)`, which short-circuits `shouldStart` and therefore suppresses metrics as well. There is no way to record an operation's metrics while deliberately not producing a span for it. Upcoming messaging work needs exactly that: pull operations should always report `messaging.client.operation.duration`, while receive spans stay opt-in.

```java
InstrumenterUtil.startAndEndWithoutSpan(
    instrumenter, parentContext, request, response, error, timer.startTime(), timer.now());
```

It mirrors `startAndEnd`, including the start/end timestamps, but skips span name extraction, span links, span creation, local root and HTTP route bookkeeping, and span suppressor storage. Attribute extractors, operation listener attribute extractors, context customizers, operation listeners, and exception logs all run exactly as they do for a recorded operation.

`doEnd` targets `Span.getInvalid()` rather than reading the span from the context. With no span added to the context, reading it back would return the ambient parent span and write the operation's attributes and status onto it.

It returns nothing, unlike `startAndEnd`. The resulting context must not be used for parenting, since the point is that tracing behaves exactly as if the operation had not been recorded, so returning `void` makes that misuse impossible rather than merely discouraged.

Two behaviors are deliberate. Operation listeners read the current span for exemplars, so exemplars attach to the enclosing span when there is one, which correctly reflects that the operation happened inside it. And `shouldStart` keeps its span suppressor check, so an operation nested inside an outer instrumentation that already covers it records no metrics either, rather than double counting them.

The name says "without span" instead of "metrics only" because operation listeners are not the only non-span output: exception logs are still emitted, matching the existing behavior that they are emitted even when the span is not recording. `OperationListener` is also a general extension point that promises nothing about metrics, even though every implementation here is a metrics class today.

### Messaging entry point

`MessagingReceiveTelemetry.record(...)` sits on top of it and is what the messaging instrumentations will call. It runs `shouldStart`, then dispatches to either `startAndEnd` or `startAndEndWithoutSpan`, and returns the receive context when a span was created and `null` otherwise. Keeping it in one place means the six or so messaging instrumentations that pull messages don't each reimplement the rule.

The caller passes a single `spanEligible` flag, which it computes as receive spans being enabled **and** either the pull being application-initiated or having returned at least one message. An application-initiated pull such as `basicGet`, `receive`, or `ReceiveMessage` is a call the user actually made, so it is worth a span whether or not it returned anything. An internal listener polling loop is not, so an idle container produces no spans in any configuration while still reporting its pull duration.

Both entry points are internal API and are excluded from API compatibility checks.
