### PR TITLE
Add logs for agent extension loading

### DIFF
--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentStarterImpl.java
@@ -99,6 +99,7 @@ public class AgentStarterImpl implements AgentStarter {
     try {
       loggingCustomizer.init();
       EarlyInitAgentConfig.get().logEarlyConfigErrorsIfAny();
+      ExtensionClassLoader.logExtensionLoadingMessages();
 
       // start cleaner first so weak refs created during bytebuddy install get cleaned up
       WeakConcurrentMapCleaner.start();

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.channels.Channels;
@@ -210,7 +209,7 @@ public class ExtensionClassLoader extends URLClassLoader {
       }
       addLog(FINE, "Loaded extension jar file \"" + file + "\"");
       return true;
-    } catch (MalformedURLException e) {
+    } catch (IOException e) {
       addLog(WARNING, "Failed to load extension jar file \"" + file + "\": " + e.getMessage());
       return false;
     }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -46,7 +46,6 @@ import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
  * MultipleParentClassLoader}.
  */
 // TODO find a way to initialize logging before using this class
-@SuppressWarnings("SystemOut")
 public class ExtensionClassLoader extends URLClassLoader {
 
   // this class is used early, and must not use logging in most of its methods
@@ -96,6 +95,7 @@ public class ExtensionClassLoader extends URLClassLoader {
     deferredLogs.add(new SimpleImmutableEntry<>(level, message));
   }
 
+  @SuppressWarnings("SystemOut")
   private static void includeEmbeddedExtensionsIfFound(List<URL> extensions, File javaagentFile) {
     try (JarFile jarFile = new JarFile(javaagentFile, false)) {
       Enumeration<JarEntry> entryEnumeration = jarFile.entries();
@@ -198,7 +198,7 @@ public class ExtensionClassLoader extends URLClassLoader {
     return f.isFile() && f.getName().endsWith(".jar");
   }
 
-  private static boolean addFileUrl(List<URL> result, File file) {
+  private static void addFileUrl(List<URL> result, File file) {
     try {
       // skip shading extension classes if opentelemetry-api is not shaded (happens when using
       // disableShadowRelocate=true)
@@ -209,10 +209,8 @@ public class ExtensionClassLoader extends URLClassLoader {
         result.add(file.toURI().toURL());
       }
       addLog(FINE, "Loaded extension jar file \"" + file + "\"");
-      return true;
     } catch (IOException e) {
       addLog(WARNING, "Failed to load extension jar file \"" + file + "\": " + e.getMessage());
-      return false;
     }
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -164,21 +164,22 @@ public class ExtensionClassLoader extends URLClassLoader {
     }
 
     File location = new File(locationName);
-    boolean loaded = false;
+    boolean found = false;
     if (isJar(location)) {
-      loaded = addFileUrl(locations, location);
+      found = true;
+      addFileUrl(locations, location);
     } else if (location.isDirectory()) {
       File[] files = location.listFiles(ExtensionClassLoader::isJar);
       if (files != null) {
         for (File file : files) {
-          if (!file.getAbsolutePath().equals(javaagentFile.getAbsolutePath())
-              && addFileUrl(locations, file)) {
-            loaded = true;
+          if (!file.getAbsolutePath().equals(javaagentFile.getAbsolutePath())) {
+            found = true;
+            addFileUrl(locations, file);
           }
         }
       }
     }
-    if (!loaded) {
+    if (!found) {
       addLog(
           WARNING,
           "Configured extensions location \""

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -50,8 +50,9 @@ import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
 @SuppressWarnings("SystemOut")
 public class ExtensionClassLoader extends URLClassLoader {
 
-  // NOTE it's important not to use logging in this class, because this class is used before logging
-  // is initialized
+  // this class is used early, and must not use logging in most of its methods
+  // instead we save the messages here and log them later, when the logging subsystem is
+  // initialized
   private static final List<Map.Entry<Level, String>> deferredLogs = new ArrayList<>();
 
   static {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -50,8 +50,6 @@ import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
 @SuppressWarnings("SystemOut")
 public class ExtensionClassLoader extends URLClassLoader {
 
-  private final boolean isSecurityManagerSupportEnabled;
-
   // NOTE it's important not to use logging in this class, because this class is used before logging
   // is initialized
   private static final List<Map.Entry<Level, String>> deferredLogs = new ArrayList<>();
@@ -59,6 +57,8 @@ public class ExtensionClassLoader extends URLClassLoader {
   static {
     ClassLoader.registerAsParallelCapable();
   }
+
+  private final boolean isSecurityManagerSupportEnabled;
 
   public static ClassLoader getInstance(
       ClassLoader parent, File javaagentFile, boolean isSecurityManagerSupportEnabled) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoader.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.javaagent.tooling;
 
 import static java.util.Collections.emptyList;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.javaagent.tooling.config.EarlyInitAgentConfig;
@@ -23,12 +25,16 @@ import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.Permissions;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import net.bytebuddy.dynamic.loading.MultipleParentClassLoader;
 
@@ -48,6 +54,7 @@ public class ExtensionClassLoader extends URLClassLoader {
 
   // NOTE it's important not to use logging in this class, because this class is used before logging
   // is initialized
+  private static final List<Map.Entry<Level, String>> deferredLogs = new ArrayList<>();
 
   static {
     ClassLoader.registerAsParallelCapable();
@@ -72,6 +79,21 @@ public class ExtensionClassLoader extends URLClassLoader {
       delegates.add(getDelegate(parent, url, isSecurityManagerSupportEnabled));
     }
     return new MultipleParentClassLoader(parent, delegates);
+  }
+
+  static void logExtensionLoadingMessages() {
+    if (deferredLogs.isEmpty()) {
+      return;
+    }
+    Logger logger = Logger.getLogger(ExtensionClassLoader.class.getName());
+    for (Map.Entry<Level, String> entry : deferredLogs) {
+      logger.log(entry.getKey(), entry.getValue());
+    }
+    deferredLogs.clear();
+  }
+
+  private static void addLog(Level level, String message) {
+    deferredLogs.add(new SimpleImmutableEntry<>(level, message));
   }
 
   private static void includeEmbeddedExtensionsIfFound(List<URL> extensions, File javaagentFile) {
@@ -142,25 +164,40 @@ public class ExtensionClassLoader extends URLClassLoader {
     }
 
     File location = new File(locationName);
+    boolean loaded = false;
     if (isJar(location)) {
-      addFileUrl(locations, location);
+      loaded = addFileUrl(locations, location);
     } else if (location.isDirectory()) {
       File[] files = location.listFiles(ExtensionClassLoader::isJar);
       if (files != null) {
         for (File file : files) {
-          if (isJar(file) && !file.getAbsolutePath().equals(javaagentFile.getAbsolutePath())) {
-            addFileUrl(locations, file);
+          if (!file.getAbsolutePath().equals(javaagentFile.getAbsolutePath())
+              && addFileUrl(locations, file)) {
+            loaded = true;
           }
         }
       }
     }
+    if (!loaded) {
+      addLog(
+          WARNING,
+          "Configured extensions location \""
+              + locationName
+              + "\" does not exist, is not a jar file or directory, or contains no extension jar"
+              + " files; ignoring it");
+    }
+  }
+
+  // visible for testing
+  static List<Map.Entry<Level, String>> getLogsForTest() {
+    return deferredLogs;
   }
 
   private static boolean isJar(File f) {
     return f.isFile() && f.getName().endsWith(".jar");
   }
 
-  private static void addFileUrl(List<URL> result, File file) {
+  private static boolean addFileUrl(List<URL> result, File file) {
     try {
       // skip shading extension classes if opentelemetry-api is not shaded (happens when using
       // disableShadowRelocate=true)
@@ -170,8 +207,11 @@ public class ExtensionClassLoader extends URLClassLoader {
       } else {
         result.add(file.toURI().toURL());
       }
-    } catch (MalformedURLException ignored) {
-      System.err.println("Ignoring " + file);
+      addLog(FINE, "Loaded extension jar file \"" + file + "\"");
+      return true;
+    } catch (MalformedURLException e) {
+      addLog(WARNING, "Failed to load extension jar file \"" + file + "\": " + e.getMessage());
+      return false;
     }
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlStreamHandler.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/RemappingUrlStreamHandler.java
@@ -19,12 +19,8 @@ import java.util.jar.JarFile;
 class RemappingUrlStreamHandler extends URLStreamHandler {
   private final JarFile delegateJarFile;
 
-  public RemappingUrlStreamHandler(File delegateFile) {
-    try {
-      delegateJarFile = new JarFile(delegateFile, false);
-    } catch (IOException e) {
-      throw new IllegalStateException("Unable to read internal jar", e);
-    }
+  public RemappingUrlStreamHandler(File delegateFile) throws IOException {
+    delegateJarFile = new JarFile(delegateFile, false);
   }
 
   /** {@inheritDoc} */

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoaderTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/ExtensionClassLoaderTest.java
@@ -5,21 +5,32 @@
 
 package io.opentelemetry.javaagent.tooling;
 
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+import java.util.logging.Level;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class ExtensionClassLoaderTest {
   private static final File AGENT_FILE = new File("/agent.jar");
+
+  @AfterEach
+  void resetLogs() {
+    ExtensionClassLoader.getLogsForTest().clear();
+  }
 
   @Test
   void testParseLocation(@TempDir Path outputDir) throws Exception {
@@ -62,6 +73,55 @@ class ExtensionClassLoaderTest {
       List<URL> result = ExtensionClassLoader.parseLocation(jarPath1 + ",/anyfile.jar", AGENT_FILE);
       assertThat(result.size()).isEqualTo(1);
     }
+  }
+
+  @Test
+  void testParseLocationWarnings(@TempDir Path outputDir) throws Exception {
+    String jarPath1 = createJar("test-1.jar", outputDir);
+    Path emptyDir = Files.createDirectory(outputDir.resolve("empty"));
+
+    ExtensionClassLoader.parseLocation(jarPath1, AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).isEmpty();
+    assertThat(logsAtLevel(FINE)).hasSize(1);
+    ExtensionClassLoader.getLogsForTest().clear();
+
+    ExtensionClassLoader.parseLocation(outputDir.toString(), AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).isEmpty();
+    assertThat(logsAtLevel(FINE)).hasSize(1);
+    ExtensionClassLoader.getLogsForTest().clear();
+
+    ExtensionClassLoader.parseLocation("/does/not/exist", AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).hasSize(1);
+    assertThat(logsAtLevel(FINE)).isEmpty();
+    ExtensionClassLoader.getLogsForTest().clear();
+
+    ExtensionClassLoader.parseLocation(emptyDir.toString(), AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).hasSize(1);
+    assertThat(logsAtLevel(FINE)).isEmpty();
+    ExtensionClassLoader.getLogsForTest().clear();
+
+    ExtensionClassLoader.parseLocation(jarPath1 + ",/does/not/exist", AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).hasSize(1);
+    assertThat(logsAtLevel(FINE)).hasSize(1);
+    ExtensionClassLoader.getLogsForTest().clear();
+
+    ExtensionClassLoader.parseLocation(null, AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).isEmpty();
+    assertThat(logsAtLevel(FINE)).isEmpty();
+
+    ExtensionClassLoader.parseLocation("", AGENT_FILE);
+    assertThat(logsAtLevel(WARNING)).isEmpty();
+    assertThat(logsAtLevel(FINE)).isEmpty();
+  }
+
+  private static List<String> logsAtLevel(Level level) {
+    List<String> result = new ArrayList<>();
+    for (Map.Entry<Level, String> entry : ExtensionClassLoader.getLogsForTest()) {
+      if (entry.getKey().equals(level)) {
+        result.add(entry.getValue());
+      }
+    }
+    return result;
   }
 
   private static String createJar(String name, Path directory) throws Exception {


### PR DESCRIPTION
recently i was working on creating agent extension, and noticed there were no logs if the extension was loaded or not. 

i see the issue was already mentioned [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11616), and a PR was made but it was marked as stale, so i created this one based on work by @123liuziming https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11634, adding improvements mentioned in the PR review, so that correctly registered extensions are also logged, and each configured location is checked independently