### PR TITLE
Standardize deprecation warning suppressions

### DIFF
--- a/.github/agents/knowledge/general-rules.md
+++ b/.github/agents/knowledge/general-rules.md
@@ -108,10 +108,10 @@ Reason about visibility from "what does the advice method directly reference?".
 - Place `@SuppressWarnings` on the single member that needs it, or on the class when two
   or more members in the class need the same suppression. Do not move an existing
   suppression from a member to the class unless multiple members need it.
-- **Do not add `@SuppressWarnings("deprecation")` unless the build fails without it.**
-  The project disables javac's `-Xlint:deprecation` globally and uses a custom Error Prone
-  check (`OtelDeprecatedApiUsage`) instead. Only add the annotation when it is actually
-  required to fix an Error Prone error — not speculatively.
+- Use the standard `@SuppressWarnings("deprecation")`, never the check-specific
+  `@SuppressWarnings("OtelDeprecatedApiUsage")`. The custom check aliases `deprecation` so the
+  standard suppression works; normalize the check-specific spelling when touching it. Add a
+  suppression only after observing the diagnostic or verifying intentional deprecated API usage.
 - Preserve concise explanatory comments attached to existing `@SuppressWarnings` annotations
   when they explain why the suppression exists (for example `// using deprecated semconv`
   or `// using deprecated config property`). This repository has established precedent for

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -42,3 +42,6 @@ Follow `docs/contributing/style-guide.md`.
   comment; do not depend on the semconv incubating artifact. In
   `javaagent/src/main/` and tests, use semconv constants directly.
 - **`@Nullable` in tests**: do not add it to test code.
+- **Deprecation suppressions**: use `@SuppressWarnings("deprecation")`, not
+  `@SuppressWarnings("OtelDeprecatedApiUsage")`. Add one only for intentional
+  use of an API verified to be deprecated.

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -249,7 +249,7 @@ class MessagingAttributesExtractorTest {
     assertThat(attributes.build()).isEqualTo(expected);
   }
 
-  @SuppressWarnings("OtelDeprecatedApiUsage")
+  @SuppressWarnings("deprecation")
   @Test
   void shouldExtractNoAttributesIfNoneAreAvailable() {
     // given

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanKindExtractorTest.java
@@ -52,7 +52,7 @@ class MessagingSpanKindExtractorTest {
     assertThat(spanKind).isEqualTo(SpanKind.PRODUCER);
   }
 
-  @SuppressWarnings("OtelDeprecatedApiUsage")
+  @SuppressWarnings("deprecation")
   @Test
   void messageOperationUsesLegacySpanKind() {
     SpanKind receiveKind =

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingSpanNameExtractorTest.java
@@ -27,7 +27,7 @@ class MessagingSpanNameExtractorTest {
 
   @Mock MessagingAttributesGetter<Message, Void> getter;
 
-  @SuppressWarnings("OtelDeprecatedApiUsage")
+  @SuppressWarnings("deprecation")
   @Test
   void shouldKeepLegacyNameForMessageOperation() {
     Message message = new Message();

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
@@ -73,7 +73,7 @@ import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
 
 // TODO: Remove after https://github.com/open-telemetry/semantic-conventions-genai/issues/247
 // is resolved.
-@SuppressWarnings("OtelDeprecatedApiUsage")
+@SuppressWarnings("deprecation")
 class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
 
   @RegisterExtension

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
@@ -88,7 +88,7 @@ import software.amazon.awssdk.thirdparty.jackson.core.JsonFactory;
 
 // TODO: Remove after https://github.com/open-telemetry/semantic-conventions-genai/issues/247
 // is resolved.
-@SuppressWarnings("OtelDeprecatedApiUsage")
+@SuppressWarnings("deprecation")
 public abstract class AbstractAws2BedrockRuntimeTest {
   protected static final String INSTRUMENTATION_NAME = "io.opentelemetry.aws-sdk-2.2";
 

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/internal/OkHttpAttributesGetter.java
@@ -18,7 +18,7 @@ import okhttp3.Response;
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
  * any time.
  */
-@SuppressWarnings("OtelDeprecatedApiUsage") // SPDY_3 is deprecated but still used in okhttp 3.x
+@SuppressWarnings("deprecation") // SPDY_3 is deprecated but still used in okhttp 3.x
 public final class OkHttpAttributesGetter
     implements HttpClientAttributesGetter<Interceptor.Chain, Response> {
 

--- a/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 // TODO: Remove after https://github.com/open-telemetry/semantic-conventions-genai/issues/247
 // is resolved.
-@SuppressWarnings("OtelDeprecatedApiUsage")
+@SuppressWarnings("deprecation")
 class ChatTest extends AbstractChatTest {
 
   @RegisterExtension

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -81,7 +81,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 // TODO: Remove after https://github.com/open-telemetry/semantic-conventions-genai/issues/247
 // is resolved.
-@SuppressWarnings("OtelDeprecatedApiUsage")
+@SuppressWarnings("deprecation")
 public abstract class AbstractChatTest extends AbstractOpenAiTest {
 
   protected static final String TEST_CHAT_MODEL = "gpt-4o-mini";

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractEmbeddingsTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 // TODO: Remove after https://github.com/open-telemetry/semantic-conventions-genai/issues/247
 // is resolved.
-@SuppressWarnings("OtelDeprecatedApiUsage")
+@SuppressWarnings("deprecation")
 public abstract class AbstractEmbeddingsTest extends AbstractOpenAiTest {
   private static final String MODEL = "text-embedding-3-small";
 


### PR DESCRIPTION
Use the standard `@SuppressWarnings("deprecation")` spelling for deprecated API usage instead of the custom Error Prone checker name. `OtelDeprecatedApiUsage` exposes `deprecation` as an alternate name, so this remains equivalent while also being meaningful to javac and IDEs.

Normalize all existing check-specific suppressions and update the Java agent guidance to keep future agent-generated changes consistent.