### PR TITLE
Avoid deprecated config warnings when replacements are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,6 @@
   `MessagingConsumerMetrics.getForOperationType()`.
   ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
 
-### 🛠️ Bug fixes
-
-- Avoid deprecated GraphQL and runtime telemetry package-emitter configuration warnings when the
-  replacement property already determines the value.
-  ([#19573](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19573))
-
 ## Version 2.30.0 (2026-07-22)
 
 This release targets the OpenTelemetry SDK 1.64.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@
   `MessagingConsumerMetrics.getForOperationType()`.
   ([#19357](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19357))
 
+### 🛠️ Bug fixes
+
+- Avoid deprecated GraphQL and runtime telemetry package-emitter configuration warnings when the
+  replacement property already determines the value.
+  ([#19573](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19573))
+
 ## Version 2.30.0 (2026-07-22)
 
 This release targets the OpenTelemetry SDK 1.64.0.
@@ -176,8 +182,6 @@ for more details.
 
 ### 🛠️ Bug fixes
 
-- Avoid deprecated GraphQL and runtime telemetry package-emitter configuration warnings when the
-  replacement property already determines the value.
 - Fix a spurious duplicate warning when the application logger bridge is installed multiple times
   during startup.
   ([#19088](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19088))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,8 @@ for more details.
 
 ### 🛠️ Bug fixes
 
+- Avoid deprecated GraphQL and runtime telemetry package-emitter configuration warnings when the
+  replacement property already determines the value.
 - Fix a spurious duplicate warning when the application logger bridge is installed multiple times
   during startup.
   ([#19088](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19088))

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/build.gradle.kts
@@ -26,7 +26,10 @@ dependencies {
 }
 
 tasks.test {
-  jvmArgs("-Dotel.instrumentation.graphql.operation-name-in-span-name.enabled=true")
+  jvmArgs(
+    "-Dotel.instrumentation.graphql.operation-name-in-span-name.enabled=true",
+    "-Dotel.instrumentation.graphql.add-operation-name-to-span-name.enabled=false",
+  )
 
   systemProperty("collectMetadata", otelProps.collectMetadata)
 }

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
@@ -58,25 +58,30 @@ public class GraphqlSingletons {
 
       this.captureQuery = config.getBoolean("capture_query", true);
       this.querySanitizationEnabled = getQuerySanitizationEnabled(config);
-      Boolean deprecatedAddOperationNameToSpanName =
-          SemconvStability.v3Preview()
-              ? null
-              : config.get("add_operation_name_to_span_name").getBoolean("enabled");
-      if (deprecatedAddOperationNameToSpanName != null) {
-        // Support the deprecated config key until 3.0.
-        logger.warning(
-            "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
-                + " deprecated and will be removed in 3.0. Use "
-                + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+      this.operationNameInSpanNameEnabled = getOperationNameInSpanNameEnabled(config);
+    }
+
+    private static boolean getOperationNameInSpanNameEnabled(DeclarativeConfigProperties config) {
+      Boolean operationNameInSpanNameEnabled =
+          config.get("operation_name_in_span_name").getBoolean("enabled");
+      if (operationNameInSpanNameEnabled != null) {
+        return operationNameInSpanNameEnabled;
       }
-      this.operationNameInSpanNameEnabled =
-          config
-              .get("operation_name_in_span_name")
-              .getBoolean(
-                  "enabled",
-                  deprecatedAddOperationNameToSpanName != null
-                      ? deprecatedAddOperationNameToSpanName
-                      : false);
+
+      // Support the deprecated config key until 3.0.
+      if (!SemconvStability.v3Preview()) {
+        Boolean deprecatedAddOperationNameToSpanName =
+            config.get("add_operation_name_to_span_name").getBoolean("enabled");
+        if (deprecatedAddOperationNameToSpanName != null) {
+          logger.warning(
+              "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
+                  + " deprecated and will be removed in 3.0. Use "
+                  + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+          return deprecatedAddOperationNameToSpanName;
+        }
+      }
+
+      return false;
     }
 
     private static boolean getQuerySanitizationEnabled(DeclarativeConfigProperties config) {

--- a/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-12.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v12_0/GraphqlSingletons.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.GraphqlConfig;
 import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v12_0.GraphQLTelemetry;
 import java.util.logging.Logger;
@@ -58,30 +59,7 @@ public class GraphqlSingletons {
 
       this.captureQuery = config.getBoolean("capture_query", true);
       this.querySanitizationEnabled = getQuerySanitizationEnabled(config);
-      this.operationNameInSpanNameEnabled = getOperationNameInSpanNameEnabled(config);
-    }
-
-    private static boolean getOperationNameInSpanNameEnabled(DeclarativeConfigProperties config) {
-      Boolean operationNameInSpanNameEnabled =
-          config.get("operation_name_in_span_name").getBoolean("enabled");
-      if (operationNameInSpanNameEnabled != null) {
-        return operationNameInSpanNameEnabled;
-      }
-
-      // Support the deprecated config key until 3.0.
-      if (!SemconvStability.v3Preview()) {
-        Boolean deprecatedAddOperationNameToSpanName =
-            config.get("add_operation_name_to_span_name").getBoolean("enabled");
-        if (deprecatedAddOperationNameToSpanName != null) {
-          logger.warning(
-              "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
-                  + " deprecated and will be removed in 3.0. Use "
-                  + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
-          return deprecatedAddOperationNameToSpanName;
-        }
-      }
-
-      return false;
+      this.operationNameInSpanNameEnabled = GraphqlConfig.getOperationNameInSpanNameEnabled(config);
     }
 
     private static boolean getQuerySanitizationEnabled(DeclarativeConfigProperties config) {

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/build.gradle.kts
@@ -25,7 +25,10 @@ dependencies {
 
 tasks {
   withType<Test>().configureEach {
-    jvmArgs("-Dotel.instrumentation.graphql.operation-name-in-span-name.enabled=true")
+    jvmArgs(
+      "-Dotel.instrumentation.graphql.operation-name-in-span-name.enabled=true",
+      "-Dotel.instrumentation.graphql.add-operation-name-to-span-name.enabled=false",
+    )
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
 

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
@@ -69,25 +69,30 @@ public class GraphqlSingletons {
       this.dataFetcherEnabled = config.get("data_fetcher").getBoolean("enabled", false);
       this.trivialDataFetcherEnabled =
           config.get("trivial_data_fetcher").getBoolean("enabled", false);
-      Boolean deprecatedAddOperationNameToSpanName =
-          SemconvStability.v3Preview()
-              ? null
-              : config.get("add_operation_name_to_span_name").getBoolean("enabled");
-      if (deprecatedAddOperationNameToSpanName != null) {
-        // Support the deprecated config key until 3.0.
-        logger.warning(
-            "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
-                + " deprecated and will be removed in 3.0. Use "
-                + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+      this.operationNameInSpanNameEnabled = getOperationNameInSpanNameEnabled(config);
+    }
+
+    private static boolean getOperationNameInSpanNameEnabled(DeclarativeConfigProperties config) {
+      Boolean operationNameInSpanNameEnabled =
+          config.get("operation_name_in_span_name").getBoolean("enabled");
+      if (operationNameInSpanNameEnabled != null) {
+        return operationNameInSpanNameEnabled;
       }
-      this.operationNameInSpanNameEnabled =
-          config
-              .get("operation_name_in_span_name")
-              .getBoolean(
-                  "enabled",
-                  deprecatedAddOperationNameToSpanName != null
-                      ? deprecatedAddOperationNameToSpanName
-                      : false);
+
+      // Support the deprecated config key until 3.0.
+      if (!SemconvStability.v3Preview()) {
+        Boolean deprecatedAddOperationNameToSpanName =
+            config.get("add_operation_name_to_span_name").getBoolean("enabled");
+        if (deprecatedAddOperationNameToSpanName != null) {
+          logger.warning(
+              "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
+                  + " deprecated and will be removed in 3.0. Use "
+                  + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+          return deprecatedAddOperationNameToSpanName;
+        }
+      }
+
+      return false;
     }
 
     private static boolean getQuerySanitizationEnabled(DeclarativeConfigProperties config) {

--- a/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
+++ b/instrumentation/graphql-java/graphql-java-20.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/graphql/v20_0/GraphqlSingletons.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.GraphqlConfig;
 import io.opentelemetry.instrumentation.graphql.common.v12_0.internal.InstrumentationUtil;
 import io.opentelemetry.instrumentation.graphql.v20_0.GraphQLTelemetry;
 import java.util.logging.Logger;
@@ -69,30 +70,7 @@ public class GraphqlSingletons {
       this.dataFetcherEnabled = config.get("data_fetcher").getBoolean("enabled", false);
       this.trivialDataFetcherEnabled =
           config.get("trivial_data_fetcher").getBoolean("enabled", false);
-      this.operationNameInSpanNameEnabled = getOperationNameInSpanNameEnabled(config);
-    }
-
-    private static boolean getOperationNameInSpanNameEnabled(DeclarativeConfigProperties config) {
-      Boolean operationNameInSpanNameEnabled =
-          config.get("operation_name_in_span_name").getBoolean("enabled");
-      if (operationNameInSpanNameEnabled != null) {
-        return operationNameInSpanNameEnabled;
-      }
-
-      // Support the deprecated config key until 3.0.
-      if (!SemconvStability.v3Preview()) {
-        Boolean deprecatedAddOperationNameToSpanName =
-            config.get("add_operation_name_to_span_name").getBoolean("enabled");
-        if (deprecatedAddOperationNameToSpanName != null) {
-          logger.warning(
-              "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
-                  + " deprecated and will be removed in 3.0. Use "
-                  + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
-          return deprecatedAddOperationNameToSpanName;
-        }
-      }
-
-      return false;
+      this.operationNameInSpanNameEnabled = GraphqlConfig.getOperationNameInSpanNameEnabled(config);
     }
 
     private static boolean getQuerySanitizationEnabled(DeclarativeConfigProperties config) {

--- a/instrumentation/graphql-java/graphql-java-common-12.0/library/src/main/java/io/opentelemetry/instrumentation/graphql/common/v12_0/internal/GraphqlConfig.java
+++ b/instrumentation/graphql-java/graphql-java-common-12.0/library/src/main/java/io/opentelemetry/instrumentation/graphql/common/v12_0/internal/GraphqlConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.graphql.common.v12_0.internal;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import java.util.logging.Logger;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class GraphqlConfig {
+
+  private static final Logger logger = Logger.getLogger(GraphqlConfig.class.getName());
+
+  public static boolean getOperationNameInSpanNameEnabled(DeclarativeConfigProperties config) {
+    Boolean enabled = config.get("operation_name_in_span_name").getBoolean("enabled");
+    if (enabled != null) {
+      return enabled;
+    }
+
+    // Support the deprecated config key until 3.0.
+    if (!SemconvStability.v3Preview()) {
+      Boolean deprecatedEnabled =
+          config.get("add_operation_name_to_span_name").getBoolean("enabled");
+      if (deprecatedEnabled != null) {
+        logger.warning(
+            "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
+                + " deprecated and will be removed in 3.0. Use "
+                + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+        return deprecatedEnabled;
+      }
+    }
+
+    return false;
+  }
+
+  private GraphqlConfig() {}
+}

--- a/instrumentation/graphql-java/graphql-java-common-12.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/common/v12_0/internal/GraphqlConfigTest.java
+++ b/instrumentation/graphql-java/graphql-java-common-12.0/library/src/test/java/io/opentelemetry/instrumentation/graphql/common/v12_0/internal/GraphqlConfigTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.graphql.common.v12_0.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class GraphqlConfigTest {
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void replacementSettingTakesPrecedence(boolean enabled) {
+    DeclarativeConfigProperties config =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(config.get("operation_name_in_span_name").getBoolean("enabled")).thenReturn(enabled);
+    when(config.get("add_operation_name_to_span_name").getBoolean("enabled")).thenReturn(!enabled);
+
+    Logger logger = Logger.getLogger(GraphqlConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(GraphqlConfig.getOperationNameInSpanNameEnabled(config)).isEqualTo(enabled);
+      assertThat(handler.records).isEmpty();
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void deprecatedSettingIsUsedAsFallback(boolean enabled) {
+    DeclarativeConfigProperties config =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    when(config.get("operation_name_in_span_name").getBoolean("enabled")).thenReturn(null);
+    when(config.get("add_operation_name_to_span_name").getBoolean("enabled")).thenReturn(enabled);
+
+    Logger logger = Logger.getLogger(GraphqlConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(GraphqlConfig.getOperationNameInSpanNameEnabled(config)).isEqualTo(enabled);
+      assertThat(handler.records)
+          .singleElement()
+          .extracting(LogRecord::getMessage)
+          .isEqualTo(
+              "The otel.instrumentation.graphql.add-operation-name-to-span-name.enabled setting is"
+                  + " deprecated and will be removed in 3.0. Use "
+                  + "otel.instrumentation.graphql.operation-name-in-span-name.enabled instead.");
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  private static final class TestHandler extends Handler {
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+}

--- a/instrumentation/runtime-telemetry/javaagent/build.gradle.kts
+++ b/instrumentation/runtime-telemetry/javaagent/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
 
 tasks {
   test {
-    jvmArgs("-Dotel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled=true")
+    jvmArgs(
+      "-Dotel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled=true",
+      "-Dotel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second=100",
+      "-Dotel.instrumentation.runtime-telemetry.package-emitter.enabled=true",
+      "-Dotel.instrumentation.runtime-telemetry.package-emitter.jars-per-second=0",
+    )
   }
 }

--- a/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
+++ b/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
@@ -36,7 +36,7 @@ public class JarAnalyzerInstaller implements BeforeAgentListener {
 
     boolean enabledNew = newPackageEmitterConfig.getBoolean("enabled", false);
     boolean enabledOld = oldPackageEmitterConfig.getBoolean("enabled", false);
-    if (enabledOld) {
+    if (enabledOld && !enabledNew) {
       logger.warning(
           "otel.instrumentation.runtime-telemetry.package-emitter.enabled is deprecated and will"
               + " be removed in 3.0. Use"
@@ -60,18 +60,15 @@ public class JarAnalyzerInstaller implements BeforeAgentListener {
     int newJarsPerSecond = newPackageEmitterConfig.getInt("jars_per_second", -1);
     int oldJarsPerSecond = oldPackageEmitterConfig.getInt("jars_per_second", -1);
 
-    if (oldJarsPerSecond >= 0) {
+    int jarsPerSecond;
+    if (newJarsPerSecond >= 0) {
+      jarsPerSecond = newJarsPerSecond;
+    } else if (oldJarsPerSecond >= 0) {
       logger.warning(
           "otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second is deprecated"
               + " and will be removed in 3.0. Use"
               + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second"
               + " instead.");
-    }
-
-    int jarsPerSecond;
-    if (newJarsPerSecond >= 0) {
-      jarsPerSecond = newJarsPerSecond;
-    } else if (oldJarsPerSecond >= 0) {
       jarsPerSecond = oldJarsPerSecond;
     } else {
       jarsPerSecond = DEFAULT_JARS_PER_SECOND;

--- a/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
+++ b/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
@@ -15,14 +15,10 @@ import io.opentelemetry.javaagent.bootstrap.InstrumentationHolder;
 import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.lang.instrument.Instrumentation;
-import java.util.logging.Logger;
 
 /** Installs the {@link JarAnalyzer}. */
 @AutoService(BeforeAgentListener.class)
 public class JarAnalyzerInstaller implements BeforeAgentListener {
-
-  private static final Logger logger = Logger.getLogger(JarAnalyzerInstaller.class.getName());
-  private static final int DEFAULT_JARS_PER_SECOND = 10;
 
   @Override
   public void beforeAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
@@ -45,22 +41,8 @@ public class JarAnalyzerInstaller implements BeforeAgentListener {
       return;
     }
 
-    int newJarsPerSecond = newPackageEmitterConfig.getInt("jars_per_second", -1);
-    int oldJarsPerSecond = oldPackageEmitterConfig.getInt("jars_per_second", -1);
-
-    int jarsPerSecond;
-    if (newJarsPerSecond >= 0) {
-      jarsPerSecond = newJarsPerSecond;
-    } else if (oldJarsPerSecond >= 0) {
-      logger.warning(
-          "otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second is deprecated"
-              + " and will be removed in 3.0. Use"
-              + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second"
-              + " instead.");
-      jarsPerSecond = oldJarsPerSecond;
-    } else {
-      jarsPerSecond = DEFAULT_JARS_PER_SECOND;
-    }
+    int jarsPerSecond =
+        JarAnalyzerConfig.getJarsPerSecond(newPackageEmitterConfig, oldPackageEmitterConfig);
 
     JarAnalyzer jarAnalyzer = JarAnalyzer.create(openTelemetry, instrumentationName, jarsPerSecond);
     inst.addTransformer(jarAnalyzer);

--- a/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
+++ b/instrumentation/runtime-telemetry/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstaller.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.JarAnalyzerConfig;
 import io.opentelemetry.javaagent.bootstrap.InstrumentationHolder;
 import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -34,28 +35,15 @@ public class JarAnalyzerInstaller implements BeforeAgentListener {
     DeclarativeConfigProperties newPackageEmitterConfig = config.get("package_emitter/development");
     DeclarativeConfigProperties oldPackageEmitterConfig = config.get("package_emitter");
 
-    boolean enabledNew = newPackageEmitterConfig.getBoolean("enabled", false);
-    boolean enabledOld = oldPackageEmitterConfig.getBoolean("enabled", false);
-    if (enabledOld && !enabledNew) {
-      logger.warning(
-          "otel.instrumentation.runtime-telemetry.package-emitter.enabled is deprecated and will"
-              + " be removed in 3.0. Use"
-              + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled"
-              + " instead.");
-    }
-    if (!enabledNew && !enabledOld) {
+    String instrumentationName =
+        JarAnalyzerConfig.getInstrumentationName(newPackageEmitterConfig, oldPackageEmitterConfig);
+    if (instrumentationName == null) {
       return;
     }
     Instrumentation inst = InstrumentationHolder.getInstrumentation();
     if (inst == null) {
       return;
     }
-
-    // Use appropriate instrumentation name based on which config is active
-    String instrumentationName =
-        enabledNew
-            ? "io.opentelemetry.runtime-telemetry"
-            : "io.opentelemetry.runtime-telemetry-java8";
 
     int newJarsPerSecond = newPackageEmitterConfig.getInt("jars_per_second", -1);
     int oldJarsPerSecond = oldPackageEmitterConfig.getInt("jars_per_second", -1);

--- a/instrumentation/runtime-telemetry/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstallerTest.java
+++ b/instrumentation/runtime-telemetry/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/runtimetelemetry/JarAnalyzerInstallerTest.java
@@ -43,25 +43,28 @@ class JarAnalyzerInstallerTest {
     assertThat(events)
         .isNotEmpty()
         .allSatisfy(
-            logRecord ->
-                assertThat(logRecord.getAttributes())
-                    .containsEntry("package.type", "jar")
-                    .containsEntry("package.checksum_algorithm", "SHA-256")
-                    .hasEntrySatisfying(
-                        stringKey("package.checksum"),
-                        value -> assertThat(value).matches("[0-9a-f]{64}"))
-                    .hasEntrySatisfying(
-                        stringKey("package.path"), value -> assertThat(value).isNotNull())
-                    .satisfies(
-                        attributes -> {
-                          String packageName = attributes.get(stringKey("package.name"));
-                          if (packageName != null) {
-                            assertThat(packageName).matches(".*:.*");
-                          }
-                          String packageVersion = attributes.get(stringKey("package.version"));
-                          if (packageVersion != null) {
-                            assertThat(packageVersion).matches(".*\\..*");
-                          }
-                        }));
+            logRecord -> {
+              assertThat(logRecord.getInstrumentationScopeInfo().getName())
+                  .isEqualTo("io.opentelemetry.runtime-telemetry");
+              assertThat(logRecord.getAttributes())
+                  .containsEntry("package.type", "jar")
+                  .containsEntry("package.checksum_algorithm", "SHA-256")
+                  .hasEntrySatisfying(
+                      stringKey("package.checksum"),
+                      value -> assertThat(value).matches("[0-9a-f]{64}"))
+                  .hasEntrySatisfying(
+                      stringKey("package.path"), value -> assertThat(value).isNotNull())
+                  .satisfies(
+                      attributes -> {
+                        String packageName = attributes.get(stringKey("package.name"));
+                        if (packageName != null) {
+                          assertThat(packageName).matches(".*:.*");
+                        }
+                        String packageVersion = attributes.get(stringKey("package.version"));
+                        if (packageVersion != null) {
+                          assertThat(packageVersion).matches(".*\\..*");
+                        }
+                      });
+            });
   }
 }

--- a/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfig.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimetelemetry.internal;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class JarAnalyzerConfig {
+
+  private static final Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+  private static final String INSTRUMENTATION_NAME = "io.opentelemetry.runtime-telemetry";
+  private static final String LEGACY_INSTRUMENTATION_NAME =
+      "io.opentelemetry.runtime-telemetry-java8";
+
+  @Nullable
+  public static String getInstrumentationName(
+      DeclarativeConfigProperties config, DeclarativeConfigProperties deprecatedConfig) {
+    Boolean enabled = config.getBoolean("enabled");
+    if (enabled != null) {
+      return enabled ? INSTRUMENTATION_NAME : null;
+    }
+
+    Boolean deprecatedEnabled = deprecatedConfig.getBoolean("enabled");
+    if (deprecatedEnabled != null) {
+      logger.warning(
+          "otel.instrumentation.runtime-telemetry.package-emitter.enabled is deprecated and will"
+              + " be removed in 3.0. Use"
+              + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled"
+              + " instead.");
+      return deprecatedEnabled ? LEGACY_INSTRUMENTATION_NAME : null;
+    }
+
+    return null;
+  }
+
+  private JarAnalyzerConfig() {}
+}

--- a/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfig.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfig.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 public final class JarAnalyzerConfig {
 
   private static final Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+  private static final int DEFAULT_JARS_PER_SECOND = 10;
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.runtime-telemetry";
   private static final String LEGACY_INSTRUMENTATION_NAME =
       "io.opentelemetry.runtime-telemetry-java8";
@@ -39,6 +40,26 @@ public final class JarAnalyzerConfig {
     }
 
     return null;
+  }
+
+  public static int getJarsPerSecond(
+      DeclarativeConfigProperties config, DeclarativeConfigProperties deprecatedConfig) {
+    int jarsPerSecond = config.getInt("jars_per_second", -1);
+    if (jarsPerSecond >= 0) {
+      return jarsPerSecond;
+    }
+
+    int deprecatedJarsPerSecond = deprecatedConfig.getInt("jars_per_second", -1);
+    if (deprecatedJarsPerSecond >= 0) {
+      logger.warning(
+          "otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second is deprecated"
+              + " and will be removed in 3.0. Use"
+              + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second"
+              + " instead.");
+      return deprecatedJarsPerSecond;
+    }
+
+    return DEFAULT_JARS_PER_SECOND;
   }
 
   private JarAnalyzerConfig() {}

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfigTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfigTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.runtimetelemetry.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JarAnalyzerConfigTest {
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void replacementEnabledSettingTakesPrecedence(boolean enabled) {
+    DeclarativeConfigProperties config = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties deprecatedConfig = mock(DeclarativeConfigProperties.class);
+    when(config.getBoolean("enabled")).thenReturn(enabled);
+    when(deprecatedConfig.getBoolean("enabled")).thenReturn(!enabled);
+
+    Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(JarAnalyzerConfig.getInstrumentationName(config, deprecatedConfig))
+          .isEqualTo(enabled ? "io.opentelemetry.runtime-telemetry" : null);
+      assertThat(handler.records).isEmpty();
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void deprecatedEnabledSettingIsUsedAsFallback(boolean enabled) {
+    DeclarativeConfigProperties config = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties deprecatedConfig = mock(DeclarativeConfigProperties.class);
+    when(config.getBoolean("enabled")).thenReturn(null);
+    when(deprecatedConfig.getBoolean("enabled")).thenReturn(enabled);
+
+    Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(JarAnalyzerConfig.getInstrumentationName(config, deprecatedConfig))
+          .isEqualTo(enabled ? "io.opentelemetry.runtime-telemetry-java8" : null);
+      assertThat(handler.records)
+          .singleElement()
+          .extracting(LogRecord::getMessage)
+          .isEqualTo(
+              "otel.instrumentation.runtime-telemetry.package-emitter.enabled is deprecated and"
+                  + " will be removed in 3.0. Use"
+                  + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled"
+                  + " instead.");
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  private static final class TestHandler extends Handler {
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+}

--- a/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfigTest.java
+++ b/instrumentation/runtime-telemetry/library/src/test/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/JarAnalyzerConfigTest.java
@@ -16,6 +16,7 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class JarAnalyzerConfigTest {
@@ -61,6 +62,53 @@ class JarAnalyzerConfigTest {
               "otel.instrumentation.runtime-telemetry.package-emitter.enabled is deprecated and"
                   + " will be removed in 3.0. Use"
                   + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.enabled"
+                  + " instead.");
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"100, 0", "0, 100"})
+  void replacementJarsPerSecondTakesPrecedence(int jarsPerSecond, int deprecatedJarsPerSecond) {
+    DeclarativeConfigProperties config = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties deprecatedConfig = mock(DeclarativeConfigProperties.class);
+    when(config.getInt("jars_per_second", -1)).thenReturn(jarsPerSecond);
+    when(deprecatedConfig.getInt("jars_per_second", -1)).thenReturn(deprecatedJarsPerSecond);
+
+    Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(JarAnalyzerConfig.getJarsPerSecond(config, deprecatedConfig))
+          .isEqualTo(jarsPerSecond);
+      assertThat(handler.records).isEmpty();
+    } finally {
+      logger.removeHandler(handler);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {100, 0})
+  void deprecatedJarsPerSecondIsUsedAsFallback(int jarsPerSecond) {
+    DeclarativeConfigProperties config = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties deprecatedConfig = mock(DeclarativeConfigProperties.class);
+    when(config.getInt("jars_per_second", -1)).thenReturn(-1);
+    when(deprecatedConfig.getInt("jars_per_second", -1)).thenReturn(jarsPerSecond);
+
+    Logger logger = Logger.getLogger(JarAnalyzerConfig.class.getName());
+    TestHandler handler = new TestHandler();
+    logger.addHandler(handler);
+    try {
+      assertThat(JarAnalyzerConfig.getJarsPerSecond(config, deprecatedConfig))
+          .isEqualTo(jarsPerSecond);
+      assertThat(handler.records)
+          .singleElement()
+          .extracting(LogRecord::getMessage)
+          .isEqualTo(
+              "otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second is"
+                  + " deprecated and will be removed in 3.0. Use"
+                  + " otel.instrumentation.runtime-telemetry.experimental.package-emitter.jars-per-second"
                   + " instead.");
     } finally {
       logger.removeHandler(handler);


### PR DESCRIPTION
Related to convention documented in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19475

Deprecated GraphQL and runtime telemetry package emitter settings now warn only when their value is actually applied, so configuring a deprecated setting alongside its replacement, as is common during a rolling migration, no longer logs a deprecation warning.

```properties
otel.instrumentation.graphql.add-operation-name-to-span-name.enabled=false
otel.instrumentation.graphql.operation-name-in-span-name.enabled=true
```

Previously this pair applied the replacement value but still warned about the deprecated one. The deprecated setting is now consulted, and warned about, only when the replacement is absent.

The same precedence applies to `otel.instrumentation.runtime-telemetry.package-emitter.enabled` and `.jars-per-second` and their `experimental.package-emitter` replacements.

### Compatibility

The runtime telemetry `experimental.package-emitter.enabled` setting previously combined with its deprecated counterpart so that either one enabled the package emitter. It now takes precedence, so explicitly setting it to `false` disables the package emitter even when the deprecated setting is `true`.

Which setting is applied still selects the instrumentation scope name: the replacement emits under `io.opentelemetry.runtime-telemetry` and the deprecated setting keeps `io.opentelemetry.runtime-telemetry-java8`.
