### PR TITLE
Fix Lettuce connection error assertions on JDK 25

### DIFF
--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/AbstractLettuceClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/AbstractLettuceClientTest.java
@@ -14,7 +14,9 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +63,12 @@ abstract class AbstractLettuceClientTest {
 
   protected static boolean connectionTelemetryEnabled() {
     return Boolean.getBoolean("otel.instrumentation.lettuce.connection-telemetry.enabled");
+  }
+
+  protected String expectedConnectionRefusedMessagePattern(int port) {
+    String windowsGetsockopt = OS.WINDOWS.isCurrentOs() ? "getsockopt: " : "";
+    String address = windowsGetsockopt + host + "/" + ip + ":" + port;
+    return "Connection refused(?: \\(connect failed\\))?: " + Pattern.quote(address);
   }
 
   protected void withIsolatedContainer(

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -163,11 +162,6 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
 
     assertThat(exception).isInstanceOf(ExecutionException.class);
 
-    // Windows includes "getsockopt: " in the connection refused message
-    String windowsGetsockopt = OS.WINDOWS.isCurrentOs() ? "getsockopt: " : "";
-    String expectedMessage =
-        "Connection refused: " + windowsGetsockopt + host + "/" + ip + ":" + incorrectPort;
-
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -188,7 +182,12 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                                         equalTo(
                                             stringKey("exception.type"),
                                             "io.netty.channel.AbstractChannel.AnnotatedConnectException"),
-                                        equalTo(stringKey("exception.message"), expectedMessage),
+                                        satisfies(
+                                            stringKey("exception.message"),
+                                            val ->
+                                                val.matches(
+                                                    expectedConnectionRefusedMessagePattern(
+                                                        incorrectPort))),
                                         satisfies(
                                             stringKey("exception.stacktrace"),
                                             val -> val.isNotNull())))));

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.condition.OS;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class LettuceSyncClientTest extends AbstractLettuceClientTest {
@@ -121,11 +120,6 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
 
     assertThat(exception).isInstanceOf(RedisConnectionException.class);
 
-    // Windows includes "getsockopt: " in the connection refused message
-    String windowsGetsockopt = OS.WINDOWS.isCurrentOs() ? "getsockopt: " : "";
-    String expectedMessage =
-        "Connection refused: " + windowsGetsockopt + host + "/" + ip + ":" + incorrectPort;
-
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -146,7 +140,12 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                                         equalTo(
                                             stringKey("exception.type"),
                                             "io.netty.channel.AbstractChannel.AnnotatedConnectException"),
-                                        equalTo(stringKey("exception.message"), expectedMessage),
+                                        satisfies(
+                                            stringKey("exception.message"),
+                                            val ->
+                                                val.matches(
+                                                    expectedConnectionRefusedMessagePattern(
+                                                        incorrectPort))),
                                         satisfies(
                                             stringKey("exception.stacktrace"),
                                             val -> val.isNotNull())))));


### PR DESCRIPTION
JDK 25 changes the message of the `ConnectException` thrown for a refused connection, so the Lettuce connection-error assertions no longer match. On JDK 25 the message gains a ` (connect failed)` suffix, and on Windows it is additionally prefixed with `getsockopt: `.

Rather than pinning an exact string, the expected message is now built as a regular expression that tolerates both spellings:

```java
protected String expectedConnectionRefusedMessagePattern(int port) {
  String windowsGetsockopt = OS.WINDOWS.isCurrentOs() ? "getsockopt: " : "";
  String address = windowsGetsockopt + host + "/" + ip + ":" + port;
  return "Connection refused(?: \\(connect failed\\))?: " + Pattern.quote(address);
}
```

The address portion is passed through `Pattern.quote` so the host, IP, and port are still matched literally; only the platform- and version-dependent wording around it is optional.

Both the sync and async client tests share the helper, which keeps the two copies from drifting.