### PR TITLE
handle both types of partition identifcation

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarRequestDestinationTest.java
@@ -59,6 +59,26 @@ class PulsarRequestDestinationTest {
   }
 
   @Test
+  void keepsTopicNameThatOnlyContainsThePartitionSuffix() {
+    // pulsar 2.8 reads the partition index from the last '-' rather than from the last partition
+    // suffix, so it reports this non-partitioned topic as partition 7; the destination name must
+    // not be rewritten based on that
+    String topic = TOPIC + "-partition-key-7";
+    PulsarRequest request = request(message(topic));
+
+    assertThat(request.getDestination()).isEqualTo(topic);
+  }
+
+  @Test
+  void keepsTopicNameWhosePartitionSuffixIsNotTheIndex() {
+    // pulsar 2.9+ rejects a zero padded partition suffix, pulsar 2.8 reads it as partition 1
+    String topic = TOPIC + "-partition-01";
+    PulsarRequest request = request(message(topic));
+
+    assertThat(request.getDestination()).isEqualTo(topic);
+  }
+
+  @Test
   void separatesPartitionFromBatchDestinationName() {
     String partitionTopic = TOPIC + "-partition-0";
     PulsarBatchRequest request = batchRequest(message(partitionTopic), message(partitionTopic));
@@ -74,6 +94,15 @@ class PulsarRequestDestinationTest {
         batchRequest(message(TOPIC + "-partition-0"), message(TOPIC + "-partition-1"));
 
     assertThat(request.getDestination()).isEqualTo(TOPIC);
+    assertThat(request.getDestinationPartitionId()).isNull();
+  }
+
+  @Test
+  void keepsBatchTopicNameThatIsNotFullyQualifiedWhenBatchSpansMultiplePartitions() {
+    PulsarBatchRequest request =
+        batchRequest(message("test-partition-0"), message("test-partition-1"));
+
+    assertThat(request.getDestination()).isEqualTo("test");
     assertThat(request.getDestinationPartitionId()).isNull();
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/BasePulsarRequest.java
@@ -33,12 +33,34 @@ public class BasePulsarRequest {
    * embed the {@code -partition-N} suffix.
    */
   static String destination(String topicName) {
-    if (!emitStableMessagingSemconv() || TopicName.getPartitionIndex(topicName) == -1) {
+    if (!emitStableMessagingSemconv()) {
+      return topicName;
+    }
+    return stripPartitionSuffix(topicName);
+  }
+
+  /**
+   * Returns {@code topicName} without its {@code -partition-N} suffix, or {@code topicName} when it
+   * does not have one.
+   */
+  static String stripPartitionSuffix(String topicName) {
+    int partitionIndex = TopicName.getPartitionIndex(topicName);
+    if (partitionIndex == -1) {
+      return topicName;
+    }
+    int suffixIndex = topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    // pulsar 2.8 reads the partition index from the last '-' instead of from the last
+    // "-partition-", so it reports e.g. "my-topic-partition-key-1" as partition 1, and it accepts a
+    // zero padded suffix that pulsar 2.9+ rejects; only strip a suffix that is exactly the
+    // partition index, otherwise the topic name would lose more than the partition
+    if (!topicName
+        .substring(suffixIndex + TopicName.PARTITIONED_TOPIC_SUFFIX.length())
+        .equals(String.valueOf(partitionIndex))) {
       return topicName;
     }
     // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is
     // not fully qualified, e.g. "my-topic" to "persistent://public/default/my-topic"
-    return topicName.substring(0, topicName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX));
+    return topicName.substring(0, suffixIndex);
   }
 
   /** Returns the value to use for {@code messaging.destination.partition.id}. */

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarBatchRequest.java
@@ -12,7 +12,6 @@ import javax.annotation.Nullable;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
-import org.apache.pulsar.common.naming.TopicName;
 
 public class PulsarBatchRequest extends BasePulsarRequest {
   private final Messages<?> messages;
@@ -42,7 +41,7 @@ public class PulsarBatchRequest extends BasePulsarRequest {
         // this is a partitioned topic
         // persistent://public/default/test-partition-0 persistent://public/default/test-partition-1
         // return persistent://public/default/test
-        return TopicName.get(topicName).getPartitionedTopicName();
+        return stripPartitionSuffix(topicName);
       }
     }
     return topicName;

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/AbstractPulsarClientTest.java
@@ -489,8 +489,14 @@ abstract class AbstractPulsarClientTest {
 
   // the stable semantic conventions record the partition in messaging.destination.partition.id, so
   // the destination name does not include the "-partition-N" suffix there
+  // not using TopicName.getPartitionedTopicName(), because it also expands a topic name that is not
+  // fully qualified, which is not what the instrumentation does
   static String destinationName(String topic) {
-    return emitStableMessagingSemconv() ? TopicName.get(topic).getPartitionedTopicName() : topic;
+    if (!emitStableMessagingSemconv()) {
+      return topic;
+    }
+    int suffixIndex = topic.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX);
+    return suffixIndex == -1 ? topic : topic.substring(0, suffixIndex);
   }
 
   // messaging.destination.subscription.name only exists in the v1.43 messaging semantic conventions


### PR DESCRIPTION
the partition processing is different in 2.8 vs 2.9

https://github.com/apache/pulsar/blob/v2.8.0/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java#L271-L282

https://github.com/apache/pulsar/blob/v2.9.0/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java#L270
