### PR TITLE
Stop exposing instrumentation-api-incubator on library instrumentation compile classpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### ⚠️ Breaking changes to non-stable APIs
 
+- Library instrumentation artifacts no longer expose `opentelemetry-instrumentation-api-incubator`
+  on consumers' compile classpaths. Consumers that use its APIs, or APIs from its
+  `opentelemetry-api-incubator` and `opentelemetry-semconv` dependencies, must declare the
+  corresponding artifacts directly.
 - `jetty.thread.queue.size` Jetty JMX metric unit has been changed from `{thread}` to `{job}`.
 - Normalize the value of `activemq.destination.temp.utilization` JMX Metric for ActiveMQ to be between 0 and 1 (inclusive) instead of between 0 and 100 (inclusive).
 

--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.library-instrumentation.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.library-instrumentation.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 
 dependencies {
   api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
-  api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator")
+  // this is intentionally not api, so that it is not exposed on the compile classpath of consumers
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator")
 
   api("io.opentelemetry:opentelemetry-api")
 

--- a/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-autoconfigure/build.gradle.kts
@@ -32,11 +32,13 @@ sourceSets {
 }
 
 configurations {
+  // the javaSpring3 and javaSpring4 source sets are bundled into the main jar, so they need to see
+  // the same dependencies as the main source set
   named("javaSpring3CompileOnly") {
-    extendsFrom(configurations["compileOnly"])
+    extendsFrom(configurations["compileOnly"], configurations["implementation"])
   }
   named("javaSpring4CompileOnly") {
-    extendsFrom(configurations["compileOnly"])
+    extendsFrom(configurations["compileOnly"], configurations["implementation"])
   }
 }
 

--- a/instrumentation/spring/spring-boot-resources/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/spring/spring-boot-resources/javaagent-unit-tests/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
 
 dependencies {
   testImplementation(project(":instrumentation:spring:spring-boot-resources:javaagent"))
+  testImplementation("io.opentelemetry:opentelemetry-api-incubator")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
   testRuntimeOnly(project(path = ":smoke-tests:images:spring-boot", configuration = "springBootJar"))
 }


### PR DESCRIPTION
Library instrumentation artifacts no longer expose `opentelemetry-instrumentation-api-incubator` on consumers' compile classpaths. Consumers that use its APIs, or APIs from its `opentelemetry-api-incubator` and `opentelemetry-semconv` dependencies, must declare those artifacts directly:

```kotlin
dependencies {
  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator:<instrumentation-version>")
  implementation("io.opentelemetry:opentelemetry-api-incubator:<opentelemetry-version>")
  implementation("io.opentelemetry.semconv:opentelemetry-semconv:<semconv-version>")
}
```

The `otel.library-instrumentation` convention declared the incubator as an `api` dependency, which made an alpha artifact part of the effective contract of modules that are candidates for stabilization. No library instrumentation module exposes an incubator type in an exported signature, so `implementation` scope is sufficient; in published poms the incubator moves from `compile` to `runtime` scope.

Javaagent instrumentation modules are unaffected.

The two Spring build file changes fix modules that were relying on the withdrawn transitive dependencies.
