### PR TITLE
Fix CI from declarative validation

### DIFF
--- a/instrumentation/redisson/redisson-metrics-3.26/metadata.yaml
+++ b/instrumentation/redisson/redisson-metrics-3.26/metadata.yaml
@@ -5,7 +5,7 @@ semantic_conventions:
   - DATABASE_POOL_METRICS
 configurations:
   - name: otel.semconv-stability.opt-in
-    declarative_name: general.semconv_stability.opt_in
+    declarative_name: general.stability_opt_in_list
     description: >
       Opt-in to emit stable semantic conventions instead of the old
       experimental semantic conventions. Accepts a comma-separated list of semantic convention


### PR DESCRIPTION
This fix is also included in #19562 but putting up another PR in case we don't want to merge that one yet

Current builds are failing with 

```
java.lang.AssertionError: Found 1 invalid declarative_name mappings:
Deprecated declarative_name in ../instrumentation/redisson/redisson-metrics-3.26/metadata.yaml: 'general.semconv_stability.opt_in' is kept in the bridge for backwards compatibility only; use 'general.stability_opt_in_list' instead.
```