### PR TITLE
Do not treat deprecated messaging captured headers as glob patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   in favor of `otel.instrumentation.messaging.experimental.headers.included` /
   `otel.instrumentation.messaging.experimental.headers.excluded` and `setHeaders(IncludeExclude)`,
   which select message headers by glob pattern instead of by exact name only. The deprecated
-  property and methods remain include-only aliases and use the selector's glob matching.
+  property and methods remain include-only aliases and keep their exact-name matching.
 - Deprecate the Logback appender `experimental.capture-mdc-attributes` configuration property and
   `OpenTelemetryAppender#setCaptureMdcAttributes(String)` in favor of the new
   `experimental.mdc-attributes.included` and `experimental.mdc-attributes.excluded` selectors, which

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -44,6 +44,11 @@ public final class SelectorConfig {
    *
    * <p>Note that {@code null} is returned rather than an {@linkplain IncludeExclude#isEmpty()
    * empty} selector because an empty selector matches every value.
+   *
+   * <p>Use {@link #resolveCapturedNames} instead when the selector has a deprecated predecessor
+   * that took a list of literal names. This method folds those values into the returned selector,
+   * where they are matched as globs, which silently widens what a deprecated value of {@code "*"}
+   * captures.
    */
   @Nullable
   public static IncludeExclude resolve(
@@ -53,6 +58,11 @@ public final class SelectorConfig {
 
   /**
    * Returns the configured selector, or {@code null} when nothing is configured to be captured.
+   *
+   * <p>Use {@link #resolveCapturedNames} instead when the selector has a deprecated predecessor
+   * that took a list of literal names. This method folds those values into the returned selector,
+   * where they are matched as globs, which silently widens what a deprecated value of {@code "*"}
+   * captures.
    *
    * @param systemPropertyFallback whether to fall back to the flat system properties when the
    *     declarative configuration does not contain a value. This is needed by library

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -8,23 +8,18 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -129,45 +124,22 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   @Nullable private final MessagingOperationType operationType;
   @Nullable private final String operationName;
   private final boolean supportsStableSemconv;
-  @Nullable private final IncludeExclude headers;
-  // exact header names that the selector includes, queried directly so that getters which only
-  // implement getMessageHeader() keep working
-  private final List<String> exactHeaderNames;
+  private final CapturedNames headers;
   private final Map<String, AttributeKey<List<String>>> exactHeaderAttributeKeys;
-  // whether the selector can match header names that are not listed in exactHeaderNames, which
-  // requires enumerating the header names of each message
-  private final boolean enumerateHeaderNames;
 
   MessagingAttributesExtractor(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter,
       @Nullable MessagingOperationType operationType,
       @Nullable String operationName,
       boolean supportsStableSemconv,
-      @Nullable IncludeExclude headers) {
+      CapturedNames headers) {
     this.getter = getter;
     this.operationType = operationType;
     this.operationName = operationName;
     this.supportsStableSemconv = supportsStableSemconv;
     this.headers = headers;
-
-    Set<String> exactNames = new LinkedHashSet<>();
-    boolean enumerate = false;
-    if (headers != null) {
-      List<String> included = headers.getIncluded();
-      // a selector without included patterns matches every header name that is not excluded
-      enumerate = included.isEmpty();
-      for (String pattern : included) {
-        if (pattern.indexOf('*') != -1 || pattern.indexOf('?') != -1) {
-          enumerate = true;
-        } else if (headers.matches(pattern)) {
-          exactNames.add(pattern);
-        }
-      }
-    }
-    this.exactHeaderNames = unmodifiableList(new ArrayList<>(exactNames));
     this.exactHeaderAttributeKeys =
-        CapturedMessageHeadersUtil.createLiteralAttributeKeys(exactHeaderNames);
-    this.enumerateHeaderNames = enumerate;
+        CapturedMessageHeadersUtil.createLiteralAttributeKeys(headers.exactNames());
   }
 
   @Override
@@ -245,19 +217,9 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
   }
 
   private Collection<String> headerNames(REQUEST request) {
-    if (headers == null) {
-      return emptyList();
-    }
-    if (!enumerateHeaderNames) {
-      return exactHeaderNames;
-    }
-    Set<String> names = new LinkedHashSet<>(exactHeaderNames);
-    for (String name : getter.getMessageHeaderNames(request)) {
-      if (headers.matches(name)) {
-        names.add(name);
-      }
-    }
-    return names;
+    return headers.enumerateNames()
+        ? headers.matchingNames(getter.getMessageHeaderNames(request))
+        : headers.exactNames();
   }
 
   /**

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
@@ -18,7 +20,7 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @Nullable private final MessagingOperationType operationType;
   @Nullable private final String operationName;
   private final boolean supportsStableSemconv;
-  @Nullable IncludeExclude headers;
+  CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
 
   MessagingAttributesExtractorBuilder(
       MessagingAttributesGetter<REQUEST, RESPONSE> getter,
@@ -52,7 +54,20 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    */
   @CanIgnoreReturnValue
   public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setHeaders(IncludeExclude headers) {
-    this.headers = headers.isEmpty() ? null : headers;
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> internalSetHeaders(
+      CapturedNames headers) {
+    this.headers = headers;
     return this;
   }
 
@@ -64,6 +79,8 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
    * replaced by underscores unless {@code otel.instrumentation.common.v3-preview} is enabled, in
    * which case dashes are preserved.
    *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
+   *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
    *     release.
@@ -72,7 +89,8 @@ public final class MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> {
   @CanIgnoreReturnValue
   public MessagingAttributesExtractorBuilder<REQUEST, RESPONSE> setCapturedHeaders(
       Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfig.java
@@ -7,9 +7,10 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.interna
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 
 /**
  * Resolves the common messaging header selector, shared by every messaging instrumentation so that
@@ -20,25 +21,23 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorCo
  */
 public final class MessagingConfig {
 
-  private static final IncludeExclude NONE = IncludeExclude.builder().build();
-
   /**
-   * Returns the configured messaging header selector, or an {@linkplain IncludeExclude#isEmpty()
-   * empty} selector when no headers are configured to be captured.
+   * Returns the messaging headers to capture, which is {@linkplain CapturedNames#isEmpty() empty}
+   * when no headers are configured to be captured.
    */
-  public static IncludeExclude getHeaders(OpenTelemetry openTelemetry) {
+  public static CapturedNames getHeaders(OpenTelemetry openTelemetry) {
     return getHeaders(openTelemetry, false);
   }
 
   /**
-   * Returns the configured messaging header selector, or an {@linkplain IncludeExclude#isEmpty()
-   * empty} selector when no headers are configured to be captured.
+   * Returns the messaging headers to capture, which is {@linkplain CapturedNames#isEmpty() empty}
+   * when no headers are configured to be captured.
    *
    * @param systemPropertyFallback whether to fall back to the flat system properties when the
    *     declarative configuration does not contain a value. This is needed by library
    *     instrumentation entry points that have no programmatic configuration surface.
    */
-  public static IncludeExclude getHeaders(
+  public static CapturedNames getHeaders(
       OpenTelemetry openTelemetry, boolean systemPropertyFallback) {
     return getHeaders(
         DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "common").get("messaging"),
@@ -46,11 +45,14 @@ public final class MessagingConfig {
   }
 
   // visible for testing
-  static IncludeExclude getHeaders(
+  static CapturedNames getHeaders(
       DeclarativeConfigProperties messagingConfig, boolean systemPropertyFallback) {
-    IncludeExclude selector =
-        SelectorConfig.resolve(messagingConfig, "messaging", "headers", systemPropertyFallback);
-    return selector == null ? NONE : selector;
+    return SelectorConfig.resolveCapturedNames(
+        messagingConfig,
+        "messaging",
+        "headers",
+        systemPropertyFallback,
+        CaseSensitivity.CASE_SENSITIVE);
   }
 
   private MessagingConfig() {}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -34,6 +34,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -176,7 +178,11 @@ class MessagingAttributesExtractorTest {
   void shouldReturnSpanKey(MessagingOperationType operationType, SpanKey spanKey) {
     MessagingAttributesExtractor<Map<String, String>, String> underTest =
         new MessagingAttributesExtractor<>(
-            TestGetter.INSTANCE, operationType, operationType.legacyOperationName(), true, null);
+            TestGetter.INSTANCE,
+            operationType,
+            operationType.legacyOperationName(),
+            true,
+            CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE));
 
     assertThat(underTest.internalGetSpanKey()).isSameAs(spanKey);
   }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingHeadersTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingHeadersTest.java
@@ -141,6 +141,27 @@ class MessagingHeadersTest {
     assertThat(attributes.build().asMap()).isEmpty();
   }
 
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersSetterDoesNotTreatStarAsWildcard() {
+    AttributesBuilder attributes = Attributes.builder();
+    builder()
+        .setCapturedHeaders(singletonList("*"))
+        .build()
+        .onEnd(attributes, Context.root(), MESSAGE, null, null);
+
+    assertThat(attributes.build().asMap()).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    assertThat(capture(selector(singletonList("*"), emptyList())))
+        .containsOnly(
+            headerEntry("Test-Message-Header", "one"),
+            headerEntry("Test-Message-Other", "two"),
+            headerEntry("Authorization", "secret"));
+  }
+
   private static Map<AttributeKey<?>, Object> capture(IncludeExclude headers) {
     AttributesBuilder attributes = Attributes.builder();
     extractor(new MapGetter(true), headers).onEnd(attributes, Context.root(), MESSAGE, null, null);

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfigTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -25,7 +26,8 @@ class MessagingConfigTest {
             .getScalarList("included", String.class))
         .thenReturn(singletonList("Test-*"));
 
-    assertThat(MessagingConfig.getHeaders(openTelemetry).getIncluded()).containsExactly("Test-*");
+    assertThat(MessagingConfig.getHeaders(openTelemetry).matchingNames(asList("Test-1", "other")))
+        .containsExactly("Test-1");
   }
 
   @Test
@@ -34,8 +36,31 @@ class MessagingConfigTest {
     when(messagingConfig(openTelemetry).getScalarList("capture_headers/development", String.class))
         .thenReturn(singletonList("deprecated"));
 
-    assertThat(MessagingConfig.getHeaders(openTelemetry).getIncluded())
+    assertThat(MessagingConfig.getHeaders(openTelemetry).exactNames())
         .containsExactly("deprecated");
+  }
+
+  @Test
+  void deprecatedSelectorMatchesLiterally() {
+    ExtendedOpenTelemetry openTelemetry = mockOpenTelemetry();
+    when(messagingConfig(openTelemetry).getScalarList("capture_headers/development", String.class))
+        .thenReturn(singletonList("*"));
+
+    // the deprecated setting never supported "*" as capturing every header
+    assertThat(MessagingConfig.getHeaders(openTelemetry).enumerateNames()).isFalse();
+    assertThat(MessagingConfig.getHeaders(openTelemetry).exactNames()).containsExactly("*");
+  }
+
+  @Test
+  void selectorMatchesGlobs() {
+    ExtendedOpenTelemetry openTelemetry = mockOpenTelemetry();
+    when(messagingConfig(openTelemetry)
+            .get("headers/development")
+            .getScalarList("included", String.class))
+        .thenReturn(singletonList("*"));
+
+    assertThat(MessagingConfig.getHeaders(openTelemetry).matchingNames(asList("Test-1", "other")))
+        .containsExactly("Test-1", "other");
   }
 
   @Test
@@ -49,7 +74,7 @@ class MessagingConfigTest {
     System.setProperty("otel.instrumentation.messaging.experimental.headers.included", "from-prop");
     try {
       assertThat(MessagingConfig.getHeaders(openTelemetry, false).isEmpty()).isTrue();
-      assertThat(MessagingConfig.getHeaders(openTelemetry, true).getIncluded())
+      assertThat(MessagingConfig.getHeaders(openTelemetry, true).exactNames())
           .containsExactly("from-prop");
     } finally {
       System.clearProperty("otel.instrumentation.messaging.experimental.headers.included");

--- a/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -41,7 +41,7 @@ public class TracingRequestHandler extends RequestHandler2 {
                   .getBoolean("experimental_span_attributes/development", false))
           .setMessagingReceiveTelemetryEnabled(
               ExperimentalConfig.get().messagingReceiveInstrumentationEnabled())
-          .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .build()
           .createRequestHandler();
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/autoconfigure/TracingRequestHandler.java
@@ -45,7 +45,7 @@ public final class TracingRequestHandler extends RequestHandler2 {
                     SystemProperty.getBoolean(
                         "otel.instrumentation.messaging.experimental.receive-telemetry.enabled",
                         false)))
-        .setHeaders(MessagingConfig.getHeaders(openTelemetry, true))
+        .internalSetHeaders(MessagingConfig.getHeaders(openTelemetry, true))
         .build()
         .createRequestHandler();
   }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   compileOnly(project(":muzzle"))
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-1.11:testing"))
+  testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13")
 
   testLibrary("com.amazonaws:aws-java-sdk-dynamodb:1.11.106")
   testLibrary("com.amazonaws:aws-java-sdk-ec2:1.11.106")

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetry.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetry.java
@@ -10,8 +10,8 @@ import com.amazonaws.Response;
 import com.amazonaws.handlers.RequestHandler2;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.awssdk.v1_11.internal.AwsSdkInstrumenterFactory;
 import io.opentelemetry.instrumentation.awssdk.v1_11.internal.SqsProcessRequest;
 import io.opentelemetry.instrumentation.awssdk.v1_11.internal.SqsReceiveRequest;
@@ -49,7 +49,7 @@ public final class AwsSdkTelemetry {
 
   AwsSdkTelemetry(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes,
       boolean messagingReceiveInstrumentationEnabled) {
     AwsSdkInstrumenterFactory instrumenterFactory =

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.awssdk.v1_11;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.Collection;
 
 /** A builder of {@link AwsSdkTelemetry}. */
@@ -15,7 +17,7 @@ public final class AwsSdkTelemetryBuilder {
 
   private final OpenTelemetry openTelemetry;
 
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes;
   private boolean messagingReceiveTelemetryEnabled;
 
@@ -38,12 +40,26 @@ public final class AwsSdkTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setHeaders(IncludeExclude headers) {
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder internalSetHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -52,7 +68,8 @@ public final class AwsSdkTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -25,7 +25,6 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
@@ -39,6 +38,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,13 +68,13 @@ public final class AwsSdkInstrumenterFactory {
       extendedAttributesExtractors = createAttributesExtractors(true);
 
   private final OpenTelemetry openTelemetry;
-  private final IncludeExclude headers;
+  private final CapturedNames headers;
   private final boolean captureExperimentalSpanAttributes;
   private final boolean messagingReceiveInstrumentationEnabled;
 
   public AwsSdkInstrumenterFactory(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes,
       boolean messagingReceiveInstrumentationEnabled) {
     this.openTelemetry = openTelemetry;
@@ -119,7 +119,7 @@ public final class AwsSdkInstrumenterFactory {
       MessagingOperationType operationType,
       String operationName) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilderTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v1_11/AwsSdkTelemetryBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v1_11;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.test.utils.PortUtils;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.elasticmq.rest.sqs.SQSRestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class AwsSdkTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  private int sqsPort;
+  private SQSRestServer sqsRestServer;
+
+  @BeforeEach
+  void setUp() {
+    sqsPort = PortUtils.findOpenPort();
+    sqsRestServer = SQSRestServerBuilder.withPort(sqsPort).withInterface("localhost").start();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    if (sqsRestServer != null) {
+      sqsRestServer.stopAndWait();
+    }
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    assertThat(capturedHeaderKeys(builder -> builder.setCapturedHeaders(singletonList("*"))))
+        .isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    assertThat(
+            capturedHeaderKeys(
+                builder -> builder.setHeaders(IncludeExclude.builder().setIncluded("*").build())))
+        .isNotEmpty();
+  }
+
+  private List<String> capturedHeaderKeys(UnaryOperator<AwsSdkTelemetryBuilder> configure) {
+    AmazonSQSAsync sqsClient = createClient(configure);
+    sqsClient.createQueue("testSdkSqs");
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+
+    SendMessageRequest sendMessageRequest =
+        new SendMessageRequest(queueUrl, "{\"type\": \"hello\"}");
+    sendMessageRequest.addMessageAttributesEntry(
+        "Test-Message-Header",
+        new MessageAttributeValue().withDataType("String").withStringValue("test"));
+    sqsClient.sendMessage(sendMessageRequest);
+
+    sqsClient.receiveMessage(
+        new ReceiveMessageRequest(queueUrl).withMessageAttributeNames("Test-Message-Header"));
+
+    return testing.spans().stream()
+        .map(SpanData::getAttributes)
+        .flatMap(attributes -> attributes.asMap().keySet().stream())
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+
+  private AmazonSQSAsync createClient(UnaryOperator<AwsSdkTelemetryBuilder> configure) {
+    AwsSdkTelemetryBuilder builder =
+        AwsSdkTelemetry.builder(testing.getOpenTelemetry())
+            .setMessagingReceiveTelemetryEnabled(true);
+    return AmazonSQSAsyncClient.asyncBuilder()
+        .withRequestHandlers(configure.apply(builder).build().createRequestHandler())
+        .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("x", "x")))
+        .withEndpointConfiguration(
+            new AwsClientBuilder.EndpointConfiguration("http://localhost:" + sqsPort, "elasticmq"))
+        .build();
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   compileOnly("software.amazon.awssdk:bedrockruntime:2.25.63")
 
   testImplementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
+  testImplementation("org.elasticmq:elasticmq-rest-sqs_2.13")
 
   testLibrary("software.amazon.awssdk:dynamodb:2.2.0")
   testLibrary("software.amazon.awssdk:ec2:2.2.0")

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetry.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetry.java
@@ -8,8 +8,8 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.AwsSdkInstrumenterFactory;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.BedrockRuntimeImpl;
 import io.opentelemetry.instrumentation.awssdk.v2_2.internal.Response;
@@ -76,7 +76,7 @@ public class AwsSdkTelemetry {
 
   AwsSdkTelemetry(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes,
       boolean useMessagingPropagator,
       boolean useXrayPropagator,

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.Collection;
 
 /** A builder of {@link AwsSdkTelemetry}. */
@@ -15,7 +17,7 @@ public final class AwsSdkTelemetryBuilder {
 
   private final OpenTelemetry openTelemetry;
 
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes;
   private boolean useMessagingPropagator;
   private boolean recordIndividualHttpError;
@@ -42,12 +44,26 @@ public final class AwsSdkTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setHeaders(IncludeExclude headers) {
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public AwsSdkTelemetryBuilder internalSetHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -56,7 +72,8 @@ public final class AwsSdkTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public AwsSdkTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -26,7 +26,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiClientMetrics;
@@ -43,6 +42,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
@@ -101,7 +101,7 @@ public final class AwsSdkInstrumenterFactory {
 
   private final OpenTelemetry openTelemetry;
   @Nullable private final TextMapPropagator messagingPropagator;
-  private final IncludeExclude headers;
+  private final CapturedNames headers;
   private final boolean captureExperimentalSpanAttributes;
   private final boolean messagingReceiveInstrumentationEnabled;
   private final boolean useXrayPropagator;
@@ -109,7 +109,7 @@ public final class AwsSdkInstrumenterFactory {
   public AwsSdkInstrumenterFactory(
       OpenTelemetry openTelemetry,
       @Nullable TextMapPropagator messagingPropagator,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes,
       boolean messagingReceiveInstrumentationEnabled,
       boolean useXrayPropagator) {
@@ -148,7 +148,7 @@ public final class AwsSdkInstrumenterFactory {
       MessagingOperationType operationType,
       String operationName) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkTelemetryFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkTelemetryFactory.java
@@ -40,7 +40,7 @@ public final class AwsSdkTelemetryFactory {
         DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "aws_sdk");
 
     return AwsSdkTelemetry.builder(openTelemetry)
-        .setHeaders(
+        .internalSetHeaders(
             MessagingConfig.getHeaders(openTelemetry, systemProperties == SystemProperties.ENABLED))
         .setCaptureExperimentalSpanAttributes(
             awsSdk.getBoolean(

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilderTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/test/java/io/opentelemetry/instrumentation/awssdk/v2_2/AwsSdkTelemetryBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.test.utils.PortUtils;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.net.URI;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.elasticmq.rest.sqs.SQSRestServer;
+import org.elasticmq.rest.sqs.SQSRestServerBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+class AwsSdkTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  private int sqsPort;
+  private SQSRestServer sqsRestServer;
+
+  @BeforeEach
+  void setUp() {
+    sqsPort = PortUtils.findOpenPort();
+    sqsRestServer = SQSRestServerBuilder.withPort(sqsPort).withInterface("localhost").start();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    if (sqsRestServer != null) {
+      sqsRestServer.stopAndWait();
+    }
+  }
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    assertThat(capturedHeaderKeys(builder -> builder.setCapturedHeaders(singletonList("*"))))
+        .isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    assertThat(
+            capturedHeaderKeys(
+                builder -> builder.setHeaders(IncludeExclude.builder().setIncluded("*").build())))
+        .isNotEmpty();
+  }
+
+  private List<String> capturedHeaderKeys(UnaryOperator<AwsSdkTelemetryBuilder> configure) {
+    AwsSdkTelemetryBuilder telemetryBuilder =
+        AwsSdkTelemetry.builder(testing.getOpenTelemetry())
+            .setMessagingReceiveTelemetryEnabled(true);
+    AwsSdkTelemetry telemetry = configure.apply(telemetryBuilder).build();
+
+    SqsClient sqsClient =
+        telemetry.wrap(
+            SqsClient.builder()
+                .endpointOverride(URI.create("http://localhost:" + sqsPort))
+                .region(Region.AP_NORTHEAST_1)
+                .credentialsProvider(
+                    StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+                .overrideConfiguration(
+                    ClientOverrideConfiguration.builder()
+                        .addExecutionInterceptor(telemetry.createExecutionInterceptor())
+                        .build())
+                .build());
+
+    sqsClient.createQueue(builder -> builder.queueName("testSdkSqs"));
+    String queueUrl = "http://localhost:" + sqsPort + "/000000000000/testSdkSqs";
+
+    sqsClient.sendMessage(
+        SendMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .messageBody("{\"type\": \"hello\"}")
+            .messageAttributes(
+                singletonMap(
+                    "Test-Message-Header",
+                    MessageAttributeValue.builder().dataType("String").stringValue("test").build()))
+            .build());
+
+    sqsClient.receiveMessage(
+        ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .messageAttributeNames("Test-Message-Header")
+            .build());
+
+    return testing.spans().stream()
+        .map(SpanData::getAttributes)
+        .flatMap(attributes -> attributes.asMap().keySet().stream())
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
+++ b/instrumentation/jms/jms-common-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/common/v1_1/JmsInstrumenterFactory.java
@@ -12,7 +12,6 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanKindExtractor;
@@ -21,6 +20,8 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 
 public class JmsInstrumenterFactory {
@@ -32,7 +33,7 @@ public class JmsInstrumenterFactory {
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean messagingReceiveInstrumentationEnabled = false;
 
   public JmsInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
@@ -41,7 +42,7 @@ public class JmsInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public JmsInstrumenterFactory setHeaders(IncludeExclude headers) {
+  public JmsInstrumenterFactory setHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
@@ -115,7 +116,7 @@ public class JmsInstrumenterFactory {
       MessagingOperationType operationType, String operationName) {
     return MessagingAttributesExtractor.builder(
             new JmsMessageAttributesGetter(), operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilder.java
@@ -11,6 +11,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProducerRequest;
@@ -30,7 +32,7 @@ public final class KafkaTelemetryBuilder {
       consumerProcessAttributesExtractors = new ArrayList<>();
   private final List<AttributesExtractor<KafkaReceiveRequest, Void>>
       consumerReceiveAttributesExtractors = new ArrayList<>();
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes = false;
   private boolean propagationEnabled = true;
   private boolean messagingReceiveInstrumentationEnabled = false;
@@ -76,12 +78,14 @@ public final class KafkaTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public KafkaTelemetryBuilder setHeaders(IncludeExclude headers) {
-    this.headers = headers;
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -90,7 +94,8 @@ public final class KafkaTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public KafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilderTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/KafkaTelemetryBuilderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.v2_6;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class KafkaTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    KafkaTelemetry telemetry =
+        KafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedHeaders(singletonList("*"))
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    KafkaTelemetry telemetry =
+        KafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setHeaders(IncludeExclude.builder().setIncluded("*").build())
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isNotEmpty();
+  }
+
+  private static List<String> capturedHeaderKeys(KafkaTelemetry telemetry) {
+    ProducerRecord<String, String> record = new ProducerRecord<>("topic", "value");
+    record.headers().add("Test-Message-Header", "test".getBytes(UTF_8));
+
+    try (MockProducer<String, String> mockProducer =
+        new MockProducer<>(true, new StringSerializer(), new StringSerializer())) {
+      Producer<String, String> producer = telemetry.wrap(mockProducer);
+      producer.send(record);
+    }
+
+    List<SpanData> spans = testing.waitForTraces(1).get(0);
+    return spans.get(0).getAttributes().asMap().keySet().stream()
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -13,7 +13,6 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
@@ -25,6 +24,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
@@ -40,7 +41,7 @@ public final class KafkaInstrumenterFactory {
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes = false;
   private boolean messagingReceiveInstrumentationEnabled = false;
   private boolean messagingReceiveInstrumentationConfigured = false;
@@ -57,7 +58,7 @@ public final class KafkaInstrumenterFactory {
   }
 
   @CanIgnoreReturnValue
-  public KafkaInstrumenterFactory setHeaders(IncludeExclude headers) {
+  public KafkaInstrumenterFactory setHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
@@ -202,9 +203,9 @@ public final class KafkaInstrumenterFactory {
           MessagingAttributesGetter<REQUEST, RESPONSE> getter,
           MessagingOperationType operationType,
           String operationName,
-          IncludeExclude headers) {
+          CapturedNames headers) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 }

--- a/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/NatsSingletons.java
+++ b/instrumentation/nats/nats-2.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/nats/v2_17/NatsSingletons.java
@@ -10,14 +10,14 @@ import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumen
 import static io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory.createRequestInstrumenter;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.nats.v2_17.internal.NatsRequest;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 
 class NatsSingletons {
 
-  private static final IncludeExclude headers = ExperimentalConfig.get().getMessagingHeaders();
+  private static final CapturedNames headers = ExperimentalConfig.get().getMessagingHeaders();
 
   private static final Instrumenter<NatsRequest, NatsRequest> publishInstrumenter =
       createPublishInstrumenter(GlobalOpenTelemetry.get(), headers);

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.nats.v2_17;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.nats.v2_17.internal.NatsInstrumenterFactory;
 import java.util.Collection;
 
@@ -15,7 +17,7 @@ import java.util.Collection;
 public final class NatsTelemetryBuilder {
 
   private final OpenTelemetry openTelemetry;
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
 
   NatsTelemetryBuilder(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -36,12 +38,14 @@ public final class NatsTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public NatsTelemetryBuilder setHeaders(IncludeExclude headers) {
-    this.headers = headers;
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -50,7 +54,8 @@ public final class NatsTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public NatsTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /** Returns a new {@link NatsTelemetry} with the settings of this {@link NatsTelemetryBuilder}. */

--- a/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
+++ b/instrumentation/nats/nats-2.17/library/src/main/java/io/opentelemetry/instrumentation/nats/v2_17/internal/NatsInstrumenterFactory.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingOperationType;
@@ -20,6 +19,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -34,17 +34,17 @@ public final class NatsInstrumenterFactory {
   private static final String PROCESS_OPERATION_NAME = "process";
 
   public static Instrumenter<NatsRequest, NatsRequest> createPublishInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers) {
+      OpenTelemetry openTelemetry, CapturedNames headers) {
     return createProducerInstrumenter(openTelemetry, headers, PUBLISH_OPERATION_NAME);
   }
 
   public static Instrumenter<NatsRequest, NatsRequest> createRequestInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers) {
+      OpenTelemetry openTelemetry, CapturedNames headers) {
     return createProducerInstrumenter(openTelemetry, headers, REQUEST_OPERATION_NAME);
   }
 
   private static Instrumenter<NatsRequest, NatsRequest> createProducerInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers, String operationName) {
+      OpenTelemetry openTelemetry, CapturedNames headers, String operationName) {
     InstrumenterBuilder<NatsRequest, NatsRequest> builder =
         Instrumenter.<NatsRequest, NatsRequest>builder(
                 openTelemetry,
@@ -61,7 +61,7 @@ public final class NatsInstrumenterFactory {
   }
 
   public static Instrumenter<NatsRequest, Void> createConsumerProcessInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers) {
+      OpenTelemetry openTelemetry, CapturedNames headers) {
     InstrumenterBuilder<NatsRequest, Void> builder =
         Instrumenter.<NatsRequest, Void>builder(
                 openTelemetry,
@@ -85,10 +85,10 @@ public final class NatsInstrumenterFactory {
   }
 
   private static AttributesExtractor<NatsRequest, Object> messagingAttributesExtractor(
-      MessagingOperationType operationType, String operationName, IncludeExclude headers) {
+      MessagingOperationType operationType, String operationName, CapturedNames headers) {
     return MessagingAttributesExtractor.builder(
             new NatsRequestMessagingAttributesGetter(), operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 

--- a/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilderTest.java
+++ b/instrumentation/nats/nats-2.17/library/src/test/java/io/opentelemetry/instrumentation/nats/v2_17/NatsTelemetryBuilderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.nats.v2_17;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.nats.client.Connection;
+import io.nats.client.Options;
+import io.nats.client.api.ServerInfo;
+import io.nats.client.impl.Headers;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class NatsTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    NatsTelemetry telemetry =
+        NatsTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedHeaders(singletonList("*"))
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    NatsTelemetry telemetry =
+        NatsTelemetry.builder(testing.getOpenTelemetry())
+            .setHeaders(IncludeExclude.builder().setIncluded("*").build())
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isNotEmpty();
+  }
+
+  private static List<String> capturedHeaderKeys(NatsTelemetry telemetry) {
+    Headers headers = new Headers();
+    headers.add("Test-Message-Header", "test");
+
+    Connection delegate = mock(Connection.class);
+    when(delegate.getServerInfo()).thenReturn(mock(ServerInfo.class));
+    when(delegate.getOptions()).thenReturn(new Options.Builder().build());
+
+    Connection connection = telemetry.wrap(delegate);
+    connection.publish("subject", headers, "body".getBytes(UTF_8));
+
+    List<SpanData> spans = testing.waitForTraces(1).get(0);
+    return spans.get(0).getAttributes().asMap().keySet().stream()
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/telemetry/PulsarSingletons.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
@@ -29,6 +28,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.PropagatorBasedSpanLinksExtractor;
 import io.opentelemetry.instrumentation.api.internal.Timer;
@@ -53,7 +53,7 @@ public class PulsarSingletons {
   private static final OpenTelemetry telemetry = GlobalOpenTelemetry.get();
   private static final TextMapPropagator propagator =
       telemetry.getPropagators().getTextMapPropagator();
-  private static final IncludeExclude headers = ExperimentalConfig.get().getMessagingHeaders();
+  private static final CapturedNames headers = ExperimentalConfig.get().getMessagingHeaders();
   private static final boolean receiveInstrumentationEnabled =
       ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
 
@@ -180,7 +180,7 @@ public class PulsarSingletons {
       MessagingOperationType operationType,
       String operationName) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 

--- a/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
+++ b/instrumentation/rabbitmq-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rabbitmq/v2_7/RabbitSingletons.java
@@ -233,7 +233,7 @@ public class RabbitSingletons {
       MessagingOperationType operationType,
       String operationName) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+        .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
         .build();
   }
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqSingletons.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v4_8/RocketMqSingletons.java
@@ -16,7 +16,7 @@ public class RocketMqSingletons {
 
   private static final RocketMqTelemetry telemetry =
       RocketMqTelemetry.builder(GlobalOpenTelemetry.get())
-          .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(
                       GlobalOpenTelemetry.get(), "rocketmq_client")

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
@@ -29,6 +28,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import javax.annotation.Nullable;
 import org.apache.rocketmq.client.hook.ConsumeMessageContext;
 import org.apache.rocketmq.client.hook.SendMessageContext;
@@ -53,7 +53,7 @@ class RocketMqInstrumenterFactory {
 
   static Instrumenter<SendMessageContext, Void> createProducerInstrumenter(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes) {
 
     RocketMqProducerAttributeGetter getter = new RocketMqProducerAttributeGetter();
@@ -98,7 +98,7 @@ class RocketMqInstrumenterFactory {
 
   static RocketMqConsumerInstrumenter createConsumerInstrumenter(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes) {
 
     // the receive span only exists under the old conventions, where it groups the per-message
@@ -126,7 +126,7 @@ class RocketMqInstrumenterFactory {
   private static Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext>
       createBatchProcessInstrumenter(
           OpenTelemetry openTelemetry,
-          IncludeExclude headers,
+          CapturedNames headers,
           boolean captureExperimentalSpanAttributes) {
 
     RocketMqConsumerAttributeGetter getter = new RocketMqConsumerAttributeGetter();
@@ -162,7 +162,7 @@ class RocketMqInstrumenterFactory {
   private static Instrumenter<RocketMqConsumerRequest, ConsumeMessageContext>
       createProcessInstrumenter(
           OpenTelemetry openTelemetry,
-          IncludeExclude headers,
+          CapturedNames headers,
           boolean captureExperimentalSpanAttributes,
           boolean batch) {
 
@@ -237,9 +237,9 @@ class RocketMqInstrumenterFactory {
       MessagingAttributesGetter<T, R> getter,
       MessagingOperationType operationType,
       String operationName,
-      IncludeExclude headers) {
+      CapturedNames headers) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetry.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetry.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import org.apache.rocketmq.client.hook.ConsumeMessageHook;
 import org.apache.rocketmq.client.hook.SendMessageContext;
 import org.apache.rocketmq.client.hook.SendMessageHook;
@@ -31,7 +31,7 @@ public final class RocketMqTelemetry {
 
   RocketMqTelemetry(
       OpenTelemetry openTelemetry,
-      IncludeExclude headers,
+      CapturedNames headers,
       boolean captureExperimentalSpanAttributes) {
     rocketMqConsumerInstrumenter =
         RocketMqInstrumenterFactory.createConsumerInstrumenter(

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.Collection;
 
 /** A builder of {@link RocketMqTelemetry}. */
@@ -15,7 +17,7 @@ public final class RocketMqTelemetryBuilder {
 
   private final OpenTelemetry openTelemetry;
 
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes;
 
   RocketMqTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -49,12 +51,26 @@ public final class RocketMqTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public RocketMqTelemetryBuilder setHeaders(IncludeExclude headers) {
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public RocketMqTelemetryBuilder internalSetHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -63,7 +79,8 @@ public final class RocketMqTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public RocketMqTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
@@ -26,8 +26,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -52,7 +53,9 @@ class RocketMqInstrumenterFactoryTest {
     when(request.getMessage()).thenReturn(new Message("topic", new byte[0]));
     Instrumenter<SendMessageContext, Void> instrumenter =
         RocketMqInstrumenterFactory.createProducerInstrumenter(
-            testing.getOpenTelemetry(), IncludeExclude.builder().build(), false);
+            testing.getOpenTelemetry(),
+            CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE),
+            false);
     Context parentContext = Context.root();
 
     assertThat(instrumenter.shouldStart(parentContext, request)).isTrue();
@@ -95,7 +98,9 @@ class RocketMqInstrumenterFactoryTest {
     response.setProps(singletonMap(MixAll.CONSUME_CONTEXT_TYPE, ConsumeReturnType.TIME_OUT.name()));
     RocketMqConsumerInstrumenter instrumenter =
         RocketMqInstrumenterFactory.createConsumerInstrumenter(
-            testing.getOpenTelemetry(), IncludeExclude.builder().build(), false);
+            testing.getOpenTelemetry(),
+            CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE),
+            false);
 
     RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
         requireNonNull(

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqMetricsTest.java
@@ -25,8 +25,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import java.util.List;
@@ -49,7 +50,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class RocketMqMetricsTest {
 
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.rocketmq-client-4.8";
-  private static final IncludeExclude NO_HEADERS = IncludeExclude.builder().build();
+  private static final CapturedNames NO_HEADERS =
+      CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
 
   @RegisterExtension
   private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilderTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqTelemetryBuilderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.rocketmqclient.v4_8;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.apache.rocketmq.client.hook.SendMessageContext;
+import org.apache.rocketmq.client.hook.SendMessageHook;
+import org.apache.rocketmq.client.impl.CommunicationMode;
+import org.apache.rocketmq.common.message.Message;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RocketMqTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    RocketMqTelemetry telemetry =
+        RocketMqTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedHeaders(singletonList("*"))
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    RocketMqTelemetry telemetry =
+        RocketMqTelemetry.builder(testing.getOpenTelemetry())
+            .setHeaders(IncludeExclude.builder().setIncluded("*").build())
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isNotEmpty();
+  }
+
+  private static List<String> capturedHeaderKeys(RocketMqTelemetry telemetry) {
+    Message message = new Message("topic", new byte[0]);
+    message.putUserProperty("Test-Message-Header", "test");
+    SendMessageContext context = new SendMessageContext();
+    context.setMessage(message);
+    context.setCommunicationMode(CommunicationMode.ONEWAY);
+
+    SendMessageHook hook = telemetry.createSendMessageHook();
+    hook.sendMessageBefore(context);
+    hook.sendMessageAfter(context);
+
+    List<SpanData> spans = testing.waitForTraces(1).get(0);
+    Attributes attributes = spans.get(0).getAttributes();
+    return attributes.asMap().keySet().stream()
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqInstrumenterFactory.java
@@ -12,7 +12,6 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingConsumerMetrics;
@@ -26,6 +25,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import java.util.List;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.message.MessageView;
@@ -43,7 +43,7 @@ final class RocketMqInstrumenterFactory {
   private RocketMqInstrumenterFactory() {}
 
   public static Instrumenter<PublishingMessageImpl, SendReceiptImpl> createProducerInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers) {
+      OpenTelemetry openTelemetry, CapturedNames headers) {
     RocketMqProducerAttributeGetter getter = new RocketMqProducerAttributeGetter();
     MessagingOperationType operationType = MessagingOperationType.SEND;
 
@@ -64,7 +64,7 @@ final class RocketMqInstrumenterFactory {
 
   public static Instrumenter<RocketMqReceiveRequest, List<MessageView>>
       createConsumerReceiveInstrumenter(
-          OpenTelemetry openTelemetry, IncludeExclude headers, boolean enabled) {
+          OpenTelemetry openTelemetry, CapturedNames headers, boolean enabled) {
     RocketMqConsumerReceiveAttributeGetter getter = new RocketMqConsumerReceiveAttributeGetter();
     MessagingOperationType operationType = MessagingOperationType.RECEIVE;
 
@@ -92,7 +92,7 @@ final class RocketMqInstrumenterFactory {
   }
 
   public static Instrumenter<MessageView, ConsumeResult> createConsumerProcessInstrumenter(
-      OpenTelemetry openTelemetry, IncludeExclude headers, boolean receiveInstrumentationEnabled) {
+      OpenTelemetry openTelemetry, CapturedNames headers, boolean receiveInstrumentationEnabled) {
     RocketMqConsumerProcessAttributeGetter getter = new RocketMqConsumerProcessAttributeGetter();
     MessagingOperationType operationType = MessagingOperationType.PROCESS;
 
@@ -132,9 +132,9 @@ final class RocketMqInstrumenterFactory {
       MessagingAttributesGetter<T, R> getter,
       MessagingOperationType operationType,
       String operationName,
-      IncludeExclude headers) {
+      CapturedNames headers) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 }

--- a/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
+++ b/instrumentation/rocketmq/rocketmq-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rocketmqclient/v5_0/RocketMqSingletons.java
@@ -7,8 +7,8 @@ package io.opentelemetry.javaagent.instrumentation.rocketmqclient.v5_0;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import io.opentelemetry.javaagent.bootstrap.internal.ExperimentalConfig;
 import java.util.List;
 import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
@@ -27,7 +27,7 @@ public class RocketMqSingletons {
 
   static {
     OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
-    IncludeExclude messagingHeaders = ExperimentalConfig.get().getMessagingHeaders();
+    CapturedNames messagingHeaders = ExperimentalConfig.get().getMessagingHeaders();
     boolean receiveInstrumentationEnabled =
         ExperimentalConfig.get().messagingReceiveInstrumentationEnabled();
 

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/internal/instrumentation/kafka/KafkaInstrumentationAutoConfiguration.java
@@ -47,7 +47,7 @@ public class KafkaInstrumentationAutoConfiguration {
                 .get("messaging")
                 .get("receive_telemetry/development")
                 .getBoolean("enabled", false))
-        .setHeaders(MessagingConfig.getHeaders(openTelemetry))
+        .internalSetHeaders(MessagingConfig.getHeaders(openTelemetry))
         .build();
   }
 

--- a/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationSingletons.java
+++ b/instrumentation/spring/spring-integration-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/integration/v4_1/SpringIntegrationSingletons.java
@@ -23,7 +23,7 @@ public class SpringIntegrationSingletons {
 
   private static final ChannelInterceptor interceptor =
       SpringIntegrationTelemetry.builder(GlobalOpenTelemetry.get())
-          .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setProducerSpanEnabled(
               DeclarativeConfigUtil.getInstrumentationConfig(
                       GlobalOpenTelemetry.get(), "spring_integration")

--- a/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/main/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilder.java
@@ -24,6 +24,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,7 +42,7 @@ public final class SpringIntegrationTelemetryBuilder {
   private final List<AttributesExtractor<MessageWithChannel, Void>> additionalAttributeExtractors =
       new ArrayList<>();
 
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean producerSpanEnabled = false;
 
   SpringIntegrationTelemetryBuilder(OpenTelemetry openTelemetry) {
@@ -73,12 +75,26 @@ public final class SpringIntegrationTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public SpringIntegrationTelemetryBuilder setHeaders(IncludeExclude headers) {
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public SpringIntegrationTelemetryBuilder internalSetHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -87,7 +103,8 @@ public final class SpringIntegrationTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public SpringIntegrationTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   /**
@@ -157,9 +174,9 @@ public final class SpringIntegrationTelemetryBuilder {
       MessagingAttributesGetter<MessageWithChannel, Void> getter,
       MessagingOperationType operationType,
       String operationName,
-      IncludeExclude headers) {
+      CapturedNames headers) {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
-        .setHeaders(headers)
+        .internalSetHeaders(headers)
         .build();
   }
 }

--- a/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilderTest.java
+++ b/instrumentation/spring/spring-integration-4.1/library/src/test/java/io/opentelemetry/instrumentation/spring/integration/v4_1/SpringIntegrationTelemetryBuilderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.integration.v4_1;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.GenericMessage;
+
+class SpringIntegrationTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    SpringIntegrationTelemetry telemetry =
+        SpringIntegrationTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedHeaders(singletonList("*"))
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    SpringIntegrationTelemetry telemetry =
+        SpringIntegrationTelemetry.builder(testing.getOpenTelemetry())
+            .setHeaders(IncludeExclude.builder().setIncluded("*").build())
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isNotEmpty();
+  }
+
+  private static List<String> capturedHeaderKeys(SpringIntegrationTelemetry telemetry) {
+    Message<String> message =
+        new GenericMessage<>("body", singletonMap("Test-Message-Header", "test"));
+    MessageChannel channel = (m, timeout) -> true;
+
+    ChannelInterceptor interceptor = telemetry.createChannelInterceptor();
+    Message<?> sent = interceptor.preSend(message, channel);
+    interceptor.afterSendCompletion(sent, channel, true, null);
+
+    List<SpanData> spans = testing.waitForTraces(1).get(0);
+    return spans.get(0).getAttributes().asMap().keySet().stream()
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaSingletons.java
@@ -19,7 +19,7 @@ public class SpringKafkaSingletons {
 
   private static final SpringKafkaTelemetry telemetry =
       SpringKafkaTelemetry.builder(GlobalOpenTelemetry.get())
-          .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+          .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
           .setCaptureExperimentalSpanAttributes(
               DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "kafka")
                   .getBoolean("experimental_span_attributes/development", false))

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilder.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.spring.kafka.v2_7;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames.CaseSensitivity;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.spring.kafka.v2_7.internal.SpringKafkaErrorCauseExtractor;
 import java.util.Collection;
@@ -18,7 +20,7 @@ public final class SpringKafkaTelemetryBuilder {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.spring-kafka-2.7";
 
   private final OpenTelemetry openTelemetry;
-  private IncludeExclude headers = IncludeExclude.builder().build();
+  private CapturedNames headers = CapturedNames.create(null, CaseSensitivity.CASE_SENSITIVE);
   private boolean captureExperimentalSpanAttributes = false;
   private boolean messagingReceiveInstrumentationEnabled = false;
 
@@ -41,12 +43,26 @@ public final class SpringKafkaTelemetryBuilder {
    */
   @CanIgnoreReturnValue
   public SpringKafkaTelemetryBuilder setHeaders(IncludeExclude headers) {
+    this.headers = CapturedNames.create(headers, CaseSensitivity.CASE_SENSITIVE);
+    return this;
+  }
+
+  /**
+   * Configures which message headers are captured as span attributes.
+   *
+   * <p>This method is internal and is hence not for public use. Its API is unstable and can change
+   * at any time.
+   */
+  @CanIgnoreReturnValue
+  public SpringKafkaTelemetryBuilder internalSetHeaders(CapturedNames headers) {
     this.headers = headers;
     return this;
   }
 
   /**
    * Configures the messaging headers that will be captured as span attributes.
+   *
+   * <p>Header names are matched literally and case-sensitively; wildcards are not supported.
    *
    * @param capturedHeaders A list of messaging header names.
    * @deprecated Use {@link #setHeaders(IncludeExclude)} instead. May be removed in the next minor
@@ -55,7 +71,8 @@ public final class SpringKafkaTelemetryBuilder {
   @Deprecated // may be removed in the next minor release
   @CanIgnoreReturnValue
   public SpringKafkaTelemetryBuilder setCapturedHeaders(Collection<String> capturedHeaders) {
-    return setHeaders(IncludeExclude.builder().setIncluded(capturedHeaders).build());
+    this.headers = CapturedNames.createExact(capturedHeaders, CaseSensitivity.CASE_SENSITIVE);
+    return this;
   }
 
   @CanIgnoreReturnValue

--- a/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilderTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaTelemetryBuilderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.kafka.v2_7;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.kafka.listener.RecordInterceptor;
+
+class SpringKafkaTelemetryBuilderTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @SuppressWarnings("deprecation") // testing deprecated API
+  @Test
+  void deprecatedCapturedHeadersDoesNotTreatStarAsWildcard() {
+    SpringKafkaTelemetry telemetry =
+        SpringKafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setCapturedHeaders(singletonList("*"))
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isEmpty();
+  }
+
+  @Test
+  void selectorStarCapturesEveryHeader() {
+    SpringKafkaTelemetry telemetry =
+        SpringKafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setHeaders(IncludeExclude.builder().setIncluded("*").build())
+            .build();
+
+    assertThat(capturedHeaderKeys(telemetry)).isNotEmpty();
+  }
+
+  private static List<String> capturedHeaderKeys(SpringKafkaTelemetry telemetry) {
+    ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 0L, "key", "value");
+    record.headers().add("Test-Message-Header", "test".getBytes(UTF_8));
+
+    try (Consumer<String, String> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST)) {
+      RecordInterceptor<String, String> interceptor = telemetry.createRecordInterceptor();
+      interceptor.intercept(record, consumer);
+      interceptor.success(record, consumer);
+    }
+
+    List<SpanData> spans = testing.waitForTraces(1).get(0);
+    return spans.get(0).getAttributes().asMap().keySet().stream()
+        .map(AttributeKey::getKey)
+        .filter(key -> key.startsWith("messaging.header."))
+        .collect(toList());
+  }
+}

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/pulsar/v1_0/SpringPulsarSingletons.java
@@ -55,7 +55,7 @@ public class SpringPulsarSingletons {
                 MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(getter, operationType, PROCESS_OPERATION_NAME)
-                    .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+                    .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build())
             .addOperationMetrics(MessagingProcessMetrics.get());
     if (recordConsumedMessages) {

--- a/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
+++ b/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/v1_0/SpringRabbitSingletons.java
@@ -39,7 +39,7 @@ public class SpringRabbitSingletons {
                 MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
             .addAttributesExtractor(
                 MessagingAttributesExtractor.builder(getter, operationType, PROCESS_OPERATION_NAME)
-                    .setHeaders(ExperimentalConfig.get().getMessagingHeaders())
+                    .internalSetHeaders(ExperimentalConfig.get().getMessagingHeaders())
                     .build())
             .addAttributesExtractor(new SpringRabbitExtraAttributesExtractor())
             .addOperationMetrics(MessagingProcessMetrics.get());

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/ExperimentalConfig.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/bootstrap/internal/ExperimentalConfig.java
@@ -8,9 +8,9 @@ package io.opentelemetry.javaagent.bootstrap.internal;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DeclarativeConfigUtil;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingConfig;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -22,7 +22,7 @@ public final class ExperimentalConfig {
       new ExperimentalConfig(GlobalOpenTelemetry.get());
 
   private final DeclarativeConfigProperties commonConfig;
-  private final IncludeExclude messagingHeaders;
+  private final CapturedNames messagingHeaders;
 
   /** Returns the global agent configuration. */
   public static ExperimentalConfig get() {
@@ -50,10 +50,10 @@ public final class ExperimentalConfig {
   }
 
   /**
-   * Returns the messaging header selector, or an {@linkplain IncludeExclude#isEmpty() empty}
-   * selector when no headers should be captured.
+   * Returns the messaging headers to capture, which is {@linkplain CapturedNames#isEmpty() empty}
+   * when no headers should be captured.
    */
-  public IncludeExclude getMessagingHeaders() {
+  public CapturedNames getMessagingHeaders() {
     return messagingHeaders;
   }
 }

--- a/javaagent-extension-api/src/test/java/io/opentelemetry/javaagent/bootstrap/internal/ExperimentalConfigTest.java
+++ b/javaagent-extension-api/src/test/java/io/opentelemetry/javaagent/bootstrap/internal/ExperimentalConfigTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.CapturedNames;
 import org.junit.jupiter.api.Test;
 
 class ExperimentalConfigTest {
@@ -29,10 +29,10 @@ class ExperimentalConfigTest {
     when(messaging.get("headers/development").getScalarList("excluded", String.class))
         .thenReturn(singletonList("*-secret"));
 
-    IncludeExclude headers = new ExperimentalConfig(openTelemetry).getMessagingHeaders();
+    CapturedNames headers = new ExperimentalConfig(openTelemetry).getMessagingHeaders();
 
-    assertThat(headers.getIncluded()).containsExactly("Test-*", "other");
-    assertThat(headers.getExcluded()).containsExactly("*-secret");
+    assertThat(headers.matchingNames(asList("Test-1", "Test-secret", "other", "unrelated")))
+        .containsExactly("other", "Test-1");
   }
 
   @Test
@@ -44,15 +44,31 @@ class ExperimentalConfigTest {
             .getScalarList("capture_headers/development", String.class))
         .thenReturn(singletonList("deprecated"));
 
-    IncludeExclude headers = new ExperimentalConfig(openTelemetry).getMessagingHeaders();
+    CapturedNames headers = new ExperimentalConfig(openTelemetry).getMessagingHeaders();
 
-    assertThat(headers.getIncluded()).containsExactly("deprecated");
-    assertThat(headers.getExcluded()).isEmpty();
+    assertThat(headers.exactNames()).containsExactly("deprecated");
+    assertThat(headers.enumerateNames()).isFalse();
+  }
+
+  @Test
+  void deprecatedCaptureHeadersDoesNotTreatStarAsWildcard() {
+    ExtendedOpenTelemetry openTelemetry = mockOpenTelemetry();
+    when(openTelemetry
+            .getInstrumentationConfig("common")
+            .get("messaging")
+            .getScalarList("capture_headers/development", String.class))
+        .thenReturn(singletonList("*"));
+
+    CapturedNames headers = new ExperimentalConfig(openTelemetry).getMessagingHeaders();
+
+    // only a header literally named "*" is looked up, so nothing is captured in practice
+    assertThat(headers.enumerateNames()).isFalse();
+    assertThat(headers.exactNames()).containsExactly("*");
   }
 
   @Test
   void absentConfigCapturesNothing() {
-    IncludeExclude headers = new ExperimentalConfig(mockOpenTelemetry()).getMessagingHeaders();
+    CapturedNames headers = new ExperimentalConfig(mockOpenTelemetry()).getMessagingHeaders();
 
     assertThat(headers.isEmpty()).isTrue();
   }


### PR DESCRIPTION
`otel.instrumentation.messaging.experimental.capture-headers` and the deprecated `setCapturedHeaders(Collection<String>)` builder methods have always matched message header names exactly. #19523 converted messaging header capture to the `IncludeExclude` glob-selector model and routed the deprecated values through `IncludeExclude.builder().setIncluded(capturedHeaders).build()`, which turned those literal names into glob patterns. That is unreleased, so this corrects it before it ships.

The practical effect is a silent widening. `otel.instrumentation.messaging.experimental.capture-headers=*` used to look for a header literally named `*` and capture nothing; on `main` today it captures every header on every message, including ones carrying credentials. The same applies to `setCapturedHeaders(singletonList("*"))` on `AwsSdkTelemetryBuilder` (1.11 and 2.2), `KafkaTelemetryBuilder`, `NatsTelemetryBuilder`, `RocketMqTelemetryBuilder`, `SpringIntegrationTelemetryBuilder`, `SpringKafkaTelemetryBuilder` and `MessagingAttributesExtractorBuilder`.

After this change the deprecated inputs are resolved with `CapturedNames.createExact` and go back to exact, case-sensitive name matching, while the new selector keeps its glob semantics:

```java
// captures nothing - "*" is a header name, not a pattern
builder.setCapturedHeaders(singletonList("*"));

// captures every header
builder.setHeaders(IncludeExclude.builder().setIncluded("*").build());
```

`IncludeExclude` remains the public input type. No public signature changed; the deprecated setters simply stop converting through a selector on the way to the internal representation, which is now `CapturedNames` throughout the messaging stack. The `CHANGELOG` entry from #19523 documented the glob behavior as intended for the deprecated property, so it is corrected here as well.

`MessagingAttributesExtractor` carried its own copy of the exact-versus-enumerate logic that `CapturedNames` already implements; that duplicate is removed.

`SelectorConfig.resolve` has no production callers left after this change. Deleting it belongs in a later cleanup PR because several in-flight PRs are editing the surrounding code, so for now it carries a javadoc note pointing at `resolveCapturedNames` for settings that have a deprecated literal predecessor.
