### PR TITLE
Do not treat deprecated capture settings as glob selectors

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -9,6 +9,8 @@ import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.api.internal.SystemProperty;
 import java.util.HashSet;
 import java.util.List;
@@ -72,6 +74,33 @@ public final class SelectorConfig {
     return deprecated == null || deprecated.isEmpty()
         ? null
         : IncludeExclude.builder().setIncluded(deprecated).build();
+  }
+
+  /**
+   * Returns the configured selector resolved into the names to capture.
+   *
+   * <p>Unlike {@link #resolve}, the values of the deprecated include-only setting are matched
+   * literally rather than as globs. Those settings never supported {@code *} as capturing
+   * everything, so interpreting their values as globs would silently widen what is captured.
+   *
+   * @param systemPropertyFallback whether to fall back to the flat system properties when the
+   *     declarative configuration does not contain a value. This is needed by library
+   *     instrumentation entry points that have no programmatic configuration surface.
+   */
+  public static CapturedNames resolveCapturedNames(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      boolean systemPropertyFallback,
+      CaseSensitivity caseSensitivity) {
+    IncludeExclude selector =
+        getSelector(config, instrumentationName, selectorName, systemPropertyFallback);
+    if (selector != null) {
+      return CapturedNames.create(selector, caseSensitivity);
+    }
+    return CapturedNames.createExact(
+        getDeprecated(config, instrumentationName, selectorName, systemPropertyFallback),
+        caseSensitivity);
   }
 
   /**

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -222,6 +224,51 @@ class SelectorConfigTest {
     assertThat(literal.test("embedded-value")).isFalse();
     assertThat(literal.test("*")).isTrue();
     assertThat(literal.test("other")).isFalse();
+  }
+
+  @Test
+  void resolveCapturedNamesMatchesDeprecatedValuesLiterally() {
+    DeclarativeConfigProperties config = mockConfig();
+    when(config.getScalarList("capture_mdc_attributes/development", String.class))
+        .thenReturn(singletonList("*"));
+
+    CapturedNames captured =
+        SelectorConfig.resolveCapturedNames(
+            config, "resolve-captured-names", SELECTOR, false, CaseSensitivity.CASE_SENSITIVE);
+
+    // the deprecated setting never supported wildcards, so "*" captures nothing unless a name is
+    // literally called "*"
+    assertThat(captured.isEmpty()).isFalse();
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(captured.exactNames()).containsExactly("*");
+  }
+
+  @Test
+  void resolveCapturedNamesMatchesSelectorPatternsAsGlobs() {
+    DeclarativeConfigProperties config = mockConfig();
+    when(config.get("mdc_attributes/development").getScalarList("included", String.class))
+        .thenReturn(singletonList("prefix.*"));
+
+    CapturedNames captured =
+        SelectorConfig.resolveCapturedNames(
+            config, "resolve-captured-selector", SELECTOR, false, CaseSensitivity.CASE_SENSITIVE);
+
+    assertThat(captured.enumerateNames()).isTrue();
+    assertThat(captured.matchingNames(asList("prefix.value", "other")))
+        .containsExactly("prefix.value");
+  }
+
+  @Test
+  void resolveCapturedNamesCapturesNothingWhenUnconfigured() {
+    CapturedNames captured =
+        SelectorConfig.resolveCapturedNames(
+            mockConfig(),
+            "resolve-captured-absent",
+            SELECTOR,
+            false,
+            CaseSensitivity.CASE_SENSITIVE);
+
+    assertThat(captured.isEmpty()).isTrue();
   }
 
   private static DeclarativeConfigProperties mockConfig() {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CapturedNames.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/CapturedNames.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static java.util.Collections.unmodifiableList;
+
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * The names that an instrumentation captures from a carrier such as HTTP headers, gRPC metadata,
+ * messaging headers or servlet request parameters, resolved either from an {@link IncludeExclude}
+ * selector or, for the deprecated settings, from a list of exact names.
+ *
+ * <p>The two resolutions differ in what {@code *} and {@code ?} mean. In a selector they are glob
+ * wildcards, while the deprecated settings never supported them as wildcards, so {@link
+ * #createExact} matches their values literally. Interpreting those values as globs would silently
+ * widen what is captured: a value of {@code "*"} that previously looked for a name literally called
+ * {@code *}, and therefore captured nothing, would start capturing every name, including ones
+ * holding credentials.
+ *
+ * <p>Whether names are matched case-insensitively is a property of the carrier, so it is resolved
+ * here rather than by each caller. When it is, both the configured names and the names offered to
+ * {@link #matchingNames(Iterable)} are lowercased, and every name returned by this class is
+ * lowercase.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class CapturedNames {
+
+  @Nullable private final IncludeExclude selector;
+  // the exact names configured by a deprecated setting, which are matched literally
+  @Nullable private final Set<String> exactOnlyNames;
+  private final boolean caseInsensitive;
+  // the names that the selector includes literally, which are looked up directly so that getters
+  // which do not enumerate names keep working
+  private final List<String> exactNames;
+  // whether the selector can match names that are not listed in exactNames, which requires
+  // enumerating the names carried by each request
+  private final boolean enumerateNames;
+
+  /**
+   * Creates the names captured by a selector, whose patterns are matched as globs.
+   *
+   * @param selector the selector, or {@code null} when nothing is configured to be captured
+   */
+  public static CapturedNames create(
+      @Nullable IncludeExclude selector, CaseSensitivity caseSensitivity) {
+    return new CapturedNames(
+        selector == null || selector.isEmpty() ? null : selector, null, caseSensitivity);
+  }
+
+  /**
+   * Creates the names captured by a deprecated setting, whose values are exact names rather than
+   * glob patterns.
+   *
+   * @param names the exact names, or {@code null} when nothing is configured to be captured
+   */
+  public static CapturedNames createExact(
+      @Nullable Collection<String> names, CaseSensitivity caseSensitivity) {
+    if (names == null || names.isEmpty()) {
+      return new CapturedNames(null, null, caseSensitivity);
+    }
+    Set<String> exactOnlyNames = new LinkedHashSet<>();
+    for (String name : names) {
+      exactOnlyNames.add(normalize(name, caseSensitivity));
+    }
+    return new CapturedNames(null, exactOnlyNames, caseSensitivity);
+  }
+
+  private CapturedNames(
+      @Nullable IncludeExclude selector,
+      @Nullable Set<String> exactOnlyNames,
+      CaseSensitivity caseSensitivity) {
+    this.caseInsensitive = caseSensitivity == CaseSensitivity.CASE_INSENSITIVE;
+    this.selector = selector == null ? null : normalize(selector, caseSensitivity);
+    this.exactOnlyNames = exactOnlyNames;
+
+    Set<String> names = new LinkedHashSet<>();
+    boolean enumerate = false;
+    if (exactOnlyNames != null) {
+      names.addAll(exactOnlyNames);
+    } else if (this.selector != null) {
+      List<String> included = this.selector.getIncluded();
+      // a selector without included patterns matches every name that is not excluded
+      enumerate = included.isEmpty();
+      for (String pattern : included) {
+        if (pattern.indexOf('*') != -1 || pattern.indexOf('?') != -1) {
+          enumerate = true;
+        } else if (matches(pattern)) {
+          names.add(pattern);
+        }
+      }
+    }
+    this.exactNames = unmodifiableList(new ArrayList<>(names));
+    this.enumerateNames = enumerate;
+  }
+
+  /** Returns whether nothing is configured to be captured. */
+  public boolean isEmpty() {
+    return selector == null && exactOnlyNames == null;
+  }
+
+  /**
+   * Returns whether names that are not listed by {@link #exactNames()} can be captured, which
+   * requires enumerating the names carried by each request and passing them to {@link
+   * #matchingNames(Iterable)}.
+   */
+  public boolean enumerateNames() {
+    return enumerateNames;
+  }
+
+  /**
+   * Returns the captured names that are known without enumerating the names carried by a request,
+   * so that they can be looked up directly.
+   */
+  public List<String> exactNames() {
+    return exactNames;
+  }
+
+  /**
+   * Returns the captured names among {@code enumeratedNames}, together with {@link #exactNames()}.
+   */
+  public Collection<String> matchingNames(Iterable<String> enumeratedNames) {
+    Set<String> names = new LinkedHashSet<>(exactNames);
+    for (String name : enumeratedNames) {
+      String normalized = normalize(name);
+      if (matches(normalized)) {
+        names.add(normalized);
+      }
+    }
+    return names;
+  }
+
+  private boolean matches(String normalizedName) {
+    if (exactOnlyNames != null) {
+      return exactOnlyNames.contains(normalizedName);
+    }
+    return selector != null && selector.matches(normalizedName);
+  }
+
+  private String normalize(String value) {
+    return caseInsensitive ? value.toLowerCase(Locale.ROOT) : value;
+  }
+
+  private static String normalize(String value, CaseSensitivity caseSensitivity) {
+    return caseSensitivity == CaseSensitivity.CASE_INSENSITIVE
+        ? value.toLowerCase(Locale.ROOT)
+        : value;
+  }
+
+  private static IncludeExclude normalize(
+      IncludeExclude selector, CaseSensitivity caseSensitivity) {
+    if (caseSensitivity == CaseSensitivity.CASE_SENSITIVE) {
+      return selector;
+    }
+    return IncludeExclude.builder()
+        .setIncluded(normalize(selector.getIncluded(), caseSensitivity))
+        .setExcluded(normalize(selector.getExcluded(), caseSensitivity))
+        .build();
+  }
+
+  private static List<String> normalize(List<String> values, CaseSensitivity caseSensitivity) {
+    List<String> normalized = new ArrayList<>(values.size());
+    for (String value : values) {
+      normalized.add(normalize(value, caseSensitivity));
+    }
+    return normalized;
+  }
+
+  /**
+   * Whether the names of a carrier are matched case-sensitively.
+   *
+   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+   * at any time.
+   */
+  public enum CaseSensitivity {
+    /** Names are matched exactly as they are configured and carried, e.g. servlet parameters. */
+    CASE_SENSITIVE,
+    /** Names are lowercased before they are matched, e.g. HTTP headers. */
+    CASE_INSENSITIVE
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CapturedNamesTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/CapturedNamesTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity.CASE_INSENSITIVE;
+import static io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity.CASE_SENSITIVE;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class CapturedNamesTest {
+
+  @Test
+  void deprecatedWildcardValueCapturesNothing() {
+    CapturedNames captured = CapturedNames.createExact(singletonList("*"), CASE_SENSITIVE);
+
+    assertThat(captured.isEmpty()).isFalse();
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(captured.exactNames()).containsExactly("*");
+    assertThat(capture(captured, "authorization", "x-foo")).isEmpty();
+  }
+
+  @Test
+  void deprecatedWildcardValueCapturesNameLiterallyCalledWildcard() {
+    CapturedNames captured = CapturedNames.createExact(singletonList("*"), CASE_SENSITIVE);
+
+    assertThat(capture(captured, "authorization", "*")).containsExactly("*");
+  }
+
+  @Test
+  void selectorWildcardPatternCapturesEverything() {
+    CapturedNames captured = CapturedNames.create(selector(singletonList("*")), CASE_SENSITIVE);
+
+    assertThat(captured.enumerateNames()).isTrue();
+    assertThat(captured.exactNames()).isEmpty();
+    assertThat(capture(captured, "authorization", "x-foo"))
+        .containsExactly("authorization", "x-foo");
+  }
+
+  @Test
+  void deprecatedValuesAreMatchedLiterally() {
+    CapturedNames captured =
+        CapturedNames.createExact(asList("x-*", "x-fo?", "x-foo"), CASE_SENSITIVE);
+
+    assertThat(capture(captured, "x-foo", "x-fob", "x-bar")).containsExactly("x-foo");
+  }
+
+  @Test
+  void selectorPatternsAreMatchedAsGlobs() {
+    CapturedNames captured = CapturedNames.create(selector(asList("x-*", "y-fo?")), CASE_SENSITIVE);
+
+    assertThat(capture(captured, "x-foo", "y-fob", "y-fooo", "z-bar"))
+        .containsExactly("x-foo", "y-fob");
+  }
+
+  @Test
+  void caseInsensitiveLowercasesSelectorPatternsAndNames() {
+    CapturedNames captured =
+        CapturedNames.create(selector(asList("X-Foo", "Y-*")), CASE_INSENSITIVE);
+
+    assertThat(captured.exactNames()).containsExactly("x-foo");
+    assertThat(capture(captured, "x-foo", "y-bar")).containsExactly("x-foo", "y-bar");
+  }
+
+  @Test
+  void caseInsensitiveLowercasesDeprecatedValues() {
+    CapturedNames captured = CapturedNames.createExact(singletonList("X-Foo"), CASE_INSENSITIVE);
+
+    assertThat(captured.exactNames()).containsExactly("x-foo");
+  }
+
+  @Test
+  void caseInsensitiveLowercasesEnumeratedNames() {
+    CapturedNames captured = CapturedNames.create(selector(singletonList("x-*")), CASE_INSENSITIVE);
+
+    assertThat(captured.matchingNames(singletonList("X-Foo"))).containsExactly("x-foo");
+  }
+
+  @Test
+  void caseSensitiveDoesNotMatchDifferentCasing() {
+    CapturedNames captured = CapturedNames.create(selector(asList("X-Foo", "Y-*")), CASE_SENSITIVE);
+
+    assertThat(captured.exactNames()).containsExactly("X-Foo");
+    assertThat(capture(captured, "x-foo", "y-bar")).isEmpty();
+    assertThat(capture(captured, "X-Foo", "Y-Bar")).containsExactly("X-Foo", "Y-Bar");
+  }
+
+  @Test
+  void caseSensitiveDeprecatedValuesDoNotMatchDifferentCasing() {
+    CapturedNames captured = CapturedNames.createExact(singletonList("X-Foo"), CASE_SENSITIVE);
+
+    assertThat(captured.exactNames()).containsExactly("X-Foo");
+    assertThat(capture(captured, "x-foo")).isEmpty();
+  }
+
+  @Test
+  void excludedPatternsTakePrecedence() {
+    CapturedNames captured =
+        CapturedNames.create(
+            IncludeExclude.builder()
+                .setIncluded(asList("x-*", "x-secret"))
+                .setExcluded(singletonList("x-secret"))
+                .build(),
+            CASE_SENSITIVE);
+
+    // an included name that is also excluded is not looked up directly
+    assertThat(captured.exactNames()).isEmpty();
+    assertThat(capture(captured, "x-foo", "x-secret")).containsExactly("x-foo");
+  }
+
+  @Test
+  void excludedPatternsAreMatchedCaseInsensitively() {
+    CapturedNames captured =
+        CapturedNames.create(
+            IncludeExclude.builder()
+                .setIncluded(singletonList("X-*"))
+                .setExcluded(singletonList("X-Secret"))
+                .build(),
+            CASE_INSENSITIVE);
+
+    assertThat(capture(captured, "x-foo", "x-secret")).containsExactly("x-foo");
+  }
+
+  @Test
+  void excludeOnlySelectorEnumeratesNames() {
+    CapturedNames captured =
+        CapturedNames.create(
+            IncludeExclude.builder().setExcluded(singletonList("authorization")).build(),
+            CASE_SENSITIVE);
+
+    assertThat(captured.isEmpty()).isFalse();
+    assertThat(captured.enumerateNames()).isTrue();
+    assertThat(captured.exactNames()).isEmpty();
+    assertThat(capture(captured, "authorization", "x-foo")).containsExactly("x-foo");
+  }
+
+  @Test
+  void literalSelectorDoesNotEnumerateNames() {
+    CapturedNames captured =
+        CapturedNames.create(selector(asList("x-foo", "x-bar")), CASE_SENSITIVE);
+
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(captured.exactNames()).containsExactly("x-foo", "x-bar");
+  }
+
+  @Test
+  void deprecatedValuesDoNotEnumerateNames() {
+    CapturedNames captured = CapturedNames.createExact(asList("x-*", "x-foo"), CASE_SENSITIVE);
+
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(captured.exactNames()).containsExactly("x-*", "x-foo");
+  }
+
+  @Test
+  void nullSelectorCapturesNothing() {
+    CapturedNames captured = CapturedNames.create(null, CASE_SENSITIVE);
+
+    assertThat(captured.isEmpty()).isTrue();
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(captured.exactNames()).isEmpty();
+    assertThat(capture(captured, "x-foo")).isEmpty();
+  }
+
+  @Test
+  void emptySelectorCapturesNothing() {
+    CapturedNames captured = CapturedNames.create(IncludeExclude.builder().build(), CASE_SENSITIVE);
+
+    assertThat(captured.isEmpty()).isTrue();
+    assertThat(captured.enumerateNames()).isFalse();
+    assertThat(capture(captured, "x-foo")).isEmpty();
+  }
+
+  @Test
+  void nullAndEmptyDeprecatedValuesCaptureNothing() {
+    assertThat(CapturedNames.createExact(null, CASE_SENSITIVE).isEmpty()).isTrue();
+    assertThat(CapturedNames.createExact(emptyList(), CASE_SENSITIVE).isEmpty()).isTrue();
+  }
+
+  @Test
+  void duplicateNamesAreDeduplicated() {
+    CapturedNames captured =
+        CapturedNames.createExact(asList("X-Foo", "x-foo", "x-bar"), CASE_INSENSITIVE);
+
+    assertThat(captured.exactNames()).containsExactly("x-foo", "x-bar");
+  }
+
+  @Test
+  void matchingNamesIncludesExactNamesThatAreNotEnumerated() {
+    CapturedNames captured = CapturedNames.create(selector(asList("x-foo", "y-*")), CASE_SENSITIVE);
+
+    assertThat(captured.matchingNames(singletonList("y-bar"))).containsExactly("x-foo", "y-bar");
+  }
+
+  private static IncludeExclude selector(List<String> included) {
+    return IncludeExclude.builder().setIncluded(included).build();
+  }
+
+  /**
+   * Captures from a carrier that holds {@code carrierNames}, the way an attributes extractor does:
+   * enumerating its names only when the resolved selector requires it, and otherwise looking up
+   * each exact name directly.
+   */
+  private static List<String> capture(CapturedNames captured, String... carrierNames) {
+    Set<String> carrier = new LinkedHashSet<>(asList(carrierNames));
+    if (captured.isEmpty()) {
+      return emptyList();
+    }
+    Collection<String> names =
+        captured.enumerateNames() ? captured.matchingNames(carrier) : captured.exactNames();
+    List<String> result = new ArrayList<>();
+    for (String name : names) {
+      if (carrier.contains(name)) {
+        result.add(name);
+      }
+    }
+    return result;
+  }
+}

--- a/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
+++ b/instrumentation/grpc-1.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/grpc/v1_6/GrpcSingletons.java
@@ -20,6 +20,7 @@ import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetryBuilder;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.ContextStorageBridge;
 import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcConfig;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -53,18 +54,33 @@ public class GrpcSingletons {
         GrpcTelemetry.builder(openTelemetry)
             .setEmitMessageEvents(emitMessageEvents)
             .setCaptureExperimentalSpanAttributes(experimentalSpanAttributes);
-    IncludeExclude clientRequestMetadata = grpcConfig.getClientRequestMetadata();
-    if (clientRequestMetadata != null) {
-      telemetryBuilder.setClientRequestMetadata(clientRequestMetadata);
-    }
-    IncludeExclude serverRequestMetadata = grpcConfig.getServerRequestMetadata();
-    if (serverRequestMetadata != null) {
-      telemetryBuilder.setServerRequestMetadata(serverRequestMetadata);
-    }
+    setRequestMetadata(telemetryBuilder, grpcConfig);
     GrpcTelemetry telemetry = telemetryBuilder.build();
 
     clientInterceptor = telemetry.createClientInterceptor();
     serverInterceptor = telemetry.createServerInterceptor();
+  }
+
+  // the deprecated setters are used on purpose: unlike the selectors, the values of the deprecated
+  // settings are matched literally rather than as glob patterns
+  @SuppressWarnings("deprecation")
+  private static void setRequestMetadata(
+      GrpcTelemetryBuilder telemetryBuilder, GrpcConfig grpcConfig) {
+    IncludeExclude clientRequestMetadata = grpcConfig.getClientRequestMetadata();
+    List<String> deprecatedClientRequestMetadata = grpcConfig.getDeprecatedClientRequestMetadata();
+    if (clientRequestMetadata != null) {
+      telemetryBuilder.setClientRequestMetadata(clientRequestMetadata);
+    } else if (deprecatedClientRequestMetadata != null) {
+      telemetryBuilder.setCapturedClientRequestMetadata(deprecatedClientRequestMetadata);
+    }
+
+    IncludeExclude serverRequestMetadata = grpcConfig.getServerRequestMetadata();
+    List<String> deprecatedServerRequestMetadata = grpcConfig.getDeprecatedServerRequestMetadata();
+    if (serverRequestMetadata != null) {
+      telemetryBuilder.setServerRequestMetadata(serverRequestMetadata);
+    } else if (deprecatedServerRequestMetadata != null) {
+      telemetryBuilder.setCapturedServerRequestMetadata(deprecatedServerRequestMetadata);
+    }
   }
 
   public static ClientInterceptor clientInterceptor() {

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/CapturedGrpcMetadataUtil.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/CapturedGrpcMetadataUtil.java
@@ -5,15 +5,12 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
-import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 final class CapturedGrpcMetadataUtil {
@@ -22,55 +19,42 @@ final class CapturedGrpcMetadataUtil {
   private static final String RPC_STABLE_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX =
       "rpc.request.metadata.";
 
-  static List<String> lowercase(List<String> names) {
-    return unmodifiableList(names.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(toList()));
+  static Map<String, AttributeKey<List<String>>> createExactRequestAttributeKeys(
+      CapturedNames requestMetadata) {
+    return createExactAttributeKeys(requestMetadata, RPC_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
   }
 
-  static IncludeExclude lowercase(IncludeExclude selector) {
-    return IncludeExclude.builder()
-        .setIncluded(lowercase(selector.getIncluded()))
-        .setExcluded(lowercase(selector.getExcluded()))
-        .build();
-  }
-
-  static Map<String, AttributeKey<List<String>>> createLiteralRequestAttributeKeys(
-      IncludeExclude selector) {
-    return createLiteralAttributeKeys(selector, RPC_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
-  }
-
-  static Map<String, AttributeKey<List<String>>> createLiteralStableRequestAttributeKeys(
-      IncludeExclude selector) {
-    return createLiteralAttributeKeys(selector, RPC_STABLE_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
+  static Map<String, AttributeKey<List<String>>> createExactStableRequestAttributeKeys(
+      CapturedNames requestMetadata) {
+    return createExactAttributeKeys(
+        requestMetadata, RPC_STABLE_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
   }
 
   static AttributeKey<List<String>> requestAttributeKey(
-      String metadataKey, Map<String, AttributeKey<List<String>>> literalAttributeKeys) {
-    return attributeKey(
-        metadataKey, literalAttributeKeys, RPC_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
+      String metadataKey, Map<String, AttributeKey<List<String>>> exactAttributeKeys) {
+    return attributeKey(metadataKey, exactAttributeKeys, RPC_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
   }
 
   static AttributeKey<List<String>> stableRequestAttributeKey(
-      String metadataKey, Map<String, AttributeKey<List<String>>> literalAttributeKeys) {
+      String metadataKey, Map<String, AttributeKey<List<String>>> exactAttributeKeys) {
     return attributeKey(
-        metadataKey, literalAttributeKeys, RPC_STABLE_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
+        metadataKey, exactAttributeKeys, RPC_STABLE_REQUEST_METADATA_KEY_ATTRIBUTE_PREFIX);
   }
 
-  private static Map<String, AttributeKey<List<String>>> createLiteralAttributeKeys(
-      IncludeExclude selector, String prefix) {
+  private static Map<String, AttributeKey<List<String>>> createExactAttributeKeys(
+      CapturedNames requestMetadata, String prefix) {
     Map<String, AttributeKey<List<String>>> result = new HashMap<>();
-    for (String pattern : selector.getIncluded()) {
-      if (pattern.indexOf('*') == -1 && pattern.indexOf('?') == -1) {
-        result.put(pattern, AttributeKey.stringArrayKey(prefix + pattern));
-      }
+    for (String metadataKey : requestMetadata.exactNames()) {
+      result.put(metadataKey, AttributeKey.stringArrayKey(prefix + metadataKey));
     }
     return unmodifiableMap(result);
   }
 
   private static AttributeKey<List<String>> attributeKey(
       String metadataKey,
-      Map<String, AttributeKey<List<String>>> literalAttributeKeys,
+      Map<String, AttributeKey<List<String>>> exactAttributeKeys,
       String prefix) {
-    AttributeKey<List<String>> attributeKey = literalAttributeKeys.get(metadataKey);
+    AttributeKey<List<String>> attributeKey = exactAttributeKeys.get(metadataKey);
     return attributeKey != null ? attributeKey : AttributeKey.stringArrayKey(prefix + metadataKey);
   }
 

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractor.java
@@ -7,22 +7,20 @@ package io.opentelemetry.instrumentation.grpc.v1_6;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
-import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createLiteralRequestAttributeKeys;
-import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createLiteralStableRequestAttributeKeys;
-import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.lowercase;
+import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createExactRequestAttributeKeys;
+import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createExactStableRequestAttributeKeys;
 import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.requestAttributeKey;
 import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.stableRequestAttributeKey;
-import static java.util.Collections.emptyMap;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -34,29 +32,21 @@ final class GrpcAttributesExtractor implements AttributesExtractor<GrpcRequest, 
   private static final AttributeKey<String> RPC_RESPONSE_STATUS_CODE =
       AttributeKey.stringKey("rpc.response.status_code");
   private final GrpcRpcAttributesGetter getter;
-  @Nullable private final IncludeExclude requestMetadata;
+  private final CapturedNames requestMetadata;
 
-  // Only literal included names are stored here. We intentionally do not cache wildcard or
+  // Only exact captured names are stored here. We intentionally do not cache wildcard or
   // exclude-only matches, even in a bounded cache: peer-controlled names could churn its entries,
   // making allocation behavior depend on prior traffic. Creating those attribute keys on demand
-  // provides a fixed per-capture cost with no peer-controlled retained state, while literal
+  // provides a fixed per-capture cost with no peer-controlled retained state, while exact
   // configured keys remain allocation-free.
-  private final Map<String, AttributeKey<List<String>>> literalRequestAttributeKeys;
-  private final Map<String, AttributeKey<List<String>>> literalStableRequestAttributeKeys;
+  private final Map<String, AttributeKey<List<String>>> exactRequestAttributeKeys;
+  private final Map<String, AttributeKey<List<String>>> exactStableRequestAttributeKeys;
 
-  GrpcAttributesExtractor(
-      GrpcRpcAttributesGetter getter, @Nullable IncludeExclude requestMetadata) {
+  GrpcAttributesExtractor(GrpcRpcAttributesGetter getter, CapturedNames requestMetadata) {
     this.getter = getter;
-    if (requestMetadata == null || requestMetadata.isEmpty()) {
-      this.requestMetadata = null;
-      literalRequestAttributeKeys = emptyMap();
-      literalStableRequestAttributeKeys = emptyMap();
-    } else {
-      this.requestMetadata = lowercase(requestMetadata);
-      literalRequestAttributeKeys = createLiteralRequestAttributeKeys(this.requestMetadata);
-      literalStableRequestAttributeKeys =
-          createLiteralStableRequestAttributeKeys(this.requestMetadata);
-    }
+    this.requestMetadata = requestMetadata;
+    exactRequestAttributeKeys = createExactRequestAttributeKeys(requestMetadata);
+    exactStableRequestAttributeKeys = createExactStableRequestAttributeKeys(requestMetadata);
   }
 
   @Override
@@ -79,30 +69,28 @@ final class GrpcAttributesExtractor implements AttributesExtractor<GrpcRequest, 
         attributes.put(RPC_RESPONSE_STATUS_CODE, status.getCode().name());
       }
     }
-    if (requestMetadata == null || request.getMetadata() == null) {
+    Metadata metadata = request.getMetadata();
+    if (requestMetadata.isEmpty() || metadata == null) {
       return;
     }
-    for (String key : request.getMetadata().keys()) {
-      // binary metadata and HTTP/2 pseudo-headers are never captured, even when the selector
-      // matches, because reading them below with Metadata.Key.of() would throw
-      if (!isAsciiMetadataKey(key)) {
-        continue;
-      }
-      // gRPC lowercases metadata key names, but normalize defensively so that matching is
-      // case-insensitive as documented and an excluded key cannot be captured because a transport
-      // surfaced its name with different casing
-      String metadataKey = key.toLowerCase(Locale.ROOT);
-      if (!requestMetadata.matches(metadataKey)) {
+    Collection<String> metadataKeys =
+        requestMetadata.enumerateNames()
+            ? requestMetadata.matchingNames(metadata.keys())
+            : requestMetadata.exactNames();
+    for (String metadataKey : metadataKeys) {
+      // binary metadata and HTTP/2 pseudo-headers are never captured, even when they are matched,
+      // because reading them below with Metadata.Key.of() would throw
+      if (!isAsciiMetadataKey(metadataKey)) {
         continue;
       }
       List<String> value = getter.metadataValue(request, metadataKey);
       if (!value.isEmpty()) {
         if (emitOldRpcSemconv()) {
-          attributes.put(requestAttributeKey(metadataKey, literalRequestAttributeKeys), value);
+          attributes.put(requestAttributeKey(metadataKey, exactRequestAttributeKeys), value);
         }
         if (emitStableRpcSemconv()) {
           attributes.put(
-              stableRequestAttributeKey(metadataKey, literalStableRequestAttributeKeys), value);
+              stableRequestAttributeKey(metadataKey, exactStableRequestAttributeKeys), value);
         }
       }
     }

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTelemetryBuilder.java
@@ -23,6 +23,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.api.internal.Experimental;
 import io.opentelemetry.instrumentation.api.semconv.network.NetworkAttributesExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
@@ -30,7 +32,6 @@ import io.opentelemetry.instrumentation.grpc.v1_6.internal.GrpcClientNetworkAttr
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nullable;
 
 /** A builder of {@link GrpcTelemetry}. */
 public final class GrpcTelemetryBuilder {
@@ -52,8 +53,10 @@ public final class GrpcTelemetryBuilder {
 
   private boolean captureExperimentalSpanAttributes;
   private boolean emitMessageEvents = true;
-  @Nullable private IncludeExclude clientRequestMetadata;
-  @Nullable private IncludeExclude serverRequestMetadata;
+  private CapturedNames clientRequestMetadata =
+      CapturedNames.create(null, CaseSensitivity.CASE_INSENSITIVE);
+  private CapturedNames serverRequestMetadata =
+      CapturedNames.create(null, CaseSensitivity.CASE_INSENSITIVE);
 
   GrpcTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -149,12 +152,15 @@ public final class GrpcTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public GrpcTelemetryBuilder setClientRequestMetadata(IncludeExclude clientRequestMetadata) {
-    this.clientRequestMetadata = clientRequestMetadata;
+    this.clientRequestMetadata =
+        CapturedNames.create(clientRequestMetadata, CaseSensitivity.CASE_INSENSITIVE);
     return this;
   }
 
   /**
    * Sets which metadata request values should be captured as span attributes on client spans.
+   *
+   * <p>Metadata keys are matched literally and case-insensitively; wildcards are not supported.
    *
    * @deprecated Use {@link #setClientRequestMetadata(IncludeExclude)} instead. May be removed in
    *     the next minor release.
@@ -164,9 +170,7 @@ public final class GrpcTelemetryBuilder {
   public GrpcTelemetryBuilder setCapturedClientRequestMetadata(
       List<String> capturedClientRequestMetadata) {
     clientRequestMetadata =
-        capturedClientRequestMetadata.isEmpty()
-            ? null
-            : IncludeExclude.builder().setIncluded(capturedClientRequestMetadata).build();
+        CapturedNames.createExact(capturedClientRequestMetadata, CaseSensitivity.CASE_INSENSITIVE);
     return this;
   }
 
@@ -181,12 +185,15 @@ public final class GrpcTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public GrpcTelemetryBuilder setServerRequestMetadata(IncludeExclude serverRequestMetadata) {
-    this.serverRequestMetadata = serverRequestMetadata;
+    this.serverRequestMetadata =
+        CapturedNames.create(serverRequestMetadata, CaseSensitivity.CASE_INSENSITIVE);
     return this;
   }
 
   /**
    * Sets which metadata request values should be captured as span attributes on server spans.
+   *
+   * <p>Metadata keys are matched literally and case-insensitively; wildcards are not supported.
    *
    * @deprecated Use {@link #setServerRequestMetadata(IncludeExclude)} instead. May be removed in
    *     the next minor release.
@@ -196,9 +203,7 @@ public final class GrpcTelemetryBuilder {
   public GrpcTelemetryBuilder setCapturedServerRequestMetadata(
       List<String> capturedServerRequestMetadata) {
     serverRequestMetadata =
-        capturedServerRequestMetadata.isEmpty()
-            ? null
-            : IncludeExclude.builder().setIncluded(capturedServerRequestMetadata).build();
+        CapturedNames.createExact(capturedServerRequestMetadata, CaseSensitivity.CASE_INSENSITIVE);
     return this;
   }
 

--- a/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcConfig.java
+++ b/instrumentation/grpc-1.6/library/src/main/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcConfig.java
@@ -38,6 +38,8 @@ public class GrpcConfig {
 
   @Nullable private final IncludeExclude clientRequestMetadata;
   @Nullable private final IncludeExclude serverRequestMetadata;
+  @Nullable private final List<String> deprecatedClientRequestMetadata;
+  @Nullable private final List<String> deprecatedServerRequestMetadata;
 
   public static GrpcConfig create(OpenTelemetry openTelemetry) {
     return new GrpcConfig(
@@ -46,39 +48,67 @@ public class GrpcConfig {
   }
 
   GrpcConfig(DeclarativeConfigProperties config, boolean v3Preview) {
-    clientRequestMetadata =
-        getRequestMetadata(
-            config,
-            "client",
-            DEPRECATED_CLIENT_REQUEST_METADATA,
-            CLIENT_REQUEST_METADATA_INCLUDED,
-            v3Preview);
-    serverRequestMetadata =
-        getRequestMetadata(
-            config,
-            "server",
-            DEPRECATED_SERVER_REQUEST_METADATA,
-            SERVER_REQUEST_METADATA_INCLUDED,
-            v3Preview);
+    clientRequestMetadata = getRequestMetadata(config, "client");
+    serverRequestMetadata = getRequestMetadata(config, "server");
+    deprecatedClientRequestMetadata =
+        clientRequestMetadata == null
+            ? getDeprecatedRequestMetadata(
+                config,
+                "client",
+                DEPRECATED_CLIENT_REQUEST_METADATA,
+                CLIENT_REQUEST_METADATA_INCLUDED,
+                v3Preview)
+            : null;
+    deprecatedServerRequestMetadata =
+        serverRequestMetadata == null
+            ? getDeprecatedRequestMetadata(
+                config,
+                "server",
+                DEPRECATED_SERVER_REQUEST_METADATA,
+                SERVER_REQUEST_METADATA_INCLUDED,
+                v3Preview)
+            : null;
   }
 
+  /** Returns the client request metadata selector, or {@code null} if it is not configured. */
   @Nullable
   public IncludeExclude getClientRequestMetadata() {
     return clientRequestMetadata;
   }
 
+  /** Returns the server request metadata selector, or {@code null} if it is not configured. */
   @Nullable
   public IncludeExclude getServerRequestMetadata() {
     return serverRequestMetadata;
   }
 
+  /**
+   * Returns the metadata keys configured through the deprecated client setting, or {@code null} if
+   * the selector is configured or the deprecated setting is not.
+   *
+   * <p>These keys are kept separate from {@link #getClientRequestMetadata()} because the deprecated
+   * setting never supported wildcards, so its values are matched literally.
+   */
+  @Nullable
+  public List<String> getDeprecatedClientRequestMetadata() {
+    return deprecatedClientRequestMetadata;
+  }
+
+  /**
+   * Returns the metadata keys configured through the deprecated server setting, or {@code null} if
+   * the selector is configured or the deprecated setting is not.
+   *
+   * <p>These keys are kept separate from {@link #getServerRequestMetadata()} because the deprecated
+   * setting never supported wildcards, so its values are matched literally.
+   */
+  @Nullable
+  public List<String> getDeprecatedServerRequestMetadata() {
+    return deprecatedServerRequestMetadata;
+  }
+
   @Nullable
   private static IncludeExclude getRequestMetadata(
-      DeclarativeConfigProperties config,
-      String side,
-      String deprecatedProperty,
-      String replacementProperty,
-      boolean v3Preview) {
+      DeclarativeConfigProperties config, String side) {
     DeclarativeConfigProperties requestMetadata = config.get(side).get("request_metadata");
     List<String> included = requestMetadata.getScalarList("included", String.class);
     List<String> excluded = requestMetadata.getScalarList("excluded", String.class);
@@ -89,10 +119,16 @@ public class GrpcConfig {
             .build();
     // an empty selector is equivalent to no selector at all, matching flat configuration where
     // empty property values cannot be distinguished from unset ones
-    if (!selector.isEmpty()) {
-      return selector;
-    }
+    return selector.isEmpty() ? null : selector;
+  }
 
+  @Nullable
+  private static List<String> getDeprecatedRequestMetadata(
+      DeclarativeConfigProperties config,
+      String side,
+      String deprecatedProperty,
+      String replacementProperty,
+      boolean v3Preview) {
     if (v3Preview) {
       return null;
     }
@@ -112,8 +148,6 @@ public class GrpcConfig {
               + replacementProperty
               + " or equivalent declarative configuration instead.");
     }
-    return deprecatedIncluded.isEmpty()
-        ? null
-        : IncludeExclude.builder().setIncluded(deprecatedIncluded).build();
+    return deprecatedIncluded.isEmpty() ? null : deprecatedIncluded;
   }
 }

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/CapturedGrpcMetadataUtilTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/CapturedGrpcMetadataUtilTest.java
@@ -5,13 +5,15 @@
 
 package io.opentelemetry.instrumentation.grpc.v1_6;
 
-import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createLiteralRequestAttributeKeys;
+import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.createExactRequestAttributeKeys;
 import static io.opentelemetry.instrumentation.grpc.v1_6.CapturedGrpcMetadataUtil.requestAttributeKey;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -19,19 +21,20 @@ import org.junit.jupiter.api.Test;
 class CapturedGrpcMetadataUtilTest {
 
   @Test
-  void retainsOnlyLiteralRequestAttributeKeys() {
+  void retainsOnlyExactRequestAttributeKeys() {
     IncludeExclude selector =
         IncludeExclude.builder()
             .setIncluded(asList("literal-key", "wildcard-*", "single-?"))
             .build();
 
-    Map<String, AttributeKey<List<String>>> literalAttributeKeys =
-        createLiteralRequestAttributeKeys(selector);
+    Map<String, AttributeKey<List<String>>> exactAttributeKeys =
+        createExactRequestAttributeKeys(
+            CapturedNames.create(selector, CaseSensitivity.CASE_INSENSITIVE));
 
-    assertThat(literalAttributeKeys).containsOnlyKeys("literal-key");
-    assertThat(requestAttributeKey("literal-key", literalAttributeKeys))
-        .isSameAs(literalAttributeKeys.get("literal-key"));
-    assertThat(requestAttributeKey("wildcard-key", literalAttributeKeys))
-        .isNotSameAs(requestAttributeKey("wildcard-key", literalAttributeKeys));
+    assertThat(exactAttributeKeys).containsOnlyKeys("literal-key");
+    assertThat(requestAttributeKey("literal-key", exactAttributeKeys))
+        .isSameAs(exactAttributeKeys.get("literal-key"));
+    assertThat(requestAttributeKey("wildcard-key", exactAttributeKeys))
+        .isNotSameAs(requestAttributeKey("wildcard-key", exactAttributeKeys));
   }
 }

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractorTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcAttributesExtractorTest.java
@@ -14,7 +14,9 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Metadata;
@@ -24,6 +26,9 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -51,7 +56,7 @@ class GrpcAttributesExtractorTest {
             .build();
     AttributesBuilder attributes = Attributes.builder();
 
-    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), selector)
+    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), captured(selector))
         .onEnd(attributes, Context.root(), request, null, null);
 
     Attributes result = attributes.build();
@@ -71,7 +76,9 @@ class GrpcAttributesExtractorTest {
     GrpcRequest request = new GrpcRequest(mock(MethodDescriptor.class), metadata, null, null);
     AttributesBuilder attributes = Attributes.builder();
 
-    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), null)
+    new GrpcAttributesExtractor(
+            new GrpcRpcAttributesGetter(),
+            CapturedNames.create(null, CaseSensitivity.CASE_INSENSITIVE))
         .onEnd(attributes, Context.root(), request, null, null);
 
     assertExcludedMetadata(attributes.build(), "some-key");
@@ -84,10 +91,47 @@ class GrpcAttributesExtractorTest {
     GrpcRequest request = new GrpcRequest(mock(MethodDescriptor.class), metadata, null, null);
     AttributesBuilder attributes = Attributes.builder();
 
-    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), IncludeExclude.builder().build())
+    new GrpcAttributesExtractor(
+            new GrpcRpcAttributesGetter(), captured(IncludeExclude.builder().build()))
         .onEnd(attributes, Context.root(), request, null, null);
 
     assertExcludedMetadata(attributes.build(), "some-key");
+  }
+
+  @Test
+  void deprecatedMetadataKeysAreLookedUpDirectly() {
+    Metadata delegate = new Metadata();
+    delegate.put(Metadata.Key.of("some-key", Metadata.ASCII_STRING_MARSHALLER), "some-value");
+    Metadata metadata = spy(delegate);
+    GrpcRequest request = new GrpcRequest(mock(MethodDescriptor.class), metadata, null, null);
+    AttributesBuilder attributes = Attributes.builder();
+
+    new GrpcAttributesExtractor(
+            new GrpcRpcAttributesGetter(), capturedExact(asList("SOME-KEY", "missing-key")))
+        .onEnd(attributes, Context.root(), request, null, null);
+
+    Attributes result = attributes.build();
+    assertThat(result.get(oldMetadataAttributeKey("some-key")))
+        .isEqualTo(emitOldRpcSemconv() ? singletonList("some-value") : null);
+    assertThat(result.get(stableMetadataAttributeKey("some-key")))
+        .isEqualTo(emitStableRpcSemconv() ? singletonList("some-value") : null);
+    assertExcludedMetadata(result, "missing-key");
+    verify(metadata, never()).keys();
+  }
+
+  @Test
+  void deprecatedWildcardMetadataKeyCapturesNothing() {
+    Metadata metadata = new Metadata();
+    metadata.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), "secret");
+    GrpcRequest request = new GrpcRequest(mock(MethodDescriptor.class), metadata, null, null);
+    AttributesBuilder attributes = Attributes.builder();
+
+    // the deprecated setting never supported wildcards, so "*" only matches a metadata key that is
+    // literally named "*", which gRPC cannot even represent
+    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), capturedExact(singletonList("*")))
+        .onEnd(attributes, Context.root(), request, null, null);
+
+    assertThat(attributes.build()).isEqualTo(Attributes.empty());
   }
 
   @Test
@@ -108,7 +152,7 @@ class GrpcAttributesExtractorTest {
             .build();
     AttributesBuilder attributes = Attributes.builder();
 
-    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), selector)
+    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), captured(selector))
         .onEnd(attributes, Context.root(), request, null, null);
 
     Attributes result = attributes.build();
@@ -130,10 +174,18 @@ class GrpcAttributesExtractorTest {
     AttributesBuilder attributes = Attributes.builder();
     IncludeExclude selector = IncludeExclude.builder().setIncluded(singleton("*")).build();
 
-    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), selector)
+    new GrpcAttributesExtractor(new GrpcRpcAttributesGetter(), captured(selector))
         .onEnd(attributes, Context.root(), request, null, null);
 
     assertThat(attributes.build()).isEqualTo(Attributes.empty());
+  }
+
+  private static CapturedNames captured(IncludeExclude selector) {
+    return CapturedNames.create(selector, CaseSensitivity.CASE_INSENSITIVE);
+  }
+
+  private static CapturedNames capturedExact(Collection<String> names) {
+    return CapturedNames.createExact(names, CaseSensitivity.CASE_INSENSITIVE);
   }
 
   private static void assertExcludedMetadata(Attributes attributes, String key) {

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/GrpcTest.java
@@ -26,6 +26,7 @@ import io.grpc.Status;
 import io.grpc.stub.MetadataUtils;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
@@ -186,6 +187,84 @@ class GrpcTest extends AbstractGrpcTest {
                                     emitStableRpcSemconv() && captureMetadata
                                         ? singletonList(serverMetadataValue)
                                         : null))));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void deprecatedRequestMetadataSettersDoNotSupportWildcards() throws Exception {
+    BindableService greeter =
+        new GreeterGrpc.GreeterImplBase() {
+          @Override
+          public void sayHello(
+              Helloworld.Request req, StreamObserver<Helloworld.Response> responseObserver) {
+            responseObserver.onNext(
+                Helloworld.Response.newBuilder().setMessage("Hello " + req.getName()).build());
+            responseObserver.onCompleted();
+          }
+        };
+
+    Server server =
+        ServerBuilder.forPort(0)
+            .addService(greeter)
+            .intercept(
+                GrpcTelemetry.builder(testing.getOpenTelemetry())
+                    .setCapturedServerRequestMetadata(singletonList("*"))
+                    .build()
+                    .createServerInterceptor())
+            .build()
+            .start();
+    ManagedChannel channel =
+        createChannel(
+            ManagedChannelBuilder.forAddress("localhost", server.getPort())
+                .intercept(
+                    GrpcTelemetry.builder(testing.getOpenTelemetry())
+                        .setCapturedClientRequestMetadata(singletonList("*"))
+                        .build()
+                        .createClientInterceptor()));
+    closer.add(() -> channel.shutdownNow().awaitTermination(10, SECONDS));
+    closer.add(() -> server.shutdownNow().awaitTermination());
+
+    Metadata metadata = new Metadata();
+    metadata.put(
+        Metadata.Key.of(CLIENT_REQUEST_METADATA_KEY, Metadata.ASCII_STRING_MARSHALLER),
+        "client-value");
+    metadata.put(
+        Metadata.Key.of(SERVER_REQUEST_METADATA_KEY, Metadata.ASCII_STRING_MARSHALLER),
+        "server-value");
+
+    GreeterGrpc.GreeterBlockingStub client =
+        GreeterGrpc.newBlockingStub(channel)
+            .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    Helloworld.Response response =
+        testing()
+            .runWithSpan(
+                "parent",
+                () -> client.sayHello(Helloworld.Request.newBuilder().setName("test").build()));
+
+    assertThat(response.getMessage()).isEqualTo("Hello test");
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                    span ->
+                        span.hasName("example.Greeter/SayHello")
+                            .hasKind(SpanKind.CLIENT)
+                            .hasAttributesSatisfying(GrpcTest::assertNoMetadataCaptured),
+                    span ->
+                        span.hasName("example.Greeter/SayHello")
+                            .hasKind(SpanKind.SERVER)
+                            .hasAttributesSatisfying(GrpcTest::assertNoMetadataCaptured)));
+  }
+
+  private static void assertNoMetadataCaptured(Attributes attributes) {
+    assertThat(attributes.asMap().keySet())
+        .extracting(AttributeKey::getKey)
+        .noneMatch(
+            key ->
+                key.startsWith("rpc.grpc.request.metadata.")
+                    || key.startsWith("rpc.request.metadata."));
   }
 
   /**

--- a/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcConfigTest.java
+++ b/instrumentation/grpc-1.6/library/src/test/java/io/opentelemetry/instrumentation/grpc/v1_6/internal/GrpcConfigTest.java
@@ -68,6 +68,20 @@ class GrpcConfigTest {
     GrpcConfig grpcConfig = new GrpcConfig(config, false);
 
     assertThat(grpcConfig.getClientRequestMetadata().getIncluded()).containsExactly("new");
+    assertThat(grpcConfig.getDeprecatedClientRequestMetadata()).isNull();
+  }
+
+  @Test
+  void deprecatedConfigIsNotExposedAsSelector() {
+    DeclarativeConfigProperties config = mockConfig();
+    when(config.get("capture_metadata").get("client").getScalarList("request", String.class))
+        .thenReturn(singletonList("*"));
+
+    GrpcConfig grpcConfig = new GrpcConfig(config, false);
+
+    // the deprecated setting never supported wildcards, so "*" must not become a glob selector
+    assertThat(grpcConfig.getClientRequestMetadata()).isNull();
+    assertThat(grpcConfig.getDeprecatedClientRequestMetadata()).containsExactly("*");
   }
 
   @Test
@@ -82,9 +96,10 @@ class GrpcConfigTest {
       GrpcConfig first = new GrpcConfig(config, false);
       GrpcConfig second = new GrpcConfig(config, false);
 
-      assertThat(first.getClientRequestMetadata().getIncluded()).containsExactly("deprecated");
-      assertThat(first.getClientRequestMetadata().getExcluded()).isEmpty();
-      assertThat(second.getClientRequestMetadata()).isEqualTo(first.getClientRequestMetadata());
+      assertThat(first.getClientRequestMetadata()).isNull();
+      assertThat(first.getDeprecatedClientRequestMetadata()).containsExactly("deprecated");
+      assertThat(second.getDeprecatedClientRequestMetadata())
+          .isEqualTo(first.getDeprecatedClientRequestMetadata());
       assertThat(handler.records).hasSize(1);
       assertThat(handler.records.get(0).getMessage())
           .isEqualTo(
@@ -107,6 +122,7 @@ class GrpcConfigTest {
     GrpcConfig grpcConfig = new GrpcConfig(config, false);
 
     assertThat(grpcConfig.getClientRequestMetadata()).isNull();
+    assertThat(grpcConfig.getDeprecatedClientRequestMetadata()).isNull();
   }
 
   @Test
@@ -131,6 +147,7 @@ class GrpcConfigTest {
     GrpcConfig grpcConfig = new GrpcConfig(config, true);
 
     assertThat(grpcConfig.getClientRequestMetadata()).isNull();
+    assertThat(grpcConfig.getDeprecatedClientRequestMetadata()).isNull();
   }
 
   @Test
@@ -148,6 +165,7 @@ class GrpcConfigTest {
     GrpcConfig config = GrpcConfig.create(openTelemetry);
 
     assertThat(config.getClientRequestMetadata()).isNull();
+    assertThat(config.getDeprecatedClientRequestMetadata()).isNull();
   }
 
   private static DeclarativeConfigProperties mockConfig() {

--- a/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/internal/Experimental.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v3_0/internal/Experimental.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.servlet.v3_0.internal;
 
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.servlet.v3_0.ServletTelemetryBuilder;
 import java.util.Collection;
 import java.util.function.BiConsumer;
@@ -29,7 +31,7 @@ public final class Experimental {
   private static volatile BiConsumer<ServletTelemetryBuilder, Boolean> setCaptureEnduserId;
 
   @Nullable
-  private static volatile BiConsumer<ServletTelemetryBuilder, IncludeExclude> setRequestParameters;
+  private static volatile BiConsumer<ServletTelemetryBuilder, CapturedNames> setRequestParameters;
 
   /**
    * Sets whether experimental HTTP telemetry should be emitted.
@@ -91,6 +93,12 @@ public final class Experimental {
    */
   public static void setRequestParameters(
       ServletTelemetryBuilder builder, IncludeExclude requestParameters) {
+    setRequestParameters(
+        builder, CapturedNames.create(requestParameters, CaseSensitivity.CASE_SENSITIVE));
+  }
+
+  private static void setRequestParameters(
+      ServletTelemetryBuilder builder, CapturedNames requestParameters) {
     if (setRequestParameters != null) {
       setRequestParameters.accept(builder, requestParameters);
     }
@@ -98,6 +106,10 @@ public final class Experimental {
 
   /**
    * Sets the request parameters to be captured as span attributes.
+   *
+   * <p>The parameter names are matched literally. Unlike {@link
+   * #setRequestParameters(ServletTelemetryBuilder, IncludeExclude)}, {@code *} and {@code ?} are
+   * not treated as glob patterns, since this setting never supported them as wildcards.
    *
    * @param builder the telemetry builder
    * @param captureRequestParameters request parameter names to capture
@@ -109,7 +121,8 @@ public final class Experimental {
   public static void setCaptureRequestParameters(
       ServletTelemetryBuilder builder, Collection<String> captureRequestParameters) {
     setRequestParameters(
-        builder, IncludeExclude.builder().setIncluded(captureRequestParameters).build());
+        builder,
+        CapturedNames.createExact(captureRequestParameters, CaseSensitivity.CASE_SENSITIVE));
   }
 
   public static void internalSetEmitExperimentalTelemetry(
@@ -128,7 +141,7 @@ public final class Experimental {
   }
 
   public static void internalSetRequestParameters(
-      BiConsumer<ServletTelemetryBuilder, IncludeExclude> setRequestParameters) {
+      BiConsumer<ServletTelemetryBuilder, CapturedNames> setRequestParameters) {
     Experimental.setRequestParameters = setRequestParameters;
   }
 

--- a/instrumentation/servlet/servlet-5.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/internal/Experimental.java
+++ b/instrumentation/servlet/servlet-5.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/internal/Experimental.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.instrumentation.servlet.v5_0.internal;
 
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.servlet.v5_0.ServletTelemetryBuilder;
 import java.util.Collection;
 import java.util.function.BiConsumer;
@@ -29,7 +31,7 @@ public final class Experimental {
   private static volatile BiConsumer<ServletTelemetryBuilder, Boolean> setCaptureEnduserId;
 
   @Nullable
-  private static volatile BiConsumer<ServletTelemetryBuilder, IncludeExclude> setRequestParameters;
+  private static volatile BiConsumer<ServletTelemetryBuilder, CapturedNames> setRequestParameters;
 
   /**
    * Sets whether experimental HTTP telemetry should be emitted.
@@ -91,6 +93,12 @@ public final class Experimental {
    */
   public static void setRequestParameters(
       ServletTelemetryBuilder builder, IncludeExclude requestParameters) {
+    setRequestParameters(
+        builder, CapturedNames.create(requestParameters, CaseSensitivity.CASE_SENSITIVE));
+  }
+
+  private static void setRequestParameters(
+      ServletTelemetryBuilder builder, CapturedNames requestParameters) {
     if (setRequestParameters != null) {
       setRequestParameters.accept(builder, requestParameters);
     }
@@ -98,6 +106,10 @@ public final class Experimental {
 
   /**
    * Sets the request parameters to be captured as span attributes.
+   *
+   * <p>The parameter names are matched literally. Unlike {@link
+   * #setRequestParameters(ServletTelemetryBuilder, IncludeExclude)}, {@code *} and {@code ?} are
+   * not treated as glob patterns, since this setting never supported them as wildcards.
    *
    * @param builder the telemetry builder
    * @param captureRequestParameters request parameter names to capture
@@ -109,7 +121,8 @@ public final class Experimental {
   public static void setCaptureRequestParameters(
       ServletTelemetryBuilder builder, Collection<String> captureRequestParameters) {
     setRequestParameters(
-        builder, IncludeExclude.builder().setIncluded(captureRequestParameters).build());
+        builder,
+        CapturedNames.createExact(captureRequestParameters, CaseSensitivity.CASE_SENSITIVE));
   }
 
   public static void internalSetEmitExperimentalTelemetry(
@@ -128,7 +141,7 @@ public final class Experimental {
   }
 
   public static void internalSetRequestParameters(
-      BiConsumer<ServletTelemetryBuilder, IncludeExclude> setRequestParameters) {
+      BiConsumer<ServletTelemetryBuilder, CapturedNames> setRequestParameters) {
     Experimental.setRequestParameters = setRequestParameters;
   }
 

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/BaseServletHelper.java
@@ -14,9 +14,9 @@ import static io.opentelemetry.semconv.incubating.UserIncubatingAttributes.USER_
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
 import io.opentelemetry.instrumentation.servlet.common.internal.ServletAccessor;
 import io.opentelemetry.instrumentation.servlet.common.internal.ServletAdditionalAttributesExtractor;
@@ -51,11 +51,11 @@ public abstract class BaseServletHelper<REQUEST, RESPONSE> {
     this.accessor = accessor;
     this.spanNameProvider = new ServletSpanNameProvider<>(accessor);
     this.contextPathExtractor = accessor::getRequestContextPath;
-    IncludeExclude requestParameters = servletConfig.getRequestParameters();
+    CapturedNames requestParameters = servletConfig.getRequestParameters();
     this.parameterExtractor =
-        requestParameters != null
-            ? new ServletRequestParametersExtractor<>(accessor, requestParameters)
-            : null;
+        requestParameters.isEmpty()
+            ? null
+            : new ServletRequestParametersExtractor<>(accessor, requestParameters);
   }
 
   public boolean shouldStart(Context parentContext, ServletRequestContext<REQUEST> requestContext) {

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/ServletConfig.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/ServletConfig.java
@@ -7,15 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.servlet.common;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
-import javax.annotation.Nullable;
 
 class ServletConfig {
 
-  @Nullable private final IncludeExclude requestParameters;
+  private final CapturedNames requestParameters;
   private final boolean captureExperimentalAttributes;
   private final boolean traceIdRequestAttributeEnabled;
 
@@ -24,15 +24,16 @@ class ServletConfig {
   }
 
   ServletConfig(DeclarativeConfigProperties config, boolean v3Preview) {
-    requestParameters = SelectorConfig.resolve(config, "servlet", "request-parameters");
+    requestParameters =
+        SelectorConfig.resolveCapturedNames(
+            config, "servlet", "request-parameters", false, CaseSensitivity.CASE_SENSITIVE);
     captureExperimentalAttributes =
         config.getBoolean("experimental_span_attributes/development", false);
     traceIdRequestAttributeEnabled =
         config.get("trace_id_request_attribute/development").getBoolean("enabled", !v3Preview);
   }
 
-  @Nullable
-  IncludeExclude getRequestParameters() {
+  CapturedNames getRequestParameters() {
     return requestParameters;
   }
 

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletInstrumenterBuilder.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletInstrumenterBuilder.java
@@ -7,17 +7,17 @@ package io.opentelemetry.instrumentation.servlet.common.internal;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpServerInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.ContextCustomizer;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -35,7 +35,8 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
   private boolean propagateOperationListenersToOnEnd;
   private boolean captureExperimentalAttributes;
   private boolean captureEnduserId;
-  @Nullable private IncludeExclude requestParameters;
+  private CapturedNames requestParameters =
+      CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
 
   public static <REQUEST, RESPONSE> ServletInstrumenterBuilder<REQUEST, RESPONSE> create(
       String instrumentationName,
@@ -97,7 +98,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
 
   @CanIgnoreReturnValue
   public ServletInstrumenterBuilder<REQUEST, RESPONSE> setRequestParameters(
-      @Nullable IncludeExclude requestParameters) {
+      CapturedNames requestParameters) {
     this.requestParameters = requestParameters;
     return this;
   }
@@ -109,7 +110,7 @@ public final class ServletInstrumenterBuilder<REQUEST, RESPONSE> {
 
     builder.setBuilderCustomizer(
         builder -> {
-          if (requestParameters != null && !requestParameters.isEmpty()) {
+          if (!requestParameters.isEmpty()) {
             AttributesExtractor<ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>>
                 requestParametersExtractor =
                     new ServletRequestParametersExtractor<>(accessor, requestParameters);

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletRequestParametersExtractor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletRequestParametersExtractor.java
@@ -8,9 +8,10 @@ package io.opentelemetry.instrumentation.servlet.common.internal;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -27,14 +28,14 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
         ServletRequestContext<REQUEST>, ServletResponseContext<RESPONSE>> {
 
   private final ServletAccessor<REQUEST, RESPONSE> accessor;
-  private final IncludeExclude requestParameters;
-  private final Map<String, AttributeKey<List<String>>> literalParameterKeys;
+  private final CapturedNames requestParameters;
+  private final Map<String, AttributeKey<List<String>>> exactParameterKeys;
 
   public ServletRequestParametersExtractor(
-      ServletAccessor<REQUEST, RESPONSE> accessor, IncludeExclude requestParameters) {
+      ServletAccessor<REQUEST, RESPONSE> accessor, CapturedNames requestParameters) {
     this.accessor = accessor;
     this.requestParameters = requestParameters;
-    this.literalParameterKeys = createLiteralParameterKeys(requestParameters);
+    this.exactParameterKeys = createExactParameterKeys(requestParameters);
   }
 
   public void setAttributes(
@@ -42,10 +43,11 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
     if (requestParameters.isEmpty()) {
       return;
     }
-    for (String name : accessor.getRequestParameterNames(request)) {
-      if (!requestParameters.matches(name)) {
-        continue;
-      }
+    Collection<String> names =
+        requestParameters.enumerateNames()
+            ? requestParameters.matchingNames(accessor.getRequestParameterNames(request))
+            : requestParameters.exactNames();
+    for (String name : names) {
       List<String> values = accessor.getRequestParameterValues(request, name);
       if (!values.isEmpty()) {
         consumer.accept(parameterAttributeKey(name), values);
@@ -73,17 +75,15 @@ public class ServletRequestParametersExtractor<REQUEST, RESPONSE>
   }
 
   private AttributeKey<List<String>> parameterAttributeKey(String parameterName) {
-    AttributeKey<List<String>> key = literalParameterKeys.get(parameterName);
+    AttributeKey<List<String>> key = exactParameterKeys.get(parameterName);
     return key != null ? key : createKey(parameterName);
   }
 
-  private static Map<String, AttributeKey<List<String>>> createLiteralParameterKeys(
-      IncludeExclude selector) {
+  private static Map<String, AttributeKey<List<String>>> createExactParameterKeys(
+      CapturedNames requestParameters) {
     Map<String, AttributeKey<List<String>>> result = new HashMap<>();
-    for (String pattern : selector.getIncluded()) {
-      if (pattern.indexOf('*') == -1 && pattern.indexOf('?') == -1) {
-        result.put(pattern, createKey(pattern));
-      }
+    for (String name : requestParameters.exactNames()) {
+      result.put(name, createKey(name));
     }
     return result;
   }

--- a/instrumentation/servlet/servlet-common/library/src/test/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletRequestParametersExtractorTest.java
+++ b/instrumentation/servlet/servlet-common/library/src/test/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletRequestParametersExtractorTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 class ServletRequestParametersExtractorTest {
@@ -44,7 +47,7 @@ class ServletRequestParametersExtractorTest {
             .build();
     AttributesBuilder attributes = Attributes.builder();
 
-    new ServletRequestParametersExtractor<>(accessor, selector)
+    new ServletRequestParametersExtractor<>(accessor, captured(selector))
         .setAttributes(request, attributes::put);
 
     assertThat(attributes.build().asMap())
@@ -66,7 +69,7 @@ class ServletRequestParametersExtractorTest {
     IncludeExclude selector = IncludeExclude.builder().setExcluded(singletonList("secret")).build();
     AttributesBuilder attributes = Attributes.builder();
 
-    new ServletRequestParametersExtractor<>(accessor, selector)
+    new ServletRequestParametersExtractor<>(accessor, captured(selector))
         .setAttributes(request, attributes::put);
 
     assertThat(attributes.build().asMap())
@@ -80,10 +83,67 @@ class ServletRequestParametersExtractorTest {
     IncludeExclude selector =
         IncludeExclude.builder().setIncluded(emptyList()).setExcluded(emptyList()).build();
 
-    new ServletRequestParametersExtractor<>(accessor, selector)
+    new ServletRequestParametersExtractor<>(accessor, captured(selector))
         .setAttributes(request, (key, value) -> {});
 
     verify(accessor, never()).getRequestParameterNames(request);
     verify(accessor, never()).getRequestParameterValues(request, "anything");
+  }
+
+  @Test
+  void looksUpDeprecatedParameterNamesDirectly() {
+    when(accessor.getRequestParameterValues(request, "exact")).thenReturn(singletonList("one"));
+    AttributesBuilder attributes = Attributes.builder();
+
+    new ServletRequestParametersExtractor<>(accessor, capturedExact(asList("exact", "missing")))
+        .setAttributes(request, attributes::put);
+
+    assertThat(attributes.build().asMap())
+        .containsOnly(
+            entry(stringArrayKey("servlet.request.parameter.exact"), singletonList("one")));
+    verify(accessor, never()).getRequestParameterNames(request);
+  }
+
+  @Test
+  void deprecatedWildcardParameterNameCapturesNothing() {
+    when(accessor.getRequestParameterNames(request)).thenReturn(asList("password", "*"));
+    when(accessor.getRequestParameterValues(request, "password"))
+        .thenReturn(singletonList("hunter2"));
+    AttributesBuilder attributes = Attributes.builder();
+
+    // the deprecated setting never supported wildcards, so "*" only matches a parameter that is
+    // literally named "*"
+    new ServletRequestParametersExtractor<>(accessor, capturedExact(singletonList("*")))
+        .setAttributes(request, attributes::put);
+
+    assertThat(attributes.build().asMap()).isEmpty();
+    verify(accessor, never()).getRequestParameterNames(request);
+    verify(accessor, never()).getRequestParameterValues(request, "password");
+  }
+
+  @Test
+  void matchesParameterNamesCaseSensitively() {
+    when(accessor.getRequestParameterNames(request)).thenReturn(asList("Parameter", "parameter"));
+    when(accessor.getRequestParameterValues(request, "parameter"))
+        .thenReturn(singletonList("value"));
+    IncludeExclude selector =
+        IncludeExclude.builder().setIncluded(singletonList("parameter*")).build();
+    AttributesBuilder attributes = Attributes.builder();
+
+    new ServletRequestParametersExtractor<>(accessor, captured(selector))
+        .setAttributes(request, attributes::put);
+
+    assertThat(attributes.build().asMap())
+        .containsOnly(
+            entry(stringArrayKey("servlet.request.parameter.parameter"), singletonList("value")));
+    verify(accessor, never()).getRequestParameterValues(request, "Parameter");
+  }
+
+  private static CapturedNames captured(IncludeExclude selector) {
+    return CapturedNames.create(selector, CaseSensitivity.CASE_SENSITIVE);
+  }
+
+  private static CapturedNames capturedExact(Collection<String> names) {
+    return CapturedNames.createExact(names, CaseSensitivity.CASE_SENSITIVE);
   }
 }


### PR DESCRIPTION
Three settings had their deprecated literal values reinterpreted as glob patterns when they were converted to `IncludeExclude` selectors. Those settings never supported `*` as a wildcard, so a configured `*` used to look for a key literally named `*` and therefore captured nothing. After the conversion it captures every key, including `authorization`. This silently widens capture and can leak credentials into span attributes. None of the three conversions has been released, so this corrects them before they ship.

Concretely, with `otel.instrumentation.grpc.capture-metadata.client.request=*`, the current `main` captures every request metadata entry. With this change it again captures only an entry whose key is literally `*`, which is what the setting always meant. The same applies to `otel.instrumentation.servlet.experimental.capture-request-parameters`. The selector forms keep glob semantics: `otel.instrumentation.grpc.metadata.client.request.included=*` still captures everything.

The fix is a new internal `CapturedNames` type that resolves either a glob selector or a list of exact names into a single matcher. Callers ask it whether it needs to enumerate the names a request carries, or whether a direct lookup of a known set of names is enough, which also restores the direct-lookup behavior the deprecated paths had before.

Whether names match case-insensitively is a property of the carrier, so it is a flag on `CapturedNames` rather than something each caller normalizes. gRPC metadata keys are matched case-insensitively; servlet request parameters are matched case-sensitively.

`IncludeExclude` remains the public input type and no public signature changes. Only the internal resolved representation changes, and the deprecated setters stop converting through `IncludeExclude` on their way to it.

This covers the gRPC and servlet settings. The equivalent messaging fix is a sibling pull request.
