### PR TITLE
Add HTTP header selectors to the Jetty client and Armeria library instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@
   exact name only. The deprecated methods still match header names literally, so `*` and `?` are not
   treated as glob patterns.
   ([#19606](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19606))
+- Deprecate the `setCapturedRequestHeaders` and `setCapturedResponseHeaders` methods on
+  `JettyClientTelemetryBuilder` (Jetty HTTP client 9.2 and 12.0), `ArmeriaClientTelemetryBuilder`
+  and `ArmeriaServerTelemetryBuilder` in favor of `setRequestHeaders(IncludeExclude)` and
+  `setResponseHeaders(IncludeExclude)`, which select HTTP headers by glob pattern instead of by
+  exact name only. The deprecated methods still match header names literally, so `*` and `?` are not
+  treated as glob patterns.
+  ([#19603](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19603))
 - Deprecate the Logback appender `experimental.capture-mdc-attributes` configuration property and
   `OpenTelemetryAppender#setCaptureMdcAttributes(String)` in favor of the new
   `experimental.mdc-attributes.included` and `experimental.mdc-attributes.excluded` selectors, which

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
@@ -9,6 +9,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -55,14 +56,46 @@ public final class ArmeriaClientTelemetryBuilder {
   }
 
   /**
+   * Configures which HTTP request headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public ArmeriaClientTelemetryBuilder setRequestHeaders(IncludeExclude requestHeaders) {
+    builder.setRequestHeaders(requestHeaders);
+    return this;
+  }
+
+  /**
    * Configures HTTP request headers to capture as span attributes.
    *
    * @param requestHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedRequestHeaders(
       Collection<String> requestHeaders) {
-    builder.setCapturedRequestHeaders(requestHeaders);
+    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+  }
+
+  /**
+   * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public ArmeriaClientTelemetryBuilder setResponseHeaders(IncludeExclude responseHeaders) {
+    builder.setResponseHeaders(responseHeaders);
     return this;
   }
 
@@ -70,12 +103,14 @@ public final class ArmeriaClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * @param responseHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    builder.setCapturedResponseHeaders(responseHeaders);
-    return this;
+    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
   }
 
   /**

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
@@ -58,6 +58,9 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures which HTTP request headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.request.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -73,9 +76,8 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param requestHeaders HTTP header names to capture.
    * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
@@ -92,6 +94,9 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures which HTTP response headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.response.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -107,9 +112,8 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param responseHeaders HTTP header names to capture.
    * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
@@ -74,7 +74,7 @@ public final class ArmeriaClientTelemetryBuilder {
    * Configures HTTP request headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param requestHeaders HTTP header names to capture.
@@ -108,7 +108,7 @@ public final class ArmeriaClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param responseHeaders HTTP header names to capture.

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaClientTelemetryBuilder.java
@@ -73,15 +73,20 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param requestHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
+   *     rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedRequestHeaders(
       Collection<String> requestHeaders) {
-    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+    builder.setCapturedRequestHeaders(requestHeaders);
+    return this;
   }
 
   /**
@@ -102,15 +107,20 @@ public final class ArmeriaClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param responseHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob
+   *     patterns rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
+    builder.setCapturedResponseHeaders(responseHeaders);
+    return this;
   }
 
   /**

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
@@ -74,15 +74,20 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param requestHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
+   *     rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedRequestHeaders(
       Collection<String> requestHeaders) {
-    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+    builder.setCapturedRequestHeaders(requestHeaders);
+    return this;
   }
 
   /**
@@ -103,15 +108,20 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param responseHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob
+   *     patterns rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
+    builder.setCapturedResponseHeaders(responseHeaders);
+    return this;
   }
 
   /**

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
@@ -59,6 +59,9 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures which HTTP request headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.request.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -74,9 +77,8 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param requestHeaders HTTP header names to capture.
    * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
@@ -93,6 +95,9 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures which HTTP response headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.response.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -108,9 +113,8 @@ public final class ArmeriaServerTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param responseHeaders HTTP header names to capture.
    * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
@@ -75,7 +75,7 @@ public final class ArmeriaServerTelemetryBuilder {
    * Configures HTTP request headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param requestHeaders HTTP header names to capture.
@@ -109,7 +109,7 @@ public final class ArmeriaServerTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param responseHeaders HTTP header names to capture.

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaServerTelemetryBuilder.java
@@ -9,6 +9,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpServerInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -56,14 +57,46 @@ public final class ArmeriaServerTelemetryBuilder {
   }
 
   /**
+   * Configures which HTTP request headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public ArmeriaServerTelemetryBuilder setRequestHeaders(IncludeExclude requestHeaders) {
+    builder.setRequestHeaders(requestHeaders);
+    return this;
+  }
+
+  /**
    * Configures HTTP request headers to capture as span attributes.
    *
    * @param requestHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedRequestHeaders(
       Collection<String> requestHeaders) {
-    builder.setCapturedRequestHeaders(requestHeaders);
+    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+  }
+
+  /**
+   * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public ArmeriaServerTelemetryBuilder setResponseHeaders(IncludeExclude responseHeaders) {
+    builder.setResponseHeaders(responseHeaders);
     return this;
   }
 
@@ -71,12 +104,14 @@ public final class ArmeriaServerTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * @param responseHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public ArmeriaServerTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    builder.setCapturedResponseHeaders(responseHeaders);
-    return this;
+    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
   }
 
   /**

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHeaderUtil.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHeaderUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.armeria.v1_3.internal;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+final class ArmeriaHeaderUtil {
+
+  static Collection<String> getHeaderNames(HttpHeaders headers) {
+    List<String> names = new ArrayList<>(headers.size());
+    for (CharSequence name : headers.names()) {
+      // armeria carries the method, path, scheme, authority and status as HTTP/2 pseudo-headers,
+      // which are not HTTP headers
+      if (name.length() != 0 && name.charAt(0) != ':') {
+        names.add(name.toString());
+      }
+    }
+    return names;
+  }
+
+  private ArmeriaHeaderUtil() {}
+}

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpClientAttributesGetter.java
@@ -13,6 +13,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -65,6 +66,11 @@ final class ArmeriaHttpClientAttributesGetter
   }
 
   @Override
+  public Collection<String> getHttpRequestHeaderNames(ClientRequestContext ctx) {
+    return ArmeriaHeaderUtil.getHeaderNames(request(ctx).headers());
+  }
+
+  @Override
   @Nullable
   public Integer getHttpResponseStatusCode(
       ClientRequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
@@ -79,6 +85,12 @@ final class ArmeriaHttpClientAttributesGetter
   public List<String> getHttpResponseHeader(
       ClientRequestContext ctx, RequestLog requestLog, String name) {
     return requestLog.responseHeaders().getAll(name);
+  }
+
+  @Override
+  public Collection<String> getHttpResponseHeaderNames(
+      ClientRequestContext ctx, RequestLog requestLog) {
+    return ArmeriaHeaderUtil.getHeaderNames(requestLog.responseHeaders());
   }
 
   @Override

--- a/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpServerAttributesGetter.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/main/java/io/opentelemetry/instrumentation/armeria/v1_3/internal/ArmeriaHttpServerAttributesGetter.java
@@ -12,6 +12,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -50,6 +51,11 @@ final class ArmeriaHttpServerAttributesGetter
   }
 
   @Override
+  public Collection<String> getHttpRequestHeaderNames(ServiceRequestContext ctx) {
+    return ArmeriaHeaderUtil.getHeaderNames(request(ctx).headers());
+  }
+
+  @Override
   @Nullable
   public Integer getHttpResponseStatusCode(
       ServiceRequestContext ctx, RequestLog requestLog, @Nullable Throwable error) {
@@ -64,6 +70,12 @@ final class ArmeriaHttpServerAttributesGetter
   public List<String> getHttpResponseHeader(
       ServiceRequestContext ctx, RequestLog requestLog, String name) {
     return requestLog.responseHeaders().getAll(name);
+  }
+
+  @Override
+  public Collection<String> getHttpResponseHeaderNames(
+      ServiceRequestContext ctx, RequestLog requestLog) {
+    return ArmeriaHeaderUtil.getHeaderNames(requestLog.responseHeaders());
   }
 
   @Override

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -66,6 +66,14 @@ class ArmeriaHeaderSelectorTest {
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
                             singletonList("response-value"))
+                        // an excluded header is not captured
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.x-ignored-request"))
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.response.header.x-ignored-response")))
                         // pseudo-headers are not HTTP headers
                         .satisfies(
                             spanData ->
@@ -103,7 +111,7 @@ class ArmeriaHeaderSelectorTest {
                     ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
                         .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
                         .setResponseHeaders(
-                            IncludeExclude.builder().setExcluded("content-*").build())
+                            IncludeExclude.builder().setExcluded("x-ignored-*").build())
                         .build()
                         .createDecorator()));
 
@@ -177,6 +185,7 @@ class ArmeriaHeaderSelectorTest {
             HttpResponse.of(
                 ResponseHeaders.builder(HttpStatus.OK)
                     .add("x-test-response", "response-value")
+                    .add("x-ignored-response", "ignored-value")
                     .build(),
                 HttpData.ofUtf8("success")));
 
@@ -191,6 +200,7 @@ class ArmeriaHeaderSelectorTest {
             .execute(
                 RequestHeaders.builder(HttpMethod.GET, "/test")
                     .add("x-test-request", "request-value")
+                    .add("x-ignored-request", "ignored-value")
                     .build())
             .aggregate()
             .join();
@@ -208,7 +218,15 @@ class ArmeriaHeaderSelectorTest {
                             singletonList("request-value"))
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
-                            singletonList("response-value"))));
+                            singletonList("response-value"))
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.x-ignored-request"))
+                                    .doesNotContainKey(
+                                        stringArrayKey(
+                                            "http.response.header.x-ignored-response")))));
   }
 
   private static void assertNoCapturedHeaders() {

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.armeria.v1_3;
+
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ArmeriaHeaderSelectorTest {
+
+  @RegisterExtension
+  static final LibraryInstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  private Server server;
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop().join();
+    }
+  }
+
+  @Test
+  void clientCapturesHeadersMatchingSelectors() {
+    int port = startServer(UnaryOperator.identity());
+
+    WebClient client =
+        WebClient.builder("http://localhost:" + port)
+            .decorator(
+                ArmeriaClientTelemetry.builder(testing.getOpenTelemetry())
+                    .setRequestHeaders(IncludeExclude.builder().setExcluded("x-ignored-*").build())
+                    .setResponseHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
+                    .build()
+                    .createDecorator())
+            .build();
+
+    sendRequest(client);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttribute(
+                            stringArrayKey("http.request.header.x-test-request"),
+                            singletonList("request-value"))
+                        .hasAttribute(
+                            stringArrayKey("http.response.header.x-test-response"),
+                            singletonList("response-value"))
+                        // pseudo-headers are not HTTP headers
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.:method")))));
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void clientCapturesHeadersFromDeprecatedSetters() {
+    int port = startServer(UnaryOperator.identity());
+
+    WebClient client =
+        WebClient.builder("http://localhost:" + port)
+            .decorator(
+                ArmeriaClientTelemetry.builder(testing.getOpenTelemetry())
+                    .setCapturedRequestHeaders(singletonList("x-test-request"))
+                    .setCapturedResponseHeaders(singletonList("x-test-response"))
+                    .build()
+                    .createDecorator())
+            .build();
+
+    sendRequest(client);
+
+    assertCapturedHeaders();
+  }
+
+  @Test
+  void serverCapturesHeadersMatchingSelectors() {
+    int port =
+        startServer(
+            sb ->
+                sb.decorator(
+                    ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
+                        .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
+                        .setResponseHeaders(
+                            IncludeExclude.builder().setExcluded("content-*").build())
+                        .build()
+                        .createDecorator()));
+
+    sendRequest(WebClient.of("http://localhost:" + port));
+
+    assertCapturedHeaders();
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void serverCapturesHeadersFromDeprecatedSetters() {
+    int port =
+        startServer(
+            sb ->
+                sb.decorator(
+                    ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
+                        .setCapturedRequestHeaders(singletonList("x-test-request"))
+                        .setCapturedResponseHeaders(singletonList("x-test-response"))
+                        .build()
+                        .createDecorator()));
+
+    sendRequest(WebClient.of("http://localhost:" + port));
+
+    assertCapturedHeaders();
+  }
+
+  private int startServer(UnaryOperator<ServerBuilder> customizer) {
+    ServerBuilder sb = Server.builder();
+    sb.http(0);
+    sb.service(
+        "/test",
+        (ctx, req) ->
+            HttpResponse.of(
+                ResponseHeaders.builder(HttpStatus.OK)
+                    .add("x-test-response", "response-value")
+                    .build(),
+                HttpData.ofUtf8("success")));
+
+    server = customizer.apply(sb).build();
+    server.start().join();
+    return server.activeLocalPort();
+  }
+
+  private static void sendRequest(WebClient client) {
+    AggregatedHttpResponse response =
+        client
+            .execute(
+                RequestHeaders.builder(HttpMethod.GET, "/test")
+                    .add("x-test-request", "request-value")
+                    .build())
+            .aggregate()
+            .join();
+
+    assertThat(response.status()).isEqualTo(HttpStatus.OK);
+  }
+
+  private static void assertCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttribute(
+                            stringArrayKey("http.request.header.x-test-request"),
+                            singletonList("request-value"))
+                        .hasAttribute(
+                            stringArrayKey("http.response.header.x-test-response"),
+                            singletonList("response-value"))));
+  }
+}

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -226,8 +226,10 @@ class ArmeriaHeaderSelectorTest {
                                     .doesNotContainKey(
                                         stringArrayKey("http.request.header.x-ignored-request"))
                                     .doesNotContainKey(
-                                        stringArrayKey(
-                                            "http.response.header.x-ignored-response")))));
+                                        stringArrayKey("http.response.header.x-ignored-response"))
+                                    // pseudo-headers are not HTTP headers
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.response.header.:status")))));
   }
 
   private static void assertNoCapturedHeaders() {

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -41,7 +41,7 @@ class ArmeriaHeaderSelectorTest {
   }
 
   @Test
-  void clientCapturesHeadersMatchingSelectors() {
+  void clientCapturesHeadersMatchingSelectorPatterns() {
     int port = startServer(UnaryOperator.identity());
 
     WebClient client =
@@ -84,7 +84,7 @@ class ArmeriaHeaderSelectorTest {
 
   @SuppressWarnings("deprecation") // testing deprecated API
   @Test
-  void clientCapturesHeadersFromDeprecatedSetters() {
+  void clientCapturesHeadersConfiguredByName() {
     int port = startServer(UnaryOperator.identity());
 
     WebClient client =
@@ -103,7 +103,7 @@ class ArmeriaHeaderSelectorTest {
   }
 
   @Test
-  void serverCapturesHeadersMatchingSelectors() {
+  void serverCapturesHeadersMatchingSelectorPatterns() {
     int port =
         startServer(
             sb ->
@@ -122,7 +122,7 @@ class ArmeriaHeaderSelectorTest {
 
   @SuppressWarnings("deprecation") // testing deprecated API
   @Test
-  void serverCapturesHeadersFromDeprecatedSetters() {
+  void serverCapturesHeadersConfiguredByName() {
     int port =
         startServer(
             sb ->

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -130,6 +130,44 @@ class ArmeriaHeaderSelectorTest {
     assertCapturedHeaders();
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void clientDeprecatedSettersMatchHeaderNamesLiterally() {
+    int port = startServer(UnaryOperator.identity());
+
+    WebClient client =
+        WebClient.builder("http://localhost:" + port)
+            .decorator(
+                ArmeriaClientTelemetry.builder(testing.getOpenTelemetry())
+                    .setCapturedRequestHeaders(singletonList("*"))
+                    .setCapturedResponseHeaders(singletonList("*"))
+                    .build()
+                    .createDecorator())
+            .build();
+
+    sendRequest(client);
+
+    assertNoCapturedHeaders();
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void serverDeprecatedSettersMatchHeaderNamesLiterally() {
+    int port =
+        startServer(
+            sb ->
+                sb.decorator(
+                    ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
+                        .setCapturedRequestHeaders(singletonList("*"))
+                        .setCapturedResponseHeaders(singletonList("*"))
+                        .build()
+                        .createDecorator()));
+
+    sendRequest(WebClient.of("http://localhost:" + port));
+
+    assertNoCapturedHeaders();
+  }
+
   private int startServer(UnaryOperator<ServerBuilder> customizer) {
     ServerBuilder sb = Server.builder();
     sb.http(0);
@@ -171,5 +209,19 @@ class ArmeriaHeaderSelectorTest {
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
                             singletonList("response-value"))));
+  }
+
+  private static void assertNoCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttributesSatisfying(
+                        attributes ->
+                            attributes.forEach(
+                                (key, value) ->
+                                    assertThat(key.getKey())
+                                        .doesNotStartWith("http.request.header.")
+                                        .doesNotStartWith("http.response.header.")))));
   }
 }

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHeaderSelectorTest.java
@@ -201,6 +201,7 @@ class ArmeriaHeaderSelectorTest {
                 RequestHeaders.builder(HttpMethod.GET, "/test")
                     .add("x-test-request", "request-value")
                     .add("x-ignored-request", "ignored-value")
+                    .add("authorization", "******")
                     .build())
             .aggregate()
             .join();
@@ -235,11 +236,18 @@ class ArmeriaHeaderSelectorTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasAttributesSatisfying(
-                        attributes ->
-                            attributes.forEach(
-                                (key, value) ->
-                                    assertThat(key.getKey())
-                                        .doesNotStartWith("http.request.header.")
-                                        .doesNotStartWith("http.response.header.")))));
+                            attributes ->
+                                attributes.forEach(
+                                    (key, value) ->
+                                        assertThat(key.getKey())
+                                            .doesNotStartWith("http.request.header.")
+                                            .doesNotStartWith("http.response.header.")))
+                        // "*" is a legal header name character, so the deprecated exact-name
+                        // setters must not capture every header and expose credentials
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.authorization")))));
   }
 }

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 import static java.util.Collections.singletonList;
 
 import com.linecorp.armeria.client.WebClientBuilder;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -23,8 +24,14 @@ class ArmeriaHttpClientTest extends AbstractArmeriaHttpClientTest {
   protected WebClientBuilder configureClient(WebClientBuilder clientBuilder) {
     return clientBuilder.decorator(
         ArmeriaClientTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-            .setCapturedResponseHeaders(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+            .setRequestHeaders(
+                IncludeExclude.builder()
+                    .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
+                    .build())
+            .setResponseHeaders(
+                IncludeExclude.builder()
+                    .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+                    .build())
             .build()
             .createDecorator());
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.armeria.v1_3;
 import static java.util.Collections.singletonList;
 
 import com.linecorp.armeria.server.ServerBuilder;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -23,8 +24,14 @@ class ArmeriaHttpServerTest extends AbstractArmeriaHttpServerTest {
   protected ServerBuilder configureServer(ServerBuilder sb) {
     return sb.decorator(
         ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
-            .setCapturedRequestHeaders(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-            .setCapturedResponseHeaders(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
+            .setRequestHeaders(
+                IncludeExclude.builder()
+                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
+                    .build())
+            .setResponseHeaders(
+                IncludeExclude.builder()
+                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
+                    .build())
             .build()
             .createDecorator());
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v12_0;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
@@ -44,13 +45,45 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
+   * Configures which HTTP request headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public JettyClientTelemetryBuilder setRequestHeaders(IncludeExclude requestHeaders) {
+    builder.setRequestHeaders(requestHeaders);
+    return this;
+  }
+
+  /**
    * Configures HTTP request headers to capture as span attributes.
    *
    * @param requestHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
-    builder.setCapturedRequestHeaders(requestHeaders);
+    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+  }
+
+  /**
+   * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public JettyClientTelemetryBuilder setResponseHeaders(IncludeExclude responseHeaders) {
+    builder.setResponseHeaders(responseHeaders);
     return this;
   }
 
@@ -58,12 +91,14 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * @param responseHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    builder.setCapturedResponseHeaders(responseHeaders);
-    return this;
+    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
   }
 
   /**

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -63,7 +63,7 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP request headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param requestHeaders HTTP header names to capture.
@@ -96,7 +96,7 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param responseHeaders HTTP header names to capture.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -62,14 +62,19 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param requestHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
+   *     rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
-    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+    builder.setCapturedRequestHeaders(requestHeaders);
+    return this;
   }
 
   /**
@@ -90,15 +95,20 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param responseHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob
+   *     patterns rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
+    builder.setCapturedResponseHeaders(responseHeaders);
+    return this;
   }
 
   /**

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyClientTelemetryBuilder.java
@@ -47,6 +47,9 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures which HTTP request headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.request.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -62,9 +65,8 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param requestHeaders HTTP header names to capture.
    * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
@@ -79,6 +81,9 @@ public final class JettyClientTelemetryBuilder {
 
   /**
    * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Header values are captured under the {@code http.response.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
    *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
@@ -95,9 +100,8 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param responseHeaders HTTP header names to capture.
    * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/internal/JettyClientHttpAttributesGetter.java
@@ -7,10 +7,14 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v12_0.internal;
 
 import io.opentelemetry.instrumentation.api.internal.HttpProtocolUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
 
 /**
@@ -37,6 +41,11 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   }
 
   @Override
+  public Collection<String> getHttpRequestHeaderNames(Request request) {
+    return headerNames(request.getHeaders());
+  }
+
+  @Override
   public Integer getHttpResponseStatusCode(
       Request request, Response response, @Nullable Throwable error) {
     return response.getStatus();
@@ -45,6 +54,11 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   @Override
   public List<String> getHttpResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getValuesList(name);
+  }
+
+  @Override
+  public Collection<String> getHttpResponseHeaderNames(Request request, Response response) {
+    return headerNames(response.getHeaders());
   }
 
   @Override
@@ -77,5 +91,13 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   @Override
   public Integer getServerPort(Request request) {
     return request.getPort();
+  }
+
+  private static Collection<String> headerNames(HttpFields headers) {
+    List<String> names = new ArrayList<>(headers.size());
+    for (HttpField header : headers) {
+      names.add(header.getName());
+    }
+    return names;
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
@@ -79,6 +79,21 @@ class JettyHttpClient12HeaderSelectorTest {
     assertCapturedHeaders();
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedSettersMatchHeaderNamesLiterally() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedRequestHeaders(singletonList("*"))
+            .setCapturedResponseHeaders(singletonList("*"))
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertNoCapturedHeaders();
+  }
+
   private void sendRequest() throws Exception {
     client.start();
 
@@ -102,5 +117,19 @@ class JettyHttpClient12HeaderSelectorTest {
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
                             singletonList("response-value"))));
+  }
+
+  private static void assertNoCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttributesSatisfying(
+                        attributes ->
+                            attributes.forEach(
+                                (key, value) ->
+                                    assertThat(key.getKey())
+                                        .doesNotStartWith("http.request.header.")
+                                        .doesNotStartWith("http.response.header.")))));
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
@@ -110,6 +110,7 @@ class JettyHttpClient12HeaderSelectorTest {
                 headers -> {
                   headers.put(new HttpField("x-test-request", "request-value"));
                   headers.put(new HttpField("x-ignored-request", "ignored-value"));
+                  headers.put(new HttpField("authorization", "******"));
                 })
             .send();
 
@@ -143,11 +144,18 @@ class JettyHttpClient12HeaderSelectorTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasAttributesSatisfying(
-                        attributes ->
-                            attributes.forEach(
-                                (key, value) ->
-                                    assertThat(key.getKey())
-                                        .doesNotStartWith("http.request.header.")
-                                        .doesNotStartWith("http.response.header.")))));
+                            attributes ->
+                                attributes.forEach(
+                                    (key, value) ->
+                                        assertThat(key.getKey())
+                                            .doesNotStartWith("http.request.header.")
+                                            .doesNotStartWith("http.response.header.")))
+                        // "*" is a legal header name character, so the deprecated exact-name
+                        // setters must not capture every header and expose credentials
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.authorization")))));
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jetty.httpclient.v12_0;
+
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.net.InetSocketAddress;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpField;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class JettyHttpClient12HeaderSelectorTest {
+
+  @RegisterExtension
+  static final LibraryInstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  private HttpServer server;
+  private HttpClient client;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          exchange.getResponseHeaders().add("x-test-response", "response-value");
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    server.stop(0);
+  }
+
+  @Test
+  void capturesHeadersMatchingSelectors() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
+            .setResponseHeaders(IncludeExclude.builder().setExcluded("content-*").build())
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertCapturedHeaders();
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void capturesHeadersFromDeprecatedSetters() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedRequestHeaders(singletonList("x-test-request"))
+            .setCapturedResponseHeaders(singletonList("x-test-response"))
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertCapturedHeaders();
+  }
+
+  private void sendRequest() throws Exception {
+    client.start();
+
+    ContentResponse response =
+        client
+            .newRequest("http://localhost:" + server.getAddress().getPort() + "/")
+            .headers(headers -> headers.put(new HttpField("x-test-request", "request-value")))
+            .send();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  private static void assertCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttribute(
+                            stringArrayKey("http.request.header.x-test-request"),
+                            singletonList("request-value"))
+                        .hasAttribute(
+                            stringArrayKey("http.response.header.x-test-response"),
+                            singletonList("response-value"))));
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
@@ -36,6 +36,7 @@ class JettyHttpClient12HeaderSelectorTest {
         "/",
         exchange -> {
           exchange.getResponseHeaders().add("x-test-response", "response-value");
+          exchange.getResponseHeaders().add("x-ignored-response", "ignored-value");
           exchange.sendResponseHeaders(200, -1);
           exchange.close();
         });
@@ -44,10 +45,15 @@ class JettyHttpClient12HeaderSelectorTest {
 
   @AfterEach
   void stopServer() throws Exception {
-    if (client != null) {
-      client.stop();
+    try {
+      if (client != null) {
+        client.stop();
+      }
+    } finally {
+      if (server != null) {
+        server.stop(0);
+      }
     }
-    server.stop(0);
   }
 
   @Test
@@ -55,7 +61,7 @@ class JettyHttpClient12HeaderSelectorTest {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
-            .setResponseHeaders(IncludeExclude.builder().setExcluded("content-*").build())
+            .setResponseHeaders(IncludeExclude.builder().setExcluded("x-ignored-*").build())
             .build()
             .createHttpClient();
 
@@ -100,7 +106,11 @@ class JettyHttpClient12HeaderSelectorTest {
     ContentResponse response =
         client
             .newRequest("http://localhost:" + server.getAddress().getPort() + "/")
-            .headers(headers -> headers.put(new HttpField("x-test-request", "request-value")))
+            .headers(
+                headers -> {
+                  headers.put(new HttpField("x-test-request", "request-value"));
+                  headers.put(new HttpField("x-ignored-request", "ignored-value"));
+                })
             .send();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -116,7 +126,15 @@ class JettyHttpClient12HeaderSelectorTest {
                             singletonList("request-value"))
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
-                            singletonList("response-value"))));
+                            singletonList("response-value"))
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.x-ignored-request"))
+                                    .doesNotContainKey(
+                                        stringArrayKey(
+                                            "http.response.header.x-ignored-response")))));
   }
 
   private static void assertNoCapturedHeaders() {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12HeaderSelectorTest.java
@@ -57,7 +57,7 @@ class JettyHttpClient12HeaderSelectorTest {
   }
 
   @Test
-  void capturesHeadersMatchingSelectors() throws Exception {
+  void capturesHeadersMatchingSelectorPatterns() throws Exception {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
@@ -72,7 +72,7 @@ class JettyHttpClient12HeaderSelectorTest {
 
   @SuppressWarnings("deprecation") // testing deprecated API
   @Test
-  void capturesHeadersFromDeprecatedSetters() throws Exception {
+  void capturesHeadersConfiguredByName() throws Exception {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setCapturedRequestHeaders(singletonList("x-test-request"))

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12LibraryTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12LibraryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v12_0;
 
 import static java.util.Collections.singletonList;
 
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -23,8 +24,14 @@ class JettyHttpClient12LibraryTest extends AbstractJettyClient12Test {
   @Override
   protected HttpClient createStandardClient() {
     return JettyClientTelemetry.builder(testing.getOpenTelemetry())
-        .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-        .setCapturedResponseHeaders(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+        .setRequestHeaders(
+            IncludeExclude.builder()
+                .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
+                .build())
+        .setResponseHeaders(
+            IncludeExclude.builder()
+                .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+                .build())
         .build()
         .createHttpClient();
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -63,14 +63,19 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param requestHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
+   *     rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
-    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+    builder.setCapturedRequestHeaders(requestHeaders);
+    return this;
   }
 
   /**
@@ -91,15 +96,20 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
+   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * them as wildcards.
+   *
    * @param responseHeaders HTTP header names to capture.
-   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
-   *     minor release.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob
+   *     patterns rather than literal header names. May be removed in the next minor release.
    */
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
+    builder.setCapturedResponseHeaders(responseHeaders);
+    return this;
   }
 
   /**

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v9_2;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -45,13 +46,45 @@ public final class JettyClientTelemetryBuilder {
   }
 
   /**
+   * Configures which HTTP request headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public JettyClientTelemetryBuilder setRequestHeaders(IncludeExclude requestHeaders) {
+    builder.setRequestHeaders(requestHeaders);
+    return this;
+  }
+
+  /**
    * Configures HTTP request headers to capture as span attributes.
    *
    * @param requestHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedRequestHeaders(Collection<String> requestHeaders) {
-    builder.setCapturedRequestHeaders(requestHeaders);
+    return setRequestHeaders(IncludeExclude.builder().setIncluded(requestHeaders).build());
+  }
+
+  /**
+   * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Selector patterns are matched case-insensitively, since HTTP header names are
+   * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
+   * characters, including none. Excluded patterns take precedence over included patterns. A
+   * selector with no included patterns captures every header that is not excluded, and an
+   * {@linkplain IncludeExclude#isEmpty() empty} selector captures no headers.
+   */
+  @CanIgnoreReturnValue
+  public JettyClientTelemetryBuilder setResponseHeaders(IncludeExclude responseHeaders) {
+    builder.setResponseHeaders(responseHeaders);
     return this;
   }
 
@@ -59,12 +92,14 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * @param responseHeaders HTTP header names to capture.
+   * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead. May be removed in the next
+   *     minor release.
    */
+  @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public JettyClientTelemetryBuilder setCapturedResponseHeaders(
       Collection<String> responseHeaders) {
-    builder.setCapturedResponseHeaders(responseHeaders);
-    return this;
+    return setResponseHeaders(IncludeExclude.builder().setIncluded(responseHeaders).build());
   }
 
   /**

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -48,6 +48,9 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures which HTTP request headers are captured as span attributes.
    *
+   * <p>Header values are captured under the {@code http.request.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
+   *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
    * characters, including none. Excluded patterns take precedence over included patterns. A
@@ -63,9 +66,8 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP request headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param requestHeaders HTTP header names to capture.
    * @deprecated Use {@link #setRequestHeaders(IncludeExclude)} instead, which matches glob patterns
@@ -80,6 +82,9 @@ public final class JettyClientTelemetryBuilder {
 
   /**
    * Configures which HTTP response headers are captured as span attributes.
+   *
+   * <p>Header values are captured under the {@code http.response.header.<key>} attribute key. The
+   * {@code <key>} part in the attribute key is the lowercase header name.
    *
    * <p>Selector patterns are matched case-insensitively, since HTTP header names are
    * case-insensitive. {@code ?} matches one character and {@code *} matches any number of
@@ -96,9 +101,8 @@ public final class JettyClientTelemetryBuilder {
   /**
    * Configures HTTP response headers to capture as span attributes.
    *
-   * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
-   * them as wildcards.
+   * <p>The header names are matched literally, so {@code *} and {@code ?} are not treated as glob
+   * patterns.
    *
    * @param responseHeaders HTTP header names to capture.
    * @deprecated Use {@link #setResponseHeaders(IncludeExclude)} instead, which matches glob

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyClientTelemetryBuilder.java
@@ -64,7 +64,7 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP request headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setRequestHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param requestHeaders HTTP header names to capture.
@@ -97,7 +97,7 @@ public final class JettyClientTelemetryBuilder {
    * Configures HTTP response headers to capture as span attributes.
    *
    * <p>The header names are matched literally. Unlike {@link #setResponseHeaders(IncludeExclude)},
-   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never documented
+   * {@code *} and {@code ?} are not treated as glob patterns, since this setting never supported
    * them as wildcards.
    *
    * @param responseHeaders HTTP header names to capture.

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/main/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/internal/JettyClientHttpAttributesGetter.java
@@ -8,10 +8,14 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v9_2.internal;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.api.internal.HttpProtocolUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
 
 /**
@@ -38,6 +42,11 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   }
 
   @Override
+  public Collection<String> getHttpRequestHeaderNames(Request request) {
+    return headerNames(request.getHeaders());
+  }
+
+  @Override
   public Integer getHttpResponseStatusCode(
       Request request, Response response, @Nullable Throwable error) {
     return response.getStatus();
@@ -46,6 +55,11 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   @Override
   public List<String> getHttpResponseHeader(Request request, Response response, String name) {
     return response.getHeaders().getValuesList(name);
+  }
+
+  @Override
+  public Collection<String> getHttpResponseHeaderNames(Request request, Response response) {
+    return headerNames(response.getHeaders());
   }
 
   @Override
@@ -79,5 +93,13 @@ class JettyClientHttpAttributesGetter implements HttpClientAttributesGetter<Requ
   @Nullable
   public Integer getServerPort(Request request) {
     return HttpConstants.portOrDefaultFromScheme(request.getPort(), request.getScheme());
+  }
+
+  private static Collection<String> headerNames(HttpFields headers) {
+    List<String> names = new ArrayList<>(headers.size());
+    for (HttpField header : headers) {
+      names.add(header.getName());
+    }
+    return names;
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
@@ -35,6 +35,7 @@ class JettyHttpClient9HeaderSelectorTest {
         "/",
         exchange -> {
           exchange.getResponseHeaders().add("x-test-response", "response-value");
+          exchange.getResponseHeaders().add("x-ignored-response", "ignored-value");
           exchange.sendResponseHeaders(200, -1);
           exchange.close();
         });
@@ -43,10 +44,15 @@ class JettyHttpClient9HeaderSelectorTest {
 
   @AfterEach
   void stopServer() throws Exception {
-    if (client != null) {
-      client.stop();
+    try {
+      if (client != null) {
+        client.stop();
+      }
+    } finally {
+      if (server != null) {
+        server.stop(0);
+      }
     }
-    server.stop(0);
   }
 
   @Test
@@ -54,7 +60,7 @@ class JettyHttpClient9HeaderSelectorTest {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
-            .setResponseHeaders(IncludeExclude.builder().setExcluded("content-*").build())
+            .setResponseHeaders(IncludeExclude.builder().setExcluded("x-ignored-*").build())
             .build()
             .createHttpClient();
 
@@ -100,6 +106,7 @@ class JettyHttpClient9HeaderSelectorTest {
         client
             .newRequest("http://localhost:" + server.getAddress().getPort() + "/")
             .header("x-test-request", "request-value")
+            .header("x-ignored-request", "ignored-value")
             .send();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -115,7 +122,15 @@ class JettyHttpClient9HeaderSelectorTest {
                             singletonList("request-value"))
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
-                            singletonList("response-value"))));
+                            singletonList("response-value"))
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.x-ignored-request"))
+                                    .doesNotContainKey(
+                                        stringArrayKey(
+                                            "http.response.header.x-ignored-response")))));
   }
 
   private static void assertNoCapturedHeaders() {

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
@@ -78,6 +78,21 @@ class JettyHttpClient9HeaderSelectorTest {
     assertCapturedHeaders();
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedSettersMatchHeaderNamesLiterally() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedRequestHeaders(singletonList("*"))
+            .setCapturedResponseHeaders(singletonList("*"))
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertNoCapturedHeaders();
+  }
+
   private void sendRequest() throws Exception {
     client.start();
 
@@ -101,5 +116,19 @@ class JettyHttpClient9HeaderSelectorTest {
                         .hasAttribute(
                             stringArrayKey("http.response.header.x-test-response"),
                             singletonList("response-value"))));
+  }
+
+  private static void assertNoCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttributesSatisfying(
+                        attributes ->
+                            attributes.forEach(
+                                (key, value) ->
+                                    assertThat(key.getKey())
+                                        .doesNotStartWith("http.request.header.")
+                                        .doesNotStartWith("http.response.header.")))));
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jetty.httpclient.v9_2;
+
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.net.InetSocketAddress;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class JettyHttpClient9HeaderSelectorTest {
+
+  @RegisterExtension
+  static final LibraryInstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  private HttpServer server;
+  private HttpClient client;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          exchange.getResponseHeaders().add("x-test-response", "response-value");
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void stopServer() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    server.stop(0);
+  }
+
+  @Test
+  void capturesHeadersMatchingSelectors() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
+            .setResponseHeaders(IncludeExclude.builder().setExcluded("content-*").build())
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertCapturedHeaders();
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void capturesHeadersFromDeprecatedSetters() throws Exception {
+    client =
+        JettyClientTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedRequestHeaders(singletonList("x-test-request"))
+            .setCapturedResponseHeaders(singletonList("x-test-response"))
+            .build()
+            .createHttpClient();
+
+    sendRequest();
+
+    assertCapturedHeaders();
+  }
+
+  private void sendRequest() throws Exception {
+    client.start();
+
+    ContentResponse response =
+        client
+            .newRequest("http://localhost:" + server.getAddress().getPort() + "/")
+            .header("x-test-request", "request-value")
+            .send();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  private static void assertCapturedHeaders() {
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttribute(
+                            stringArrayKey("http.request.header.x-test-request"),
+                            singletonList("request-value"))
+                        .hasAttribute(
+                            stringArrayKey("http.response.header.x-test-response"),
+                            singletonList("response-value"))));
+  }
+}

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
@@ -56,7 +56,7 @@ class JettyHttpClient9HeaderSelectorTest {
   }
 
   @Test
-  void capturesHeadersMatchingSelectors() throws Exception {
+  void capturesHeadersMatchingSelectorPatterns() throws Exception {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setRequestHeaders(IncludeExclude.builder().setIncluded("x-test-*").build())
@@ -71,7 +71,7 @@ class JettyHttpClient9HeaderSelectorTest {
 
   @SuppressWarnings("deprecation") // testing deprecated API
   @Test
-  void capturesHeadersFromDeprecatedSetters() throws Exception {
+  void capturesHeadersConfiguredByName() throws Exception {
     client =
         JettyClientTelemetry.builder(testing.getOpenTelemetry())
             .setCapturedRequestHeaders(singletonList("x-test-request"))

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9HeaderSelectorTest.java
@@ -107,6 +107,7 @@ class JettyHttpClient9HeaderSelectorTest {
             .newRequest("http://localhost:" + server.getAddress().getPort() + "/")
             .header("x-test-request", "request-value")
             .header("x-ignored-request", "ignored-value")
+            .header("authorization", "******")
             .send();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -139,11 +140,18 @@ class JettyHttpClient9HeaderSelectorTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasAttributesSatisfying(
-                        attributes ->
-                            attributes.forEach(
-                                (key, value) ->
-                                    assertThat(key.getKey())
-                                        .doesNotStartWith("http.request.header.")
-                                        .doesNotStartWith("http.response.header.")))));
+                            attributes ->
+                                attributes.forEach(
+                                    (key, value) ->
+                                        assertThat(key.getKey())
+                                            .doesNotStartWith("http.request.header.")
+                                            .doesNotStartWith("http.response.header.")))
+                        // "*" is a legal header name character, so the deprecated exact-name
+                        // setters must not capture every header and expose credentials
+                        .satisfies(
+                            spanData ->
+                                assertThat(spanData.getAttributes().asMap())
+                                    .doesNotContainKey(
+                                        stringArrayKey("http.request.header.authorization")))));
   }
 }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jetty.httpclient.v9_2;
 
 import static java.util.Collections.singletonList;
 
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -22,8 +23,14 @@ class JettyHttpClient9LibraryTest extends AbstractJettyClient9Test {
   @Override
   protected HttpClient createStandardClient() {
     return JettyClientTelemetry.builder(testing.getOpenTelemetry())
-        .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-        .setCapturedResponseHeaders(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+        .setRequestHeaders(
+            IncludeExclude.builder()
+                .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
+                .build())
+        .setResponseHeaders(
+            IncludeExclude.builder()
+                .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
+                .build())
         .build()
         .createHttpClient();
   }


### PR DESCRIPTION
The Jetty HTTP client and Armeria library instrumentations can now select which HTTP headers to capture by glob pattern instead of by an exact list of names. This adds `setRequestHeaders(IncludeExclude)` and `setResponseHeaders(IncludeExclude)` to `JettyClientTelemetryBuilder` (9.2 and 12.0), `ArmeriaClientTelemetryBuilder`, and `ArmeriaServerTelemetryBuilder`.

```java
// before
JettyClientTelemetry.builder(openTelemetry)
    .setCapturedRequestHeaders(asList("x-request-id", "x-tenant-id"))
    .build();

// after
JettyClientTelemetry.builder(openTelemetry)
    .setRequestHeaders(
        IncludeExclude.builder().setIncluded("x-*").setExcluded("x-secret-*").build())
    .build();
```

### Matching semantics

`?` matches one character and `*` matches any number of characters, including none. Excluded patterns take precedence over included patterns, so a selector with no included patterns captures every header that is not excluded. Matching is case-insensitive, since HTTP header names are. No headers are captured when no selector is configured, or when the configured selector is empty.

### Header name enumeration

A wildcard or exclude-only selector has to know which headers a message actually carries, so it resolves names through `HttpCommonAttributesGetter#getHttpRequestHeaderNames` and `#getHttpResponseHeaderNames`, added in #19598. The Jetty client and Armeria attributes getters implement them over the header collections each library exposes.

The Jetty getters iterate `HttpFields` as an `Iterable<HttpField>` rather than calling `getFieldNamesCollection()`, whose return type changed from `Collection<String>` in 9.2 to `Set<String>` in 9.4, which would make code compiled against 9.2 fail with `NoSuchMethodError` on later versions. Iteration is stable across 9.2 through 12.1.

Armeria carries HTTP/2 pseudo-headers such as `:method` and `:status` in the same header map as the real headers, so the Armeria getters skip names beginning with `:`. Otherwise an exclude-only selector would produce attributes like `http.request.header.:method`.

### Compatibility

`setCapturedRequestHeaders` and `setCapturedResponseHeaders` on those builders are deprecated in favor of `setRequestHeaders(IncludeExclude)` and `setResponseHeaders(IncludeExclude)`. They keep matching header names literally, so `*` and `?` in their values are not glob patterns: a configured `*` still captures only a header literally named `*`, which is nothing, and their javadoc says so. Moving a value to a selector is therefore a deliberate behavior change to review rather than a rename. Each module has a regression test covering this.

Part of #19444.