### PR TITLE
Retain Cassandra 3 server data on failed operations

### DIFF
--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
@@ -28,10 +28,12 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
-class CassandraAttributesExtractor implements AttributesExtractor<CassandraRequest, ExecutionInfo> {
+class CassandraAttributesExtractor
+    implements AttributesExtractor<CassandraRequest, CassandraResponse> {
 
   @Nullable
   private static final Method GET_SPECULATIVE_EXECUTIONS =
@@ -58,16 +60,25 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
       AttributesBuilder attributes,
       Context context,
       CassandraRequest request,
-      @Nullable ExecutionInfo executionInfo,
+      @Nullable CassandraResponse response,
       @Nullable Throwable error) {
+    if (response == null) {
+      return;
+    }
+
+    InetSocketAddress coordinatorAddress = response.getCoordinatorAddress();
+    if (coordinatorAddress != null) {
+      attributes.put(SERVER_ADDRESS, coordinatorAddress.getHostString());
+      attributes.put(SERVER_PORT, coordinatorAddress.getPort());
+    }
+
+    ExecutionInfo executionInfo = response.getExecutionInfo();
     if (executionInfo == null) {
       return;
     }
 
     Host coordinator = executionInfo.getQueriedHost();
     if (coordinator != null) {
-      attributes.put(SERVER_ADDRESS, coordinator.getSocketAddress().getHostString());
-      attributes.put(SERVER_PORT, coordinator.getSocketAddress().getPort());
       if (emitStableDatabaseSemconv()) {
         attributes.put(CASSANDRA_COORDINATOR_DC, coordinator.getDatacenter());
       }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraResponse.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
+
+import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.exceptions.CoordinatorException;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+class CassandraResponse {
+  @Nullable private final ExecutionInfo executionInfo;
+  @Nullable private final InetSocketAddress coordinatorAddress;
+
+  private CassandraResponse(
+      @Nullable ExecutionInfo executionInfo, @Nullable InetSocketAddress coordinatorAddress) {
+    this.executionInfo = executionInfo;
+    this.coordinatorAddress = coordinatorAddress;
+  }
+
+  static CassandraResponse create(ExecutionInfo executionInfo) {
+    Host coordinator = executionInfo.getQueriedHost();
+    return new CassandraResponse(
+        executionInfo, coordinator == null ? null : coordinator.getSocketAddress());
+  }
+
+  @Nullable
+  static CassandraResponse create(Throwable throwable) {
+    if (throwable instanceof CoordinatorException) {
+      return new CassandraResponse(null, ((CoordinatorException) throwable).getAddress());
+    }
+    return null;
+  }
+
+  @Nullable
+  ExecutionInfo getExecutionInfo() {
+    return executionInfo;
+  }
+
+  @Nullable
+  InetSocketAddress getCoordinatorAddress() {
+    return coordinatorAddress;
+  }
+}

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSingletons.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
 
-import com.datastax.driver.core.ExecutionInfo;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
@@ -22,15 +21,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 class CassandraSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.cassandra-3.0";
 
-  // could use RESPONSE "ResultSet" here, but using RESPONSE "ExecutionInfo" in cassandra-4.0
-  // instrumentation (see comment over there for why), so also using here for consistency
-  private static final Instrumenter<CassandraRequest, ExecutionInfo> instrumenter;
+  private static final Instrumenter<CassandraRequest, CassandraResponse> instrumenter;
 
   static {
     CassandraSqlAttributesGetter attributesGetter = new CassandraSqlAttributesGetter();
 
-    InstrumenterBuilder<CassandraRequest, ExecutionInfo> builder =
-        Instrumenter.<CassandraRequest, ExecutionInfo>builder(
+    InstrumenterBuilder<CassandraRequest, CassandraResponse> builder =
+        Instrumenter.<CassandraRequest, CassandraResponse>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(attributesGetter))
@@ -48,7 +45,7 @@ class CassandraSingletons {
     instrumenter = builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
-  static Instrumenter<CassandraRequest, ExecutionInfo> instrumenter() {
+  static Instrumenter<CassandraRequest, CassandraResponse> instrumenter() {
     return instrumenter;
   }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraSqlAttributesGetter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
 
-import com.datastax.driver.core.ExecutionInfo;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
@@ -16,7 +15,7 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 
 final class CassandraSqlAttributesGetter
-    implements SqlClientAttributesGetter<CassandraRequest, ExecutionInfo> {
+    implements SqlClientAttributesGetter<CassandraRequest, CassandraResponse> {
 
   @Override
   public String getDbSystemName(CassandraRequest request) {
@@ -50,8 +49,8 @@ final class CassandraSqlAttributesGetter
   @Nullable
   @Override
   public InetSocketAddress getNetworkPeerInetSocketAddress(
-      CassandraRequest request, @Nullable ExecutionInfo executionInfo) {
-    return executionInfo == null ? null : executionInfo.getQueriedHost().getSocketAddress();
+      CassandraRequest request, @Nullable CassandraResponse response) {
+    return response == null ? null : response.getCoordinatorAddress();
   }
 
   @Override

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/TracingSession.java
@@ -53,10 +53,11 @@ public class TracingSession implements Session {
     try (Scope ignored = context.makeCurrent()) {
       resultSet = session.execute(query);
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
-    instrumenter().end(context, request, resultSet.getExecutionInfo(), null);
+    instrumenter()
+        .end(context, request, CassandraResponse.create(resultSet.getExecutionInfo()), null);
     return resultSet;
   }
 
@@ -68,10 +69,11 @@ public class TracingSession implements Session {
     try (Scope ignored = context.makeCurrent()) {
       resultSet = session.execute(query, values);
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
-    instrumenter().end(context, request, resultSet.getExecutionInfo(), null);
+    instrumenter()
+        .end(context, request, CassandraResponse.create(resultSet.getExecutionInfo()), null);
     return resultSet;
   }
 
@@ -83,10 +85,11 @@ public class TracingSession implements Session {
     try (Scope ignored = context.makeCurrent()) {
       resultSet = session.execute(query, values);
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
-    instrumenter().end(context, request, resultSet.getExecutionInfo(), null);
+    instrumenter()
+        .end(context, request, CassandraResponse.create(resultSet.getExecutionInfo()), null);
     return resultSet;
   }
 
@@ -98,10 +101,11 @@ public class TracingSession implements Session {
     try (Scope ignored = context.makeCurrent()) {
       resultSet = session.execute(statement);
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
-    instrumenter().end(context, request, resultSet.getExecutionInfo(), null);
+    instrumenter()
+        .end(context, request, CassandraResponse.create(resultSet.getExecutionInfo()), null);
     return resultSet;
   }
 
@@ -114,7 +118,7 @@ public class TracingSession implements Session {
       addCallbackToEndSpan(future, context, request);
       return future;
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
   }
@@ -128,7 +132,7 @@ public class TracingSession implements Session {
       addCallbackToEndSpan(future, context, request);
       return future;
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
   }
@@ -142,7 +146,7 @@ public class TracingSession implements Session {
       addCallbackToEndSpan(future, context, request);
       return future;
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
   }
@@ -156,7 +160,7 @@ public class TracingSession implements Session {
       addCallbackToEndSpan(future, context, request);
       return future;
     } catch (Throwable t) {
-      instrumenter().end(context, request, null, t);
+      instrumenter().end(context, request, CassandraResponse.create(t), t);
       throw t;
     }
   }
@@ -213,12 +217,14 @@ public class TracingSession implements Session {
         new FutureCallback<ResultSet>() {
           @Override
           public void onSuccess(ResultSet resultSet) {
-            instrumenter().end(context, request, resultSet.getExecutionInfo(), null);
+            instrumenter()
+                .end(
+                    context, request, CassandraResponse.create(resultSet.getExecutionInfo()), null);
           }
 
           @Override
           public void onFailure(Throwable t) {
-            instrumenter().end(context, request, null, t);
+            instrumenter().end(context, request, CassandraResponse.create(t), t);
           }
         },
         Runnable::run);

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -16,6 +16,9 @@ import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -34,6 +37,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.CASSANDRA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -48,6 +52,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.exceptions.SyntaxError;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -60,6 +65,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,6 +150,11 @@ class CassandraClientTest {
                         .hasStatus(StatusData.error())
                         .hasException(thrown)
                         .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                             equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM missing_table"),
                             equalTo(
@@ -184,6 +195,11 @@ class CassandraClientTest {
                         .hasStatus(StatusData.error())
                         .hasException(thrown)
                         .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
                             equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
                             equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM missing_table"),
                             equalTo(
@@ -641,6 +657,61 @@ class CassandraClientTest {
     } catch (NoSuchMethodException ignored) {
       return false;
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("failureScenarios")
+  void failureTelemetry(Consumer<Session> execute) {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+    testing.clearData();
+
+    assertThatThrownBy(() -> execute.accept(session)).isInstanceOf(SyntaxError.class);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "cassandra" : "DB Query")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error())
+                        .hasEventsSatisfyingExactly(
+                            event ->
+                                event
+                                    .hasName("exception")
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(EXCEPTION_TYPE, SyntaxError.class.getName()),
+                                        satisfies(
+                                            EXCEPTION_MESSAGE,
+                                            val -> val.contains("line 1:0 no viable alternative")),
+                                        satisfies(
+                                            EXCEPTION_STACKTRACE,
+                                            val -> val.isInstanceOf(String.class))))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(NETWORK_TYPE, emitStableDatabaseSemconv() ? null : "ipv4"),
+                            equalTo(SERVER_ADDRESS, cassandraHost),
+                            equalTo(SERVER_PORT, cassandraPort),
+                            equalTo(NETWORK_PEER_ADDRESS, cassandraIp),
+                            equalTo(NETWORK_PEER_PORT, cassandraPort),
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(maybeStable(DB_STATEMENT), "invalid"),
+                            equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                            equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                            equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? SyntaxError.class.getName()
+                                    : null))));
+  }
+
+  private static Stream<Arguments> failureScenarios() {
+    return Stream.of(
+        argumentSet("sync", (Consumer<Session>) session -> session.execute("invalid")),
+        argumentSet(
+            "async",
+            (Consumer<Session>) session -> session.executeAsync("invalid").getUninterruptibly()));
   }
 
   private static Stream<Arguments> batchScenarios() {


### PR DESCRIPTION
Failed Cassandra driver 3 operations now keep the server and network peer address and port attributes that previously appeared only on successful operations, in both the legacy and stable database semantic conventions.

The attributes were derived only from a successful result's execution information, which is unavailable once the operation throws.

They are now recovered from the driver exception that identifies the coordinator which served the request, so a failure that never reached a coordinator, such as `NoHostAvailableException`, still reports no server attributes.

The coordinator data center, coordinator identifier, and speculative-execution count stay absent on failures, since those are read from the execution information a failed operation never produces. Request-derived attributes such as the consistency level are unaffected and were already emitted on failures.

The original exception is passed through unchanged, so error status, `error.type`, and exception events behave exactly as before.