### PR TITLE
Detect bound values in Cassandra 3 regular statements

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -33,8 +33,7 @@ abstract class CassandraRequest {
     if (statement instanceof BatchStatement) {
       return create(session, (BatchStatement) statement);
     }
-    return create(
-        session, singleton(getQuery(statement)), statement instanceof BoundStatement, null, null);
+    return create(session, singleton(getQuery(statement)), hasQueryValues(statement), null, null);
   }
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {
@@ -45,7 +44,7 @@ abstract class CassandraRequest {
     int queryIndex = 0;
     for (Statement batchEntry : batchStatement.getStatements()) {
       queryTexts.add(getQuery(batchEntry));
-      boolean parameterizedQuery = batchEntry instanceof BoundStatement;
+      boolean parameterizedQuery = hasQueryValues(batchEntry);
       if (!parameterizedQuery) {
         allQueriesParameterized = false;
       }
@@ -94,6 +93,16 @@ abstract class CassandraRequest {
     }
 
     return query == null ? "" : query;
+  }
+
+  private static boolean hasQueryValues(Statement statement) {
+    if (statement instanceof BoundStatement) {
+      return true;
+    }
+    if (statement instanceof RegularStatement) {
+      return ((RegularStatement) statement).hasValues();
+    }
+    return false;
   }
 
   abstract Session getSession();

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -34,6 +34,7 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
@@ -276,6 +277,70 @@ class CassandraClientTest {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("simpleStatementScenarios")
+  void simpleStatementSanitization(
+      SimpleStatement statement, String stableQueryText, String legacyQueryText) {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+
+    session.execute("DROP KEYSPACE IF EXISTS simple_values_test");
+    session.execute(
+        "CREATE KEYSPACE simple_values_test WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1}");
+    session.execute("CREATE TABLE simple_values_test.users ( name text PRIMARY KEY, age int )");
+    testing.clearData();
+
+    session.execute(statement);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("INSERT simple_values_test.users")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                emitStableDatabaseSemconv() ? stableQueryText : legacyQueryText),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv()
+                                    ? "INSERT simple_values_test.users"
+                                    : null),
+                            equalTo(maybeStable(DB_OPERATION), "INSERT"),
+                            equalTo(maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
+  }
+
+  private static Stream<Arguments> simpleStatementScenarios() {
+    return Stream.of(
+        argumentSet(
+            "no values",
+            new SimpleStatement(
+                "INSERT INTO simple_values_test.users (name, age) values ('carol', 3)"),
+            "INSERT INTO simple_values_test.users (name, age) values (?, ?)",
+            "INSERT INTO simple_values_test.users (name, age) values (?, ?)"),
+        argumentSet(
+            "positional values",
+            new SimpleStatement(
+                "INSERT INTO simple_values_test.users (name, age) values ('alice', ?)", 1),
+            "INSERT INTO simple_values_test.users (name, age) values ('alice', ?)",
+            "INSERT INTO simple_values_test.users (name, age) values (?, ?)"),
+        argumentSet(
+            "named values",
+            new SimpleStatement(
+                "INSERT INTO simple_values_test.users (name, age) values (:name, :age)",
+                ImmutableMap.<String, Object>of("name", "bob", "age", 2)),
+            "INSERT INTO simple_values_test.users (name, age) values (:name, :age)",
+            "INSERT INTO simple_values_test.users (name, age) values (:name, :age)"));
+  }
+
   @Test
   void testMetrics() {
     Session session = cluster.connect();
@@ -404,10 +469,10 @@ class CassandraClientTest {
             BatchScenario.builder()
                 .buildBatch(
                     session -> {
-                      PreparedStatement insert =
-                          session.prepare("INSERT INTO batch_test.records (id, num) values (4, ?)");
                       return new BatchStatement()
-                          .add(insert.bind(4))
+                          .add(
+                              new SimpleStatement(
+                                  "INSERT INTO batch_test.records (id, num) values (4, ?)", 4))
                           .add(
                               new SimpleStatement(
                                   "UPDATE batch_test.records SET num = 5 WHERE id = 4"));

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -335,10 +335,10 @@ class CassandraClientTest {
         argumentSet(
             "named values",
             new SimpleStatement(
-                "INSERT INTO simple_values_test.users (name, age) values (:name, :age)",
-                ImmutableMap.<String, Object>of("name", "bob", "age", 2)),
-            "INSERT INTO simple_values_test.users (name, age) values (:name, :age)",
-            "INSERT INTO simple_values_test.users (name, age) values (:name, :age)"));
+                "INSERT INTO simple_values_test.users (name, age) values ('bob', :age)",
+                ImmutableMap.<String, Object>of("age", 2)),
+            "INSERT INTO simple_values_test.users (name, age) values ('bob', :age)",
+            "INSERT INTO simple_values_test.users (name, age) values (?, :age)"));
   }
 
   @Test


### PR DESCRIPTION
Cassandra driver 3.x simple and other regular statements carrying bound values now preserve already-parameterized query text under stable database semantic conventions, matching Cassandra 4.x. For example, stable `db.query.text` for `new SimpleStatement("... values ('alice', ?)", 1)` remains `... values ('alice', ?)` instead of becoming `... values (?, ?)`.

Batch statements apply this decision independently per entry, so mixed parameterized and unparameterized batches preserve bind-safe text while sanitizing literals in raw entries. Legacy database semantic convention sanitization remains unchanged.