### PR TITLE
Guard DefaultErrorCauseExtractor against cyclic exception causes

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
@@ -5,11 +5,9 @@
 
 package io.opentelemetry.instrumentation.api.instrumenter;
 
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
@@ -21,15 +19,7 @@ final class DefaultErrorCauseExtractor implements ErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
-    Throwable current = error;
-    while (current.getCause() != null && isUnwrappableWrapper(current)) {
-      if (!visited.add(current)) {
-        break;
-      }
-      current = current.getCause();
-    }
-    return current;
+    return CauseUnwrapper.unwrapCause(error, DefaultErrorCauseExtractor::isUnwrappableWrapper);
   }
 
   private static boolean isUnwrappableWrapper(Throwable error) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
@@ -19,7 +19,7 @@ final class DefaultErrorCauseExtractor implements ErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    return CauseUnwrapper.unwrapCause(error, DefaultErrorCauseExtractor::isUnwrappableWrapper);
+    return CauseUnwrapper.unwrap(error, DefaultErrorCauseExtractor::isUnwrappableWrapper);
   }
 
   private static boolean isUnwrappableWrapper(Throwable error) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractor.java
@@ -7,6 +7,9 @@ package io.opentelemetry.instrumentation.api.instrumenter;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
@@ -18,14 +21,22 @@ final class DefaultErrorCauseExtractor implements ErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    if (error.getCause() != null
-        && (error instanceof ExecutionException
-            || isInstanceOfCompletionException(error)
-            || error instanceof InvocationTargetException
-            || error instanceof UndeclaredThrowableException)) {
-      return extract(error.getCause());
+    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    Throwable current = error;
+    while (current.getCause() != null && isUnwrappableWrapper(current)) {
+      if (!visited.add(current)) {
+        break;
+      }
+      current = current.getCause();
     }
-    return error;
+    return current;
+  }
+
+  private static boolean isUnwrappableWrapper(Throwable error) {
+    return error instanceof ExecutionException
+        || isInstanceOfCompletionException(error)
+        || error instanceof InvocationTargetException
+        || error instanceof UndeclaredThrowableException;
   }
 
   private static boolean isInstanceOfCompletionException(Throwable error) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public final class CauseUnwrapper {
+public class CauseUnwrapper {
 
   /**
    * Repeatedly replaces {@code error} with {@code nextCause.apply(error)} while {@code

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
@@ -28,8 +28,6 @@ import java.util.function.Predicate;
  */
 public final class CauseUnwrapper {
 
-  private CauseUnwrapper() {}
-
   /**
    * Repeatedly replaces {@code error} with {@code nextCause.apply(error)} while {@code
    * shouldUnwrap.test(error)} returns {@code true}, and returns the last value reached.
@@ -75,4 +73,6 @@ public final class CauseUnwrapper {
   public static Throwable rootCause(Throwable error) {
     return unwrap(error, unused -> true);
   }
+
+  private CauseUnwrapper() {}
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
@@ -64,15 +64,15 @@ public final class CauseUnwrapper {
    * Equivalent to {@link #unwrap(Throwable, Predicate, Function)}, using {@link
    * Throwable#getCause()} to advance to the next cause.
    */
-  public static Throwable unwrapCause(Throwable error, Predicate<Throwable> shouldUnwrap) {
+  public static Throwable unwrap(Throwable error, Predicate<Throwable> shouldUnwrap) {
     return unwrap(error, shouldUnwrap, Throwable::getCause);
   }
 
   /**
-   * Follows {@link Throwable#getCause()} to the deepest cause in the chain, halting safely if the
+   * Follows {@link Throwable#getCause()} to the root cause in the chain, halting safely if the
    * chain contains a cycle.
    */
-  public static Throwable deepestCause(Throwable error) {
-    return unwrapCause(error, unused -> true);
+  public static Throwable rootCause(Throwable error) {
+    return unwrap(error, unused -> true);
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A helper for safely walking a chain of {@link Throwable} causes.
+ *
+ * <p>Instrumentation frequently needs to unwrap wrapper exceptions (e.g. {@link
+ * java.util.concurrent.ExecutionException}, framework-specific wrapper types) to find the
+ * underlying error. A naive loop or recursive method that follows {@link Throwable#getCause()} (or
+ * a similar library-specific accessor) until some stop condition is met can loop forever, or
+ * overflow the stack if written recursively, when a cause chain contains a cycle - which can happen
+ * with adversarial or buggy exceptions since nothing prevents {@link
+ * Throwable#initCause(Throwable)} from being used to create one. The helpers in this class detect
+ * such cycles using identity comparisons and stop unwrapping instead of looping.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class CauseUnwrapper {
+
+  private CauseUnwrapper() {}
+
+  /**
+   * Repeatedly replaces {@code error} with {@code nextCause.apply(error)} while {@code
+   * shouldUnwrap.test(error)} returns {@code true}, and returns the last value reached.
+   *
+   * <p>Unwrapping halts, whichever happens first: when {@code shouldUnwrap} returns {@code false},
+   * when {@code nextCause} returns {@code null}, or when a throwable that has already been visited
+   * (compared by identity) would be visited again.
+   */
+  public static Throwable unwrap(
+      Throwable error,
+      Predicate<Throwable> shouldUnwrap,
+      Function<Throwable, Throwable> nextCause) {
+    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    Throwable current = error;
+    while (shouldUnwrap.test(current)) {
+      Throwable next = nextCause.apply(current);
+      if (next == null || !visited.add(current)) {
+        break;
+      }
+      current = next;
+    }
+    return current;
+  }
+
+  /**
+   * Equivalent to {@link #unwrap(Throwable, Predicate, Function)}, using {@link
+   * Throwable#getCause()} to advance to the next cause.
+   */
+  public static Throwable unwrapCause(Throwable error, Predicate<Throwable> shouldUnwrap) {
+    return unwrap(error, shouldUnwrap, Throwable::getCause);
+  }
+
+  /**
+   * Follows {@link Throwable#getCause()} to the deepest cause in the chain, halting safely if the
+   * chain contains a cycle.
+   */
+  public static Throwable deepestCause(Throwable error) {
+    return unwrapCause(error, unused -> true);
+  }
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapper.java
@@ -42,11 +42,17 @@ public final class CauseUnwrapper {
       Throwable error,
       Predicate<Throwable> shouldUnwrap,
       Function<Throwable, Throwable> nextCause) {
-    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    Set<Throwable> visited = null;
     Throwable current = error;
     while (shouldUnwrap.test(current)) {
       Throwable next = nextCause.apply(current);
-      if (next == null || !visited.add(current)) {
+      if (next == null) {
+        break;
+      }
+      if (visited == null) {
+        visited = Collections.newSetFromMap(new IdentityHashMap<>());
+      }
+      if (!visited.add(current)) {
         break;
       }
       current = next;

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractorTest.java
@@ -49,8 +49,11 @@ class DefaultErrorCauseExtractorTest {
 
   @Test
   void cyclicWrapperCauseChain() {
-    ExecutionException exception1 = new ExecutionException(null);
-    ExecutionException exception2 = new ExecutionException(null);
+    // the public ExecutionException constructors always set a (possibly null) cause, after which
+    // initCause() throws IllegalStateException; a no-arg subclass leaves the cause unset so it
+    // can be assigned below to form a cycle
+    ExecutionException exception1 = new ExecutionException() {};
+    ExecutionException exception2 = new ExecutionException() {};
     exception1.initCause(exception2);
     exception2.initCause(exception1);
 

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractorTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/instrumenter/DefaultErrorCauseExtractorTest.java
@@ -48,6 +48,16 @@ class DefaultErrorCauseExtractorTest {
   }
 
   @Test
+  void cyclicWrapperCauseChain() {
+    ExecutionException exception1 = new ExecutionException(null);
+    ExecutionException exception2 = new ExecutionException(null);
+    exception1.initCause(exception2);
+    exception2.initCause(exception1);
+
+    assertThat(ErrorCauseExtractor.getDefault().extract(exception1)).isSameAs(exception1);
+  }
+
+  @Test
   void notWrapped() {
     assertThat(ErrorCauseExtractor.getDefault().extract(new IllegalArgumentException("test")))
         .isInstanceOf(IllegalArgumentException.class)

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
@@ -41,19 +41,15 @@ class CauseUnwrapperTest {
 
   @Test
   void supportsCustomAccessor() {
-    ExecutionException exception1 = new ExecutionException() {};
-    ExecutionException exception2 = new ExecutionException() {};
-    IllegalStateException root = new IllegalStateException("root");
-    exception1.initCause(exception2);
-    exception2.initCause(root);
+    IllegalStateException underlying = new IllegalStateException("underlying");
+    // getCause() is null, so reaching the underlying error is only possible via the accessor
+    ExecutionException wrapper = new ExecutionException("wrapper", null);
 
-    // a custom "next" function that always follows getCause(), regardless of type, still stops
-    // safely if the chain (hypothetically) cycled back to an already-visited throwable
     Throwable result =
         CauseUnwrapper.unwrap(
-            exception1, error -> error instanceof ExecutionException, Throwable::getCause);
+            wrapper, error -> error instanceof ExecutionException, unused -> underlying);
 
-    assertThat(result).isSameAs(root);
+    assertThat(result).isSameAs(underlying);
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class CauseUnwrapperTest {
+
+  @Test
+  void unwrapsUntilPredicateIsFalse() {
+    IllegalArgumentException root = new IllegalArgumentException("root");
+    ExecutionException wrapper = new ExecutionException(root);
+
+    assertThat(CauseUnwrapper.unwrapCause(wrapper, error -> error instanceof ExecutionException))
+        .isSameAs(root);
+  }
+
+  @Test
+  void stopsAtNullCause() {
+    IllegalArgumentException error = new IllegalArgumentException("no cause");
+
+    assertThat(CauseUnwrapper.unwrapCause(error, unused -> true)).isSameAs(error);
+  }
+
+  @Test
+  void haltsOnCyclicCauseChain() {
+    ExecutionException exception1 = new ExecutionException() {};
+    ExecutionException exception2 = new ExecutionException() {};
+    exception1.initCause(exception2);
+    exception2.initCause(exception1);
+
+    assertThat(CauseUnwrapper.unwrapCause(exception1, error -> error instanceof ExecutionException))
+        .isSameAs(exception1);
+  }
+
+  @Test
+  void supportsCustomAccessor() {
+    ExecutionException exception1 = new ExecutionException() {};
+    ExecutionException exception2 = new ExecutionException() {};
+    IllegalStateException root = new IllegalStateException("root");
+    exception1.initCause(exception2);
+    exception2.initCause(root);
+
+    // a custom "next" function that always follows getCause(), regardless of type, still stops
+    // safely if the chain (hypothetically) cycled back to an already-visited throwable
+    Throwable result =
+        CauseUnwrapper.unwrap(
+            exception1, error -> error instanceof ExecutionException, Throwable::getCause);
+
+    assertThat(result).isSameAs(root);
+  }
+
+  @Test
+  void deepestCauseFindsBottomOfChain() {
+    IllegalStateException root = new IllegalStateException("root");
+    IllegalArgumentException middle = new IllegalArgumentException("middle", root);
+    ExecutionException top = new ExecutionException(middle);
+
+    assertThat(CauseUnwrapper.deepestCause(top)).isSameAs(root);
+  }
+
+  @Test
+  void deepestCauseHaltsOnCyclicCauseChain() {
+    ExecutionException exception1 = new ExecutionException() {};
+    ExecutionException exception2 = new ExecutionException() {};
+    exception1.initCause(exception2);
+    exception2.initCause(exception1);
+
+    // walking exception1 -> exception2 -> exception1 revisits exception1, so unwrapping halts
+    // and returns it rather than looping forever
+    assertThat(CauseUnwrapper.deepestCause(exception1)).isSameAs(exception1);
+  }
+
+  @Test
+  void deepestCauseWithNoCauseReturnsSameThrowable() {
+    IllegalArgumentException error = new IllegalArgumentException("test");
+
+    assertThat(CauseUnwrapper.deepestCause(error)).isSameAs(error);
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CauseUnwrapperTest.java
@@ -17,7 +17,7 @@ class CauseUnwrapperTest {
     IllegalArgumentException root = new IllegalArgumentException("root");
     ExecutionException wrapper = new ExecutionException(root);
 
-    assertThat(CauseUnwrapper.unwrapCause(wrapper, error -> error instanceof ExecutionException))
+    assertThat(CauseUnwrapper.unwrap(wrapper, error -> error instanceof ExecutionException))
         .isSameAs(root);
   }
 
@@ -25,7 +25,7 @@ class CauseUnwrapperTest {
   void stopsAtNullCause() {
     IllegalArgumentException error = new IllegalArgumentException("no cause");
 
-    assertThat(CauseUnwrapper.unwrapCause(error, unused -> true)).isSameAs(error);
+    assertThat(CauseUnwrapper.unwrap(error, unused -> true)).isSameAs(error);
   }
 
   @Test
@@ -35,7 +35,7 @@ class CauseUnwrapperTest {
     exception1.initCause(exception2);
     exception2.initCause(exception1);
 
-    assertThat(CauseUnwrapper.unwrapCause(exception1, error -> error instanceof ExecutionException))
+    assertThat(CauseUnwrapper.unwrap(exception1, error -> error instanceof ExecutionException))
         .isSameAs(exception1);
   }
 
@@ -53,16 +53,16 @@ class CauseUnwrapperTest {
   }
 
   @Test
-  void deepestCauseFindsBottomOfChain() {
+  void rootCauseFindsBottomOfChain() {
     IllegalStateException root = new IllegalStateException("root");
     IllegalArgumentException middle = new IllegalArgumentException("middle", root);
     ExecutionException top = new ExecutionException(middle);
 
-    assertThat(CauseUnwrapper.deepestCause(top)).isSameAs(root);
+    assertThat(CauseUnwrapper.rootCause(top)).isSameAs(root);
   }
 
   @Test
-  void deepestCauseHaltsOnCyclicCauseChain() {
+  void rootCauseHaltsOnCyclicCauseChain() {
     ExecutionException exception1 = new ExecutionException() {};
     ExecutionException exception2 = new ExecutionException() {};
     exception1.initCause(exception2);
@@ -70,13 +70,13 @@ class CauseUnwrapperTest {
 
     // walking exception1 -> exception2 -> exception1 revisits exception1, so unwrapping halts
     // and returns it rather than looping forever
-    assertThat(CauseUnwrapper.deepestCause(exception1)).isSameAs(exception1);
+    assertThat(CauseUnwrapper.rootCause(exception1)).isSameAs(exception1);
   }
 
   @Test
-  void deepestCauseWithNoCauseReturnsSameThrowable() {
+  void rootCauseWithNoCauseReturnsSameThrowable() {
     IllegalArgumentException error = new IllegalArgumentException("test");
 
-    assertThat(CauseUnwrapper.deepestCause(error)).isSameAs(error);
+    assertThat(CauseUnwrapper.rootCause(error)).isSameAs(error);
   }
 }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/yaml/RuleParser.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/yaml/RuleParser.java
@@ -208,7 +208,7 @@ public class RuleParser {
    */
   private static String rootCause(Throwable exception) {
     // Go to the bottom of it
-    Throwable rootCause = CauseUnwrapper.deepestCause(exception);
+    Throwable rootCause = CauseUnwrapper.rootCause(exception);
     String message = rootCause.getMessage();
     return message == null ? rootCause.getClass().getSimpleName() : message;
   }

--- a/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/yaml/RuleParser.java
+++ b/instrumentation/jmx-metrics/library/src/main/java/io/opentelemetry/instrumentation/jmx/internal/yaml/RuleParser.java
@@ -9,6 +9,7 @@ import static java.util.Collections.emptyList;
 import static java.util.logging.Level.FINE;
 import static java.util.stream.Collectors.toList;
 
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.instrumentation.jmx.internal.engine.MetricDef;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -206,13 +207,9 @@ public class RuleParser {
    * @return a String describing the probable root cause
    */
   private static String rootCause(Throwable exception) {
-    String rootClass = "";
-    String message = null;
     // Go to the bottom of it
-    for (; exception != null; exception = exception.getCause()) {
-      rootClass = exception.getClass().getSimpleName();
-      message = exception.getMessage();
-    }
-    return message == null ? rootClass : message;
+    Throwable rootCause = CauseUnwrapper.deepestCause(exception);
+    String message = rootCause.getMessage();
+    return message == null ? rootCause.getClass().getSimpleName() : message;
   }
 }

--- a/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfErrorCauseExtractor.java
@@ -6,14 +6,13 @@
 package io.opentelemetry.javaagent.instrumentation.jsf.common.jakarta;
 
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import jakarta.faces.FacesException;
 
 public class JsfErrorCauseExtractor implements ErrorCauseExtractor {
   @Override
   public Throwable extract(Throwable error) {
-    while (error.getCause() != null && error instanceof FacesException) {
-      error = error.getCause();
-    }
-    return ErrorCauseExtractor.getDefault().extract(error);
+    Throwable unwrapped = CauseUnwrapper.unwrapCause(error, e -> e instanceof FacesException);
+    return ErrorCauseExtractor.getDefault().extract(unwrapped);
   }
 }

--- a/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfErrorCauseExtractor.java
@@ -12,7 +12,7 @@ import jakarta.faces.FacesException;
 public class JsfErrorCauseExtractor implements ErrorCauseExtractor {
   @Override
   public Throwable extract(Throwable error) {
-    Throwable unwrapped = CauseUnwrapper.unwrapCause(error, e -> e instanceof FacesException);
+    Throwable unwrapped = CauseUnwrapper.unwrap(error, e -> e instanceof FacesException);
     return ErrorCauseExtractor.getDefault().extract(unwrapped);
   }
 }

--- a/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfErrorCauseExtractor.java
@@ -6,15 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.jsf.common.javax;
 
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import javax.faces.FacesException;
 
 public class JsfErrorCauseExtractor implements ErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    while (error.getCause() != null && error instanceof FacesException) {
-      error = error.getCause();
-    }
-    return ErrorCauseExtractor.getDefault().extract(error);
+    Throwable unwrapped = CauseUnwrapper.unwrapCause(error, e -> e instanceof FacesException);
+    return ErrorCauseExtractor.getDefault().extract(unwrapped);
   }
 }

--- a/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfErrorCauseExtractor.java
@@ -13,7 +13,7 @@ public class JsfErrorCauseExtractor implements ErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    Throwable unwrapped = CauseUnwrapper.unwrapCause(error, e -> e instanceof FacesException);
+    Throwable unwrapped = CauseUnwrapper.unwrap(error, e -> e instanceof FacesException);
     return ErrorCauseExtractor.getDefault().extract(unwrapped);
   }
 }

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v1_2/MyFacesErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v1_2/MyFacesErrorCauseExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jsf.myfaces.v1_2;
 
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.javaagent.instrumentation.jsf.common.javax.JsfErrorCauseExtractor;
 import javax.el.ELException;
 
@@ -12,10 +13,7 @@ final class MyFacesErrorCauseExtractor extends JsfErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    error = super.extract(error);
-    while (error.getCause() != null && error instanceof ELException) {
-      error = error.getCause();
-    }
-    return error;
+    Throwable unwrapped = super.extract(error);
+    return CauseUnwrapper.unwrapCause(unwrapped, e -> e instanceof ELException);
   }
 }

--- a/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v1_2/MyFacesErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-myfaces-1.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v1_2/MyFacesErrorCauseExtractor.java
@@ -14,6 +14,6 @@ final class MyFacesErrorCauseExtractor extends JsfErrorCauseExtractor {
   @Override
   public Throwable extract(Throwable error) {
     Throwable unwrapped = super.extract(error);
-    return CauseUnwrapper.unwrapCause(unwrapped, e -> e instanceof ELException);
+    return CauseUnwrapper.unwrap(unwrapped, e -> e instanceof ELException);
   }
 }

--- a/instrumentation/jsf/jsf-myfaces-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v3_0/MyFacesErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-myfaces-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v3_0/MyFacesErrorCauseExtractor.java
@@ -14,6 +14,6 @@ class MyFacesErrorCauseExtractor extends JsfErrorCauseExtractor {
   @Override
   public Throwable extract(Throwable error) {
     Throwable unwrapped = super.extract(error);
-    return CauseUnwrapper.unwrapCause(unwrapped, e -> e instanceof ELException);
+    return CauseUnwrapper.unwrap(unwrapped, e -> e instanceof ELException);
   }
 }

--- a/instrumentation/jsf/jsf-myfaces-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v3_0/MyFacesErrorCauseExtractor.java
+++ b/instrumentation/jsf/jsf-myfaces-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/myfaces/v3_0/MyFacesErrorCauseExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jsf.myfaces.v3_0;
 
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.javaagent.instrumentation.jsf.common.jakarta.JsfErrorCauseExtractor;
 import jakarta.el.ELException;
 
@@ -12,10 +13,7 @@ class MyFacesErrorCauseExtractor extends JsfErrorCauseExtractor {
 
   @Override
   public Throwable extract(Throwable error) {
-    error = super.extract(error);
-    while (error.getCause() != null && error instanceof ELException) {
-      error = error.getCause();
-    }
-    return error;
+    Throwable unwrapped = super.extract(error);
+    return CauseUnwrapper.unwrapCause(unwrapped, e -> e instanceof ELException);
   }
 }

--- a/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzErrorCauseExtractor.java
+++ b/instrumentation/quartz-2.0/library/src/main/java/io/opentelemetry/instrumentation/quartz/v2_0/QuartzErrorCauseExtractor.java
@@ -6,15 +6,17 @@
 package io.opentelemetry.instrumentation.quartz.v2_0;
 
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import org.quartz.SchedulerException;
 
 final class QuartzErrorCauseExtractor implements ErrorCauseExtractor {
   @Override
   public Throwable extract(Throwable error) {
-    while (error instanceof SchedulerException
-        && ((SchedulerException) error).getUnderlyingException() != null) {
-      error = ((SchedulerException) error).getUnderlyingException();
-    }
-    return ErrorCauseExtractor.getDefault().extract(error);
+    Throwable unwrapped =
+        CauseUnwrapper.unwrap(
+            error,
+            candidate -> candidate instanceof SchedulerException,
+            candidate -> ((SchedulerException) candidate).getUnderlyingException());
+    return ErrorCauseExtractor.getDefault().extract(unwrapped);
   }
 }

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
@@ -68,8 +68,7 @@ public class RoutingContextHandlerWrapper implements Handler<RoutingContext> {
   }
 
   private static Throwable unwrapThrowable(Throwable throwable) {
-    return CauseUnwrapper.unwrap(
-        throwable, RoutingContextHandlerWrapper::isUnwrappableWrapper);
+    return CauseUnwrapper.unwrap(throwable, RoutingContextHandlerWrapper::isUnwrappableWrapper);
   }
 
   private static boolean isUnwrappableWrapper(Throwable throwable) {

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
@@ -68,7 +68,7 @@ public class RoutingContextHandlerWrapper implements Handler<RoutingContext> {
   }
 
   private static Throwable unwrapThrowable(Throwable throwable) {
-    return CauseUnwrapper.unwrapCause(
+    return CauseUnwrapper.unwrap(
         throwable, RoutingContextHandlerWrapper::isUnwrappableWrapper);
   }
 

--- a/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
+++ b/instrumentation/vertx/vertx-web-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/web/v3_0/RoutingContextHandlerWrapper.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
 import io.vertx.core.Handler;
@@ -67,13 +68,14 @@ public class RoutingContextHandlerWrapper implements Handler<RoutingContext> {
   }
 
   private static Throwable unwrapThrowable(Throwable throwable) {
-    if (throwable.getCause() != null
-        && (throwable instanceof ExecutionException
-            || throwable instanceof CompletionException
-            || throwable instanceof InvocationTargetException
-            || throwable instanceof UndeclaredThrowableException)) {
-      return unwrapThrowable(throwable.getCause());
-    }
-    return throwable;
+    return CauseUnwrapper.unwrapCause(
+        throwable, RoutingContextHandlerWrapper::isUnwrappableWrapper);
+  }
+
+  private static boolean isUnwrappableWrapper(Throwable throwable) {
+    return throwable instanceof ExecutionException
+        || throwable instanceof CompletionException
+        || throwable instanceof InvocationTargetException
+        || throwable instanceof UndeclaredThrowableException;
   }
 }

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -41,12 +42,10 @@ class DefaultExceptionMapperInstrumentation implements TypeInstrumentation {
       Span serverSpan = LocalRootSpan.fromContextOrNull(Java8BytecodeBridge.currentContext());
       if (serverSpan != null) {
         // unwrap exception
-        Throwable throwable = exception;
-        while (throwable.getCause() != null
-            && (throwable instanceof WicketRuntimeException
-                || throwable instanceof InvocationTargetException)) {
-          throwable = throwable.getCause();
-        }
+        Throwable throwable =
+            CauseUnwrapper.unwrapCause(
+                exception,
+                t -> t instanceof WicketRuntimeException || t instanceof InvocationTargetException);
         // as we don't create a span for wicket we record exception on server span
         serverSpan.recordException(throwable);
       }

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
@@ -39,8 +39,6 @@ class DefaultExceptionMapperInstrumentation implements TypeInstrumentation {
       Span serverSpan = LocalRootSpan.fromContextOrNull(Java8BytecodeBridge.currentContext());
       if (serverSpan != null) {
         // unwrap exception
-        // this must be delegated to a helper class: advice is inlined into the instrumented class,
-        // where the synthetic lambda methods of this class would not be accessible
         Throwable throwable = WicketErrorUnwrapper.unwrap(exception);
         // as we don't create a span for wicket we record exception on server span
         serverSpan.recordException(throwable);

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/DefaultExceptionMapperInstrumentation.java
@@ -10,15 +10,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
-import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import java.lang.reflect.InvocationTargetException;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.apache.wicket.WicketRuntimeException;
 
 class DefaultExceptionMapperInstrumentation implements TypeInstrumentation {
 
@@ -42,10 +39,9 @@ class DefaultExceptionMapperInstrumentation implements TypeInstrumentation {
       Span serverSpan = LocalRootSpan.fromContextOrNull(Java8BytecodeBridge.currentContext());
       if (serverSpan != null) {
         // unwrap exception
-        Throwable throwable =
-            CauseUnwrapper.unwrapCause(
-                exception,
-                t -> t instanceof WicketRuntimeException || t instanceof InvocationTargetException);
+        // this must be delegated to a helper class: advice is inlined into the instrumented class,
+        // where the synthetic lambda methods of this class would not be accessible
+        Throwable throwable = WicketErrorUnwrapper.unwrap(exception);
         // as we don't create a span for wicket we record exception on server span
         serverSpan.recordException(throwable);
       }

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
@@ -14,10 +14,6 @@ public class WicketErrorUnwrapper {
   /**
    * Unwraps the wicket-specific wrapper exceptions from {@code error} to find the error that
    * actually caused the failure.
-   *
-   * <p>This lives in a helper class rather than in the advice itself because advice bodies are
-   * inlined into the instrumented class, and inlined code cannot reference the synthetic lambda
-   * methods that the compiler would generate for the predicate below.
    */
   public static Throwable unwrap(Throwable error) {
     return CauseUnwrapper.unwrap(error, WicketErrorUnwrapper::isWrapperException);

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
@@ -20,7 +20,7 @@ public final class WicketErrorUnwrapper {
    * methods that the compiler would generate for the predicate below.
    */
   public static Throwable unwrap(Throwable error) {
-    return CauseUnwrapper.unwrapCause(error, WicketErrorUnwrapper::isWrapperException);
+    return CauseUnwrapper.unwrap(error, WicketErrorUnwrapper::isWrapperException);
   }
 
   private static boolean isWrapperException(Throwable error) {

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.wicket.v8_0;
+
+import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
+import java.lang.reflect.InvocationTargetException;
+import org.apache.wicket.WicketRuntimeException;
+
+public final class WicketErrorUnwrapper {
+
+  /**
+   * Unwraps the wicket-specific wrapper exceptions from {@code error} to find the error that
+   * actually caused the failure.
+   *
+   * <p>This lives in a helper class rather than in the advice itself because advice bodies are
+   * inlined into the instrumented class, and inlined code cannot reference the synthetic lambda
+   * methods that the compiler would generate for the predicate below.
+   */
+  public static Throwable unwrap(Throwable error) {
+    return CauseUnwrapper.unwrapCause(error, WicketErrorUnwrapper::isWrapperException);
+  }
+
+  private static boolean isWrapperException(Throwable error) {
+    return error instanceof WicketRuntimeException || error instanceof InvocationTargetException;
+  }
+
+  private WicketErrorUnwrapper() {}
+}

--- a/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
+++ b/instrumentation/wicket-8.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/wicket/v8_0/WicketErrorUnwrapper.java
@@ -9,7 +9,7 @@ import io.opentelemetry.instrumentation.api.internal.CauseUnwrapper;
 import java.lang.reflect.InvocationTargetException;
 import org.apache.wicket.WicketRuntimeException;
 
-public final class WicketErrorUnwrapper {
+public class WicketErrorUnwrapper {
 
   /**
    * Unwraps the wicket-specific wrapper exceptions from {@code error} to find the error that


### PR DESCRIPTION
Fixes #19585

## Summary

Per @johnbley's [comment on the issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19585#issuecomment-5314814655), this now fixes all of the enumerated cause-traversal sites through one shared halting implementation instead of copy-pasting the guard:

- Added `io.opentelemetry.instrumentation.api.internal.CauseUnwrapper`: a small internal helper with an identity-`Set`-based visited-tracking loop. It takes a caller-supplied `Predicate<Throwable>` ("should I keep unwrapping this one?") and a `Function<Throwable, Throwable>` ("what's next?", defaulting to `Throwable::getCause` via `unwrapCause`), so every call site keeps its own exact unwrap condition while sharing the cycle-safe traversal.
- Migrated onto it:
  - `DefaultErrorCauseExtractor` (instrumentation-api)
  - `QuartzErrorCauseExtractor` — uses a non-`getCause()` accessor (`SchedulerException#getUnderlyingException`), which is why the helper takes a pluggable "next" function rather than hardcoding `getCause()`
  - Vert.x web's `RoutingContextHandlerWrapper#unwrapThrowable`
  - wicket's `DefaultExceptionMapperInstrumentation.ExceptionAdvice`
  - all 4 JSF/MyFaces `extract` methods (`jsf-common-javax`, `jsf-common-jakarta`, `jsf-myfaces-1.2`, `jsf-myfaces-3.0`) — the MyFaces subclasses call `super.extract()` then run a second, independently-bounded unwrap pass for `ELException`
  - JMX metrics' `RuleParser#rootCause` (not instrumentation, but same unbounded-`getCause()`-walk pattern) via a `deepestCause` convenience method
- Each site's original type predicate (and the Android-safe reflective `CompletionException` check in `DefaultErrorCauseExtractor`) is preserved as-is; only the traversal/halting logic is shared.
- Added `CauseUnwrapperTest` covering the predicate/accessor variants and cyclic chains, and fixed the previously-added `cyclicWrapperCauseChain` regression test: the public `ExecutionException(Throwable)` constructor always sets the cause field (even to `null`), so a later `initCause()` call throws `IllegalStateException`; switched to a no-arg anonymous subclass so the cause is still unset when the cyclic `initCause()` calls run — this is also what broke CI on the previous version of this PR.

## Test plan

- `./gradlew :instrumentation-api:test --tests "*ErrorCause*" --tests "*CauseUnwrapper*"` (JDK 21)
- `./gradlew :instrumentation:quartz-2.0:library:compileJava :instrumentation:vertx:vertx-web-3.0:javaagent:compileJava :instrumentation:wicket-8.0:javaagent:compileJava :instrumentation:jsf:jsf-common-javax:javaagent:compileJava :instrumentation:jsf:jsf-common-jakarta:javaagent:compileJava :instrumentation:jsf:jsf-myfaces-1.2:javaagent:compileJava :instrumentation:jsf:jsf-myfaces-3.0:javaagent:compileJava :instrumentation:jmx-metrics:library:compileJava`
- `spotlessCheck` / `checkstyleMain` / `checkstyleTest` for all touched modules
