### PR TITLE
Align JMX metric descriptions

### DIFF
--- a/instrumentation/jmx-metrics/library/activemq.md
+++ b/instrumentation/jmx-metrics/library/activemq.md
@@ -4,26 +4,26 @@ Here is the list of metrics based on MBeans exposed by ActiveMQ.
 
 For now, only ActiveMQ classic is supported.
 
-| Metric Name                               | Type          | Unit         | Attributes                                                                  | Description                                                           |
-| ----------------------------------------- | ------------- | ------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| activemq.producer.count                   | UpDownCounter | {producer}   | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of producers attached to this destination                  |
-| activemq.consumer.count                   | UpDownCounter | {consumer}   | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of consumers subscribed to this destination                |
-| activemq.destination.memory.usage         | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of used memory by this destination                         |
-| activemq.destination.memory.limit         | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of configured memory limit for this destination            |
-| activemq.destination.temp.utilization     | Gauge         | 1            | messaging.destination.name, activemq.broker.name, activemq.destination.type | The fraction of non-persistent storage used by this destination       |
-| activemq.destination.temp.limit           | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of configured non-persistent storage limit                 |
-| activemq.message.queue.size               | UpDownCounter | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The current number of messages waiting to be consumed                 |
-| activemq.message.expired                  | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages not delivered because they expired             |
-| activemq.message.enqueued                 | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages sent to this destination                       |
-| activemq.message.dequeued                 | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages acknowledged and removed from this destination |
-| activemq.message.enqueue.average_duration | Gauge         | s            | messaging.destination.name, activemq.broker.name, activemq.destination.type | The average time a message was held on this destination               |
-| activemq.connection.count                 | UpDownCounter | {connection} | activemq.broker.name                                                        | The number of active connections                                      |
-| activemq.memory.utilization               | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker memory used                                    |
-| activemq.memory.limit                     | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker memory limit                          |
-| activemq.store.utilization                | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker persistent storage used                        |
-| activemq.store.limit                      | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker persistent storage limit              |
-| activemq.temp.utilization                 | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker non-persistent storage used                    |
-| activemq.temp.limit                       | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker non-persistent storage limit          |
+| Metric Name                               | Type          | Unit         | Attributes                                                                  | Description                                                                 |
+| ----------------------------------------- | ------------- | ------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| activemq.producer.count                   | UpDownCounter | {producer}   | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of producers attached to this destination.                       |
+| activemq.consumer.count                   | UpDownCounter | {consumer}   | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of consumers subscribed to this destination.                     |
+| activemq.destination.memory.usage         | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of used memory by this destination.                              |
+| activemq.destination.memory.limit         | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of configured memory limit for this destination.                 |
+| activemq.destination.temp.utilization     | Gauge         | 1            | messaging.destination.name, activemq.broker.name, activemq.destination.type | The fraction of non-persistent storage used by this destination.            |
+| activemq.destination.temp.limit           | UpDownCounter | By           | messaging.destination.name, activemq.broker.name, activemq.destination.type | The amount of configured non-persistent storage limit for this destination. |
+| activemq.message.queue.size               | UpDownCounter | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The current number of messages waiting to be consumed.                      |
+| activemq.message.expired                  | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages not delivered because they expired.                  |
+| activemq.message.enqueued                 | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages sent to this destination.                            |
+| activemq.message.dequeued                 | Counter       | {message}    | messaging.destination.name, activemq.broker.name, activemq.destination.type | The number of messages acknowledged and removed from this destination.      |
+| activemq.message.enqueue.average_duration | Gauge         | s            | messaging.destination.name, activemq.broker.name, activemq.destination.type | The average time a message was held on this destination.                    |
+| activemq.connection.count                 | UpDownCounter | {connection} | activemq.broker.name                                                        | The number of active connections.                                           |
+| activemq.memory.utilization               | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker memory used.                                         |
+| activemq.memory.limit                     | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker memory limit.                               |
+| activemq.store.utilization                | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker persistent storage used.                             |
+| activemq.store.limit                      | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker persistent storage limit.                   |
+| activemq.temp.utilization                 | Gauge         | 1            | activemq.broker.name                                                        | The fraction of broker non-persistent storage used.                         |
+| activemq.temp.limit                       | UpDownCounter | By           | activemq.broker.name                                                        | The amount of configured broker non-persistent storage limit.               |
 
 ## Attributes
 

--- a/instrumentation/jmx-metrics/library/hadoop.md
+++ b/instrumentation/jmx-metrics/library/hadoop.md
@@ -2,15 +2,15 @@
 
 Here is the list of metrics based on MBeans exposed by Hadoop.
 
-| Metric Name                     | Type          | Unit         | Attributes       | Description                                            |
-| ------------------------------- | ------------- | ------------ | ---------------- | ------------------------------------------------------ |
-| hadoop.dfs.capacity.limit       | UpDownCounter | By           | hadoop.node.name | Current raw capacity of data nodes.                    |
-| hadoop.dfs.capacity.used        | UpDownCounter | By           | hadoop.node.name | Current used capacity across all data nodes.           |
-| hadoop.dfs.block.count          | UpDownCounter | {block}      | hadoop.node.name | Current number of allocated blocks in the system.      |
-| hadoop.dfs.block.missing        | UpDownCounter | {block}      | hadoop.node.name | Current number of missing blocks.                      |
-| hadoop.dfs.block.corrupt        | UpDownCounter | {block}      | hadoop.node.name | Current number of blocks with corrupt replicas.        |
-| hadoop.dfs.volume.failure.count | Counter       | {failure}    | hadoop.node.name | Total number of volume failures across all data nodes. |
-| hadoop.dfs.file.count           | UpDownCounter | {file}       | hadoop.node.name | Current number of files and directories.               |
-| hadoop.dfs.connection.count     | UpDownCounter | {connection} | hadoop.node.name | Current number of connections.                         |
-| hadoop.datanode.live            | UpDownCounter | {node}       | hadoop.node.name | Number of data nodes which are currently live.         |
-| hadoop.datanode.dead            | UpDownCounter | {node}       | hadoop.node.name | Number of data nodes which are currently dead.         |
+| Metric Name                     | Type          | Unit         | Attributes       | Description                                           |
+| ------------------------------- | ------------- | ------------ | ---------------- | ----------------------------------------------------- |
+| hadoop.dfs.capacity.limit       | UpDownCounter | By           | hadoop.node.name | Current raw capacity of DataNodes.                    |
+| hadoop.dfs.capacity.used        | UpDownCounter | By           | hadoop.node.name | Current used capacity across all DataNodes.           |
+| hadoop.dfs.block.count          | UpDownCounter | {block}      | hadoop.node.name | Current number of allocated blocks in the system.     |
+| hadoop.dfs.block.missing        | UpDownCounter | {block}      | hadoop.node.name | Current number of missing blocks.                     |
+| hadoop.dfs.block.corrupt        | UpDownCounter | {block}      | hadoop.node.name | Current number of blocks with corrupt replicas.       |
+| hadoop.dfs.volume.failure.count | Counter       | {failure}    | hadoop.node.name | Total number of volume failures across all DataNodes. |
+| hadoop.dfs.file.count           | UpDownCounter | {file}       | hadoop.node.name | Current number of files and directories.              |
+| hadoop.dfs.connection.count     | UpDownCounter | {connection} | hadoop.node.name | Current number of connections.                        |
+| hadoop.datanode.live            | UpDownCounter | {node}       | hadoop.node.name | Number of data nodes which are currently live.        |
+| hadoop.datanode.dead            | UpDownCounter | {node}       | hadoop.node.name | Number of data nodes which are currently dead.        |

--- a/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/camel.yaml
+++ b/instrumentation/jmx-metrics/library/src/main/resources/jmx/rules/camel.yaml
@@ -55,7 +55,7 @@ rules:
         metric: exchange.redelivered.count
         type: counter
         unit: "{exchange}"
-        desc: Number of exchanges redelivered (internal only)  since context start-up or the last reset operation.
+        desc: Number of exchanges redelivered (internal only) since context start-up or the last reset operation.
       # camel.context.exchange.redelivered.external
       ExternalRedeliveries:
         metric: exchange.redelivered.external
@@ -148,7 +148,7 @@ rules:
         metric: exchange.redelivered.count
         type: counter
         unit: "{exchange}"
-        desc: Number of exchanges redelivered (internal only)  since route start-up or the last reset operation.
+        desc: Number of exchanges redelivered (internal only) since route start-up or the last reset operation.
       # camel.route.exchange.redelivered.external
       ExternalRedeliveries:
         metric: exchange.redelivered.external
@@ -243,7 +243,7 @@ rules:
         metric: exchange.redelivered.count
         type: counter
         unit: "{exchange}"
-        desc: Number of exchanges redelivered (internal only)  since selected processor start-up or the last reset operation.
+        desc: Number of exchanges redelivered (internal only) since selected processor start-up or the last reset operation.
       # camel.processor.exchange.redelivered.external
       ExternalRedeliveries:
         metric: exchange.redelivered.external

--- a/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CamelTest.java
+++ b/instrumentation/jmx-metrics/library/src/test/java/io/opentelemetry/instrumentation/jmx/rules/CamelTest.java
@@ -240,7 +240,7 @@ class CamelTest extends TargetSystemTest {
                 metric
                     .isCounter()
                     .hasDescription(
-                        "Number of exchanges redelivered (internal only)  since context start-up or the last reset operation.")
+                        "Number of exchanges redelivered (internal only) since context start-up or the last reset operation.")
                     .hasUnit("{exchange}")
                     .hasDataPointsWithIntValues(value -> value.isEqualTo(0))
                     .hasDataPointsWithAttributes(contextAttributes))
@@ -369,7 +369,7 @@ class CamelTest extends TargetSystemTest {
                 metric
                     .isCounter()
                     .hasDescription(
-                        "Number of exchanges redelivered (internal only)  since route start-up or the last reset operation.")
+                        "Number of exchanges redelivered (internal only) since route start-up or the last reset operation.")
                     .hasUnit("{exchange}")
                     .hasDataPointsWithIntValues(value -> value.isEqualTo(0))
                     .hasDataPointsWithAttributes(routeAttributes))
@@ -512,7 +512,7 @@ class CamelTest extends TargetSystemTest {
                 metric
                     .isCounter()
                     .hasDescription(
-                        "Number of exchanges redelivered (internal only)  since selected processor start-up or the last reset operation.")
+                        "Number of exchanges redelivered (internal only) since selected processor start-up or the last reset operation.")
                     .hasUnit("{exchange}")
                     .hasDataPointsWithIntValues(value -> value.isEqualTo(0))
                     .hasDataPointsWithAttributes(

--- a/instrumentation/jmx-metrics/model/activemq.yaml
+++ b/instrumentation/jmx-metrics/model/activemq.yaml
@@ -42,7 +42,7 @@ groups:
     metric_name: activemq.consumer.count
     type: metric
     stability: development
-    brief: The number of consumers subscribed to this destination
+    brief: The number of consumers subscribed to this destination.
     unit: "{consumer}"
     instrument: updowncounter
     attributes:
@@ -54,7 +54,7 @@ groups:
     metric_name: activemq.destination.memory.usage
     type: metric
     stability: development
-    brief: The amount of used memory by this destination
+    brief: The amount of used memory by this destination.
     unit: By
     instrument: updowncounter
     attributes:
@@ -66,7 +66,7 @@ groups:
     metric_name: activemq.destination.memory.limit
     type: metric
     stability: development
-    brief: The amount of configured memory limit for this destination
+    brief: The amount of configured memory limit for this destination.
     unit: By
     instrument: updowncounter
     attributes:
@@ -78,7 +78,7 @@ groups:
     metric_name: activemq.destination.temp.utilization
     type: metric
     stability: development
-    brief: The fraction of non-persistent storage used by this destination
+    brief: The fraction of non-persistent storage used by this destination.
     unit: "1"
     instrument: gauge
     attributes:
@@ -90,7 +90,7 @@ groups:
     metric_name: activemq.destination.temp.limit
     type: metric
     stability: development
-    brief: The amount of configured non-persistent storage limit for this destination
+    brief: The amount of configured non-persistent storage limit for this destination.
     unit: By
     instrument: updowncounter
     attributes:
@@ -102,7 +102,7 @@ groups:
     metric_name: activemq.message.queue.size
     type: metric
     stability: development
-    brief: The current number of messages waiting to be consumed
+    brief: The current number of messages waiting to be consumed.
     unit: "{message}"
     instrument: updowncounter
     attributes:
@@ -114,7 +114,7 @@ groups:
     metric_name: activemq.message.expired
     type: metric
     stability: development
-    brief: The number of messages not delivered because they expired
+    brief: The number of messages not delivered because they expired.
     unit: "{message}"
     instrument: counter
     attributes:
@@ -126,7 +126,7 @@ groups:
     metric_name: activemq.message.enqueued
     type: metric
     stability: development
-    brief: The number of messages sent to this destination
+    brief: The number of messages sent to this destination.
     unit: "{message}"
     instrument: counter
     attributes:
@@ -138,7 +138,7 @@ groups:
     metric_name: activemq.message.dequeued
     type: metric
     stability: development
-    brief: The number of messages acknowledged and removed from this destination
+    brief: The number of messages acknowledged and removed from this destination.
     unit: "{message}"
     instrument: counter
     attributes:
@@ -150,7 +150,7 @@ groups:
     metric_name: activemq.message.enqueue.average_duration
     type: metric
     stability: development
-    brief: The average time a message was held on this destination
+    brief: The average time a message was held on this destination.
     unit: "s"
     instrument: gauge
     attributes:
@@ -162,7 +162,7 @@ groups:
     metric_name: activemq.connection.count
     type: metric
     stability: development
-    brief: The number of active connections
+    brief: The number of active connections.
     unit: "{connection}"
     instrument: updowncounter
     attributes:
@@ -172,7 +172,7 @@ groups:
     metric_name: activemq.memory.utilization
     type: metric
     stability: development
-    brief: The fraction of broker memory used
+    brief: The fraction of broker memory used.
     unit: "1"
     instrument: gauge
     attributes:
@@ -182,7 +182,7 @@ groups:
     metric_name: activemq.memory.limit
     type: metric
     stability: development
-    brief: The amount of configured broker memory limit
+    brief: The amount of configured broker memory limit.
     unit: By
     instrument: updowncounter
     attributes:
@@ -192,7 +192,7 @@ groups:
     metric_name: activemq.store.utilization
     type: metric
     stability: development
-    brief: The fraction of broker persistent storage used
+    brief: The fraction of broker persistent storage used.
     unit: "1"
     instrument: gauge
     attributes:
@@ -202,7 +202,7 @@ groups:
     metric_name: activemq.store.limit
     type: metric
     stability: development
-    brief: The amount of configured broker persistent storage limit
+    brief: The amount of configured broker persistent storage limit.
     unit: By
     instrument: updowncounter
     attributes:
@@ -212,7 +212,7 @@ groups:
     metric_name: activemq.temp.utilization
     type: metric
     stability: development
-    brief: The fraction of broker non-persistent storage used
+    brief: The fraction of broker non-persistent storage used.
     unit: "1"
     instrument: gauge
     attributes:
@@ -222,7 +222,7 @@ groups:
     metric_name: activemq.temp.limit
     type: metric
     stability: development
-    brief: The amount of configured broker non-persistent storage limit
+    brief: The amount of configured broker non-persistent storage limit.
     unit: By
     instrument: updowncounter
     attributes:

--- a/instrumentation/jmx-metrics/model/camel.yaml
+++ b/instrumentation/jmx-metrics/model/camel.yaml
@@ -114,7 +114,7 @@ groups:
     metric_name: camel.context.exchange.redelivered.count
     type: metric
     stability: development
-    brief: Number of exchanges redelivered (internal only)  since context start-up or the last reset operation.
+    brief: Number of exchanges redelivered (internal only) since context start-up or the last reset operation.
     unit: "{exchange}"
     instrument: counter
     attributes:
@@ -251,7 +251,7 @@ groups:
     metric_name: camel.route.exchange.redelivered.count
     type: metric
     stability: development
-    brief: Number of exchanges redelivered (internal only)  since route start-up or the last reset operation.
+    brief: Number of exchanges redelivered (internal only) since route start-up or the last reset operation.
     unit: "{exchange}"
     instrument: counter
     attributes:
@@ -406,7 +406,7 @@ groups:
     metric_name: camel.processor.exchange.redelivered.count
     type: metric
     stability: development
-    brief: Number of exchanges redelivered (internal only)  since selected processor start-up or the last reset operation.
+    brief: Number of exchanges redelivered (internal only) since selected processor start-up or the last reset operation.
     unit: "{exchange}"
     instrument: counter
     attributes:

--- a/instrumentation/jmx-metrics/model/tomcat.yaml
+++ b/instrumentation/jmx-metrics/model/tomcat.yaml
@@ -76,7 +76,7 @@ groups:
     metric_name: tomcat.request.duration.sum
     stability: development
     type: metric
-    brief: The total duration of requests processed.
+    brief: Total time of processing all requests.
     unit: "s"
     instrument: counter
     attributes:
@@ -86,7 +86,7 @@ groups:
     metric_name: tomcat.thread.count
     stability: development
     type: metric
-    brief: Tomcat thread count.
+    brief: Total thread count of the thread pool.
     unit: "{thread}"
     instrument: updowncounter
     attributes:
@@ -107,7 +107,7 @@ groups:
     metric_name: tomcat.thread.limit
     stability: development
     type: metric
-    brief: Tomcat thread limit.
+    brief: Maximum possible number of threads in the thread pool.
     unit: "{thread}"
     instrument: updowncounter
     attributes:
@@ -117,7 +117,7 @@ groups:
     metric_name: tomcat.thread.busy.count
     stability: development
     type: metric
-    brief: Tomcat busy thread count.
+    brief: Number of busy threads in the thread pool.
     unit: "{thread}"
     instrument: updowncounter
     attributes:


### PR DESCRIPTION
Aligns 28 ActiveMQ, Camel, Tomcat, and Hadoop metric descriptions across the JMX runtime rules, the semantic convention model, the documentation, and test expectations. Each description is duplicated in up to four places, and Weaver's live-check validates only metric names and units, so these copies drifted without failing CI.

Where copies disagreed, the runtime rule `desc` wins: it is the text actually exported, and the only copy pinned by test assertions. So most of the diff updates model `brief` values and Markdown tables to match what is already emitted.

The exception is three Camel `exchange.redelivered.count` rules whose emitted text contained a doubled space. Removing it is the only user-visible change here, and `CamelTest` is updated to match.

Future Weaver enforcement of description/brief consistency, registry-driven Markdown, and duplication reduction is already tracked in #19227.