### PR TITLE
Document experimental telemetry metadata

### DIFF
--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -14,7 +14,8 @@ Each configuration entry includes:
   MUST have a `declarative_name`.
 - `declarative_name`: YAML key path (e.g., `java.grpc.emit_message_events`)
 - `type`: `boolean`, `string`, `list`, `int`, `map`. Describes the **flat** form.
-- `description`: Human-readable explanation
+- `description`: Human-readable explanation. For `experimental-span-attributes`, follow the
+  attribute-key requirements below.
 - `default`: Default value
 - `examples` (optional): Only for module-specific configs with non-obvious format
 - `declarative_type` (optional): Overrides the declarative-form shape when it differs from the flat
@@ -22,6 +23,18 @@ Each configuration entry includes:
   `int` (see Scalar Overrides).
 - `declarative_schema` (optional): Per-item object schema, required when
   `declarative_type: structured_list` (see Structured Lists).
+
+## Experimental Span Attribute Descriptions
+
+Descriptions for `otel.instrumentation.*.experimental-span-attributes` MUST name the exact
+attribute keys that enabling the property can emit. When the implementation creates a genuinely
+dynamic key family, name the narrowest precise prefix or wildcard instead (for example,
+`http.request.header.*`). Do not replace known keys with a generic phrase such as "experimental span
+attributes."
+
+Verify the keys against the implementation or tests before changing the description. Do not
+speculate. When supported keys differ across instrumentation versions, each module's description
+must list only the keys emitted by that version.
 
 ## Structured Lists
 
@@ -231,7 +244,9 @@ FAIL in ../instrumentation/liberty/liberty-20.0/metadata.yaml:
 - name: otel.instrumentation.grpc.experimental-span-attributes
   declarative_name: java.grpc.experimental_span_attributes/development
   type: boolean
-  description: Enable capture of experimental span attributes.
+  description: >
+    Enables experimental span attributes `grpc.received.message_count`, `grpc.sent.message_count`,
+    and `grpc.canceled`.
   default: false
 ```
 

--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -14,8 +14,8 @@ Each configuration entry includes:
   MUST have a `declarative_name`.
 - `declarative_name`: YAML key path (e.g., `java.grpc.emit_message_events`)
 - `type`: `boolean`, `string`, `list`, `int`, `map`. Describes the **flat** form.
-- `description`: Human-readable explanation. For `experimental-span-attributes`, follow the
-  attribute-key requirements below.
+- `description`: Human-readable explanation. For experimental telemetry enablement properties,
+  follow the requirements below.
 - `default`: Default value
 - `examples` (optional): Only for module-specific configs with non-obvious format
 - `declarative_type` (optional): Overrides the declarative-form shape when it differs from the flat
@@ -24,7 +24,7 @@ Each configuration entry includes:
 - `declarative_schema` (optional): Per-item object schema, required when
   `declarative_type: structured_list` (see Structured Lists).
 
-## Experimental Span Attribute Descriptions
+## Experimental Telemetry Descriptions
 
 Descriptions for `otel.instrumentation.*.experimental-span-attributes` MUST name the exact
 attribute keys that enabling the property can emit. When the implementation creates a genuinely
@@ -32,9 +32,17 @@ dynamic key family, name the narrowest precise prefix or wildcard instead (for e
 `http.request.header.*`). Do not replace known keys with a generic phrase such as "experimental span
 attributes."
 
-Verify the keys against the implementation or tests before changing the description. Do not
-speculate. When supported keys differ across instrumentation versions, each module's description
-must list only the keys emitted by that version.
+Descriptions for broader experimental telemetry enablement properties, such as
+`otel.instrumentation.*.emit-experimental-telemetry` and
+`otel.instrumentation.*.experimental.*-telemetry.enabled`, MUST identify what enabling the property
+emits. Name fixed telemetry identifiers such as span attribute keys, metric names, and event names,
+and describe behavioral changes such as creating spans, changing span names, or changing trace
+links. Do not require an attribute list when a property enables only broader span behavior, and use
+precise prefixes or wildcards for genuinely dynamic telemetry families.
+
+Verify the telemetry against the implementation or tests before changing the description. Do not
+speculate. When supported telemetry differs across instrumentation versions, each module's
+description must identify only the telemetry emitted by that version.
 
 ## Structured Lists
 

--- a/.github/instructions/metadata.instructions.md
+++ b/.github/instructions/metadata.instructions.md
@@ -4,12 +4,18 @@ applyTo: "**/metadata.yaml"
 
 # Metadata Rules (first-pass review)
 
-## [Config] Experimental Span Attribute Descriptions
+## [Config] Experimental Telemetry Descriptions
 
 For `otel.instrumentation.*.experimental-span-attributes`, require the description to name every
 attribute key that enabling the property can emit. Accept a precise prefix or wildcard only for a
 genuinely dynamic key family. Generic descriptions such as "Enables experimental span attributes"
 are insufficient.
 
-Verify keys against the changed module's implementation or tests, account for version-specific key
-sets, and do not speculate about keys that cannot be proven.
+For broader enablement properties such as `otel.instrumentation.*.emit-experimental-telemetry` and
+`otel.instrumentation.*.experimental.*-telemetry.enabled`, require the description to identify the
+enabled telemetry. Name fixed attribute keys, metric names, and event names, and describe span
+creation, naming, or linking behavior. Do not demand attribute keys when the property enables only
+broader span behavior; accept a precise prefix or wildcard for genuinely dynamic telemetry.
+
+Verify telemetry against the changed module's implementation or tests, account for version-specific
+behavior, and do not speculate about telemetry that cannot be proven.

--- a/.github/instructions/metadata.instructions.md
+++ b/.github/instructions/metadata.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/metadata.yaml"
+applyTo: "**/metadata.yaml,instrumentation-docs/src/main/resources/shared-config-definitions.yaml"
 ---
 
 # Metadata Rules (first-pass review)

--- a/.github/instructions/metadata.instructions.md
+++ b/.github/instructions/metadata.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**/metadata.yaml"
+---
+
+# Metadata Rules (first-pass review)
+
+## [Config] Experimental Span Attribute Descriptions
+
+For `otel.instrumentation.*.experimental-span-attributes`, require the description to name every
+attribute key that enabling the property can emit. Accept a precise prefix or wildcard only for a
+genuinely dynamic key family. Generic descriptions such as "Enables experimental span attributes"
+are insufficient.
+
+Verify keys against the changed module's implementation or tests, account for version-specific key
+sets, and do not speculate about keys that cannot be proven.

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -57,7 +57,7 @@ configurations:
   http.client.emit-experimental-telemetry:
     name: otel.instrumentation.http.client.emit-experimental-telemetry
     declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: "Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.client.request.body.size` and `http.client.response.body.size` metrics."
+    description: "Enables experimental HTTP client telemetry. When available, adds the `url.template`, `http.request.body.size`, and `http.response.body.size` span attributes, uses the URL template in the span name, and records the `http.client.request.body.size` and `http.client.response.body.size` metrics."
     type: boolean
     default: false
 
@@ -78,7 +78,7 @@ configurations:
   http.server.emit-experimental-telemetry:
     name: otel.instrumentation.http.server.emit-experimental-telemetry
     declarative_name: java.common.http.server.emit_experimental_telemetry/development
-    description: "Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size` and `http.response.body.size` attributes to spans, and records `http.server.request.body.size` and `http.server.response.body.size` metrics."
+    description: "Enables experimental HTTP server telemetry. When available, adds the `http.request.body.size` and `http.response.body.size` span attributes, and records the `http.server.active_requests`, `http.server.request.body.size`, and `http.server.response.body.size` metrics."
     type: boolean
     default: false
 

--- a/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
@@ -8,7 +8,9 @@ library_link: https://github.com/couchbase/couchbase-java-client
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying Couchbase library.
+    description: >
+      Enables experimental span attributes `db.couchbase.scope`, `db.couchbase.retries`, and
+      `db.couchbase.service`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1.6/metadata.yaml
@@ -9,8 +9,8 @@ configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
     description: >
-      Enables experimental span attributes `db.couchbase.scope`, `db.couchbase.retries`, and
-      `db.couchbase.service`.
+      Enables experimental span attributes with `db.couchbase.*` keys emitted by the underlying
+      Couchbase library, except `db.couchbase.collection`, which is translated to `db.collection.name`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.1/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1/metadata.yaml
@@ -9,7 +9,8 @@ configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
     description: >
-      Enables experimental span attributes `db.couchbase.scope` and `db.couchbase.service`.
+      Enables experimental span attributes with `db.couchbase.*` keys emitted by the underlying
+      Couchbase library, except `db.couchbase.collection`, which is translated to `db.collection.name`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.1/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.1/metadata.yaml
@@ -8,7 +8,8 @@ library_link: https://github.com/couchbase/couchbase-java-client
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying Couchbase library.
+    description: >
+      Enables experimental span attributes `db.couchbase.scope` and `db.couchbase.service`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.2/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.2/metadata.yaml
@@ -8,7 +8,9 @@ library_link: https://github.com/couchbase/couchbase-java-client
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying Couchbase library.
+    description: >
+      Enables experimental span attributes `db.couchbase.document_id`, `db.couchbase.scope`,
+      `db.couchbase.retries`, and `db.couchbase.service`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.2/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.2/metadata.yaml
@@ -9,8 +9,8 @@ configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
     description: >
-      Enables experimental span attributes `db.couchbase.document_id`, `db.couchbase.scope`,
-      `db.couchbase.retries`, and `db.couchbase.service`.
+      Enables experimental span attributes with `db.couchbase.*` keys emitted by the underlying
+      Couchbase library, except `db.couchbase.collection`, which is translated to `db.collection.name`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.4/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.4/metadata.yaml
@@ -8,7 +8,9 @@ semantic_conventions:
 configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
-    description: Enables experimental span attributes emitted from the underlying Couchbase library.
+    description: >
+      Enables experimental span attributes `db.couchbase.document_id`, `db.couchbase.scope`,
+      `db.couchbase.retries`, and `db.couchbase.service`.
     type: boolean
     default: false
 features:

--- a/instrumentation/couchbase/couchbase-3.4/metadata.yaml
+++ b/instrumentation/couchbase/couchbase-3.4/metadata.yaml
@@ -9,8 +9,8 @@ configurations:
   - name: otel.instrumentation.couchbase.experimental-span-attributes
     declarative_name: java.couchbase.experimental_span_attributes/development
     description: >
-      Enables experimental span attributes `db.couchbase.document_id`, `db.couchbase.scope`,
-      `db.couchbase.retries`, and `db.couchbase.service`.
+      Enables experimental span attributes with `db.couchbase.*` keys emitted by the underlying
+      Couchbase library, except `db.couchbase.collection`, which is translated to `db.collection.name`.
     type: boolean
     default: false
 features:

--- a/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
+++ b/instrumentation/spring/spring-web/spring-web-6.0/metadata.yaml
@@ -6,13 +6,7 @@ features:
   - HTTP_ROUTE
 library_link: https://github.com/spring-projects/spring-framework
 configurations:
-  - name: otel.instrumentation.http.client.emit-experimental-telemetry
-    declarative_name: java.common.http.client.emit_experimental_telemetry/development
-    description: >
-      Enables the capture of experimental HTTP client telemetry, including URL template
-      as the span name.
-    type: boolean
-    default: false
+  - ref: http.client.emit-experimental-telemetry
   - declarative_name: java.common.http.client.url_template_rules
     description: >
       Rules for deriving low-cardinality URL templates (routes) from HTTP client request URLs. Only


### PR DESCRIPTION
Requires experimental telemetry metadata descriptions to identify the exact emitted keys for span-attribute flags and the fixed attributes, metrics, events, or span behavior enabled by broader telemetry flags. Precise prefixes or wildcards remain valid only for genuinely dynamic families.

Updates the four version-specific Couchbase descriptions and the shared HTTP client/server experimental telemetry definitions, including URL-template span naming and body-size or active-request metrics. An audit covered all 65 experimental span-attribute entries and all 78 experimental telemetry metadata occurrences.