### PR TITLE
Emit Cassandra attributes for driver 3

### DIFF
--- a/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
+++ b/instrumentation/camel-2.20/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/decorators/CassandraTest.java
@@ -21,6 +21,12 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_CONSISTENCY_LEVEL;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_COORDINATOR_DC;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_COORDINATOR_ID;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_PAGE_SIZE;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_QUERY_IDEMPOTENT;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -164,7 +170,14 @@ class CassandraTest extends AbstractHttpServerUsingTest<ConfigurableApplicationC
                               equalTo(
                                   DB_QUERY_TEXT,
                                   "select * from test.users where id=1 ALLOW FILTERING"),
-                              equalTo(DB_QUERY_SUMMARY, "select test.users"))));
+                              equalTo(DB_QUERY_SUMMARY, "select test.users"),
+                              equalTo(CASSANDRA_CONSISTENCY_LEVEL, "LOCAL_ONE"),
+                              equalTo(CASSANDRA_COORDINATOR_DC, "datacenter1"),
+                              satisfies(
+                                  CASSANDRA_COORDINATOR_ID, val -> val.isInstanceOf(String.class)),
+                              equalTo(CASSANDRA_PAGE_SIZE, 5000),
+                              equalTo(CASSANDRA_QUERY_IDEMPOTENT, false),
+                              equalTo(CASSANDRA_SPECULATIVE_EXECUTION_COUNT, 0))));
     } else {
       testing.waitAndAssertTraces(
           trace ->

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
@@ -5,19 +5,63 @@
 
 package io.opentelemetry.javaagent.instrumentation.cassandra.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_CONSISTENCY_LEVEL;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_COORDINATOR_DC;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_COORDINATOR_ID;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_PAGE_SIZE;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_QUERY_IDEMPOTENT;
+import static io.opentelemetry.semconv.incubating.CassandraIncubatingAttributes.CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_CONSISTENCY_LEVEL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_COORDINATOR_DC;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_COORDINATOR_ID;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_IDEMPOTENCE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_PAGE_SIZE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
 
 import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.Host;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 
 class CassandraAttributesExtractor implements AttributesExtractor<CassandraRequest, ExecutionInfo> {
+
+  private static final ClassValue<Method> speculativeExecutionsMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("getSpeculativeExecutions");
+          } catch (NoSuchMethodException ignored) {
+            return null;
+          }
+        }
+      };
+
+  private static final ClassValue<Method> hostIdMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("getHostId");
+          } catch (NoSuchMethodException ignored) {
+            return null;
+          }
+        }
+      };
+
   @Override
   public void onStart(AttributesBuilder attributes, Context context, CassandraRequest request) {}
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   @Override
   public void onEnd(
       AttributesBuilder attributes,
@@ -28,8 +72,66 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
     if (executionInfo == null) {
       return;
     }
-    attributes.put(
-        SERVER_ADDRESS, executionInfo.getQueriedHost().getSocketAddress().getHostString());
-    attributes.put(SERVER_PORT, executionInfo.getQueriedHost().getSocketAddress().getPort());
+
+    Host coordinator = executionInfo.getQueriedHost();
+    if (coordinator != null) {
+      attributes.put(SERVER_ADDRESS, coordinator.getSocketAddress().getHostString());
+      attributes.put(SERVER_PORT, coordinator.getSocketAddress().getPort());
+      if (emitStableDatabaseSemconv()) {
+        attributes.put(CASSANDRA_COORDINATOR_DC, coordinator.getDatacenter());
+      }
+      if (emitOldDatabaseSemconv()) {
+        attributes.put(DB_CASSANDRA_COORDINATOR_DC, coordinator.getDatacenter());
+      }
+      String coordinatorId = getCoordinatorId(coordinator);
+      if (emitStableDatabaseSemconv()) {
+        attributes.put(CASSANDRA_COORDINATOR_ID, coordinatorId);
+      }
+      if (emitOldDatabaseSemconv()) {
+        attributes.put(DB_CASSANDRA_COORDINATOR_ID, coordinatorId);
+      }
+    }
+
+    if (emitStableDatabaseSemconv()) {
+      attributes.put(CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
+      attributes.put(CASSANDRA_PAGE_SIZE, request.getPageSize());
+      attributes.put(CASSANDRA_QUERY_IDEMPOTENT, request.isIdempotent());
+    }
+    if (emitOldDatabaseSemconv()) {
+      attributes.put(DB_CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
+      attributes.put(DB_CASSANDRA_PAGE_SIZE, request.getPageSize());
+      attributes.put(DB_CASSANDRA_IDEMPOTENCE, request.isIdempotent());
+    }
+
+    Integer speculativeExecutionCount = getSpeculativeExecutionCount(executionInfo);
+    if (speculativeExecutionCount != null) {
+      if (emitStableDatabaseSemconv()) {
+        attributes.put(CASSANDRA_SPECULATIVE_EXECUTION_COUNT, speculativeExecutionCount);
+      }
+      if (emitOldDatabaseSemconv()) {
+        attributes.put(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT, speculativeExecutionCount);
+      }
+    }
+  }
+
+  @Nullable
+  private static Integer getSpeculativeExecutionCount(ExecutionInfo executionInfo) {
+    try {
+      Method method = speculativeExecutionsMethod.get(executionInfo.getClass());
+      return method == null ? null : (Integer) method.invoke(executionInfo);
+    } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
+  }
+
+  @Nullable
+  private static String getCoordinatorId(Host coordinator) {
+    try {
+      Method method = hostIdMethod.get(coordinator.getClass());
+      Object hostId = method == null ? null : method.invoke(coordinator);
+      return hostId == null ? null : hostId.toString();
+    } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
   }
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
@@ -33,31 +33,11 @@ import javax.annotation.Nullable;
 @SuppressWarnings("deprecation") // using deprecated semconv
 class CassandraAttributesExtractor implements AttributesExtractor<CassandraRequest, ExecutionInfo> {
 
-  private static final ClassValue<Method> speculativeExecutionsMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("getSpeculativeExecutions");
-          } catch (NoSuchMethodException ignored) {
-            return null;
-          }
-        }
-      };
+  @Nullable
+  private static final Method GET_SPECULATIVE_EXECUTIONS =
+      findMethod(ExecutionInfo.class, "getSpeculativeExecutions");
 
-  private static final ClassValue<Method> hostIdMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("getHostId");
-          } catch (NoSuchMethodException ignored) {
-            return null;
-          }
-        }
-      };
+  @Nullable private static final Method GET_HOST_ID = findMethod(Host.class, "getHostId");
 
   @Override
   public void onStart(AttributesBuilder attributes, Context context, CassandraRequest request) {
@@ -117,8 +97,9 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
   @Nullable
   private static Integer getSpeculativeExecutionCount(ExecutionInfo executionInfo) {
     try {
-      Method method = speculativeExecutionsMethod.get(executionInfo.getClass());
-      return method == null ? null : (Integer) method.invoke(executionInfo);
+      return GET_SPECULATIVE_EXECUTIONS == null
+          ? null
+          : (Integer) GET_SPECULATIVE_EXECUTIONS.invoke(executionInfo);
     } catch (ReflectiveOperationException ignored) {
       return null;
     }
@@ -127,10 +108,18 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
   @Nullable
   private static String getCoordinatorId(Host coordinator) {
     try {
-      Method method = hostIdMethod.get(coordinator.getClass());
-      Object hostId = method == null ? null : method.invoke(coordinator);
+      Object hostId = GET_HOST_ID == null ? null : GET_HOST_ID.invoke(coordinator);
       return hostId == null ? null : hostId.toString();
     } catch (ReflectiveOperationException ignored) {
+      return null;
+    }
+  }
+
+  @Nullable
+  private static Method findMethod(Class<?> type, String name) {
+    try {
+      return type.getMethod(name);
+    } catch (NoSuchMethodException ignored) {
       return null;
     }
   }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraAttributesExtractor.java
@@ -30,6 +30,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.lang.reflect.Method;
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation") // using deprecated semconv
 class CassandraAttributesExtractor implements AttributesExtractor<CassandraRequest, ExecutionInfo> {
 
   private static final ClassValue<Method> speculativeExecutionsMethod =
@@ -59,9 +60,19 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
       };
 
   @Override
-  public void onStart(AttributesBuilder attributes, Context context, CassandraRequest request) {}
+  public void onStart(AttributesBuilder attributes, Context context, CassandraRequest request) {
+    if (emitStableDatabaseSemconv()) {
+      attributes.put(CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
+      attributes.put(CASSANDRA_PAGE_SIZE, request.getPageSize());
+      attributes.put(CASSANDRA_QUERY_IDEMPOTENT, request.isIdempotent());
+    }
+    if (emitOldDatabaseSemconv()) {
+      attributes.put(DB_CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
+      attributes.put(DB_CASSANDRA_PAGE_SIZE, request.getPageSize());
+      attributes.put(DB_CASSANDRA_IDEMPOTENCE, request.isIdempotent());
+    }
+  }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   @Override
   public void onEnd(
       AttributesBuilder attributes,
@@ -90,17 +101,6 @@ class CassandraAttributesExtractor implements AttributesExtractor<CassandraReque
       if (emitOldDatabaseSemconv()) {
         attributes.put(DB_CASSANDRA_COORDINATOR_ID, coordinatorId);
       }
-    }
-
-    if (emitStableDatabaseSemconv()) {
-      attributes.put(CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
-      attributes.put(CASSANDRA_PAGE_SIZE, request.getPageSize());
-      attributes.put(CASSANDRA_QUERY_IDEMPOTENT, request.isIdempotent());
-    }
-    if (emitOldDatabaseSemconv()) {
-      attributes.put(DB_CASSANDRA_CONSISTENCY_LEVEL, request.getConsistencyLevel());
-      attributes.put(DB_CASSANDRA_PAGE_SIZE, request.getPageSize());
-      attributes.put(DB_CASSANDRA_IDEMPOTENCE, request.isIdempotent());
     }
 
     Integer speculativeExecutionCount = getSpeculativeExecutionCount(executionInfo);

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -9,6 +9,7 @@ import static java.util.Collections.singleton;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
@@ -22,18 +23,19 @@ import javax.annotation.Nullable;
 abstract class CassandraRequest {
 
   static CassandraRequest create(Session session, String queryText, boolean parameterizedQuery) {
-    return create(session, singleton(queryText), parameterizedQuery, null, null);
+    return create(session, singleton(queryText), parameterizedQuery, null, null, null);
   }
 
   static CassandraRequest create(Session session, String queryText) {
-    return create(session, singleton(queryText), false, null, null);
+    return create(session, singleton(queryText), false, null, null, null);
   }
 
   static CassandraRequest create(Session session, Statement statement) {
     if (statement instanceof BatchStatement) {
       return create(session, (BatchStatement) statement);
     }
-    return create(session, singleton(getQuery(statement)), hasQueryValues(statement), null, null);
+    return create(
+        session, singleton(getQuery(statement)), hasQueryValues(statement), null, null, statement);
   }
 
   private static CassandraRequest create(Session session, BatchStatement batchStatement) {
@@ -71,7 +73,8 @@ abstract class CassandraRequest {
         queryTexts,
         allQueriesParameterizedResult,
         mixedParameterizedQueries,
-        Long.valueOf(batchStatement.size()));
+        Long.valueOf(batchStatement.size()),
+        batchStatement);
   }
 
   private static CassandraRequest create(
@@ -79,9 +82,29 @@ abstract class CassandraRequest {
       Collection<String> queryTexts,
       boolean allQueriesParameterized,
       @Nullable List<Boolean> mixedParameterizedQueries,
-      @Nullable Long batchSize) {
+      @Nullable Long batchSize,
+      @Nullable Statement statement) {
+    QueryOptions queryOptions = session.getCluster().getConfiguration().getQueryOptions();
+    String consistencyLevel =
+        (statement == null || statement.getConsistencyLevel() == null)
+            ? queryOptions.getConsistencyLevel().name()
+            : statement.getConsistencyLevel().name();
+    int pageSize =
+        (statement == null || statement.getFetchSize() <= 0)
+            ? queryOptions.getFetchSize()
+            : statement.getFetchSize();
+    Boolean idempotent = statement == null ? null : statement.isIdempotent();
+    boolean queryIdempotent =
+        idempotent == null ? queryOptions.getDefaultIdempotence() : idempotent;
     return new AutoValue_CassandraRequest(
-        session, queryTexts, allQueriesParameterized, mixedParameterizedQueries, batchSize);
+        session,
+        queryTexts,
+        allQueriesParameterized,
+        mixedParameterizedQueries,
+        batchSize,
+        consistencyLevel,
+        pageSize,
+        queryIdempotent);
   }
 
   private static String getQuery(Statement statement) {
@@ -123,4 +146,10 @@ abstract class CassandraRequest {
 
   @Nullable
   abstract Long getBatchSize();
+
+  abstract String getConsistencyLevel();
+
+  abstract int getPageSize();
+
+  abstract boolean isIdempotent();
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraRequest.java
@@ -89,10 +89,14 @@ abstract class CassandraRequest {
         (statement == null || statement.getConsistencyLevel() == null)
             ? queryOptions.getConsistencyLevel().name()
             : statement.getConsistencyLevel().name();
-    int pageSize =
+    int fetchSize =
         (statement == null || statement.getFetchSize() <= 0)
             ? queryOptions.getFetchSize()
             : statement.getFetchSize();
+    // the driver treats Integer.MAX_VALUE as a request to disable paging and never sends a page
+    // size, so there is no page size to report
+    Long pageSize =
+        (fetchSize <= 0 || fetchSize == Integer.MAX_VALUE) ? null : Long.valueOf(fetchSize);
     Boolean idempotent = statement == null ? null : statement.isIdempotent();
     boolean queryIdempotent =
         idempotent == null ? queryOptions.getDefaultIdempotence() : idempotent;
@@ -149,7 +153,8 @@ abstract class CassandraRequest {
 
   abstract String getConsistencyLevel();
 
-  abstract int getPageSize();
+  @Nullable
+  abstract Long getPageSize();
 
   abstract boolean isIdempotent();
 }

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
@@ -19,6 +20,12 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_CONSISTENCY_LEVEL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_COORDINATOR_DC;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_COORDINATOR_ID;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_IDEMPOTENCE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_PAGE_SIZE;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CASSANDRA_TABLE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -30,6 +37,9 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.Host;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
@@ -64,6 +74,9 @@ class CassandraClientTest {
   private static final Logger logger = LoggerFactory.getLogger(CassandraClientTest.class);
 
   private static final ExecutorService executor = Executors.newCachedThreadPool();
+
+  private static final boolean speculativeExecutionCountAvailable = hasSpeculativeExecutionCount();
+  private static final boolean coordinatorIdAvailable = hasCoordinatorId();
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -136,9 +149,21 @@ class CassandraClientTest {
                                   emitStableDatabaseSemconv() ? "USE" : null),
                               equalTo(
                                   DB_QUERY_SUMMARY,
-                                  emitStableDatabaseSemconv()
-                                      ? "USE " + parameter.keyspace
-                                      : null))),
+                                  emitStableDatabaseSemconv() ? "USE " + parameter.keyspace : null),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span ->
@@ -158,6 +183,20 @@ class CassandraClientTest {
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
                               equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()),
                               equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     } else {
       testing.waitAndAssertTraces(
@@ -179,6 +218,20 @@ class CassandraClientTest {
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
                               equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()),
                               equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table))));
     }
   }
@@ -220,9 +273,21 @@ class CassandraClientTest {
                                   emitStableDatabaseSemconv() ? "USE" : null),
                               equalTo(
                                   DB_QUERY_SUMMARY,
-                                  emitStableDatabaseSemconv()
-                                      ? "USE " + parameter.keyspace
-                                      : null))),
+                                  emitStableDatabaseSemconv() ? "USE " + parameter.keyspace : null),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
@@ -243,6 +308,20 @@ class CassandraClientTest {
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
                               equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()),
                               equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
@@ -269,6 +348,20 @@ class CassandraClientTest {
                                   DB_QUERY_SUMMARY,
                                   emitStableDatabaseSemconv() ? parameter.spanName : null),
                               equalTo(maybeStable(DB_OPERATION), parameter.operation),
+                              equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                              equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                  coordinatorIdAvailable
+                                      ? val -> val.isInstanceOf(String.class)
+                                      : val -> val.isNull()),
+                              equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                              equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                              satisfies(
+                                  maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                  speculativeExecutionCountAvailable
+                                      ? val -> val.isEqualTo(0)
+                                      : val -> val.isNull()),
                               equalTo(maybeStable(DB_CASSANDRA_TABLE), parameter.table)),
                   span ->
                       span.hasName("callbackListener")
@@ -315,6 +408,20 @@ class CassandraClientTest {
                                     ? "INSERT simple_values_test.users"
                                     : null),
                             equalTo(maybeStable(DB_OPERATION), "INSERT"),
+                            equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "LOCAL_ONE"),
+                            equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                            satisfies(
+                                maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                coordinatorIdAvailable
+                                    ? val -> val.isInstanceOf(String.class)
+                                    : val -> val.isNull()),
+                            equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), false),
+                            equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 5000),
+                            satisfies(
+                                maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                speculativeExecutionCountAvailable
+                                    ? val -> val.isEqualTo(0)
+                                    : val -> val.isNull()),
                             equalTo(maybeStable(DB_CASSANDRA_TABLE), "simple_values_test.users"))));
   }
 
@@ -416,7 +523,41 @@ class CassandraClientTest {
                                 maybeStable(DB_CASSANDRA_TABLE),
                                 emitStableDatabaseSemconv()
                                     ? scenario.collectionName
-                                    : scenario.oldCollectionName()))));
+                                    : scenario.oldCollectionName()),
+                            equalTo(
+                                maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL),
+                                scenario.consistencyLevel),
+                            equalTo(maybeStable(DB_CASSANDRA_COORDINATOR_DC), "datacenter1"),
+                            satisfies(
+                                maybeStable(DB_CASSANDRA_COORDINATOR_ID),
+                                coordinatorIdAvailable
+                                    ? val -> val.isInstanceOf(String.class)
+                                    : val -> val.isNull()),
+                            equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), scenario.idempotent),
+                            equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), scenario.pageSize),
+                            satisfies(
+                                maybeStable(DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT),
+                                speculativeExecutionCountAvailable
+                                    ? val -> val.isEqualTo(0)
+                                    : val -> val.isNull()))));
+  }
+
+  private static boolean hasSpeculativeExecutionCount() {
+    try {
+      ExecutionInfo.class.getMethod("getSpeculativeExecutions");
+      return true;
+    } catch (NoSuchMethodException ignored) {
+      return false;
+    }
+  }
+
+  private static boolean hasCoordinatorId() {
+    try {
+      Host.class.getMethod("getHostId");
+      return true;
+    } catch (NoSuchMethodException ignored) {
+      return false;
+    }
   }
 
   private static Stream<Arguments> batchScenarios() {
@@ -429,6 +570,7 @@ class CassandraClientTest {
                 .oldSpanName("DB Query")
                 .querySummary("BATCH")
                 .batchSize(0)
+                .idempotent(true)
                 .build()),
         argumentSet(
             "single",
@@ -437,7 +579,11 @@ class CassandraClientTest {
                     session -> {
                       PreparedStatement insert =
                           session.prepare("INSERT INTO batch_test.records (id, num) values (?, ?)");
-                      return new BatchStatement().add(insert.bind(1, 1));
+                      BatchStatement batch = new BatchStatement().add(insert.bind(1, 1));
+                      batch.setConsistencyLevel(ConsistencyLevel.ONE);
+                      batch.setFetchSize(123);
+                      batch.setIdempotent(true);
+                      return batch;
                     })
                 .spanName("INSERT batch_test.records")
                 .oldSpanName("INSERT batch_test.records")
@@ -446,6 +592,9 @@ class CassandraClientTest {
                 .querySummary("INSERT batch_test.records")
                 .operationName("INSERT")
                 .collectionName("batch_test.records")
+                .consistencyLevel("ONE")
+                .pageSize(123)
+                .idempotent(true)
                 .build()),
         argumentSet(
             "twoSameOperation",
@@ -630,6 +779,9 @@ class CassandraClientTest {
     final Long batchSize;
     final String operationName;
     final String collectionName;
+    final String consistencyLevel;
+    final int pageSize;
+    final boolean idempotent;
 
     BatchScenario(Builder builder) {
       this.buildBatch = builder.buildBatch;
@@ -641,6 +793,9 @@ class CassandraClientTest {
       this.batchSize = builder.batchSize;
       this.operationName = builder.operationName;
       this.collectionName = builder.collectionName;
+      this.consistencyLevel = builder.consistencyLevel;
+      this.pageSize = builder.pageSize;
+      this.idempotent = builder.idempotent;
     }
 
     static Builder builder() {
@@ -665,6 +820,9 @@ class CassandraClientTest {
       private Long batchSize;
       private String operationName;
       private String collectionName;
+      private String consistencyLevel = "LOCAL_ONE";
+      private int pageSize = 5000;
+      private boolean idempotent;
 
       Builder buildBatch(Function<Session, BatchStatement> buildBatch) {
         this.buildBatch = buildBatch;
@@ -708,6 +866,21 @@ class CassandraClientTest {
 
       Builder collectionName(String collectionName) {
         this.collectionName = collectionName;
+        return this;
+      }
+
+      Builder consistencyLevel(String consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+        return this;
+      }
+
+      Builder pageSize(int pageSize) {
+        this.pageSize = pageSize;
+        return this;
+      }
+
+      Builder idempotent(boolean idempotent) {
+        this.idempotent = idempotent;
         return this;
       }
 

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -32,6 +33,8 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.CASSANDRA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -44,11 +47,13 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.StatusData;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -115,6 +120,45 @@ class CassandraClientTest {
             .build();
     cleanup.deferAfterAll(cluster);
     cleanup.deferAfterAll(() -> executor.shutdownNow());
+  }
+
+  @Test
+  void shouldEmitRequestAttributesWhenExecutionFails() {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+    SimpleStatement statement = new SimpleStatement("SELECT * FROM missing_table");
+    statement.setConsistencyLevel(ConsistencyLevel.ONE);
+    statement.setFetchSize(123);
+    statement.setIdempotent(true);
+
+    Throwable thrown = catchThrowable(() -> session.execute(statement));
+
+    assertThat(thrown).isInstanceOf(InvalidQueryException.class);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("SELECT missing_table")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error())
+                        .hasException(thrown)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM missing_table"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "SELECT missing_table" : null),
+                            equalTo(maybeStable(DB_OPERATION), "SELECT"),
+                            equalTo(maybeStable(DB_CASSANDRA_TABLE), "missing_table"),
+                            equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "ONE"),
+                            equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), true),
+                            equalTo(maybeStable(DB_CASSANDRA_PAGE_SIZE), 123),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? InvalidQueryException.class.getName()
+                                    : null))));
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
+++ b/instrumentation/cassandra/cassandra-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/cassandra/v3_0/CassandraClientTest.java
@@ -161,6 +161,45 @@ class CassandraClientTest {
                                     : null))));
   }
 
+  @Test
+  void shouldOmitPageSizeWhenPagingIsDisabled() {
+    Session session = cluster.connect();
+    cleanup.deferCleanup(session);
+    SimpleStatement statement = new SimpleStatement("SELECT * FROM missing_table");
+    statement.setConsistencyLevel(ConsistencyLevel.ONE);
+    // the driver treats Integer.MAX_VALUE as a request to disable paging
+    statement.setFetchSize(Integer.MAX_VALUE);
+    statement.setIdempotent(true);
+
+    Throwable thrown = catchThrowable(() -> session.execute(statement));
+
+    assertThat(thrown).isInstanceOf(InvalidQueryException.class);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("SELECT missing_table")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error())
+                        .hasException(thrown)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CASSANDRA),
+                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM missing_table"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "SELECT missing_table" : null),
+                            equalTo(maybeStable(DB_OPERATION), "SELECT"),
+                            equalTo(maybeStable(DB_CASSANDRA_TABLE), "missing_table"),
+                            equalTo(maybeStable(DB_CASSANDRA_CONSISTENCY_LEVEL), "ONE"),
+                            equalTo(maybeStable(DB_CASSANDRA_IDEMPOTENCE), true),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? InvalidQueryException.class.getName()
+                                    : null))));
+  }
+
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideSyncParameters")
   void syncTest(Parameter parameter) {


### PR DESCRIPTION
The Cassandra driver 3 instrumentation now emits the same Cassandra-specific attributes the driver 4 instrumentation already emits, so spans carry comparable detail regardless of which driver generation an application uses.

Under the stable database conventions the spans gain `cassandra.consistency.level`, `cassandra.page.size`, `cassandra.query.idempotent`, `cassandra.coordinator.dc`, `cassandra.coordinator.id`, and `cassandra.speculative_execution.count`. When the old database conventions are still enabled, the same values are emitted under the deprecated `db.cassandra.*` keys.

The three request attributes are resolved when the operation starts, falling back to the cluster's `QueryOptions` defaults whenever a statement does not override them. The coordinator and speculative-execution attributes come from the `ExecutionInfo` of the completed response.

Driver 3 treats a fetch size of `Integer.MAX_VALUE` as a request to disable paging, converting it to `-1` and omitting the page size from the request it sends. The page size attribute is left off entirely in that case rather than reporting a value the driver never uses.

`Host.getHostId` and `ExecutionInfo.getSpeculativeExecutions` were both added partway through the 3.x line, so they are looked up reflectively and cached per class. Drivers that predate them keep working and simply omit `cassandra.coordinator.id` and `cassandra.speculative_execution.count`.