### PR TITLE
Assert complete attributes on netty client spans

### DIFF
--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ClientSslTest.java
@@ -10,12 +10,17 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -196,9 +201,22 @@ class Netty40ClientSslTest {
                       equalTo(NETWORK_PEER_PORT, uri.getPort()),
                       equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
-                span -> {
-                  span.hasName("GET").hasKind(CLIENT).hasParent(trace.getSpan(0));
-                },
+                span ->
+                    span.hasName("GET")
+                        .hasKind(CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service")),
                 span -> {
                   span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(3));
                 }));

--- a/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_0/client/Netty40ConnectionSpanTest.java
@@ -11,12 +11,16 @@ import static io.opentelemetry.api.trace.SpanKind.SERVER;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -116,7 +120,22 @@ class Netty40ConnectionSpanTest {
                       equalTo(NETWORK_PEER_PORT, uri.getPort()),
                       equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"));
                 },
-                span -> span.hasName("GET").hasKind(CLIENT).hasParent(trace.getSpan(0)),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service")),
                 span ->
                     span.hasName("test-http-server").hasKind(SERVER).hasParent(trace.getSpan(2))));
   }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientPipelineTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientPipelineTest.java
@@ -5,7 +5,18 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -96,7 +107,22 @@ class Netty41ClientPipelineTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasNoParent().hasName("parent1").hasKind(SpanKind.INTERNAL),
-                span -> span.hasParent(trace.getSpan(0)).hasKind(SpanKind.CLIENT),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, "http://localhost:" + server.httpPort() + "/success"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, server.httpPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service"))
+                        .hasParent(trace.getSpan(0)),
                 span -> span.hasKind(SpanKind.SERVER).hasParent(trace.getSpan(1))));
 
     testing.clearData();
@@ -111,7 +137,22 @@ class Netty41ClientPipelineTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasNoParent().hasName("parent2").hasKind(SpanKind.INTERNAL),
-                span -> span.hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0)),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, "http://localhost:" + server.httpPort() + "/success"),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, server.httpPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service"))
+                        .hasParent(trace.getSpan(0)),
                 span -> span.hasKind(SpanKind.SERVER).hasParent(trace.getSpan(1))));
   }
 
@@ -219,7 +260,22 @@ class Netty41ClientPipelineTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasNoParent().hasName("parent").hasKind(SpanKind.INTERNAL),
                 span -> span.hasParent(trace.getSpan(0)).hasName("tracedMethod"),
-                span -> span.hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(1)),
+                span ->
+                    span.hasName(method)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, "http://localhost:" + server.httpPort() + "/success"),
+                            equalTo(HTTP_REQUEST_METHOD, method),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, "localhost"),
+                            equalTo(SERVER_PORT, server.httpPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, server.httpPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service"))
+                        .hasParent(trace.getSpan(1)),
                 span -> span.hasKind(SpanKind.SERVER).hasParent(trace.getSpan(2))));
   }
 

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ClientSslTest.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -220,7 +224,21 @@ class Netty41ClientSslTest {
                             equalTo(NETWORK_TYPE, "ipv4"),
                             equalTo(NETWORK_PEER_PORT, uri.getPort()),
                             equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1")),
-                span -> span.hasName("GET").hasKind(SpanKind.CLIENT),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service")),
                 span -> span.hasName("test-http-server").hasKind(SpanKind.SERVER)));
   }
 }

--- a/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
+++ b/instrumentation/netty/netty-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/netty/v4_1/Netty41ConnectionSpanTest.java
@@ -8,12 +8,16 @@ package io.opentelemetry.javaagent.instrumentation.netty.v4_1;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TRANSPORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -142,7 +146,22 @@ class Netty41ConnectionSpanTest {
                             equalTo(NETWORK_PEER_PORT, uri.getPort()),
                             equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"),
                             equalTo(maybeStablePeerService(), "test-peer-service")),
-                span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0)),
+                span ->
+                    span.hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, "GET"),
+                            equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            equalTo(maybeStablePeerService(), "test-peer-service")),
                 span ->
                     span.hasName("test-http-server")
                         .hasKind(SpanKind.SERVER)

--- a/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/testing/src/main/java/io/opentelemetry/instrumentation/netty/v4_1/AbstractNetty41ClientTest.java
@@ -5,8 +5,17 @@
 
 package io.opentelemetry.instrumentation.netty.v4_1;
 
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -177,7 +186,24 @@ public abstract class AbstractNetty41ClientTest
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
-                span -> span.hasName("GET").hasKind(SpanKind.CLIENT).hasNoParent(),
+                span ->
+                    span.hasName(method)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                            equalTo(URL_FULL, uri.toString()),
+                            equalTo(HTTP_REQUEST_METHOD, method),
+                            equalTo(SERVER_ADDRESS, uri.getHost()),
+                            equalTo(SERVER_PORT, uri.getPort()),
+                            satisfies(
+                                NETWORK_PEER_ADDRESS,
+                                val -> val.isIn("127.0.0.1", "0:0:0:0:0:0:0:1")),
+                            equalTo(NETWORK_PEER_PORT, uri.getPort()),
+                            satisfies(ERROR_TYPE, val -> val.isNotBlank()),
+                            equalTo(
+                                maybeStablePeerService(),
+                                testing.isJavaagent() ? "test-peer-service" : null)),
                 span -> span.hasName("test-http-server").hasParent(trace.getSpan(0))));
   }
 }


### PR DESCRIPTION
Several netty client span assertions checked only the span name and kind, so regressions in the emitted attribute set would go unnoticed. They now assert the full attribute set with `hasAttributesSatisfyingExactly`.

This covers the connection-span and TLS tests for netty 4.0 and 4.1, the pipeline test, and the shared client test base. Structural spans created by the test code itself, such as parent spans and the synthetic `test-http-server` span, are left alone because they are not emitted by the instrumentation under test.

The shared `AbstractNetty41ClientTest` runs under both the javaagent and the library, so its peer service expectation comes from `testing.isJavaagent()`.