### PR TITLE
Drain asynchronous traces before clearing test data

### DIFF
--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -186,6 +186,21 @@ fresh container.
   possible metric name. Do not add an exporter-interval sleep before or after `clearData()` solely
   to wait for metrics; the test runners force-flush metrics when reading them.
 
+## Trace Clearing After Asynchronous Operations
+
+- When test setup or cleanup performs an operation that can complete or export spans
+  asynchronously, call `testing.waitForTraces(expectedTraceCount)` before its captured telemetry
+  is cleared, whether by `testing.clearData()` or an `InstrumentationExtension` lifecycle clear.
+  Keep the wait at the end of setup or cleanup even when removing a redundant explicit clear. The
+  expected count is the total number of traces that should be captured at that point. Waiting
+  prevents spans exported after the clear from leaking into the next assertion or test.
+- Add the wait only when the exact trace count is deterministic. Do not guess a count when it can
+  vary because of retries, concurrent/background work, timing, or external-system behavior.
+- `InstrumentationExtension` already clears captured telemetry before each test. Do not add or keep
+  a setup/cleanup `clearData()` solely for per-test isolation when that lifecycle clear is
+  sufficient; keep explicit clears only when the test needs a mid-test reset, including to discard
+  telemetry from a preceding asynchronous operation after its exports have been drained.
+
 ## Attribute Assertion `satisfies()` Lambda Parameters
 
 **Attribute-assertion `satisfies()` lambda parameters are `AbstractAssert` instances, not raw

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -21,6 +21,24 @@ modules). Skip them on production sources.
 - Use `e` / `f` / `t` / `ignored` for catch variables (per the catch-variable
   naming rule in `.github/copilot-instructions.md`).
 
+## [Testing] Trace Clearing After Asynchronous Operations
+
+- When test setup or cleanup performs an operation that can complete or export
+  spans asynchronously, call `testing.waitForTraces(expectedTraceCount)` before
+  its captured telemetry is cleared, whether by `testing.clearData()` or an
+  `InstrumentationExtension` lifecycle clear. Keep the wait at the end of setup
+  or cleanup even when removing a redundant explicit clear. Use the total trace
+  count expected at that point so spans exported after the clear cannot leak
+  into the next assertion or test.
+- Add the wait only when the exact trace count is deterministic. Do not guess
+  when retries, concurrent/background work, timing, or external-system behavior
+  can vary the count.
+- `InstrumentationExtension` already clears captured telemetry before each
+  test. Do not add or keep a setup/cleanup `clearData()` solely for per-test
+  isolation when that lifecycle clear is sufficient. Keep explicit clears only
+  for a required mid-test reset, including to discard telemetry from a
+  preceding asynchronous operation after its exports have been drained.
+
 ## [Testing] AssertJ Idiomatic Simplifications
 
 Prefer built-in AssertJ collection/string/map assertions over manual extraction:

--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/JmsCamelTest.java
@@ -62,7 +62,6 @@ class JmsCamelTest {
 
     camelContext.start();
     cleanup.deferAfterAll(camelContext::stop);
-    testing.clearData();
   }
 
   @Test

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -80,9 +80,8 @@ class ClickHouseClientV1Test {
             .executeAndWait();
     response.close();
 
-    // wait for CREATE operation and clear
+    // wait for CREATE operation
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @Test

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -87,9 +87,8 @@ class ClickHouseClientV2Test {
             .join();
     response.close();
 
-    // wait for CREATE operation and clear
+    // wait for CREATE operation
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @Test

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5NodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5NodeClientTest.java
@@ -66,7 +66,6 @@ class Elasticsearch5NodeClientTest extends AbstractElasticsearchNodeClientTest {
                 .execute()
                 .actionGet(TIMEOUT));
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientTest.java
@@ -79,7 +79,6 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
                 .execute()
                 .actionGet(TIMEOUT));
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53NodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53NodeClientTest.java
@@ -79,7 +79,6 @@ class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest 
                               "cluster.routing.allocation.disk.threshold_enabled", false)));
         });
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @AfterAll

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53NodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53NodeClientTest.java
@@ -75,8 +75,8 @@ class Elasticsearch53NodeClientTest extends AbstractElasticsearchNodeClientTest 
               .updateSettings(
                   new ClusterUpdateSettingsRequest()
                       .transientSettings(
-                          singletonMap(
-                              "cluster.routing.allocation.disk.threshold_enabled", false)));
+                          singletonMap("cluster.routing.allocation.disk.threshold_enabled", false)))
+              .actionGet(TIMEOUT);
         });
     testing.waitForTraces(1);
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientTest.java
@@ -91,7 +91,6 @@ class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportC
                               "cluster.routing.allocation.disk.threshold_enabled", false)));
         });
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   @AfterAll

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientTest.java
@@ -87,8 +87,8 @@ class Elasticsearch53TransportClientTest extends AbstractElasticsearchTransportC
               .updateSettings(
                   new ClusterUpdateSettingsRequest()
                       .transientSettings(
-                          singletonMap(
-                              "cluster.routing.allocation.disk.threshold_enabled", false)));
+                          singletonMap("cluster.routing.allocation.disk.threshold_enabled", false)))
+              .actionGet(TIMEOUT);
         });
     testing.waitForTraces(1);
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -140,8 +140,8 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
               .updateSettings(
                   new ClusterUpdateSettingsRequest()
                       .transientSettings(
-                          singletonMap(
-                              "cluster.routing.allocation.disk.threshold_enabled", false)));
+                          singletonMap("cluster.routing.allocation.disk.threshold_enabled", false)))
+              .actionGet(TIMEOUT);
         });
     testing.waitForTraces(1);
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -144,7 +144,6 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
                               "cluster.routing.allocation.disk.threshold_enabled", false)));
         });
     testing.waitForTraces(1);
-    testing.clearData();
 
     autoCleanup.deferAfterAll(testNode);
     template = new ElasticsearchTemplate(client);

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6NodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6NodeClientTest.java
@@ -72,7 +72,6 @@ public abstract class AbstractElasticsearch6NodeClientTest
                               "cluster.routing.allocation.disk.threshold_enabled", false)));
         });
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   protected abstract NodeFactory getNodeFactory();

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6NodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6NodeClientTest.java
@@ -68,8 +68,8 @@ public abstract class AbstractElasticsearch6NodeClientTest
               .updateSettings(
                   new ClusterUpdateSettingsRequest()
                       .transientSettings(
-                          singletonMap(
-                              "cluster.routing.allocation.disk.threshold_enabled", false)));
+                          singletonMap("cluster.routing.allocation.disk.threshold_enabled", false)))
+              .actionGet(TIMEOUT);
         });
     testing.waitForTraces(1);
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6TransportClientTest.java
@@ -82,8 +82,8 @@ public abstract class AbstractElasticsearch6TransportClientTest
               .updateSettings(
                   new ClusterUpdateSettingsRequest()
                       .transientSettings(
-                          singletonMap(
-                              "cluster.routing.allocation.disk.threshold_enabled", false)));
+                          singletonMap("cluster.routing.allocation.disk.threshold_enabled", false)))
+              .actionGet(TIMEOUT);
         });
     testing.waitForTraces(1);
   }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractElasticsearch6TransportClientTest.java
@@ -86,7 +86,6 @@ public abstract class AbstractElasticsearch6TransportClientTest
                               "cluster.routing.allocation.disk.threshold_enabled", false)));
         });
     testing.waitForTraces(1);
-    testing.clearData();
   }
 
   protected abstract NodeFactory getNodeFactory();

--- a/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
@@ -207,7 +207,6 @@ public abstract class AbstractHbaseTest {
               seedRows();
             });
     testing().waitForTraces(1);
-    testing().clearData();
   }
 
   private void createNamespaceAndTable() throws IOException {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -133,7 +133,6 @@ class LettuceAsyncClientTest {
 
     // 1 set (+ 1 connect trace when connection telemetry is enabled)
     testing.waitForTraces(connectionTelemetryEnabled() ? 2 : 1);
-    testing.clearData();
   }
 
   private static boolean connectionTelemetryEnabled() {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveClientTest.java
@@ -91,7 +91,6 @@ class LettuceReactiveClientTest {
 
     // 1 set (+ 1 connect trace when connection telemetry is enabled)
     testing.waitForTraces(connectionTelemetryEnabled() ? 2 : 1);
-    testing.clearData();
   }
 
   private static boolean connectionTelemetryEnabled() {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
@@ -108,7 +108,6 @@ class LettuceSyncClientTest {
 
     // 2 sets (+ 1 connect trace when connection telemetry is enabled)
     testing.waitForTraces(connectionTelemetryEnabled() ? 3 : 2);
-    testing.clearData();
   }
 
   private static boolean connectionTelemetryEnabled() {

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -100,7 +100,6 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
     syncCommands.set("TESTKEY", "TESTVAL");
 
     testing.waitForTraces(connectionTelemetryEnabled() ? 2 : 1);
-    testing.clearData();
   }
 
   @AfterAll

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceReactiveClientTest.java
@@ -60,7 +60,6 @@ class LettuceReactiveClientTest extends AbstractLettuceClientTest {
     syncCommands.set("TESTKEY", "TESTVAL");
 
     testing.waitForTraces(connectionTelemetryEnabled() ? 2 : 1);
-    testing.clearData();
   }
 
   @AfterAll

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -73,7 +73,6 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
     syncCommands.hmset("TESTHM", testHashMap);
 
     testing.waitForTraces(connectionTelemetryEnabled() ? 3 : 2);
-    testing.clearData();
   }
 
   @AfterAll

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceAsyncClientTest.java
@@ -87,7 +87,6 @@ public abstract class AbstractLettuceAsyncClientTest extends AbstractLettuceClie
 
     // 1 set trace
     testing().waitForTraces(1);
-    testing().clearData();
   }
 
   boolean testCallback() {

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceReactiveClientTest.java
@@ -59,7 +59,6 @@ public abstract class AbstractLettuceReactiveClientTest extends AbstractLettuceC
 
     // 1 set trace
     testing().waitForTraces(1);
-    testing().clearData();
   }
 
   @Test

--- a/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/testing/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/AbstractLettuceSyncClientTest.java
@@ -89,7 +89,6 @@ public abstract class AbstractLettuceSyncClientTest extends AbstractLettuceClien
 
     // 2 sets
     testing().waitForTraces(2);
-    testing().clearData();
   }
 
   @Test

--- a/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitMqTest.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitMqTest.java
@@ -141,7 +141,6 @@ class RabbitMqTest extends AbstractRabbitMqTest {
   @Test
   void testMessagingClientMetrics() throws IOException {
     String queueName = channel.queueDeclare("metrics", false, true, true, null).getQueue();
-    testing.clearData();
 
     channel.basicPublish("", queueName, null, "Hello, world!".getBytes(Charset.defaultCharset()));
 
@@ -157,7 +156,6 @@ class RabbitMqTest extends AbstractRabbitMqTest {
   @Test
   void testMessagingPublishErrorMetrics() throws IOException {
     channel.abort();
-    testing.clearData();
 
     Throwable error =
         catchThrowable(
@@ -237,7 +235,6 @@ class RabbitMqTest extends AbstractRabbitMqTest {
   void testRabbitPublishPropagatesSuppressedProducerContext() throws IOException {
     String queueName = channel.queueDeclare().getQueue();
     AtomicReference<SpanContext> producerContext = new AtomicReference<>();
-    testing.clearData();
 
     testing.runWithSpan(
         "outer producer",
@@ -786,7 +783,6 @@ class RabbitMqTest extends AbstractRabbitMqTest {
   @Test
   void testRabbitSettleErrorMetrics() throws IOException {
     channel.abort();
-    testing.clearData();
 
     Throwable error = catchThrowable(() -> channel.basicAck(1, false));
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
@@ -38,7 +38,6 @@ import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageBatch;
 import org.apache.rocketmq.common.message.MessageExt;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,11 +51,6 @@ class RocketMqMetricsTest {
 
   @RegisterExtension
   private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
-
-  @BeforeEach
-  void clearData() {
-    testing.clearData();
-  }
 
   @ParameterizedTest
   @MethodSource("producerCases")

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitMqTest.java
@@ -292,8 +292,6 @@ class SpringRabbitMqTest {
 
   @Test
   void testDefaultReceiveTelemetryMetricOwnership() throws InterruptedException {
-    testing.clearData();
-
     applicationContext
         .getBean(AmqpTemplate.class)
         .convertAndSend(ConsumerConfig.METRICS_QUEUE, "test");

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -258,8 +258,6 @@ class VertxRedisClientTest {
   @ParameterizedTest
   @MethodSource("batchScenarios")
   void batchCommand(BatchScenario scenario) throws Exception {
-    testing.clearData();
-
     connection.batch(scenario.requests).toCompletionStage().toCompletableFuture().get(30, SECONDS);
 
     testing.waitAndAssertTraces(


### PR DESCRIPTION
Adds repository test guidance to drain deterministic asynchronous trace exports before captured telemetry is cleared, including by the test-extension lifecycle. It explicitly avoids guessed waits when trace counts are non-deterministic.

Audits every Java test `clearData()` usage and removes 27 lifecycle-redundant clears plus one clear-only helper while preserving required mid-test resets and deterministic setup waits.