### PR TITLE
Avoid warnings for ignored deprecated selector settings

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -64,12 +64,11 @@ public final class SelectorConfig {
       boolean systemPropertyFallback) {
     IncludeExclude selector =
         getSelector(config, instrumentationName, selectorName, systemPropertyFallback);
-    List<String> deprecated =
-        getDeprecated(
-            config, instrumentationName, selectorName, systemPropertyFallback, selector != null);
     if (selector != null) {
       return selector;
     }
+    List<String> deprecated =
+        getDeprecated(config, instrumentationName, selectorName, systemPropertyFallback);
     return deprecated == null || deprecated.isEmpty()
         ? null
         : IncludeExclude.builder().setIncluded(deprecated).build();
@@ -88,11 +87,10 @@ public final class SelectorConfig {
   public static Predicate<String> resolveLegacyLiteral(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
     IncludeExclude selector = getSelector(config, instrumentationName, selectorName, false);
-    List<String> deprecated =
-        getDeprecated(config, instrumentationName, selectorName, false, selector != null);
     if (selector != null) {
       return selector::matches;
     }
+    List<String> deprecated = getDeprecated(config, instrumentationName, selectorName, false);
     return deprecated == null ? null : resolveLegacyLiteral(deprecated);
   }
 
@@ -158,8 +156,7 @@ public final class SelectorConfig {
       DeclarativeConfigProperties config,
       String instrumentationName,
       String selectorName,
-      boolean systemPropertyFallback,
-      boolean selectorConfigured) {
+      boolean systemPropertyFallback) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, selectorName);
     List<String> deprecated =
         getList(
@@ -170,27 +167,14 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    if (selectorConfigured) {
-      warnOnce(
-          flatProperty + ":ignored",
-          "The "
-              + flatProperty
-              + " setting and the equivalent declarative configuration property are deprecated and"
-              + " ignored because "
-              + flatProperty(instrumentationName, selectorName, ".included")
-              + " or "
-              + flatProperty(instrumentationName, selectorName, ".excluded")
-              + " is configured. They may be removed in the next minor release.");
-    } else {
-      warnOnce(
-          flatProperty + ":deprecated",
-          "The "
-              + flatProperty
-              + " setting and the equivalent declarative configuration property are deprecated and"
-              + " may be removed in the next minor release. Use "
-              + flatProperty(instrumentationName, selectorName, ".included")
-              + " or equivalent declarative configuration instead.");
-    }
+    warnOnce(
+        flatProperty + ":deprecated",
+        "The "
+            + flatProperty
+            + " setting and the equivalent declarative configuration property are deprecated and"
+            + " may be removed in the next minor release. Use "
+            + flatProperty(instrumentationName, selectorName, ".included")
+            + " or equivalent declarative configuration instead.");
     return deprecated;
   }
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -11,6 +11,8 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
@@ -147,7 +149,7 @@ class SelectorConfigTest {
   }
 
   @Test
-  void selectorTakesPrecedenceAndWarnsOnce() {
+  void selectorTakesPrecedenceWithoutWarning() {
     DeclarativeConfigProperties config = mockConfig();
     when(config.get("mdc_attributes/development").getScalarList("included", String.class))
         .thenReturn(singletonList("new"));
@@ -158,21 +160,18 @@ class SelectorConfigTest {
       Predicate<String> first = SelectorConfig.resolveLegacyLiteral(config, "precedence", SELECTOR);
       Predicate<String> second =
           SelectorConfig.resolveLegacyLiteral(config, "precedence", SELECTOR);
+      IncludeExclude resolved = SelectorConfig.resolve(config, "precedence", SELECTOR);
 
       assertThat(first).isNotNull();
       assertThat(first.test("new")).isTrue();
       assertThat(first.test("legacy")).isFalse();
       assertThat(second).isNotNull();
       assertThat(second.test("new")).isTrue();
-      assertThat(handler.records).hasSize(1);
-      assertThat(handler.records.get(0).getMessage())
-          .isEqualTo(
-              "The otel.instrumentation.precedence.experimental.capture-mdc-attributes"
-                  + " setting and the equivalent declarative configuration property are deprecated"
-                  + " and ignored because"
-                  + " otel.instrumentation.precedence.experimental.mdc-attributes.included"
-                  + " or otel.instrumentation.precedence.experimental.mdc-attributes.excluded"
-                  + " is configured. They may be removed in the next minor release.");
+      assertThat(resolved).isNotNull();
+      assertThat(resolved.matches("new")).isTrue();
+      assertThat(resolved.matches("legacy")).isFalse();
+      assertThat(handler.records).isEmpty();
+      verify(config, never()).getScalarList("capture_mdc_attributes/development", String.class);
     } finally {
       detachWarningHandler(handler);
     }


### PR DESCRIPTION
Related to convention documented in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19475

Deployments that configure both a deprecated include-only setting and its replacement include/exclude selector no longer get a deprecation warning about the setting that is ignored.

For example, configuring both `otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes` and `otel.instrumentation.log4j-appender.experimental.mdc-attributes.included` previously selected the replacement value but warned that the legacy setting was ignored. The replacement still wins, and the ignored legacy setting is now not read at all.

A deprecation warning therefore identifies deployments that still rely on legacy configuration, rather than mixed-version rollouts that carry both names. The existing once-per-key warning still fires when the legacy value is the one applied.

This makes the already-merged appender and servlet selectors follow the deprecation convention documented in #19475.