### PR TITLE
Remove instrumentation-api-incubator dependency from runtime-telemetry library

### DIFF
--- a/instrumentation/runtime-telemetry/library/build.gradle.kts
+++ b/instrumentation/runtime-telemetry/library/build.gradle.kts
@@ -6,10 +6,17 @@ val mrJarVersions = listOf(17)
 
 dependencies {
   implementation(project(":instrumentation-api"))
-  implementation(project(":instrumentation-api-incubator"))
+  implementation("io.opentelemetry:opentelemetry-api-incubator")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("io.github.netmikey.logunit:logunit-jul")
+}
+
+// the otel.library-instrumentation convention adds instrumentation-api-incubator to every library
+// module; this module does not use it and must not depend on it in order to be published as stable
+configurations.implementation {
+  dependencies.removeIf { it.name == "opentelemetry-instrumentation-api-incubator" }
 }
 
 sourceSets {

--- a/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/Internal.java
+++ b/instrumentation/runtime-telemetry/library/src/main/java/io/opentelemetry/instrumentation/runtimetelemetry/internal/Internal.java
@@ -9,9 +9,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
-import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
 import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetryBuilder;
@@ -182,9 +182,9 @@ public final class Internal {
   @Nullable
   public static RuntimeTelemetry configure(OpenTelemetry openTelemetry, boolean defaultEnabled) {
     DeclarativeConfigProperties config =
-        DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "runtime_telemetry");
+        getInstrumentationConfig(openTelemetry, "runtime_telemetry");
     DeclarativeConfigProperties java17Config =
-        DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "runtime_telemetry_java17");
+        getInstrumentationConfig(openTelemetry, "runtime_telemetry_java17");
 
     // Determine which configuration is being used
     boolean baseEnabled = config.getBoolean("enabled", defaultEnabled);
@@ -313,6 +313,15 @@ public final class Internal {
     boolean captureGcCause =
         SemconvStability.v3Preview() || Boolean.TRUE.equals(captureGcCauseConfig);
     Internal.setCaptureGcCause(builder, captureGcCause);
+  }
+
+  // DeclarativeConfigUtil is not used here because it lives in instrumentation-api-incubator, which
+  // this module does not depend on
+  private static DeclarativeConfigProperties getInstrumentationConfig(
+      OpenTelemetry openTelemetry, String instrumentationName) {
+    return openTelemetry instanceof ExtendedOpenTelemetry
+        ? ((ExtendedOpenTelemetry) openTelemetry).getInstrumentationConfig(instrumentationName)
+        : DeclarativeConfigProperties.empty();
   }
 
   private static final class JfrMetricSelection {


### PR DESCRIPTION
The runtime-telemetry library module no longer depends on `instrumentation-api-incubator`, so its published pom carries no alpha dependency from this repository. This is groundwork for #16063 (stabilizing the runtime telemetry library modules), since a stable artifact cannot depend on an alpha one.

The module's only use of that artifact was `DeclarativeConfigUtil.getInstrumentationConfig`, which is now inlined as a private helper that does the same `ExtendedOpenTelemetry` check and falls back to `DeclarativeConfigProperties.empty()`. Stable `instrumentation-api` already does exactly this in `InstrumenterBuilder` for the same reason.

`opentelemetry-api-incubator` and `opentelemetry-semconv` were previously arriving transitively through `instrumentation-api-incubator`, which re-exports them as `api` dependencies, so they are now declared explicitly.

The `otel.library-instrumentation` convention still adds `instrumentation-api-incubator` to every library module, so the build script removes it from the `implementation` configuration. An `exclude` would not be enough: it drops the artifact from resolution but leaves a version-less entry in the generated pom, because `exclude` only filters transitive dependencies and does not remove a directly declared one.

The published pom is now `opentelemetry-instrumentation-api` and `opentelemetry-api` at compile scope, plus `opentelemetry-api-incubator` and `opentelemetry-semconv` at runtime scope.

Stacked on #19612.