### PR TITLE
Use varargs in Java documentation examples

### DIFF
--- a/instrumentation/runtime-telemetry/library/README.md
+++ b/instrumentation/runtime-telemetry/library/README.md
@@ -121,8 +121,8 @@ RuntimeTelemetryBuilder builder = RuntimeTelemetry.builder(openTelemetry);
 Experimental.setJfrMetrics(
     builder,
     IncludeExclude.builder()
-        .setIncluded(Arrays.asList("jvm.memory.*", "jvm.cpu.longloc?"))
-        .setExcluded(Collections.singletonList("jvm.memory.allocation"))
+        .setIncluded("jvm.memory.*", "jvm.cpu.longloc?")
+        .setExcluded("jvm.memory.allocation")
         .build());
 RuntimeTelemetry runtimeTelemetry = builder.build();
 ```


### PR DESCRIPTION
Updates the runtime telemetry JFR example to call `IncludeExcludeBuilder`'s vararg overloads for literal patterns, so the snippet no longer wraps string literals in `Arrays.asList(...)` and `Collections.singletonList(...)` just to reach the collection overloads.

```java
IncludeExclude.builder()
    .setIncluded("jvm.memory.*", "jvm.cpu.longloc?")
    .setExcluded("jvm.memory.allocation")
    .build()
```

This matches how the servlet, Log4j, and Logback examples already show the same builder.