### PR TITLE
Clear JDBC batch telemetry state after execution

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -145,10 +145,17 @@ class StatementInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void stopSpan(
+        @Advice.This Object object,
         @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Enter @Nullable JdbcAdviceScope adviceScope) {
-      if (adviceScope != null) {
-        adviceScope.end(throwable);
+      try {
+        if (adviceScope != null) {
+          adviceScope.end(throwable);
+        }
+      } finally {
+        if (throwable == null && object instanceof Statement) {
+          JdbcData.clearBatch((Statement) object);
+        }
       }
     }
   }

--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/StatementInstrumentation.java
@@ -153,7 +153,8 @@ class StatementInstrumentation implements TypeInstrumentation {
           adviceScope.end(throwable);
         }
       } finally {
-        if (throwable == null && object instanceof Statement) {
+        // Batch execution empties the statement's batch even when it fails.
+        if (object instanceof Statement) {
           JdbcData.clearBatch((Statement) object);
         }
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -425,6 +425,11 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
   // JDBC 4.2
 
   @Override
+  public long[] executeLargeBatch() throws SQLException {
+    return wrapBatchCall(delegate::executeLargeBatch);
+  }
+
+  @Override
   public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
       throws SQLException {
     delegate.setObject(parameterIndex, x, targetSqlType, scaleOrLength);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -417,9 +417,11 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
     DbRequest request = DbRequest.create(dbInfo, query, batchSize, parameters, true);
-    T result = wrapCall(request, callable);
-    clearBatchState();
-    return result;
+    try {
+      return wrapCall(request, callable);
+    } finally {
+      clearBatchState();
+    }
   }
 
   // JDBC 4.2

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryPreparedStatement.java
@@ -417,7 +417,9 @@ class OpenTelemetryPreparedStatement<S extends PreparedStatement> extends OpenTe
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
     DbRequest request = DbRequest.create(dbInfo, query, batchSize, parameters, true);
-    return wrapCall(request, callable);
+    T result = wrapCall(request, callable);
+    clearBatchState();
+    return result;
   }
 
   // JDBC 4.2

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
@@ -415,8 +415,10 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
     DbRequest request = DbRequest.create(dbInfo, batchCommands, batchSize, emptyMap(), false);
-    T result = wrapCall(request, callable);
-    clearBatchState();
-    return result;
+    try {
+      return wrapCall(request, callable);
+    } finally {
+      clearBatchState();
+    }
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryStatement.java
@@ -257,6 +257,10 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
   @Override
   public void clearBatch() throws SQLException {
     delegate.clearBatch();
+    clearBatchState();
+  }
+
+  protected final void clearBatchState() {
     batchCommands.clear();
     batchSize = 0;
   }
@@ -411,6 +415,8 @@ class OpenTelemetryStatement<S extends Statement> implements Statement {
 
   private <T, E extends Exception> T wrapBatchCall(ThrowingSupplier<T, E> callable) throws E {
     DbRequest request = DbRequest.create(dbInfo, batchCommands, batchSize, emptyMap(), false);
-    return wrapCall(request, callable);
+    T result = wrapCall(request, callable);
+    clearBatchState();
+    return result;
   }
 }

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -2204,12 +2204,13 @@ public abstract class AbstractJdbcInstrumentationTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
-  void testPreparedBatchStateRetainedAfterFailure(boolean largeBatch) throws SQLException {
-    // this test needs a driver that keeps the batch when the execution fails, sqlite for example
-    // calls the public clearBatch() from its own batch execution, which also clears the batch
-    // tracked by the javaagent; h2 implements executeLargeBatch() only in newer versions
-    Assumptions.assumeTrue(!largeBatch || testLatestDeps());
-    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+  void testPreparedBatchStateClearedAfterFailure(boolean largeBatch) throws SQLException {
+    String system = largeBatch ? "sqlite" : "h2";
+    Connection rawConnection =
+        largeBatch
+            ? new JDBC().connect(JDBC_URLS.get(system), new Properties())
+            : new org.h2.Driver().connect(JDBC_URLS.get(system), null);
+    Connection connection = wrap(rawConnection);
     cleanup.deferCleanup(connection);
     String tableName =
         largeBatch ? "prepared_large_batch_failure_test" : "prepared_batch_failure_test";
@@ -2237,20 +2238,22 @@ public abstract class AbstractJdbcInstrumentationTest {
     testing().waitForTraces(1);
     testing().clearData();
 
-    testing().runWithSpan("parent", () -> executeBatch(statement, largeBatch));
+    int executedCount = testing().runWithSpan("parent", () -> executeBatch(statement, largeBatch));
+    assertThat(executedCount).isZero();
 
     testing()
         .waitAndAssertTraces(
-            trace -> assertPreparedBatchTrace(trace, "h2", null, "h2:mem:", tableName, 2));
+            trace ->
+                assertPreparedBatchTrace(
+                    trace, system, null, largeBatch ? "sqlite:memory:" : "h2:mem:", tableName, 0));
   }
 
-  private static void executeBatch(PreparedStatement statement, boolean largeBatch)
+  private static int executeBatch(PreparedStatement statement, boolean largeBatch)
       throws SQLException {
     if (largeBatch) {
-      statement.executeLargeBatch();
-    } else {
-      statement.executeBatch();
+      return statement.executeLargeBatch().length;
     }
+    return statement.executeBatch().length;
   }
 
   private static void assertPreparedBatchTrace(

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -2199,11 +2199,70 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     testing()
         .waitAndAssertTraces(
-            trace -> assertEmptyPreparedBatchTrace(trace, "h2", null, "h2:mem:", tableName));
+            trace -> assertPreparedBatchTrace(trace, "h2", null, "h2:mem:", tableName, 0));
   }
 
-  private static void assertEmptyPreparedBatchTrace(
-      TraceAssert trace, String system, String username, String url, String tableName) {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testPreparedBatchStateRetainedAfterFailure(boolean largeBatch) throws SQLException {
+    String system = largeBatch ? "sqlite" : "h2";
+    Connection rawConnection =
+        largeBatch
+            ? new JDBC().connect(JDBC_URLS.get(system), new Properties())
+            : new org.h2.Driver().connect(JDBC_URLS.get(system), null);
+    Connection connection = wrap(rawConnection);
+    cleanup.deferCleanup(connection);
+    String tableName =
+        largeBatch ? "prepared_large_batch_failure_test" : "prepared_batch_failure_test";
+    Statement setupStatement = connection.createStatement();
+    cleanup.deferCleanup(setupStatement);
+    setupStatement.execute(
+        "CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+    setupStatement.execute("INSERT INTO " + tableName + " VALUES(1), (2)");
+    testing().waitForTraces(2);
+    testing().clearData();
+
+    PreparedStatement statement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES(?)");
+    cleanup.deferCleanup(statement);
+    statement.setInt(1, 1);
+    statement.addBatch();
+    statement.setInt(1, 2);
+    statement.addBatch();
+
+    assertThatThrownBy(() -> executeBatch(statement, largeBatch)).isInstanceOf(SQLException.class);
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    setupStatement.execute("DELETE FROM " + tableName);
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    testing().runWithSpan("parent", () -> executeBatch(statement, largeBatch));
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                assertPreparedBatchTrace(
+                    trace, system, null, largeBatch ? "sqlite:memory:" : "h2:mem:", tableName, 2));
+  }
+
+  private static void executeBatch(PreparedStatement statement, boolean largeBatch)
+      throws SQLException {
+    if (largeBatch) {
+      statement.executeLargeBatch();
+    } else {
+      statement.executeBatch();
+    }
+  }
+
+  private static void assertPreparedBatchTrace(
+      TraceAssert trace,
+      String system,
+      String username,
+      String url,
+      String tableName,
+      long batchSize) {
     trace.hasSpansSatisfyingExactly(
         span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
         span ->
@@ -2226,7 +2285,8 @@ public abstract class AbstractJdbcInstrumentationTest {
                         maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : "INSERT"),
                     equalTo(
                         maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : tableName),
-                    equalTo(DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 0L : null)));
+                    equalTo(
+                        DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? batchSize : null)));
   }
 
   // test that sqlcommenter is not enabled by default

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -1952,6 +1952,7 @@ public abstract class AbstractJdbcInstrumentationTest {
     }
 
     testing().runWithSpan("parent", statement::executeBatch);
+    testing().runWithSpan("empty parent", statement::executeBatch);
 
     testing()
         .waitAndAssertTraces(
@@ -1987,7 +1988,28 @@ public abstract class AbstractJdbcInstrumentationTest {
                                     emitStableDatabaseSemconv() ? null : scenario.oldTable),
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
-                                    emitStableDatabaseSemconv() ? scenario.batchSize : null))));
+                                    emitStableDatabaseSemconv() ? scenario.batchSize : null))),
+            trace -> assertEmptyStatementBatchTrace(trace, "h2", null, "h2:mem:"));
+  }
+
+  private static void assertEmptyStatementBatchTrace(
+      TraceAssert trace, String system, String username, String url) {
+    trace.hasSpansSatisfyingExactly(
+        span -> span.hasName("empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+        span ->
+            span.hasName(emitStableDatabaseSemconv() ? "BATCH" : DATABASE_NAME_LOWER)
+                .hasKind(SpanKind.CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
+                    equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
+                    equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
+                    equalTo(DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
+                    equalTo(maybeStable(DB_STATEMENT), null),
+                    equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "BATCH" : null),
+                    equalTo(maybeStable(DB_OPERATION), null),
+                    equalTo(maybeStable(DB_SQL_TABLE), null),
+                    equalTo(DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 0L : null)));
   }
 
   static Stream<Arguments> batchStream() throws SQLException {
@@ -2012,20 +2034,72 @@ public abstract class AbstractJdbcInstrumentationTest {
   void testLargeBatch(String system, Connection connection, String username, String url)
       throws SQLException {
 
-    Statement createTable = wrap(connection).createStatement();
+    Connection wrappedConnection = wrap(connection);
+    Statement createTable = wrappedConnection.createStatement();
     cleanup.deferCleanup(createTable);
     createTable.execute(
         "CREATE TABLE simple_batch_test_large (id INTEGER not NULL, PRIMARY KEY ( id ))");
-    Statement statement = wrap(connection).createStatement();
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    Statement statement = wrappedConnection.createStatement();
     cleanup.deferCleanup(statement);
     statement.addBatch("INSERT INTO simple_batch_test_large VALUES(1)");
     statement.addBatch("INSERT INTO simple_batch_test_large VALUES(2)");
 
     if (testLatestDeps() || "sqlite".equals(system)) {
       statement.executeLargeBatch();
+      testing().waitForTraces(1);
+      testing().clearData();
+      testing().runWithSpan("empty parent", statement::executeLargeBatch);
+      testing()
+          .waitAndAssertTraces(
+              trace -> assertEmptyStatementBatchTrace(trace, system, username, url));
     } else {
       // Older drivers don't support JDBC 4.2, expect UnsupportedOperationException
       // This is the correct behavior - instrumentation should not change driver behavior
+      assertThatThrownBy(statement::executeLargeBatch)
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("batchStream")
+  void testPreparedLargeBatch(String system, Connection connection, String username, String url)
+      throws SQLException {
+    Connection wrappedConnection = wrap(connection);
+    String tableName = "prepared_batch_test_large";
+    Statement createTable = wrappedConnection.createStatement();
+    cleanup.deferCleanup(createTable);
+    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    PreparedStatement statement =
+        wrappedConnection.prepareStatement("INSERT INTO " + tableName + " VALUES(?)");
+    cleanup.deferCleanup(statement);
+    statement.setInt(1, 1);
+    statement.addBatch();
+    statement.setInt(1, 2);
+    statement.addBatch();
+
+    if (testLatestDeps() || "sqlite".equals(system)) {
+      statement.executeLargeBatch();
+      testing().waitForTraces(1);
+      testing().clearData();
+      testing().runWithSpan("empty parent", statement::executeLargeBatch);
+      testing()
+          .waitAndAssertTraces(
+              trace ->
+                  trace.hasSpansSatisfyingExactly(
+                      span -> span.hasName("empty parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                      span -> {
+                        span.hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0));
+                        if (emitStableDatabaseSemconv()) {
+                          span.hasAttribute(equalTo(DB_OPERATION_BATCH_SIZE, 0L));
+                        }
+                      }));
+    } else {
       assertThatThrownBy(statement::executeLargeBatch)
           .isInstanceOf(UnsupportedOperationException.class);
     }
@@ -2091,6 +2165,62 @@ public abstract class AbstractJdbcInstrumentationTest {
                                 equalTo(
                                     DB_OPERATION_BATCH_SIZE,
                                     emitStableDatabaseSemconv() ? 2L : null))));
+  }
+
+  @Test
+  void testPreparedBatchStateCleared() throws SQLException {
+    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
+    cleanup.deferCleanup(connection);
+    String tableName = "prepared_batch_state_test";
+    Statement createTable = connection.createStatement();
+    createTable.execute("CREATE TABLE " + tableName + " (id INTEGER not NULL, PRIMARY KEY ( id ))");
+    cleanup.deferCleanup(createTable);
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    PreparedStatement statement =
+        connection.prepareStatement("INSERT INTO " + tableName + " VALUES(?)");
+    cleanup.deferCleanup(statement);
+    statement.setInt(1, 1);
+    statement.addBatch();
+    statement.setInt(1, 2);
+    statement.addBatch();
+    statement.executeBatch();
+    testing().waitForTraces(1);
+    testing().clearData();
+
+    testing().runWithSpan("parent", statement::executeBatch);
+
+    testing()
+        .waitAndAssertTraces(
+            trace -> assertEmptyPreparedBatchTrace(trace, "h2", null, "h2:mem:", tableName));
+  }
+
+  private static void assertEmptyPreparedBatchTrace(
+      TraceAssert trace, String system, String username, String url, String tableName) {
+    trace.hasSpansSatisfyingExactly(
+        span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+        span ->
+            span.hasName(
+                    emitStableDatabaseSemconv()
+                        ? "BATCH INSERT " + tableName
+                        : "INSERT jdbcunittest." + tableName)
+                .hasKind(SpanKind.CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), maybeStableDbSystemName(system)),
+                    equalTo(maybeStable(DB_NAME), DATABASE_NAME_LOWER),
+                    equalTo(DB_USER, emitStableDatabaseSemconv() ? null : username),
+                    equalTo(DB_CONNECTION_STRING, emitStableDatabaseSemconv() ? null : url),
+                    equalTo(maybeStable(DB_STATEMENT), "INSERT INTO " + tableName + " VALUES(?)"),
+                    equalTo(
+                        DB_QUERY_SUMMARY,
+                        emitStableDatabaseSemconv() ? "BATCH INSERT " + tableName : null),
+                    equalTo(
+                        maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : "INSERT"),
+                    equalTo(
+                        maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : tableName),
+                    equalTo(DB_OPERATION_BATCH_SIZE, emitStableDatabaseSemconv() ? 0L : null)));
   }
 
   // test that sqlcommenter is not enabled by default

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -2205,12 +2205,11 @@ public abstract class AbstractJdbcInstrumentationTest {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   void testPreparedBatchStateRetainedAfterFailure(boolean largeBatch) throws SQLException {
-    String system = largeBatch ? "sqlite" : "h2";
-    Connection rawConnection =
-        largeBatch
-            ? new JDBC().connect(JDBC_URLS.get(system), new Properties())
-            : new org.h2.Driver().connect(JDBC_URLS.get(system), null);
-    Connection connection = wrap(rawConnection);
+    // this test needs a driver that keeps the batch when the execution fails, sqlite for example
+    // calls the public clearBatch() from its own batch execution, which also clears the batch
+    // tracked by the javaagent; h2 implements executeLargeBatch() only in newer versions
+    Assumptions.assumeTrue(!largeBatch || testLatestDeps());
+    Connection connection = wrap(new org.h2.Driver().connect(JDBC_URLS.get("h2"), null));
     cleanup.deferCleanup(connection);
     String tableName =
         largeBatch ? "prepared_large_batch_failure_test" : "prepared_batch_failure_test";
@@ -2242,9 +2241,7 @@ public abstract class AbstractJdbcInstrumentationTest {
 
     testing()
         .waitAndAssertTraces(
-            trace ->
-                assertPreparedBatchTrace(
-                    trace, system, null, largeBatch ? "sqlite:memory:" : "h2:mem:", tableName, 2));
+            trace -> assertPreparedBatchTrace(trace, "h2", null, "h2:mem:", tableName, 2));
   }
 
   private static void executeBatch(PreparedStatement statement, boolean largeBatch)

--- a/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
+++ b/instrumentation/jdbc/testing/src/main/java/io/opentelemetry/instrumentation/jdbc/testing/AbstractJdbcInstrumentationTest.java
@@ -2087,7 +2087,13 @@ public abstract class AbstractJdbcInstrumentationTest {
       statement.executeLargeBatch();
       testing().waitForTraces(1);
       testing().clearData();
-      testing().runWithSpan("empty parent", statement::executeLargeBatch);
+      try {
+        testing().runWithSpan("empty parent", statement::executeLargeBatch);
+      } catch (SQLException e) {
+        if (!"hsqldb".equals(system) || e.getErrorCode() != -1256) {
+          throw e;
+        }
+      }
       testing()
           .waitAndAssertTraces(
               trace ->


### PR DESCRIPTION
Clears JDBC instrumentation-owned batch query and size state after every `executeBatch()` and `executeLargeBatch()` attempt, preventing subsequent executions from re-emitting stale telemetry when drivers empty the batch after success or failure.

Applies consistently to library wrappers and javaagent advice for ordinary `Statement` and `PreparedStatement` batches.