### PR TITLE
Preserve legacy R2DBC batch attributes in dual mode

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -189,7 +189,10 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
     @Override
     public String extract(REQUEST request) {
       SqlDialect dialect = getter.getSqlDialect(request);
-      Collection<String> rawQueryTexts = getter.getRawQueryTexts(request);
+      Collection<String> rawQueryTexts =
+          emitStableDatabaseSemconv()
+              ? getter.getRawQueryTexts(request)
+              : getter.getRawQueryTextsForOldSemconv(request);
 
       if (rawQueryTexts.isEmpty()) {
         if (emitStableDatabaseSemconv()) {
@@ -274,7 +277,7 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
       // For old semconv, use the generic span name format (operation + db.name)
       // without collection name to preserve backward compatibility
       String dbName = getter.getDbName(request);
-      Collection<String> rawQueryTexts = getter.getRawQueryTexts(request);
+      Collection<String> rawQueryTexts = getter.getRawQueryTextsForOldSemconv(request);
       String operationName = null;
       if (rawQueryTexts.size() == 1) {
         String rawQuery = rawQueryTexts.iterator().next();

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -97,7 +97,6 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
   @SuppressWarnings("deprecation") // until old db semconv are dropped
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST request) {
-    Collection<String> rawQueryTexts = getter.getRawQueryTexts(request);
     SqlDialect dialect = getter.getSqlDialect(request);
 
     Long batchSize = getter.getDbOperationBatchSize(request);
@@ -106,8 +105,9 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     boolean isBatch = batchSize != null && batchSize != 1;
 
     if (emitOldDatabaseSemconv()) {
-      if (rawQueryTexts.size() == 1) { // for backcompat(?)
-        String rawQueryText = rawQueryTexts.iterator().next();
+      Collection<String> oldSemconvRawQueryTexts = getter.getRawQueryTextsForOldSemconv(request);
+      if (oldSemconvRawQueryTexts.size() == 1) { // for backcompat(?)
+        String rawQueryText = oldSemconvRawQueryTexts.iterator().next();
         SqlQuery analyzedQuery = SqlQueryAnalyzerUtil.analyze(rawQueryText, dialect);
         String operationName = analyzedQuery.getOperationName();
         attributes.put(
@@ -120,6 +120,7 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
     }
 
     if (emitStableDatabaseSemconv()) {
+      Collection<String> rawQueryTexts = getter.getRawQueryTexts(request);
       if (isBatch) {
         attributes.put(DB_OPERATION_BATCH_SIZE, batchSize);
       }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesGetter.java
@@ -96,6 +96,21 @@ public interface SqlClientAttributesGetter<REQUEST, RESPONSE>
   Collection<String> getRawQueryTexts(REQUEST request);
 
   /**
+   * Returns the raw SQL query texts used to derive old semantic convention attributes and span
+   * names.
+   *
+   * <p>By default, this returns {@link #getRawQueryTexts(Object)}. Instrumentations may override
+   * this method when preserving old semantic convention telemetry requires a different query
+   * representation.
+   *
+   * @deprecated This method supports old database semantic conventions and will be removed in 3.0.
+   */
+  @Deprecated // to be removed in 3.0
+  default Collection<String> getRawQueryTextsForOldSemconv(REQUEST request) {
+    return getRawQueryTexts(request);
+  }
+
+  /**
    * Returns whether the query at {@code queryIndex} in {@link #getRawQueryTexts(Object)} is
    * parameterized. Prepared statements are always considered parameterized even if no parameters
    * are bound. By using a parameterized query the user is giving a strong signal that any sensitive

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -28,7 +29,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DbClientSpanNameExtractorTest {
   @Mock DbClientAttributesGetter<DbRequest, Void> dbAttributesGetter;
 
-  @Mock SqlClientAttributesGetter<DbRequest, Void> sqlAttributesGetter;
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  SqlClientAttributesGetter<DbRequest, Void> sqlAttributesGetter;
 
   @BeforeEach
   void setUp() {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -123,6 +123,15 @@ class SqlClientAttributesExtractorTest {
     }
   }
 
+  static class TestOldSemconvMultiAttributesGetter extends TestMultiAttributesGetter {
+
+    @Deprecated
+    @Override
+    public Collection<String> getRawQueryTextsForOldSemconv(Map<String, Object> map) {
+      return singleton(read(map, "db.query.text.old"));
+    }
+  }
+
   @SuppressWarnings("deprecation") // TODO DB_CONNECTION_STRING deprecation
   @Test
   void shouldExtractAllAttributes() {
@@ -455,6 +464,52 @@ class SqlClientAttributesExtractorTest {
     }
 
     assertThat(endAttributes.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldExtractSemconvSpecificMultiQueryBatchAttributes() {
+    // given
+    Map<String, Object> request = new HashMap<>();
+    request.put("db.namespace", "potatoes");
+    request.put(
+        "db.query.texts", asList("INSERT INTO potato VALUES(1)", "INSERT INTO potato VALUES(2)"));
+    request.put("db.query.text.old", "INSERT INTO potato VALUES(1);\nINSERT INTO potato VALUES(2)");
+    request.put(DB_OPERATION_BATCH_SIZE.getKey(), 2L);
+
+    AttributesExtractor<Map<String, Object>, Void> underTest =
+        SqlClientAttributesExtractor.create(new TestOldSemconvMultiAttributesGetter());
+
+    // when
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onStart(attributes, Context.root(), request);
+
+    // then
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertThat(attributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?); INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"),
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 2L));
+    } else if (emitOldDatabaseSemconv()) {
+      assertThat(attributes.build())
+          .containsOnly(
+              entry(DB_NAME, "potatoes"),
+              entry(DB_STATEMENT, "INSERT INTO potato VALUES(?); INSERT INTO potato VALUES(?)"),
+              entry(DB_OPERATION, "INSERT"),
+              entry(DB_SQL_TABLE, "potato"));
+    } else if (emitStableDatabaseSemconv()) {
+      assertThat(attributes.build())
+          .containsOnly(
+              entry(DB_NAMESPACE, "potatoes"),
+              entry(DB_QUERY_TEXT, "INSERT INTO potato VALUES(?)"),
+              entry(DB_QUERY_SUMMARY, "BATCH INSERT potato"),
+              entry(DB_OPERATION_BATCH_SIZE, 2L));
+    }
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singleton;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
@@ -65,14 +64,14 @@ public final class R2dbcSqlAttributesGetter
 
   @Override
   public Collection<String> getRawQueryTexts(DbExecution request) {
+    return request.getRawQueryTexts();
+  }
+
+  @Deprecated // to be removed in 3.0
+  @Override
+  public Collection<String> getRawQueryTextsForOldSemconv(DbExecution request) {
     Collection<String> rawQueryTexts = request.getRawQueryTexts();
-    // In old-only mode, join multi-query batches into a single query to preserve the legacy
-    // db.statement and db.operation extraction behavior. In database/dup mode, favor stable
-    // multi-query batch attributes because the shared SQL extractor can only use one raw query
-    // collection.
-    return emitStableDatabaseSemconv() || rawQueryTexts.size() == 1
-        ? rawQueryTexts
-        : singleton(join(";\n", rawQueryTexts));
+    return rawQueryTexts.size() == 1 ? rawQueryTexts : singleton(join(";\n", rawQueryTexts));
   }
 
   private static String join(String delimiter, Collection<String> collection) {
@@ -89,9 +88,7 @@ public final class R2dbcSqlAttributesGetter
   @Override
   @Nullable
   public Long getDbOperationBatchSize(DbExecution request) {
-    // Batch size is a stable database semconv signal. Keep it hidden from old-only mode so legacy
-    // extraction does not start treating existing requests as batches.
-    return emitStableDatabaseSemconv() ? request.getBatchSize() : null;
+    return request.getBatchSize();
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.r2dbc.v1_0;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.r2dbc.v1_0.internal.DbExecution;
@@ -18,6 +17,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation") // testing old database semantic conventions
 class R2dbcSqlAttributesGetterTest {
 
   private final R2dbcSqlAttributesGetter getter = new R2dbcSqlAttributesGetter();
@@ -37,6 +37,7 @@ class R2dbcSqlAttributesGetterTest {
 
     assertThat(rawQueryTexts).isSameAs(dbExecution.getRawQueryTexts());
     assertThat(rawQueryTexts).containsExactly("INSERT INTO person VALUES(1)");
+    assertThat(getter.getRawQueryTextsForOldSemconv(dbExecution)).isSameAs(rawQueryTexts);
   }
 
   @Test
@@ -54,14 +55,11 @@ class R2dbcSqlAttributesGetterTest {
 
     Collection<String> rawQueryTexts = getter.getRawQueryTexts(dbExecution);
 
-    if (emitStableDatabaseSemconv()) {
-      assertThat(rawQueryTexts)
-          .containsExactly("INSERT INTO person VALUES(1)", "INSERT INTO person VALUES(2)");
-      assertThat(getter.getDbOperationBatchSize(dbExecution)).isEqualTo(2);
-    } else {
-      assertThat(rawQueryTexts)
-          .containsExactly("INSERT INTO person VALUES(1);\nINSERT INTO person VALUES(2)");
-      assertThat(getter.getDbOperationBatchSize(dbExecution)).isNull();
-    }
+    assertThat(rawQueryTexts).isSameAs(dbExecution.getRawQueryTexts());
+    assertThat(rawQueryTexts)
+        .containsExactly("INSERT INTO person VALUES(1)", "INSERT INTO person VALUES(2)");
+    assertThat(getter.getRawQueryTextsForOldSemconv(dbExecution))
+        .containsExactly("INSERT INTO person VALUES(1);\nINSERT INTO person VALUES(2)");
+    assertThat(getter.getDbOperationBatchSize(dbExecution)).isEqualTo(2);
   }
 }


### PR DESCRIPTION
R2DBC multi-query batches now emit their legacy `db.statement`, `db.operation`, and `db.sql.table` attributes under `database/dup`, alongside the stable `db.query.text`, `db.query.summary`, and `db.operation.batch.size`. Dual mode previously had to pick one convention's view of a batch, and the legacy attributes were the ones dropped.

The shared SQL extractor reads a single raw query collection, and the two conventions want different ones: old semconv derives one `db.statement` from the joined text, while stable semconv summarizes the queries individually. `SqlClientAttributesGetter` now exposes a deprecated `getRawQueryTextsForOldSemconv` that defaults to `getRawQueryTexts`, so a getter overrides it only when legacy telemetry needs a different query representation.

R2DBC is that one override, which lets its `getRawQueryTexts` and `getDbOperationBatchSize` describe the request as it actually is instead of branching on the active semconv mode. Old-only and stable-only output are unchanged.