### PR TITLE
Fix Spring JMS process span parent under stable messaging semconv, and isolate Vert.x Kafka tests

### DIFF
--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsMessageListenerInstrumentation.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringJmsMessageListenerInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static io.opentelemetry.javaagent.instrumentation.spring.jms.v2_0.SpringJmsSingletons.listenerInstrumenter;
@@ -66,9 +67,11 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope enter(Message message) {
         Context parentContext = Context.current();
-        Context receiveContext = JmsReceiveContextHolder.getReceiveContext(parentContext);
-        if (receiveContext != null) {
-          parentContext = receiveContext;
+        if (!emitStableMessagingSemconv()) {
+          Context receiveContext = JmsReceiveContextHolder.getReceiveContext(parentContext);
+          if (receiveContext != null) {
+            parentContext = receiveContext;
+          }
         }
 
         MessageWithDestination request =

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v2_0/SpringListenerTest.java
@@ -10,19 +10,43 @@ import static io.opentelemetry.api.trace.SpanKind.CONSUMER;
 import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.spring.jms.v2_0.AbstractJmsTest;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.annotation.JmsListenerConfigurer;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerEndpoint;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.jms.listener.MessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 class SpringListenerTest extends AbstractJmsTest {
 
@@ -31,6 +55,70 @@ class SpringListenerTest extends AbstractJmsTest {
 
   @RegisterExtension
   private static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void processSpanUsesSemconvParentWithReceiveSpan() throws Exception {
+    Tracer tracer = testing.getOpenTelemetry().getTracer("test");
+    Span ambient = tracer.spanBuilder("ambient").startSpan();
+
+    AnnotationConfigApplicationContext applicationContext;
+    try (Scope ignored = Context.root().with(ambient).makeCurrent()) {
+      applicationContext = new AnnotationConfigApplicationContext();
+      applicationContext.getEnvironment().setActiveProfiles("ambient-parent");
+      applicationContext.register(AmbientParentConfig.class);
+      applicationContext.refresh();
+    }
+
+    try {
+      ConnectionFactory factory = applicationContext.getBean(ConnectionFactory.class);
+      JmsTemplate template = new JmsTemplate(factory);
+      testing.runWithSpan(
+          "producer parent", () -> template.convertAndSend("SpringListenerJms2", "a message"));
+
+      CompletableFuture<String> receivedMessage =
+          applicationContext.getBean(CompletableFuture.class);
+      assertThat(receivedMessage.get(10, SECONDS)).isEqualTo("a message");
+    } finally {
+      applicationContext.close();
+      ambient.end();
+    }
+
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("producer parent", "ambient"),
+        trace -> {
+          trace.hasSpansSatisfyingExactly(
+              span -> span.hasName("producer parent").hasNoParent(),
+              span ->
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send SpringListenerJms2"
+                              : "SpringListenerJms2 publish")
+                      .hasKind(PRODUCER)
+                      .hasParent(trace.getSpan(0)));
+          producerSpan.set(trace.getSpan(1));
+        },
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("ambient").hasNoParent(),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive SpringListenerJms2"
+                                : "SpringListenerJms2 receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext())),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process SpringListenerJms2"
+                                : "SpringListenerJms2 process")
+                        .hasKind(CONSUMER)
+                        .hasParent(trace.getSpan(emitStableMessagingSemconv() ? 0 : 1))
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))));
+  }
 
   @ParameterizedTest
   @ValueSource(classes = {AnnotatedListenerConfig.class, ManualListenerConfig.class})
@@ -43,8 +131,39 @@ class SpringListenerTest extends AbstractJmsTest {
     template.convertAndSend("SpringListenerJms2", "a message");
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    if (emitStableMessagingSemconv()) {
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(PRODUCER, CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> assertProducerSpan(span, "SpringListenerJms2", false),
+                span ->
+                    assertConsumerSpan(
+                        span,
+                        trace.getSpan(0),
+                        trace.getSpan(0),
+                        "SpringListenerJms2",
+                        "process",
+                        false,
+                        null));
+            producerSpan.set(trace.getSpan(0));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      assertConsumerSpan(
+                          span,
+                          producerSpan.get(),
+                          null,
+                          "SpringListenerJms2",
+                          "receive",
+                          false,
+                          null)));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(PRODUCER, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
+        orderByRootSpanKind(PRODUCER, CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> assertProducerSpan(span, "SpringListenerJms2", false));
@@ -70,5 +189,60 @@ class SpringListenerTest extends AbstractJmsTest {
                         "process",
                         false,
                         null)));
+  }
+
+  @TestConfiguration
+  @EnableJms
+  @Profile("ambient-parent")
+  static class AmbientParentConfig extends AbstractConfig {
+
+    @Bean
+    CompletableFuture<String> receivedMessage() {
+      return new CompletableFuture<>();
+    }
+
+    @Bean
+    JmsListenerConfigurer ambientParentListenerConfigurer(
+        CompletableFuture<String> receivedMessage) {
+      return registrar ->
+          registrar.registerEndpoint(
+              new JmsListenerEndpoint() {
+                @Override
+                public String getId() {
+                  return "ambient-parent-listener";
+                }
+
+                @Override
+                public void setupListenerContainer(MessageListenerContainer listenerContainer) {
+                  AbstractMessageListenerContainer container =
+                      (AbstractMessageListenerContainer) listenerContainer;
+                  container.setDestinationName("SpringListenerJms2");
+                  container.setupMessageListener(
+                      (SessionAwareMessageListener<Message>)
+                          (message, session) ->
+                              receivedMessage.complete(((TextMessage) message).getText()));
+                }
+              });
+    }
+
+    @Bean
+    ThreadPoolTaskExecutor ambientParentTaskExecutor() {
+      Context ambientContext = Context.current();
+      ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+      executor.setCorePoolSize(1);
+      executor.setMaxPoolSize(1);
+      executor.setTaskDecorator(ambientContext::wrap);
+      return executor;
+    }
+
+    @Override
+    @Bean
+    JmsListenerContainerFactory<?> jmsListenerContainerFactory(
+        ConnectionFactory connectionFactory) {
+      DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+      factory.setConnectionFactory(connectionFactory);
+      factory.setTaskExecutor(ambientParentTaskExecutor());
+      return factory;
+    }
   }
 }

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsMessageListenerInstrumentation.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsMessageListenerInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
 import static io.opentelemetry.javaagent.instrumentation.spring.jms.v6_0.SpringJmsSingletons.listenerInstrumenter;
@@ -66,9 +67,11 @@ class SpringJmsMessageListenerInstrumentation implements TypeInstrumentation {
       @Nullable
       public static AdviceScope start(Message message) {
         Context parentContext = Context.current();
-        Context receiveContext = JmsReceiveContextHolder.getReceiveContext(parentContext);
-        if (receiveContext != null) {
-          parentContext = receiveContext;
+        if (!emitStableMessagingSemconv()) {
+          Context receiveContext = JmsReceiveContextHolder.getReceiveContext(parentContext);
+          if (receiveContext != null) {
+            parentContext = receiveContext;
+          }
         }
         MessageWithDestination request =
             MessageWithDestination.create(JakartaMessageAdapter.create(message), null);

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -180,15 +180,12 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
 
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
+        orderByRootSpanKind(INTERNAL, CONSUMER),
         trace -> {
           trace.hasSpansSatisfyingExactly(
               span -> span.hasName("parent").hasNoParent(),
               span ->
-                  span.hasName(
-                          emitStableMessagingSemconv()
-                              ? "send spring-jms-listener"
-                              : "spring-jms-listener publish")
+                  span.hasName("spring-jms-listener publish")
                       .hasKind(PRODUCER)
                       .hasParent(trace.getSpan(0))
                       .hasAttributesSatisfyingExactly(
@@ -204,11 +201,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "receive spring-jms-listener"
-                                : "spring-jms-listener receive")
-                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                    span.hasName("spring-jms-listener receive")
+                        .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
                         .hasAttributesSatisfyingExactly(
@@ -219,10 +213,7 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                             operationType("receive"),
                             satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "process spring-jms-listener"
-                                : "spring-jms-listener process")
+                    span.hasName("spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
@@ -337,15 +328,12 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
     }
 
     testing.waitAndAssertSortedTraces(
-        orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
+        orderByRootSpanKind(INTERNAL, CONSUMER),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent(),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "send spring-jms-listener"
-                                : "spring-jms-listener publish")
+                    span.hasName("spring-jms-listener publish")
                         .hasKind(PRODUCER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -364,11 +352,8 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "receive spring-jms-listener"
-                                : "spring-jms-listener receive")
-                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                    span.hasName("spring-jms-listener receive")
+                        .hasKind(CONSUMER)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(MESSAGING_SYSTEM, "jms"),
@@ -384,10 +369,7 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
                                 stringArrayKey("messaging.header.Test_Message_Int_Header"),
                                 singletonList("1234"))),
                 span ->
-                    span.hasName(
-                            emitStableMessagingSemconv()
-                                ? "process spring-jms-listener"
-                                : "spring-jms-listener process")
+                    span.hasName("spring-jms-listener process")
                         .hasKind(CONSUMER)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
+++ b/instrumentation/spring/spring-jms/spring-jms-6.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/jms/v6_0/SpringJmsListenerTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.api.trace.SpanKind.PRODUCER;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
+import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
@@ -25,24 +26,158 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.AbstractStringAssert;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.annotation.JmsListenerConfigurer;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerEndpoint;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.jms.listener.MessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void processSpanUsesSemconvParentWithReceiveSpan() throws Exception {
+    Tracer tracer = testing.getOpenTelemetry().getTracer("test");
+    Span ambient = tracer.spanBuilder("ambient").startSpan();
+
+    SpringApplication app = new SpringApplication(AmbientParentConfig.class);
+    app.setDefaultProperties(defaultConfig());
+    app.setAdditionalProfiles("ambient-parent");
+    ConfigurableApplicationContext applicationContext;
+    try (Scope ignored = Context.root().with(ambient).makeCurrent()) {
+      applicationContext = app.run();
+    }
+
+    try {
+      JmsTemplate jmsTemplate =
+          new JmsTemplate(applicationContext.getBean(ConnectionFactory.class));
+      testing.runWithSpan(
+          "producer parent",
+          () -> jmsTemplate.convertAndSend("spring-jms-listener", "hello there"));
+
+      CompletableFuture<String> receivedMessage =
+          applicationContext.getBean(CompletableFuture.class);
+      assertThat(receivedMessage.get(10, SECONDS)).isEqualTo("hello there");
+    } finally {
+      applicationContext.close();
+      ambient.end();
+    }
+
+    AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+    testing.waitAndAssertSortedTraces(
+        orderByRootSpanName("producer parent", "ambient"),
+        trace -> {
+          trace.hasSpansSatisfyingExactly(
+              span -> span.hasName("producer parent").hasNoParent(),
+              span ->
+                  span.hasName(
+                          emitStableMessagingSemconv()
+                              ? "send spring-jms-listener"
+                              : "spring-jms-listener publish")
+                      .hasKind(PRODUCER)
+                      .hasParent(trace.getSpan(0)));
+          producerSpan.set(trace.getSpan(1));
+        },
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("ambient").hasNoParent(),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "receive spring-jms-listener"
+                                : "spring-jms-listener receive")
+                        .hasKind(emitStableMessagingSemconv() ? CLIENT : CONSUMER)
+                        .hasParent(trace.getSpan(0))
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext())),
+                span ->
+                    span.hasName(
+                            emitStableMessagingSemconv()
+                                ? "process spring-jms-listener"
+                                : "spring-jms-listener process")
+                        .hasKind(CONSUMER)
+                        .hasParent(trace.getSpan(emitStableMessagingSemconv() ? 0 : 1))
+                        .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))));
+  }
+
   @Override
   void assertSpringJmsListener() {
+    if (emitStableMessagingSemconv()) {
+      AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(INTERNAL, CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasNoParent(),
+                span ->
+                    span.hasName("send spring-jms-listener")
+                        .hasKind(PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            oldOperation("publish"),
+                            operationName("send"),
+                            operationType("send"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
+                span ->
+                    span.hasName("process spring-jms-listener")
+                        .hasKind(CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank)),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive spring-jms-listener")
+                          .hasKind(CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_SYSTEM, "jms"),
+                              equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                              oldOperation("receive"),
+                              operationName("receive"),
+                              operationType("receive"),
+                              satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank))));
+      return;
+    }
+
     AtomicReference<SpanData> producerSpan = new AtomicReference<>();
     testing.waitAndAssertSortedTraces(
         orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
@@ -133,6 +268,74 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
         applicationContext.getBean("receivedMessage", CompletableFuture.class);
     assertThat(receivedMessage.get(10, SECONDS)).isEqualTo(message);
 
+    if (emitStableMessagingSemconv()) {
+      AtomicReference<SpanData> producerSpan = new AtomicReference<>();
+      testing.waitAndAssertSortedTraces(
+          orderByRootSpanKind(INTERNAL, CLIENT),
+          trace -> {
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasNoParent(),
+                span ->
+                    span.hasName("send spring-jms-listener")
+                        .hasKind(PRODUCER)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            oldOperation("publish"),
+                            operationName("send"),
+                            operationType("send"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                            equalTo(
+                                stringArrayKey("messaging.header.Test_Message_Header"),
+                                singletonList("test")),
+                            equalTo(
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
+                                singletonList("1234"))),
+                span ->
+                    span.hasName("process spring-jms-listener")
+                        .hasKind(CONSUMER)
+                        .hasParent(trace.getSpan(1))
+                        .hasLinks(LinkData.create(trace.getSpan(1).getSpanContext()))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                            equalTo(
+                                stringArrayKey("messaging.header.Test_Message_Header"),
+                                singletonList("test")),
+                            equalTo(
+                                stringArrayKey("messaging.header.Test_Message_Int_Header"),
+                                singletonList("1234"))),
+                span -> span.hasName("consumer").hasParent(trace.getSpan(2)));
+            producerSpan.set(trace.getSpan(1));
+          },
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName("receive spring-jms-listener")
+                          .hasKind(CLIENT)
+                          .hasNoParent()
+                          .hasLinks(LinkData.create(producerSpan.get().getSpanContext()))
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(MESSAGING_SYSTEM, "jms"),
+                              equalTo(MESSAGING_DESTINATION_NAME, "spring-jms-listener"),
+                              oldOperation("receive"),
+                              operationName("receive"),
+                              operationType("receive"),
+                              satisfies(MESSAGING_MESSAGE_ID, AbstractStringAssert::isNotBlank),
+                              equalTo(
+                                  stringArrayKey("messaging.header.Test_Message_Header"),
+                                  singletonList("test")),
+                              equalTo(
+                                  stringArrayKey("messaging.header.Test_Message_Int_Header"),
+                                  singletonList("1234")))));
+      return;
+    }
+
     testing.waitAndAssertSortedTraces(
         orderByRootSpanKind(INTERNAL, emitStableMessagingSemconv() ? CLIENT : CONSUMER),
         trace ->
@@ -213,5 +416,55 @@ class SpringJmsListenerTest extends AbstractSpringJmsListenerTest {
 
   private static AttributeAssertion operationType(String operation) {
     return equalTo(MESSAGING_OPERATION_TYPE, emitStableMessagingSemconv() ? operation : null);
+  }
+
+  @TestConfiguration
+  @EnableJms
+  @Profile("ambient-parent")
+  static class AmbientParentConfig extends AbstractConfig {
+
+    @Bean
+    JmsListenerConfigurer ambientParentListenerConfigurer(
+        CompletableFuture<String> receivedMessage) {
+      return registrar ->
+          registrar.registerEndpoint(
+              new JmsListenerEndpoint() {
+                @Override
+                public String getId() {
+                  return "ambient-parent-listener";
+                }
+
+                @Override
+                public void setupListenerContainer(MessageListenerContainer listenerContainer) {
+                  AbstractMessageListenerContainer container =
+                      (AbstractMessageListenerContainer) listenerContainer;
+                  container.setDestinationName("spring-jms-listener");
+                  container.setupMessageListener(
+                      (SessionAwareMessageListener<Message>)
+                          (message, session) ->
+                              receivedMessage.complete(((TextMessage) message).getText()));
+                }
+              });
+    }
+
+    @Bean
+    ThreadPoolTaskExecutor ambientParentTaskExecutor() {
+      Context ambientContext = Context.current();
+      ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+      executor.setCorePoolSize(1);
+      executor.setMaxPoolSize(1);
+      executor.setTaskDecorator(ambientContext::wrap);
+      return executor;
+    }
+
+    @Override
+    @Bean
+    JmsListenerContainerFactory<?> jmsListenerContainerFactory(
+        ConnectionFactory connectionFactory) {
+      DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+      factory.setConnectionFactory(connectionFactory);
+      factory.setTaskExecutor(ambientParentTaskExecutor());
+      return factory;
+    }
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
@@ -35,7 +35,13 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
     // in Vertx, a batch handler is something that runs in addition to the regular single record
     // handler -- the KafkaConsumer won't start polling unless you set the regular handler
     kafkaConsumer.batchHandler(BatchRecordsHandler.INSTANCE);
-    kafkaConsumer.handler(record -> testing().runWithSpan("process " + record.value(), () -> {}));
+    kafkaConsumer.handler(
+        record -> {
+          testing().runWithSpan("process " + record.value(), () -> {});
+          if (BatchRecordsHandler.recordProcessed()) {
+            kafkaConsumer.pause();
+          }
+        });
 
     kafkaConsumer.partitionsAssignedHandler(partitions -> consumerReady.countDown());
     subscribe("testBatchTopic");

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
@@ -202,6 +202,8 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
   private void sendSingleRecord(KafkaProducerRecord<String, String> record)
       throws InterruptedException {
+    // Wait for the poll that was in flight when the consumer paused to finish.
+    Thread.sleep(1_000);
     testing().clearData();
 
     CountDownLatch sent = new CountDownLatch(1);

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
@@ -28,13 +28,21 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
   void setUpTopicAndConsumer() {
     kafkaConsumer.handler(
         record -> {
-          testing().runWithSpan("consumer", () -> {});
-          if ("error".equals(record.value())) {
-            throw new IllegalArgumentException("boom");
+          try {
+            testing().runWithSpan("consumer", () -> {});
+            if ("error".equals(record.value())) {
+              throw new IllegalArgumentException("boom");
+            }
+          } finally {
+            kafkaConsumer.pause();
           }
         });
 
-    kafkaConsumer.partitionsAssignedHandler(partitions -> consumerReady.countDown());
+    kafkaConsumer.partitionsAssignedHandler(
+        partitions -> {
+          kafkaConsumer.pause();
+          consumerReady.countDown();
+        });
     subscribe("testSingleTopic");
   }
 
@@ -44,9 +52,7 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     KafkaProducerRecord<String, String> record =
         KafkaProducerRecord.create("testSingleTopic", "10", "testSpan");
-    CountDownLatch sent = new CountDownLatch(1);
-    testing().runWithSpan("producer", () -> sendRecord(record, result -> sent.countDown()));
-    assertThat(sent.await(30, SECONDS)).isTrue();
+    sendSingleRecord(record);
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
@@ -120,9 +126,7 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
     KafkaProducerRecord<String, String> record =
         KafkaProducerRecord.create("testSingleTopic", "10", "error");
-    CountDownLatch sent = new CountDownLatch(1);
-    testing().runWithSpan("producer", () -> sendRecord(record, result -> sent.countDown()));
-    assertThat(sent.await(30, SECONDS)).isTrue();
+    sendSingleRecord(record);
 
     AtomicReference<SpanData> producer = new AtomicReference<>();
 
@@ -194,5 +198,15 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
                             .hasAttributesSatisfyingExactly(
                                 withErrorType(processAttributes(record))),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(1))));
+  }
+
+  private void sendSingleRecord(KafkaProducerRecord<String, String> record)
+      throws InterruptedException {
+    testing().clearData();
+
+    CountDownLatch sent = new CountDownLatch(1);
+    testing().runWithSpan("producer", () -> sendRecord(record, result -> sent.countDown()));
+    assertThat(sent.await(30, SECONDS)).isTrue();
+    kafkaConsumer.resume();
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractVertxKafkaTest.java
@@ -143,6 +143,7 @@ public abstract class AbstractVertxKafkaTest {
 
       // wait a bit to ensure that the consumer has really paused
       Thread.sleep(1000);
+      testing().clearData();
 
       CountDownLatch sent = new CountDownLatch(records.length);
       testing()

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/BatchRecordsHandler.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/BatchRecordsHandler.java
@@ -21,6 +21,7 @@ class BatchRecordsHandler implements Handler<KafkaConsumerRecords<String, String
   static final BatchRecordsHandler INSTANCE = new BatchRecordsHandler();
 
   private static final AtomicInteger lastBatchSize = new AtomicInteger();
+  private static final AtomicInteger remainingRecords = new AtomicInteger();
   private static volatile CountDownLatch messageReceived = new CountDownLatch(0);
 
   private BatchRecordsHandler() {}
@@ -42,6 +43,7 @@ class BatchRecordsHandler implements Handler<KafkaConsumerRecords<String, String
   static void reset(int expectedBatchSize) {
     messageReceived = new CountDownLatch(expectedBatchSize);
     lastBatchSize.set(0);
+    remainingRecords.set(expectedBatchSize);
   }
 
   static void waitForMessages() throws InterruptedException {
@@ -50,5 +52,9 @@ class BatchRecordsHandler implements Handler<KafkaConsumerRecords<String, String
 
   static int getLastBatchSize() {
     return lastBatchSize.get();
+  }
+
+  static boolean recordProcessed() {
+    return remainingRecords.decrementAndGet() == 0;
   }
 }


### PR DESCRIPTION
Under stable messaging semantic conventions, the Spring JMS listener no longer parents its `process` span to the JMS `receive` span. The receive span is a separate client operation, so the process span takes whatever context was current when the listener ran, falling back to the message creation context when nothing was current. It links the producer either way. This matches what Pulsar and RocketMQ already do, and it means a `receive` span no longer swallows the ambient parent of the listener's work:

```
# before, with -Dotel.semconv-stability.preview=messaging
ambient
└── receive spring-jms-listener
    └── process spring-jms-listener

# after
ambient
├── receive spring-jms-listener   (links to send)
└── process spring-jms-listener   (links to send)
```

With no ambient context the process span parents to the message creation context, so it joins the producer's trace and the receive span stands on its own:

```
# before
send spring-jms-listener

receive spring-jms-listener       (links to send)
└── process spring-jms-listener   (links to send)

# after
send spring-jms-listener
└── process spring-jms-listener   (links to send)

receive spring-jms-listener       (links to send)
```

Legacy semconv behavior is unchanged: the process span still parents to the receive span there.

Both `spring-jms-2.0` and `spring-jms-6.0` get a regression test that runs the listener container under an ambient span, so the process span's parent is observable rather than inferred from a root-span ordering.

### Vert.x Kafka test isolation

The Vert.x Kafka change removes a real cross-test leak rather than just tidying tests. The consumer kept polling between assertions, so records and startup poll telemetry from one test could be observed by the next.

The single-record tests now pause the consumer outside each assertion and clear telemetry before producing, so a test sees only the record it sent, and the batch tests pause once the expected batch has been processed.

That also makes this module less sensitive to whether kafka-clients emits a receive span for an empty poll under stable messaging semconv, because a stray empty-poll span no longer survives into the next assertion. The module already carried a retry loop for batch flakiness; this removes one of the sources feeding it.

### Relationship to #19490

Both changes are rescued from #19490, whose messaging receive-telemetry policy change has been abandoned. They are unrelated to that abandoned default and would otherwise be lost when that branch closes.

The rest of that branch is not extracted: its Pulsar and RocketMQ fixes all build on empty-receive telemetry that only exists there, and its AWS SDK advice change reverts part of #17661 without a failure reproducible on `main`.