### PR TITLE
Preserve Dubbo ClusterInvoker type when capturing registry address

### DIFF
--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
@@ -18,7 +18,7 @@ testing {
     register<JvmTestSuite>("testClusterInvoker") {
       dependencies {
         implementation(project())
-        implementation("org.apache.dubbo:dubbo:2.7.14")
+        implementation("org.apache.dubbo:dubbo:${baseVersion("2.7.14").orLatest()}")
       }
     }
   }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/build.gradle.kts
@@ -13,6 +13,17 @@ dependencies {
   testLibrary("org.apache.dubbo:dubbo-config-api:2.7.0")
 }
 
+testing {
+  suites {
+    register<JvmTestSuite>("testClusterInvoker") {
+      dependencies {
+        implementation(project())
+        implementation("org.apache.dubbo:dubbo:2.7.14")
+      }
+    }
+  }
+}
+
 tasks.withType<Test>().configureEach {
   systemProperty("testLatestDeps", otelProps.testLatestDeps)
   jvmArgs("-XX:+IgnoreUnrecognizedVMOptions")
@@ -40,6 +51,6 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testBothSemconv)
+    dependsOn(testing.suites, testStableSemconv, testBothSemconv)
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterWrapper.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterWrapper.java
@@ -100,6 +100,6 @@ public final class RegistryCapturingClusterWrapper implements Cluster {
     if (registryAddress == null) {
       return invoker;
     }
-    return new RegistryCapturingInvoker<>(invoker, registryAddress);
+    return RegistryCapturingInvoker.wrap(invoker, registryAddress);
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
@@ -5,13 +5,10 @@
 
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
-import static java.util.logging.Level.FINE;
-
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -28,11 +25,6 @@ final class RegistryCapturingInvoker implements InvocationHandler {
   // ClusterInvoker was introduced in Dubbo 2.7.8. It does not exist in Dubbo 2.7.0 through
   // 2.7.7, which this module supports using a 2.7.0 compile-time dependency. Load the interface
   // reflectively to avoid linking against it when instrumenting Dubbo 2.7.0 through 2.7.7.
-  private static final String CLUSTER_INVOKER_CLASS_NAME =
-      "org.apache.dubbo.rpc.cluster.ClusterInvoker";
-
-  private static final Logger logger = Logger.getLogger(RegistryCapturingInvoker.class.getName());
-
   private final Invoker<?> delegate;
   private final String registryAddress;
 
@@ -43,12 +35,7 @@ final class RegistryCapturingInvoker implements InvocationHandler {
             ? clusterInvokerClass
             : Invoker.class;
 
-    try {
-      return createProxy(delegate, registryAddress, proxyInterface);
-    } catch (RuntimeException | LinkageError e) {
-      logger.log(FINE, "Unable to wrap Dubbo Invoker", e);
-      return delegate;
-    }
+    return createProxy(delegate, registryAddress, proxyInterface);
   }
 
   private RegistryCapturingInvoker(Invoker<?> delegate, String registryAddress) {
@@ -59,7 +46,10 @@ final class RegistryCapturingInvoker implements InvocationHandler {
   @Nullable
   private static Class<?> getClusterInvokerClass(Invoker<?> delegate) {
     try {
-      return Class.forName(CLUSTER_INVOKER_CLASS_NAME, false, delegate.getClass().getClassLoader());
+      return Class.forName(
+          "org.apache.dubbo.rpc.cluster.ClusterInvoker",
+          false,
+          delegate.getClass().getClassLoader());
     } catch (ClassNotFoundException | LinkageError ignored) {
       return null;
     }
@@ -80,12 +70,31 @@ final class RegistryCapturingInvoker implements InvocationHandler {
   @Nullable
   public Object invoke(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
     if (method.getDeclaringClass() == Object.class) {
-      return invokeObjectMethod(proxy, method, args);
+      String methodName = method.getName();
+      // Preserve identity-based Object method behavior. Forwarding equals to a delegate that
+      // inherits Object.equals would make proxy.equals(proxy) return false.
+      if (methodName.equals("equals")
+          && method.getParameterCount() == 1
+          && method.getReturnType() == boolean.class) {
+        return args != null && proxy == args[0];
+      }
+      if (methodName.equals("hashCode")
+          && method.getParameterCount() == 0
+          && method.getReturnType() == int.class) {
+        return System.identityHashCode(proxy);
+      }
+      if (methodName.equals("toString")
+          && method.getParameterCount() == 0
+          && method.getReturnType() == String.class) {
+        return RegistryCapturingInvoker.class.getName()
+            + "@"
+            + Integer.toHexString(System.identityHashCode(proxy));
+      }
     }
     if (isInvokerInvoke(method)) {
       String previous = DubboRegistryUtil.pushCapturedRegistryAddress(registryAddress);
       try {
-        return delegate.invoke((Invocation) args[0]);
+        return invokeDelegate(method, args);
       } finally {
         DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
       }
@@ -106,23 +115,5 @@ final class RegistryCapturingInvoker implements InvocationHandler {
     } catch (InvocationTargetException e) {
       throw e.getCause();
     }
-  }
-
-  // Preserve identity-based Object method behavior. Forwarding equals to a delegate that inherits
-  // Object.equals would make proxy.equals(proxy) return false.
-  private static Object invokeObjectMethod(Object proxy, Method method, @Nullable Object[] args) {
-    String methodName = method.getName();
-    if (methodName.equals("equals")) {
-      return args != null && proxy == args[0];
-    }
-    if (methodName.equals("hashCode")) {
-      return System.identityHashCode(proxy);
-    }
-    if (methodName.equals("toString")) {
-      return RegistryCapturingInvoker.class.getName()
-          + "@"
-          + Integer.toHexString(System.identityHashCode(proxy));
-    }
-    throw new IllegalStateException("Unexpected Object method: " + methodName);
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
@@ -13,19 +13,17 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
-import org.apache.dubbo.rpc.Result;
 
 /**
- * Wraps a cluster invoker to publish the consumer registry address for the current thread while the
+ * Wraps a Dubbo invoker to publish the consumer registry address for the current thread while the
  * delegate chain runs (for example into the Dubbo consumer protocol filter chain).
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-final class RegistryCapturingInvoker<T> implements Invoker<T> {
+final class RegistryCapturingInvoker implements InvocationHandler {
 
   // ClusterInvoker was introduced in Dubbo 2.7.8. It does not exist in Dubbo 2.7.0 through
   // 2.7.7, which this module supports using a 2.7.0 compile-time dependency. Load the interface
@@ -35,24 +33,25 @@ final class RegistryCapturingInvoker<T> implements Invoker<T> {
 
   private static final Logger logger = Logger.getLogger(RegistryCapturingInvoker.class.getName());
 
-  private final Invoker<T> delegate;
+  private final Invoker<?> delegate;
   private final String registryAddress;
 
   static <T> Invoker<T> wrap(Invoker<T> delegate, String registryAddress) {
     Class<?> clusterInvokerClass = getClusterInvokerClass(delegate);
-    if (clusterInvokerClass == null || !clusterInvokerClass.isInstance(delegate)) {
-      return new RegistryCapturingInvoker<>(delegate, registryAddress);
-    }
+    Class<?> proxyInterface =
+        clusterInvokerClass != null && clusterInvokerClass.isInstance(delegate)
+            ? clusterInvokerClass
+            : Invoker.class;
 
     try {
-      return createClusterInvokerProxy(delegate, registryAddress, clusterInvokerClass);
+      return createProxy(delegate, registryAddress, proxyInterface);
     } catch (RuntimeException | LinkageError e) {
-      logger.log(FINE, "Unable to wrap Dubbo ClusterInvoker", e);
+      logger.log(FINE, "Unable to wrap Dubbo Invoker", e);
       return delegate;
     }
   }
 
-  RegistryCapturingInvoker(Invoker<T> delegate, String registryAddress) {
+  private RegistryCapturingInvoker(Invoker<?> delegate, String registryAddress) {
     this.delegate = delegate;
     this.registryAddress = registryAddress;
   }
@@ -66,103 +65,64 @@ final class RegistryCapturingInvoker<T> implements Invoker<T> {
     }
   }
 
-  // clusterInvokerClass is checked against delegate and ClusterInvoker extends Invoker<T>
+  // proxyInterface is either Invoker or ClusterInvoker, which extends Invoker<T>
   @SuppressWarnings("unchecked")
-  private static <T> Invoker<T> createClusterInvokerProxy(
-      Invoker<T> delegate, String registryAddress, Class<?> clusterInvokerClass) {
+  private static <T> Invoker<T> createProxy(
+      Invoker<T> delegate, String registryAddress, Class<?> proxyInterface) {
     return (Invoker<T>)
         Proxy.newProxyInstance(
-            clusterInvokerClass.getClassLoader(),
-            new Class<?>[] {clusterInvokerClass},
-            new ClusterInvokerInvocationHandler(delegate, registryAddress));
+            proxyInterface.getClassLoader(),
+            new Class<?>[] {proxyInterface},
+            new RegistryCapturingInvoker(delegate, registryAddress));
   }
 
   @Override
-  public Class<T> getInterface() {
-    return delegate.getInterface();
-  }
-
-  @Override
-  public URL getUrl() {
-    return delegate.getUrl();
-  }
-
-  @Override
-  public boolean isAvailable() {
-    return delegate.isAvailable();
-  }
-
-  @Override
-  public void destroy() {
-    delegate.destroy();
-  }
-
-  @Override
-  public Result invoke(Invocation invocation) {
-    String previous = DubboRegistryUtil.pushCapturedRegistryAddress(registryAddress);
-    try {
-      return delegate.invoke(invocation);
-    } finally {
-      DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
+  @Nullable
+  public Object invoke(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
+    if (method.getDeclaringClass() == Object.class) {
+      return invokeObjectMethod(proxy, method, args);
     }
-  }
-
-  private static class ClusterInvokerInvocationHandler implements InvocationHandler {
-
-    private final Invoker<?> delegate;
-    private final String registryAddress;
-
-    ClusterInvokerInvocationHandler(Invoker<?> delegate, String registryAddress) {
-      this.delegate = delegate;
-      this.registryAddress = registryAddress;
-    }
-
-    @Override
-    @Nullable
-    public Object invoke(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
-      if (method.getDeclaringClass() == Object.class) {
-        return invokeObjectMethod(proxy, method, args);
-      }
-      if (isInvokerInvoke(method)) {
-        String previous = DubboRegistryUtil.pushCapturedRegistryAddress(registryAddress);
-        try {
-          return delegate.invoke((Invocation) args[0]);
-        } finally {
-          DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
-        }
-      }
-      return invokeDelegate(method, args);
-    }
-
-    private static boolean isInvokerInvoke(Method method) {
-      return method.getName().equals("invoke")
-          && method.getParameterCount() == 1
-          && method.getParameterTypes()[0] == Invocation.class;
-    }
-
-    @Nullable
-    private Object invokeDelegate(Method method, @Nullable Object[] args) throws Throwable {
+    if (isInvokerInvoke(method)) {
+      String previous = DubboRegistryUtil.pushCapturedRegistryAddress(registryAddress);
       try {
-        return method.invoke(delegate, args);
-      } catch (InvocationTargetException e) {
-        throw e.getCause();
+        return delegate.invoke((Invocation) args[0]);
+      } finally {
+        DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
       }
     }
+    return invokeDelegate(method, args);
+  }
 
-    private static Object invokeObjectMethod(Object proxy, Method method, @Nullable Object[] args) {
-      String methodName = method.getName();
-      if (methodName.equals("equals")) {
-        return args != null && proxy == args[0];
-      }
-      if (methodName.equals("hashCode")) {
-        return System.identityHashCode(proxy);
-      }
-      if (methodName.equals("toString")) {
-        return RegistryCapturingInvoker.class.getName()
-            + "@"
-            + Integer.toHexString(System.identityHashCode(proxy));
-      }
-      throw new IllegalStateException("Unexpected Object method: " + methodName);
+  private static boolean isInvokerInvoke(Method method) {
+    return method.getName().equals("invoke")
+        && method.getParameterCount() == 1
+        && method.getParameterTypes()[0] == Invocation.class;
+  }
+
+  @Nullable
+  private Object invokeDelegate(Method method, @Nullable Object[] args) throws Throwable {
+    try {
+      return method.invoke(delegate, args);
+    } catch (InvocationTargetException e) {
+      throw e.getCause();
     }
+  }
+
+  // Preserve identity-based Object method behavior. Forwarding equals to a delegate that inherits
+  // Object.equals would make proxy.equals(proxy) return false.
+  private static Object invokeObjectMethod(Object proxy, Method method, @Nullable Object[] args) {
+    String methodName = method.getName();
+    if (methodName.equals("equals")) {
+      return args != null && proxy == args[0];
+    }
+    if (methodName.equals("hashCode")) {
+      return System.identityHashCode(proxy);
+    }
+    if (methodName.equals("toString")) {
+      return RegistryCapturingInvoker.class.getName()
+          + "@"
+          + Integer.toHexString(System.identityHashCode(proxy));
+    }
+    throw new IllegalStateException("Unexpected Object method: " + methodName);
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
@@ -27,8 +27,9 @@ import org.apache.dubbo.rpc.Result;
  */
 final class RegistryCapturingInvoker<T> implements Invoker<T> {
 
-  // ClusterInvoker was added after the 2.7.0 compile-time baseline of this module. Load it
-  // reflectively so that this class remains compatible with older Dubbo versions.
+  // ClusterInvoker was introduced in Dubbo 2.7.8. It does not exist in Dubbo 2.7.0 through
+  // 2.7.7, which this module supports using a 2.7.0 compile-time dependency. Load the interface
+  // reflectively to avoid linking against it when instrumenting Dubbo 2.7.0 through 2.7.7.
   private static final String CLUSTER_INVOKER_CLASS_NAME =
       "org.apache.dubbo.rpc.cluster.ClusterInvoker";
 

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
@@ -5,6 +5,14 @@
 
 package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 
+import static java.util.logging.Level.FINE;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
@@ -19,8 +27,49 @@ import org.apache.dubbo.rpc.Result;
  */
 final class RegistryCapturingInvoker<T> implements Invoker<T> {
 
+  // ClusterInvoker was added after the 2.7.0 compile-time baseline of this module. Load it
+  // reflectively so that this class remains compatible with older Dubbo versions.
+  private static final String CLUSTER_INVOKER_CLASS_NAME =
+      "org.apache.dubbo.rpc.cluster.ClusterInvoker";
+
+  private static final Logger logger = Logger.getLogger(RegistryCapturingInvoker.class.getName());
+
   private final Invoker<T> delegate;
   private final String registryAddress;
+
+  static <T> Invoker<T> wrap(Invoker<T> delegate, String registryAddress) {
+    Class<?> clusterInvokerClass = getClusterInvokerClass(delegate);
+    if (clusterInvokerClass == null || !clusterInvokerClass.isInstance(delegate)) {
+      return new RegistryCapturingInvoker<>(delegate, registryAddress);
+    }
+
+    try {
+      return createClusterInvokerProxy(delegate, registryAddress, clusterInvokerClass);
+    } catch (RuntimeException | LinkageError e) {
+      logger.log(FINE, "Unable to wrap Dubbo ClusterInvoker", e);
+      return delegate;
+    }
+  }
+
+  @Nullable
+  private static Class<?> getClusterInvokerClass(Invoker<?> delegate) {
+    try {
+      return Class.forName(CLUSTER_INVOKER_CLASS_NAME, false, delegate.getClass().getClassLoader());
+    } catch (ClassNotFoundException | LinkageError ignored) {
+      return null;
+    }
+  }
+
+  // clusterInvokerClass is checked against delegate and ClusterInvoker extends Invoker<T>
+  @SuppressWarnings("unchecked")
+  private static <T> Invoker<T> createClusterInvokerProxy(
+      Invoker<T> delegate, String registryAddress, Class<?> clusterInvokerClass) {
+    return (Invoker<T>)
+        Proxy.newProxyInstance(
+            clusterInvokerClass.getClassLoader(),
+            new Class<?>[] {clusterInvokerClass},
+            new ClusterInvokerInvocationHandler(delegate, registryAddress));
+  }
 
   RegistryCapturingInvoker(Invoker<T> delegate, String registryAddress) {
     this.delegate = delegate;
@@ -54,6 +103,65 @@ final class RegistryCapturingInvoker<T> implements Invoker<T> {
       return delegate.invoke(invocation);
     } finally {
       DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
+    }
+  }
+
+  private static class ClusterInvokerInvocationHandler implements InvocationHandler {
+
+    private final Invoker<?> delegate;
+    private final String registryAddress;
+
+    ClusterInvokerInvocationHandler(Invoker<?> delegate, String registryAddress) {
+      this.delegate = delegate;
+      this.registryAddress = registryAddress;
+    }
+
+    @Override
+    @Nullable
+    public Object invoke(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
+      if (method.getDeclaringClass() == Object.class) {
+        return invokeObjectMethod(proxy, method, args);
+      }
+      if (isInvokerInvoke(method)) {
+        String previous = DubboRegistryUtil.pushCapturedRegistryAddress(registryAddress);
+        try {
+          return delegate.invoke((Invocation) args[0]);
+        } finally {
+          DubboRegistryUtil.restoreCapturedRegistryAddress(previous);
+        }
+      }
+      return invokeDelegate(method, args);
+    }
+
+    private static boolean isInvokerInvoke(Method method) {
+      return method.getName().equals("invoke")
+          && method.getParameterCount() == 1
+          && method.getParameterTypes()[0] == Invocation.class;
+    }
+
+    @Nullable
+    private Object invokeDelegate(Method method, @Nullable Object[] args) throws Throwable {
+      try {
+        return method.invoke(delegate, args);
+      } catch (InvocationTargetException e) {
+        throw e.getCause();
+      }
+    }
+
+    private static Object invokeObjectMethod(Object proxy, Method method, @Nullable Object[] args) {
+      String methodName = method.getName();
+      if (methodName.equals("equals")) {
+        return args != null && proxy == args[0];
+      }
+      if (methodName.equals("hashCode")) {
+        return System.identityHashCode(proxy);
+      }
+      if (methodName.equals("toString")) {
+        return RegistryCapturingInvoker.class.getName()
+            + "@"
+            + Integer.toHexString(System.identityHashCode(proxy));
+      }
+      throw new IllegalStateException("Unexpected Object method: " + methodName);
     }
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingInvoker.java
@@ -52,6 +52,11 @@ final class RegistryCapturingInvoker<T> implements Invoker<T> {
     }
   }
 
+  RegistryCapturingInvoker(Invoker<T> delegate, String registryAddress) {
+    this.delegate = delegate;
+    this.registryAddress = registryAddress;
+  }
+
   @Nullable
   private static Class<?> getClusterInvokerClass(Invoker<?> delegate) {
     try {
@@ -70,11 +75,6 @@ final class RegistryCapturingInvoker<T> implements Invoker<T> {
             clusterInvokerClass.getClassLoader(),
             new Class<?>[] {clusterInvokerClass},
             new ClusterInvokerInvocationHandler(delegate, registryAddress));
-  }
-
-  RegistryCapturingInvoker(Invoker<T> delegate, String registryAddress) {
-    this.delegate = delegate;
-    this.registryAddress = registryAddress;
   }
 
   @Override

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterWrapperTest.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/test/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterWrapperTest.java
@@ -8,10 +8,12 @@ package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Proxy;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.cluster.Cluster;
 import org.apache.dubbo.rpc.cluster.Directory;
 import org.apache.dubbo.rpc.cluster.directory.StaticDirectory;
@@ -21,6 +23,20 @@ class RegistryCapturingClusterWrapperTest {
 
   private static final URL DUMMY_URL =
       URL.valueOf("dubbo://192.168.1.100:20880/com.example.Service");
+  private static final String REGISTRY_ADDRESS = "zookeeper://localhost:2181";
+
+  @Test
+  void wrapsRegularInvokerWithJdkProxy() {
+    NoopInvoker delegate = new NoopInvoker(DUMMY_URL);
+
+    Invoker<Object> wrapped = RegistryCapturingInvoker.wrap(delegate, REGISTRY_ADDRESS);
+
+    assertThat(Proxy.isProxyClass(wrapped.getClass())).isTrue();
+    assertThat(wrapped.getUrl()).isSameAs(DUMMY_URL);
+    assertThat(wrapped.invoke(new RpcInvocation())).isNull();
+    assertThat(delegate.capturedRegistryAddress).isEqualTo(REGISTRY_ADDRESS);
+    assertThat(DubboRegistryUtil.extractRegistryAddress(new RpcInvocation())).isNull();
+  }
 
   @Test
   void joinDoesNotWrapStaticDirectory() {
@@ -64,6 +80,7 @@ class RegistryCapturingClusterWrapperTest {
 
   private static class NoopInvoker implements Invoker<Object> {
     private final URL url;
+    private String capturedRegistryAddress;
 
     NoopInvoker(URL url) {
       this.url = url;
@@ -76,6 +93,8 @@ class RegistryCapturingClusterWrapperTest {
 
     @Override
     public Result invoke(Invocation invocation) {
+      capturedRegistryAddress =
+          DubboRegistryUtil.extractRegistryAddress((RpcInvocation) invocation);
       return null;
     }
 

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/testClusterInvoker/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterInvokerTest.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/testClusterInvoker/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterInvokerTest.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.rpc.RpcInvocation;
 import org.apache.dubbo.rpc.cluster.Cluster;
 import org.apache.dubbo.rpc.cluster.ClusterInvoker;
 import org.apache.dubbo.rpc.cluster.Directory;
+import org.apache.dubbo.rpc.cluster.RouterChain;
 import org.junit.jupiter.api.Test;
 
 class RegistryCapturingClusterInvokerTest {
@@ -39,6 +40,13 @@ class RegistryCapturingClusterInvokerTest {
     assertThat(clusterInvoker.getRegistryUrl()).isSameAs(REGISTRY_URL);
     assertThat(clusterInvoker.getDirectory()).isSameAs(delegate.getDirectory());
     assertThat(clusterInvoker.isDestroyed()).isFalse();
+    assertThat(clusterInvoker.equals(clusterInvoker)).isTrue();
+    assertThat(clusterInvoker.hashCode()).isEqualTo(System.identityHashCode(clusterInvoker));
+    assertThat(clusterInvoker.toString())
+        .isEqualTo(
+            RegistryCapturingInvoker.class.getName()
+                + "@"
+                + Integer.toHexString(System.identityHashCode(clusterInvoker)));
 
     Result result = clusterInvoker.invoke(new RpcInvocation());
 
@@ -71,9 +79,25 @@ class RegistryCapturingClusterInvokerTest {
       this.invoker = invoker;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({
+      "unchecked",
+      "UnusedMethod",
+      "UnusedVariable",
+      "MissingOverride",
+      "EffectivelyPrivate"
+    })
     public <T> Invoker<T> join(Directory<T> directory) {
+      return (Invoker<T>) invoker;
+    }
+
+    @SuppressWarnings({
+      "unchecked",
+      "UnusedMethod",
+      "UnusedVariable",
+      "MissingOverride",
+      "EffectivelyPrivate"
+    })
+    public <T> Invoker<T> join(Directory<T> directory, boolean buildFilterChain) {
       return (Invoker<T>) invoker;
     }
   }
@@ -164,6 +188,20 @@ class RegistryCapturingClusterInvokerTest {
 
     @Override
     public void discordAddresses() {}
+
+    @SuppressWarnings({"UnusedMethod", "MissingOverride"})
+    public RouterChain<Object> getRouterChain() {
+      return null;
+    }
+
+    @SuppressWarnings({"UnusedMethod", "UnusedVariable", "MissingOverride"})
+    public void addInvalidateInvoker(Invoker<Object> invoker) {}
+
+    @SuppressWarnings({"UnusedMethod", "UnusedVariable", "MissingOverride"})
+    public void addDisabledInvoker(Invoker<Object> invoker) {}
+
+    @SuppressWarnings({"UnusedMethod", "UnusedVariable", "MissingOverride"})
+    public void recoverDisabledInvoker(Invoker<Object> invoker) {}
 
     @Override
     public URL getUrl() {

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/testClusterInvoker/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterInvokerTest.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/testClusterInvoker/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/RegistryCapturingClusterInvokerTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.apachedubbo.v2_7.internal;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.dubbo.common.URL;
+import org.apache.dubbo.rpc.AppResponse;
+import org.apache.dubbo.rpc.Invocation;
+import org.apache.dubbo.rpc.Invoker;
+import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcException;
+import org.apache.dubbo.rpc.RpcInvocation;
+import org.apache.dubbo.rpc.cluster.Cluster;
+import org.apache.dubbo.rpc.cluster.ClusterInvoker;
+import org.apache.dubbo.rpc.cluster.Directory;
+import org.junit.jupiter.api.Test;
+
+class RegistryCapturingClusterInvokerTest {
+
+  private static final String REGISTRY_ADDRESS = "zookeeper://localhost:2181";
+  private static final URL REGISTRY_URL = URL.valueOf(REGISTRY_ADDRESS);
+  private static final URL SERVICE_URL = URL.valueOf("dubbo://localhost:20880/example.Service");
+
+  @Test
+  void preservesClusterInvokerContractAndCapturesRegistryAddress() {
+    FakeClusterInvoker delegate = new FakeClusterInvoker();
+
+    Invoker<Object> wrapped = wrapThroughCluster(delegate);
+
+    assertThat(wrapped).isInstanceOf(ClusterInvoker.class);
+    ClusterInvoker<Object> clusterInvoker = (ClusterInvoker<Object>) wrapped;
+    assertThat(clusterInvoker.getRegistryUrl()).isSameAs(REGISTRY_URL);
+    assertThat(clusterInvoker.getDirectory()).isSameAs(delegate.getDirectory());
+    assertThat(clusterInvoker.isDestroyed()).isFalse();
+
+    Result result = clusterInvoker.invoke(new RpcInvocation());
+
+    assertThat(result).isSameAs(delegate.result);
+    assertThat(delegate.capturedRegistryAddress).isEqualTo(REGISTRY_ADDRESS);
+    assertThat(DubboRegistryUtil.extractRegistryAddress(new RpcInvocation())).isNull();
+  }
+
+  @Test
+  void unwrapsDelegateExceptionAndRestoresRegistryAddress() {
+    FakeClusterInvoker delegate = new FakeClusterInvoker();
+    RpcException failure = new RpcException("expected");
+    delegate.failure = failure;
+    Invoker<Object> wrapped = wrapThroughCluster(delegate);
+
+    assertThatThrownBy(() -> wrapped.invoke(new RpcInvocation())).isSameAs(failure);
+    assertThat(DubboRegistryUtil.extractRegistryAddress(new RpcInvocation())).isNull();
+  }
+
+  private static Invoker<Object> wrapThroughCluster(FakeClusterInvoker delegate) {
+    RegistryCapturingClusterWrapper wrapper =
+        new RegistryCapturingClusterWrapper(new FakeCluster(delegate));
+    return wrapper.join(delegate.getDirectory());
+  }
+
+  private static class FakeCluster implements Cluster {
+    private final Invoker<?> invoker;
+
+    FakeCluster(Invoker<?> invoker) {
+      this.invoker = invoker;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Invoker<T> join(Directory<T> directory) {
+      return (Invoker<T>) invoker;
+    }
+  }
+
+  private static class FakeClusterInvoker implements ClusterInvoker<Object> {
+    private final Directory<Object> directory = new FakeDirectory();
+    private final Result result = new AppResponse("ok");
+
+    private String capturedRegistryAddress;
+    private RpcException failure;
+
+    @Override
+    public URL getRegistryUrl() {
+      return REGISTRY_URL;
+    }
+
+    @Override
+    public Directory<Object> getDirectory() {
+      return directory;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+      return false;
+    }
+
+    @Override
+    public Class<Object> getInterface() {
+      return Object.class;
+    }
+
+    @Override
+    public Result invoke(Invocation invocation) {
+      capturedRegistryAddress =
+          DubboRegistryUtil.extractRegistryAddress((RpcInvocation) invocation);
+      if (failure != null) {
+        throw failure;
+      }
+      return result;
+    }
+
+    @Override
+    public URL getUrl() {
+      return SERVICE_URL;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public void destroy() {}
+  }
+
+  static class FakeDirectory implements Directory<Object> {
+
+    private final FakeRegistry registry = new FakeRegistry();
+
+    public FakeRegistry getRegistry() {
+      return registry;
+    }
+
+    @Override
+    public Class<Object> getInterface() {
+      return Object.class;
+    }
+
+    @Override
+    public List<Invoker<Object>> list(Invocation invocation) {
+      return emptyList();
+    }
+
+    @Override
+    public List<Invoker<Object>> getAllInvokers() {
+      return emptyList();
+    }
+
+    @Override
+    public URL getConsumerUrl() {
+      return SERVICE_URL;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+      return false;
+    }
+
+    @Override
+    public void discordAddresses() {}
+
+    @Override
+    public URL getUrl() {
+      return SERVICE_URL;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public void destroy() {}
+  }
+
+  static class FakeRegistry {
+
+    public URL getUrl() {
+      return REGISTRY_URL;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #19427.

## Description

`RegistryCapturingClusterWrapper` wrapped every invoker returned from `Cluster.join(...)` in a `RegistryCapturingInvoker` that only implemented `Invoker`. Newer Dubbo registry and service-discovery paths expect an original `ClusterInvoker` to remain a `ClusterInvoker` and cast the returned value, which caused application startup to fail with a `ClassCastException`.

This change preserves that runtime contract while keeping compatibility with the module's Dubbo 2.7.0 compile-time baseline:

- Load the optional `ClusterInvoker` interface reflectively.
- When the delegate implements it, return a dynamic proxy that also implements `ClusterInvoker`.
- Capture and restore the registry address around `Invoker.invoke(...)`, using a direct delegate call on the RPC hot path.
- Continue using the existing wrapper for older Dubbo versions and non-`ClusterInvoker` delegates.
- Add a Dubbo 2.7.14 regression suite that exercises the complete `RegistryCapturingClusterWrapper.join(...)` path, verifies the `ClusterInvoker` cast and method forwarding, and checks context cleanup after success and failure.
