### PR TITLE
Record messaging client consumed messages metric in Kafka instrumentation

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -91,11 +91,10 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
         }
 
         Context processParentContext =
-            emitStableMessagingSemconv() ? parentContext : receiveContext;
-        if (receiveOperationStarted && emitStableMessagingSemconv()) {
-          processParentContext =
-              KafkaConsumerContextUtil.withReceiveOperation(processParentContext);
-        }
+            emitStableMessagingSemconv()
+                ? KafkaConsumerContextUtil.withReceiveOperation(
+                    parentContext, receiveOperationStarted)
+                : receiveContext;
         KafkaConsumerContext consumerContext =
             KafkaConsumerContextUtil.create(processParentContext, consumer);
         // we're attaching the consumer to the records to be able to retrieve things like consumer

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaConsumerInstrumentation.java
@@ -17,6 +17,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.javaagent.bootstrap.kafka.KafkaClientsConsumerProcessTracing;
@@ -75,6 +76,7 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
       boolean previousValue = KafkaClientsConsumerProcessTracing.setWrappingEnabled(false);
       try {
         Context receiveContext = null;
+        boolean receiveOperationStarted = false;
         if (consumerReceiveInstrumenter().shouldStart(parentContext, request)) {
           receiveContext =
               InstrumenterUtil.startAndEnd(
@@ -85,16 +87,23 @@ class KafkaConsumerInstrumentation implements TypeInstrumentation {
                   error,
                   timer.startTime(),
                   timer.now());
+          receiveOperationStarted = true;
         }
 
         Context processParentContext =
             emitStableMessagingSemconv() ? parentContext : receiveContext;
+        if (receiveOperationStarted && emitStableMessagingSemconv()) {
+          processParentContext =
+              KafkaConsumerContextUtil.withReceiveOperation(processParentContext);
+        }
+        KafkaConsumerContext consumerContext =
+            KafkaConsumerContextUtil.create(processParentContext, consumer);
         // we're attaching the consumer to the records to be able to retrieve things like consumer
         // group or clientId later
-        KafkaConsumerContextUtil.set(records, processParentContext, consumer);
+        KafkaConsumerContextUtil.set(records, consumerContext);
 
         for (ConsumerRecord<?, ?> record : records) {
-          KafkaConsumerContextUtil.set(record, processParentContext, consumer);
+          KafkaConsumerContextUtil.set(record, consumerContext);
         }
       } finally {
         KafkaClientsConsumerProcessTracing.setWrappingEnabled(previousValue);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -161,9 +161,9 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     String instrumentationName = "io.opentelemetry.kafka-clients-0.11";
     String group = testLatestDeps() ? "test" : null;
     assertSendMetrics(testing, instrumentationName, SHARED_TOPIC, "0", 1, null);
-    // every test task in this module enables receive telemetry, so the receive operation always
-    // owns the consumed messages count here; KafkaClientSuppressReceiveSpansTest covers the case
-    // where it is disabled and the process operation owns the count instead
+    // every test task that runs this class enables receive telemetry, so the receive operation
+    // always owns the consumed messages count here; KafkaClientSuppressReceiveSpansTest covers the
+    // case where it is disabled and the process operation owns the count instead
     assertReceiveMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, 1, null);
     assertProcessMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, null);
     assertTotalConsumedMessages(testing, instrumentationName, 1);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientDefaultTest.java
@@ -6,9 +6,10 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSendMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
@@ -160,8 +161,12 @@ class KafkaClientDefaultTest extends KafkaClientPropagationBaseTest {
     String instrumentationName = "io.opentelemetry.kafka-clients-0.11";
     String group = testLatestDeps() ? "test" : null;
     assertSendMetrics(testing, instrumentationName, SHARED_TOPIC, "0", 1, null);
-    assertReceiveDurationMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, null);
-    assertProcessDurationMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, null);
+    // every test task in this module enables receive telemetry, so the receive operation always
+    // owns the consumed messages count here; KafkaClientSuppressReceiveSpansTest covers the case
+    // where it is disabled and the process operation owns the count instead
+    assertReceiveMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, 1, null);
+    assertProcessMetrics(testing, instrumentationName, SHARED_TOPIC, group, "0", 1, null);
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
   }
 
   @Test

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
@@ -6,8 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.kafkaclients.v0_11;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSendMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -91,8 +92,16 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
                         .hasParent(trace.getSpan(0))));
     String instrumentationName = "io.opentelemetry.kafka-clients-0.11";
     assertSendMetrics(testing, instrumentationName, SHARED_TOPIC, "0", 1, null);
-    assertProcessDurationMetrics(
-        testing, instrumentationName, SHARED_TOPIC, testLatestDeps() ? "test" : null, "0", 1, null);
+    assertProcessMetricsWithConsumedMessages(
+        testing,
+        instrumentationName,
+        SHARED_TOPIC,
+        testLatestDeps() ? "test" : null,
+        "0",
+        1,
+        1,
+        null);
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
   }
 
   @Test

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkaclients/v0_11/KafkaClientSuppressReceiveSpansTest.java
@@ -15,8 +15,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientBaseTest;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaClientPropagationBaseTest;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import java.time.Duration;
@@ -57,7 +60,12 @@ class KafkaClientSuppressReceiveSpansTest extends KafkaClientPropagationBaseTest
 
     awaitUntilConsumerIsReady();
     // check that the message was received
-    ConsumerRecords<?, ?> records = poll(Duration.ofSeconds(5));
+    ConsumerRecords<?, ?> records;
+    Context inheritedContext =
+        KafkaConsumerContextUtil.withReceiveOperation(Context.current(), true);
+    try (Scope ignored = inheritedContext.makeCurrent()) {
+      records = poll(Duration.ofSeconds(5));
+    }
     for (ConsumerRecord<?, ?> record : records) {
       testing.runWithSpan(
           "processing",

--- a/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaTestUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-0.11/testing/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaTestUtil.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -27,7 +28,16 @@ class KafkaTestUtil {
     if (consumerPollDurationMethod != null) {
       try {
         return (ConsumerRecords<K, V>) consumerPollDurationMethod.invoke(consumer, duration);
-      } catch (Exception e) {
+      } catch (InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof RuntimeException) {
+          throw (RuntimeException) cause;
+        }
+        if (cause instanceof Error) {
+          throw (Error) cause;
+        }
+        throw new IllegalStateException(cause);
+      } catch (ReflectiveOperationException e) {
         throw new IllegalStateException(e);
       }
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -80,6 +80,7 @@ public class KafkaConsumerTelemetry {
     Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumerGroup, clientId);
     Context receiveContext = null;
+    boolean receiveOperationStarted = false;
     if (consumerReceiveInstrumenter.shouldStart(parentContext, request)) {
       receiveContext =
           InstrumenterUtil.startAndEnd(
@@ -90,9 +91,15 @@ public class KafkaConsumerTelemetry {
               null,
               timer.startTime(),
               timer.now());
+      receiveOperationStarted = true;
     }
 
-    return emitStableMessagingSemconv() ? parentContext : receiveContext;
+    if (!emitStableMessagingSemconv()) {
+      return receiveContext;
+    }
+    return receiveOperationStarted
+        ? KafkaConsumerContextUtil.withReceiveOperation(parentContext)
+        : parentContext;
   }
 
   public <K, V> void buildAndFinishErrorSpan(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -97,9 +97,7 @@ public class KafkaConsumerTelemetry {
     if (!emitStableMessagingSemconv()) {
       return receiveContext;
     }
-    return receiveOperationStarted
-        ? KafkaConsumerContextUtil.withReceiveOperation(parentContext)
-        : parentContext;
+    return KafkaConsumerContextUtil.withReceiveOperation(parentContext, receiveOperationStarted);
   }
 
   public <K, V> void buildAndFinishErrorSpan(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -12,7 +12,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertClientOperationDurationMetricAbsent;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertConsumedMessagesMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSentMessagesMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
@@ -135,8 +135,7 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
     if (receiveTelemetryEnabled()) {
       assertConsumedMessagesMetrics(
           testing, instrumentationName, SHARED_TOPIC, "test", null, 1, null);
-      assertProcessDurationMetrics(
-          testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+      assertProcessMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
     } else {
       assertProcessMetricsWithConsumedMessages(
           testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, 1, null);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -134,7 +134,7 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
     assertClientOperationDurationMetricAbsent(testing, instrumentationName);
     if (receiveTelemetryEnabled()) {
       assertConsumedMessagesMetrics(
-          testing, instrumentationName, SHARED_TOPIC, "test", null, 1, null);
+          testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
       assertProcessMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
     } else {
       assertProcessMetricsWithConsumedMessages(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -11,8 +11,9 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil.headerAttributeKey;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertClientOperationDurationMetricAbsent;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertConsumedMessagesMetricAbsent;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertConsumedMessagesMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSentMessagesMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -69,6 +70,10 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
   protected abstract KafkaTelemetry kafkaTelemetry();
 
   protected abstract boolean captureExperimentalSpanAttributes();
+
+  protected boolean receiveTelemetryEnabled() {
+    return true;
+  }
 
   @Override
   public Map<String, Object> producerProps() {
@@ -127,8 +132,15 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
     String instrumentationName = "io.opentelemetry.kafka-clients-2.6";
     assertSentMessagesMetrics(testing, instrumentationName, SHARED_TOPIC, null, 1, null);
     assertClientOperationDurationMetricAbsent(testing, instrumentationName);
-    assertConsumedMessagesMetricAbsent(testing, instrumentationName);
-    assertProcessDurationMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+    if (receiveTelemetryEnabled()) {
+      assertConsumedMessagesMetrics(
+          testing, instrumentationName, SHARED_TOPIC, "test", null, 1, null);
+      assertProcessDurationMetrics(
+          testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+    } else {
+      assertProcessMetricsWithConsumedMessages(
+          testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, 1, null);
+    }
   }
 
   void assertTraces() {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/InterceptorsSuppressReceiveSpansTest.java
@@ -51,6 +51,11 @@ class InterceptorsSuppressReceiveSpansTest extends AbstractInterceptorsTest {
   }
 
   @Override
+  protected boolean receiveTelemetryEnabled() {
+    return false;
+  }
+
+  @Override
   void assertTraces() {
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperSuppressReceiveSpansTest.java
@@ -6,8 +6,9 @@
 package io.opentelemetry.instrumentation.kafkaclients.v2_6;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSendMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
@@ -55,7 +56,9 @@ class WrapperSuppressReceiveSpansTest extends AbstractWrapperTest {
                         .hasParent(trace.getSpan(0))));
     String instrumentationName = "io.opentelemetry.kafka-clients-2.6";
     assertSendMetrics(testing, instrumentationName, SHARED_TOPIC, "0", 1, null);
-    assertProcessDurationMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+    assertProcessMetricsWithConsumedMessages(
+        testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, 1, null);
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
   }
 
   static List<AttributeAssertion> sendAttributes(boolean testHeaders, boolean testExperimental) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -11,9 +11,10 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSign
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSendMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -149,8 +150,9 @@ class WrapperTest extends AbstractWrapperTest {
   private static void assertMessagingMetrics() {
     String instrumentationName = "io.opentelemetry.kafka-clients-2.6";
     assertSendMetrics(testing, instrumentationName, SHARED_TOPIC, "0", 1, null);
-    assertReceiveDurationMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
-    assertProcessDurationMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+    assertReceiveMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, 1, null);
+    assertProcessMetrics(testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, null);
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
   }
 
   private static SpanContext asRemote(SpanContext spanContext) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
@@ -44,7 +44,7 @@ class KafkaConsumerContextUtilTest {
   }
 
   @Test
-  void clearsInheritedReceiveOperationWhenThereIsNoLeakedProcessSpan() {
+  void preservesInheritedReceiveOperationWhenThereIsNoLeakedProcessSpan() {
     assumeTrue(emitStableMessagingSemconv());
 
     Context context = KafkaConsumerContextUtil.withReceiveOperation(Context.current(), true);
@@ -52,7 +52,7 @@ class KafkaConsumerContextUtilTest {
     assertThat(
             KafkaConsumerContextUtil.hasReceiveOperation(
                 KafkaConsumerContextUtil.withoutLeakedProcessSpan(context)))
-        .isFalse();
+        .isTrue();
   }
 
   @Test

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerContextUtilTest.java
@@ -44,6 +44,18 @@ class KafkaConsumerContextUtilTest {
   }
 
   @Test
+  void clearsInheritedReceiveOperationWhenThereIsNoLeakedProcessSpan() {
+    assumeTrue(emitStableMessagingSemconv());
+
+    Context context = KafkaConsumerContextUtil.withReceiveOperation(Context.current(), true);
+
+    assertThat(
+            KafkaConsumerContextUtil.hasReceiveOperation(
+                KafkaConsumerContextUtil.withoutLeakedProcessSpan(context)))
+        .isFalse();
+  }
+
+  @Test
   void leavesUnrelatedCurrentSpanUntouched() {
     assumeTrue(emitStableMessagingSemconv());
     Span parentSpan =

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptorTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptorTest.java
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -14,7 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -69,5 +77,33 @@ class OpenTelemetryConsumerInterceptorTest {
     SerializationTestUtil.testSerialize(
         consumerConfig(),
         OpenTelemetryConsumerInterceptor.CONFIG_KEY_KAFKA_CONSUMER_TELEMETRY_SUPPLIER);
+  }
+
+  @Test
+  void deduplicatesRecordsAcrossReceiveInstrumentations() {
+    assumeTrue(emitStableMessagingSemconv());
+
+    KafkaTelemetry telemetry =
+        KafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setMessagingReceiveTelemetryEnabled(true)
+            .build();
+    Map<String, ?> config = telemetry.consumerInterceptorConfigProperties();
+    OpenTelemetryConsumerInterceptor<String, String> firstInterceptor =
+        new OpenTelemetryConsumerInterceptor<>();
+    firstInterceptor.configure(config);
+    OpenTelemetryConsumerInterceptor<String, String> secondInterceptor =
+        new OpenTelemetryConsumerInterceptor<>();
+    secondInterceptor.configure(config);
+
+    String topic = "test";
+    TopicPartition partition = new TopicPartition(topic, 0);
+    ConsumerRecord<String, String> record = new ConsumerRecord<>(topic, 0, 0, "key", "value");
+    ConsumerRecords<String, String> records =
+        new ConsumerRecords<>(singletonMap(partition, singletonList(record)));
+
+    ConsumerRecords<String, String> tracedRecords = firstInterceptor.onConsume(records);
+    secondInterceptor.onConsume(tracedRecords);
+
+    assertTotalConsumedMessages(testing, "io.opentelemetry.kafka-clients-2.6", 1);
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptorTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptorTest.java
@@ -9,9 +9,15 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
@@ -105,5 +111,40 @@ class OpenTelemetryConsumerInterceptorTest {
     secondInterceptor.onConsume(tracedRecords);
 
     assertTotalConsumedMessages(testing, "io.opentelemetry.kafka-clients-2.6", 1);
+  }
+
+  @Test
+  void disabledReceiveClearsInheritedReceiveOperation() {
+    assumeTrue(emitStableMessagingSemconv());
+
+    KafkaTelemetry telemetry =
+        KafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setMessagingReceiveTelemetryEnabled(false)
+            .build();
+    KafkaConsumerTelemetrySupplier supplier =
+        (KafkaConsumerTelemetrySupplier)
+            requireNonNull(
+                telemetry
+                    .consumerInterceptorConfigProperties()
+                    .get(
+                        OpenTelemetryConsumerInterceptor
+                            .CONFIG_KEY_KAFKA_CONSUMER_TELEMETRY_SUPPLIER));
+
+    String topic = "test";
+    TopicPartition partition = new TopicPartition(topic, 0);
+    ConsumerRecord<String, String> record = new ConsumerRecord<>(topic, 0, 0, "key", "value");
+    ConsumerRecords<String, String> records =
+        new ConsumerRecords<>(singletonMap(partition, singletonList(record)));
+
+    Context receiveContext;
+    Context inheritedContext =
+        KafkaConsumerContextUtil.withReceiveOperation(Context.current(), true);
+    try (Scope ignored = inheritedContext.makeCurrent()) {
+      receiveContext =
+          requireNonNull(
+              supplier.get().buildAndFinishSpan(records, "test", "client", Timer.start()));
+    }
+
+    assertThat(KafkaConsumerContextUtil.hasReceiveOperation(receiveContext)).isFalse();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -25,6 +25,8 @@ public final class KafkaConsumerContextUtil {
       ContextKey.named("opentelemetry-kafka-process-span");
   private static final ContextKey<Span> PROCESS_PARENT_SPAN_KEY =
       ContextKey.named("opentelemetry-kafka-process-parent-span");
+  private static final ContextKey<Boolean> RECEIVE_OPERATION_KEY =
+      ContextKey.named("opentelemetry-kafka-receive-operation");
   // these fields can be used for multiple instrumentations because of that we don't use a helper
   // class as field type
   private static final VirtualField<ConsumerRecord<?, ?>, Context> recordContextField =
@@ -54,6 +56,14 @@ public final class KafkaConsumerContextUtil {
     return context
         .with(PROCESS_SPAN_KEY, Span.fromContext(context))
         .with(PROCESS_PARENT_SPAN_KEY, Span.fromContext(parentContext));
+  }
+
+  public static Context withReceiveOperation(Context context) {
+    return context.with(RECEIVE_OPERATION_KEY, true);
+  }
+
+  public static boolean hasReceiveOperation(Context context) {
+    return Boolean.TRUE.equals(context.get(RECEIVE_OPERATION_KEY));
   }
 
   public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {
@@ -89,12 +99,6 @@ public final class KafkaConsumerContextUtil {
     return KafkaConsumerContext.create(context, consumerGroup, clientId);
   }
 
-  public static void set(ConsumerRecord<?, ?> record, Context context, Consumer<?, ?> consumer) {
-    String consumerGroup = KafkaUtil.getConsumerGroup(consumer);
-    String clientId = KafkaUtil.getClientId(consumer);
-    set(record, context, consumerGroup, clientId);
-  }
-
   public static void set(ConsumerRecord<?, ?> record, KafkaConsumerContext consumerContext) {
     set(
         record,
@@ -103,7 +107,7 @@ public final class KafkaConsumerContextUtil {
         consumerContext.getClientId());
   }
 
-  public static void set(
+  private static void set(
       ConsumerRecord<?, ?> record,
       @Nullable Context context,
       @Nullable String consumerGroup,
@@ -112,13 +116,15 @@ public final class KafkaConsumerContextUtil {
     recordConsumerInfoField.set(record, new String[] {consumerGroup, clientId});
   }
 
-  public static void set(ConsumerRecords<?, ?> records, Context context, Consumer<?, ?> consumer) {
-    String consumerGroup = KafkaUtil.getConsumerGroup(consumer);
-    String clientId = KafkaUtil.getClientId(consumer);
-    set(records, context, consumerGroup, clientId);
+  public static void set(ConsumerRecords<?, ?> records, KafkaConsumerContext consumerContext) {
+    set(
+        records,
+        consumerContext.getContext(),
+        consumerContext.getConsumerGroup(),
+        consumerContext.getClientId());
   }
 
-  public static void set(
+  private static void set(
       ConsumerRecords<?, ?> records,
       @Nullable Context context,
       @Nullable String consumerGroup,

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -60,8 +60,8 @@ public final class KafkaConsumerContextUtil {
         .with(PROCESS_PARENT_SPAN_KEY, Span.fromContext(parentContext));
   }
 
-  public static Context withReceiveOperation(Context context) {
-    return context.with(RECEIVE_OPERATION_KEY, true);
+  public static Context withReceiveOperation(Context context, boolean receiveOperation) {
+    return context.with(RECEIVE_OPERATION_KEY, receiveOperation);
   }
 
   public static boolean hasReceiveOperation(Context context) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -47,11 +47,14 @@ public final class KafkaConsumerContextUtil {
 
     Span currentSpan = Span.fromContext(context);
     if (currentSpan != context.get(PROCESS_SPAN_KEY)) {
-      return context;
+      return Boolean.TRUE.equals(context.get(RECEIVE_OPERATION_KEY))
+          ? context.with(RECEIVE_OPERATION_KEY, false)
+          : context;
     }
 
     Span parentSpan = context.get(PROCESS_PARENT_SPAN_KEY);
-    return context.with(parentSpan != null ? parentSpan : Span.getInvalid());
+    Context restored = context.with(parentSpan != null ? parentSpan : Span.getInvalid());
+    return restored.with(RECEIVE_OPERATION_KEY, false);
   }
 
   public static Context withProcessParentSpan(Context context, Context parentContext) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -52,9 +52,7 @@ public final class KafkaConsumerContextUtil {
 
     Span currentSpan = Span.fromContext(context);
     if (currentSpan != processSpan) {
-      return Boolean.TRUE.equals(context.get(RECEIVE_OPERATION_KEY))
-          ? context.with(RECEIVE_OPERATION_KEY, false)
-          : context;
+      return context;
     }
 
     Span parentSpan = context.get(PROCESS_PARENT_SPAN_KEY);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -45,8 +45,13 @@ public final class KafkaConsumerContextUtil {
       return context;
     }
 
+    Span processSpan = context.get(PROCESS_SPAN_KEY);
+    if (processSpan == null) {
+      return context;
+    }
+
     Span currentSpan = Span.fromContext(context);
-    if (currentSpan != context.get(PROCESS_SPAN_KEY)) {
+    if (currentSpan != processSpan) {
       return Boolean.TRUE.equals(context.get(RECEIVE_OPERATION_KEY))
           ? context.with(RECEIVE_OPERATION_KEY, false)
           : context;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -37,6 +37,8 @@ public final class KafkaConsumerContextUtil {
       VirtualField.find(ConsumerRecords.class, Context.class);
   private static final VirtualField<ConsumerRecords<?, ?>, String[]> recordsConsumerInfoField =
       VirtualField.find(ConsumerRecords.class, String[].class);
+  private static final VirtualField<ConsumerRecord<?, ?>, Boolean> recordCountedField =
+      VirtualField.find(ConsumerRecord.class, Boolean.class);
 
   public static Context withoutLeakedProcessSpan(Context context) {
     if (!emitStableMessagingSemconv()) {
@@ -64,6 +66,18 @@ public final class KafkaConsumerContextUtil {
 
   public static boolean hasReceiveOperation(Context context) {
     return Boolean.TRUE.equals(context.get(RECEIVE_OPERATION_KEY));
+  }
+
+  /**
+   * Returns {@code true} the first time the given record is seen, and {@code false} afterwards, so
+   * that operations that observe the same record do not count it twice.
+   */
+  public static boolean markConsumedMessageCounted(ConsumerRecord<?, ?> record) {
+    if (Boolean.TRUE.equals(recordCountedField.get(record))) {
+      return false;
+    }
+    recordCountedField.set(record, true);
+    return true;
   }
 
   public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -287,9 +287,8 @@ public final class KafkaInstrumenterFactory {
     builder
         .addContextCustomizer(
             (context, request, startAttributes) -> {
-              ConsumerRecords<?, ?> records = request.getRecords();
               return context.with(
-                  CONSUMED_MESSAGES_COUNT_KEY, countConsumedMessages(records, records.count()));
+                  CONSUMED_MESSAGES_COUNT_KEY, countConsumedMessages(request.getRecords()));
             })
         .addOperationMetrics(consumedMessagesMetrics);
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -34,8 +34,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.cache.Cache;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.ToLongFunction;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -55,13 +53,7 @@ public final class KafkaInstrumenterFactory {
       AttributeKey.longKey("messaging.batch.message_count");
   private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
-  private static final Cache<OpenTelemetry, Cache<Object, AtomicBoolean>>
-      countedDeliveryObjectsCache = Cache.weak();
-
-  private final OpenTelemetry openTelemetry;
-  private final String instrumentationName;
-  private final Cache<Object, AtomicBoolean> countedDeliveryObjects;
-  private final OperationMetrics consumedMessagesMetrics =
+  private static final OperationMetrics consumedMessagesMetrics =
       meter -> {
         OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
         return new OperationListener() {
@@ -86,6 +78,8 @@ public final class KafkaInstrumenterFactory {
         };
       };
 
+  private final OpenTelemetry openTelemetry;
+  private final String instrumentationName;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private IncludeExclude headers = IncludeExclude.builder().build();
   private boolean captureExperimentalSpanAttributes = false;
@@ -94,8 +88,6 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
     this.instrumentationName = instrumentationName;
-    countedDeliveryObjects =
-        countedDeliveryObjectsCache.computeIfAbsent(openTelemetry, unused -> Cache.weak());
   }
 
   @CanIgnoreReturnValue
@@ -243,7 +235,7 @@ public final class KafkaInstrumenterFactory {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
     addConsumedMessagesIfNoReceiveOperation(
-        builder, request -> countConsumedMessages(request.getRecord(), 1));
+        builder, request -> countConsumedMessages(request.getRecord()));
     setMessagingProcessExceptionEventExtractor(builder);
 
     return MessagingProcessInstrumenterFactory.create(
@@ -267,7 +259,7 @@ public final class KafkaInstrumenterFactory {
    * operation and the per-record process operations of the same delivery, which both run in some
    * frameworks, together count each record exactly once.
    */
-  private <REQUEST> void addConsumedMessagesIfNoReceiveOperation(
+  private static <REQUEST> void addConsumedMessagesIfNoReceiveOperation(
       InstrumenterBuilder<REQUEST, Void> builder, ToLongFunction<REQUEST> messageCounter) {
     if (emitStableMessagingSemconv()) {
       builder
@@ -283,7 +275,8 @@ public final class KafkaInstrumenterFactory {
     }
   }
 
-  private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
+  private static void addReceiveConsumedMessages(
+      InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
     builder
         .addContextCustomizer(
             (context, request, startAttributes) -> {
@@ -294,22 +287,18 @@ public final class KafkaInstrumenterFactory {
   }
 
   /**
-   * Returns {@code messageCount} the first time the given delivery object is seen, and {@code 0}
-   * afterwards, so that operations that observe the same delivery do not count it twice.
+   * Returns {@code 1} the first time the given record is seen, and {@code 0} afterwards, so that
+   * operations that observe the same record do not count it twice.
    */
-  private long countConsumedMessages(Object delivery, long messageCount) {
-    boolean firstDeliveryObject =
-        countedDeliveryObjects
-            .computeIfAbsent(delivery, unused -> new AtomicBoolean())
-            .compareAndSet(false, true);
-    return firstDeliveryObject ? messageCount : 0;
+  private static long countConsumedMessages(ConsumerRecord<?, ?> record) {
+    return KafkaConsumerContextUtil.markConsumedMessageCounted(record) ? 1 : 0;
   }
 
   /** Counts the records of a batch individually, so that they can be deduplicated one by one. */
-  private long countConsumedMessages(ConsumerRecords<?, ?> records) {
+  private static long countConsumedMessages(ConsumerRecords<?, ?> records) {
     long consumedMessagesCount = 0;
     for (ConsumerRecord<?, ?> record : records) {
-      consumedMessagesCount += countConsumedMessages(record, 1);
+      consumedMessagesCount += countConsumedMessages(record);
     }
     return consumedMessagesCount;
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -36,6 +36,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.ToLongFunction;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
@@ -240,7 +242,8 @@ public final class KafkaInstrumenterFactory {
     if (captureExperimentalSpanAttributes) {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
-    addConsumedMessagesIfNoReceiveOperation(builder);
+    addConsumedMessagesIfNoReceiveOperation(
+        builder, request -> countConsumedMessages(request.getRecord(), 1));
     setMessagingProcessExceptionEventExtractor(builder);
 
     return MessagingProcessInstrumenterFactory.create(
@@ -259,9 +262,13 @@ public final class KafkaInstrumenterFactory {
    * not counted by a receive operation. Semantic conventions require the counter to be reported
    * once per message delivery, including push-based dispatch such as listener callbacks, which have
    * no receive operation.
+   *
+   * <p>The count is deduplicated per individual {@link ConsumerRecord}, so that a batch process
+   * operation and the per-record process operations of the same delivery, which both run in some
+   * frameworks, together count each record exactly once.
    */
-  private void addConsumedMessagesIfNoReceiveOperation(
-      InstrumenterBuilder<KafkaProcessRequest, Void> builder) {
+  private <REQUEST> void addConsumedMessagesIfNoReceiveOperation(
+      InstrumenterBuilder<REQUEST, Void> builder, ToLongFunction<REQUEST> messageCounter) {
     if (emitStableMessagingSemconv()) {
       builder
           .addContextCustomizer(
@@ -269,7 +276,7 @@ public final class KafkaInstrumenterFactory {
                 long consumedMessagesCount =
                     KafkaConsumerContextUtil.hasReceiveOperation(context)
                         ? 0
-                        : countConsumedMessages(request.getRecord(), 1);
+                        : messageCounter.applyAsLong(request);
                 return context.with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
               })
           .addOperationMetrics(consumedMessagesMetrics);
@@ -299,6 +306,15 @@ public final class KafkaInstrumenterFactory {
     return firstDeliveryObject ? messageCount : 0;
   }
 
+  /** Counts the records of a batch individually, so that they can be deduplicated one by one. */
+  private long countConsumedMessages(ConsumerRecords<?, ?> records) {
+    long consumedMessagesCount = 0;
+    for (ConsumerRecord<?, ?> record : records) {
+      consumedMessagesCount += countConsumedMessages(record, 1);
+    }
+    return consumedMessagesCount;
+  }
+
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
     KafkaReceiveAttributesGetter getter = new KafkaReceiveAttributesGetter();
     MessagingOperationType operationType = MessagingOperationType.PROCESS;
@@ -317,6 +333,8 @@ public final class KafkaInstrumenterFactory {
                     openTelemetry.getPropagators().getTextMapPropagator()))
             .addOperationMetrics(MessagingProcessMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
+    addConsumedMessagesIfNoReceiveOperation(
+        builder, request -> countConsumedMessages(request.getRecords()));
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -13,6 +13,10 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter;
@@ -27,8 +31,12 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.ErrorCauseExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
+import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
@@ -40,9 +48,42 @@ public final class KafkaInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String POLL_OPERATION_NAME = "poll";
   private static final String PROCESS_OPERATION_NAME = "process";
+  // copied from MessagingIncubatingAttributes
+  private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
+      AttributeKey.longKey("messaging.batch.message_count");
+  private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
+      ContextKey.named("opentelemetry-kafka-consumed-messages-count");
+  private static final Cache<OpenTelemetry, Cache<Object, AtomicBoolean>>
+      countedDeliveryObjectsCache = Cache.weak();
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
+  private final Cache<Object, AtomicBoolean> countedDeliveryObjects;
+  private final OperationMetrics consumedMessagesMetrics =
+      meter -> {
+        OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
+        return new OperationListener() {
+          @Override
+          public Context onStart(Context context, Attributes startAttributes, long startNanos) {
+            Long consumedMessagesCount = context.get(CONSUMED_MESSAGES_COUNT_KEY);
+            return consumedMessagesCount != null && consumedMessagesCount > 0
+                ? delegate.onStart(context, startAttributes, startNanos)
+                : context;
+          }
+
+          @Override
+          public void onEnd(Context context, Attributes endAttributes, long endNanos) {
+            Long consumedMessagesCount = context.get(CONSUMED_MESSAGES_COUNT_KEY);
+            if (consumedMessagesCount != null && consumedMessagesCount > 0) {
+              delegate.onEnd(
+                  context,
+                  withConsumedMessagesCount(endAttributes, consumedMessagesCount),
+                  endNanos);
+            }
+          }
+        };
+      };
+
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private IncludeExclude headers = IncludeExclude.builder().build();
   private boolean captureExperimentalSpanAttributes = false;
@@ -51,6 +92,8 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
     this.instrumentationName = instrumentationName;
+    countedDeliveryObjects =
+        countedDeliveryObjectsCache.computeIfAbsent(openTelemetry, unused -> Cache.weak());
   }
 
   @CanIgnoreReturnValue
@@ -156,6 +199,7 @@ public final class KafkaInstrumenterFactory {
       builder.addOperationMetrics(MessagingConsumerMetrics.getClientOperationDuration());
     }
     if (emitStableMessagingSemconv()) {
+      addReceiveConsumedMessages(builder);
       builder.addSpanLinksExtractor(
           new KafkaBatchProcessSpanLinksExtractor(
               openTelemetry.getPropagators().getTextMapPropagator()));
@@ -196,6 +240,7 @@ public final class KafkaInstrumenterFactory {
     if (captureExperimentalSpanAttributes) {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
+    addConsumedMessagesIfNoReceiveOperation(builder);
     setMessagingProcessExceptionEventExtractor(builder);
 
     return MessagingProcessInstrumenterFactory.create(
@@ -207,6 +252,51 @@ public final class KafkaInstrumenterFactory {
 
   private boolean receiveInstrumentationEnabled() {
     return messagingReceiveInstrumentationEnabled;
+  }
+
+  /**
+   * Records {@code messaging.client.consumed.messages} on a process operation when the delivery was
+   * not counted by a receive operation. Semantic conventions require the counter to be reported
+   * once per message delivery, including push-based dispatch such as listener callbacks, which have
+   * no receive operation.
+   */
+  private void addConsumedMessagesIfNoReceiveOperation(
+      InstrumenterBuilder<KafkaProcessRequest, Void> builder) {
+    if (emitStableMessagingSemconv()) {
+      builder
+          .addContextCustomizer(
+              (context, request, startAttributes) -> {
+                long consumedMessagesCount =
+                    KafkaConsumerContextUtil.hasReceiveOperation(context)
+                        ? 0
+                        : countConsumedMessages(request.getRecord(), 1);
+                return context.with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+              })
+          .addOperationMetrics(consumedMessagesMetrics);
+    }
+  }
+
+  private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
+    builder
+        .addContextCustomizer(
+            (context, request, startAttributes) -> {
+              ConsumerRecords<?, ?> records = request.getRecords();
+              return context.with(
+                  CONSUMED_MESSAGES_COUNT_KEY, countConsumedMessages(records, records.count()));
+            })
+        .addOperationMetrics(consumedMessagesMetrics);
+  }
+
+  /**
+   * Returns {@code messageCount} the first time the given delivery object is seen, and {@code 0}
+   * afterwards, so that operations that observe the same delivery do not count it twice.
+   */
+  private long countConsumedMessages(Object delivery, long messageCount) {
+    boolean firstDeliveryObject =
+        countedDeliveryObjects
+            .computeIfAbsent(delivery, unused -> new AtomicBoolean())
+            .compareAndSet(false, true);
+    return firstDeliveryObject ? messageCount : 0;
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
@@ -229,6 +319,11 @@ public final class KafkaInstrumenterFactory {
             .setErrorCauseExtractor(errorCauseExtractor);
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+  }
+
+  private static Attributes withConsumedMessagesCount(
+      Attributes attributes, long consumedMessagesCount) {
+    return attributes.toBuilder().put(MESSAGING_BATCH_MESSAGE_COUNT, consumedMessagesCount).build();
   }
 
   private static <REQUEST, RESPONSE>

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsDefaultTest.java
@@ -9,8 +9,9 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -239,7 +240,7 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                         .hasLinks(receiveRecordLink(producerProcessedRef.get(), "10"))
                         .hasAttributesSatisfyingExactly(assertions));
           });
-      assertProcessDurationMetrics(
+      assertProcessMetrics(
           testing,
           "io.opentelemetry.kafka-streams-0.11",
           STREAM_PENDING,
@@ -247,14 +248,16 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
           "0",
           1,
           null);
-      assertReceiveDurationMetrics(
+      assertReceiveMetrics(
           testing,
           "io.opentelemetry.kafka-clients-0.11",
           STREAM_PENDING,
           testLatestDeps() ? "test-application" : null,
           "0",
           1,
+          1,
           null);
+      assertTotalConsumedMessages(testing, "io.opentelemetry.kafka-clients-0.11", 2);
       return;
     }
 
@@ -380,7 +383,7 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
                       .hasLinks(LinkData.create(producerProcessedRef.get().getSpanContext()))
                       .hasAttributesSatisfyingExactly(assertions);
                 }));
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.kafka-streams-0.11",
         STREAM_PENDING,
@@ -388,14 +391,16 @@ class KafkaStreamsDefaultTest extends KafkaStreamsBaseTest {
         "0",
         1,
         null);
-    assertReceiveDurationMetrics(
+    assertReceiveMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         STREAM_PENDING,
         testLatestDeps() ? "test-application" : null,
         "0",
         1,
+        1,
         null);
+    assertTotalConsumedMessages(testing, "io.opentelemetry.kafka-clients-0.11", 2);
   }
 
   private static List<AttributeAssertion> producerAttributes(String topic, boolean includeKey) {

--- a/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
+++ b/instrumentation/kafka/kafka-streams-0.11/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/kafkastreams/v0_11/KafkaStreamsSuppressReceiveSpansTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -148,12 +148,13 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
                                   "test",
                                   val -> val.startsWith("consumer"),
                                   equalTo(longKey("testing"), 123)))));
-      assertProcessDurationMetrics(
+      assertProcessMetricsWithConsumedMessages(
           testing,
           "io.opentelemetry.kafka-streams-0.11",
           STREAM_PENDING,
           testLatestDeps() ? "test-application" : null,
           "0",
+          1,
           1,
           null);
       return;
@@ -269,12 +270,13 @@ class KafkaStreamsSuppressReceiveSpansTest extends KafkaStreamsBaseTest {
                       .hasParent(trace.getSpan(2))
                       .hasAttributesSatisfyingExactly(assertions);
                 }));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing,
         "io.opentelemetry.kafka-streams-0.11",
         STREAM_PENDING,
         testLatestDeps() ? "test-application" : null,
         "0",
+        1,
         1,
         null);
   }

--- a/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
+++ b/instrumentation/reactor/reactor-kafka-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/reactor/kafka/v1_0/AbstractReactorKafkaTest.java
@@ -9,8 +9,9 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -256,21 +257,22 @@ public abstract class AbstractReactorKafkaTest {
                   }
                 },
                 span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing,
         "io.opentelemetry.reactor-kafka-1.0",
         "testTopic",
         HAS_CONSUMER_GROUP ? "test" : null,
         "0",
         1,
+        1,
         null);
   }
 
   private static void assertReceiveAndProcessMetrics() {
     String group = HAS_CONSUMER_GROUP ? "test" : null;
-    assertReceiveDurationMetrics(
-        testing, "io.opentelemetry.kafka-clients-0.11", "testTopic", group, "0", 1, null);
-    assertProcessDurationMetrics(
+    assertReceiveMetrics(
+        testing, "io.opentelemetry.kafka-clients-0.11", "testTopic", group, "0", 1, 1, null);
+    assertProcessMetrics(
         testing, "io.opentelemetry.reactor-kafka-1.0", "testTopic", group, "0", 1, null);
   }
 

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
@@ -550,12 +549,13 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
   private static void assertSingleFailureMetrics() {
     int receiveCount = testLatestDeps() ? 1 : 3;
-    assertReceiveDurationMetrics(
+    assertReceiveMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         "testSingleTopic",
         "testSingleListener",
         "0",
+        receiveCount,
         receiveCount,
         null);
     assertProcessMetrics(
@@ -578,12 +578,13 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
   private static void assertBatchFailureMetrics() {
     int receiveCount = testLatestDeps() ? 1 : 3;
-    assertReceiveDurationMetrics(
+    assertReceiveMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         "testBatchTopic",
         "testBatchListener",
         "0",
+        receiveCount,
         receiveCount,
         null);
     assertProcessMetrics(

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -9,8 +9,9 @@ import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -410,15 +411,16 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
   }
 
   private static void assertSingleMetrics() {
-    assertReceiveDurationMetrics(
+    assertReceiveMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         "testSingleTopic",
         "testSingleListener",
         "0",
         1,
+        1,
         null);
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testSingleTopic",
@@ -429,15 +431,16 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
   }
 
   private static void assertBatchMetrics() {
-    assertReceiveDurationMetrics(
+    assertReceiveMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         "testBatchTopic",
         "testBatchListener",
         "0",
         1,
+        2,
         null);
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testBatchTopic",
@@ -555,7 +558,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         null);
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testSingleTopic",
@@ -563,7 +566,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         2,
         IllegalArgumentException.class.getName());
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testSingleTopic",
@@ -583,7 +586,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         null);
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testBatchTopic",
@@ -591,7 +594,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         2,
         IllegalArgumentException.class.getName());
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",
         "testBatchTopic",

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
@@ -88,12 +89,13 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                       }
                     },
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.spring-kafka-2.7",
         "testSingleTopic",
         "testSingleListener",
         "0",
+        1,
         1,
         null);
   }

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
@@ -242,14 +243,16 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
                             .hasAttributesSatisfyingExactly(
                                 batchProcessAttributes("testBatchTopic", "testBatchListener", 2)),
                     span -> span.hasName("consumer").hasParent(trace.getSpan(0))));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.spring-kafka-2.7",
         "testBatchTopic",
         "testBatchListener",
         "0",
         1,
+        2,
         null);
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.spring-kafka-2.7", 2);
   }
 
   @Test

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
@@ -116,20 +116,27 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                             .hasAttributesSatisfyingExactly(
                                 batchProcessAttributes("testBatchTopic")),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
-    // all of the records come from the same partition, so the batch process operation and the
-    // per-record process operations share a single duration point
     assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
         hasConsumerGroup() ? "test" : null,
-        "0",
-        3,
+        null,
+        1,
         2,
         null);
-    assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 1);
-    // the batch process operation must not also count the two deliveries the per-record process
-    // operations already counted
+    assertProcessDurationMetrics(
+        testing(),
+        "io.opentelemetry.vertx-kafka-client-3.6",
+        "testBatchTopic",
+        hasConsumerGroup() ? "test" : null,
+        "0",
+        2,
+        null);
+    // batch and per-record process operations produce separate duration points
+    assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
+    // the per-record process operations must not also count the two deliveries the batch process
+    // operation already counted
     assertTotalConsumedMessages(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
   }
 
@@ -183,22 +190,21 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                             .hasAttributesSatisfyingExactly(
                                 withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
-    // the failed batch process operation gets a duration point of its own through error.type
+    assertProcessMetricsWithConsumedMessages(
+        testing(),
+        "io.opentelemetry.vertx-kafka-client-3.6",
+        "testBatchTopic",
+        hasConsumerGroup() ? "test" : null,
+        null,
+        1,
+        1,
+        IllegalArgumentException.class.getName());
     assertProcessDurationMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
-        1,
-        IllegalArgumentException.class.getName());
-    assertProcessMetricsWithConsumedMessages(
-        testing(),
-        "io.opentelemetry.vertx-kafka-client-3.6",
-        "testBatchTopic",
-        hasConsumerGroup() ? "test" : null,
-        "0",
-        1,
         1,
         null);
     assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricPointCounts;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -116,25 +115,17 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                             .hasAttributesSatisfyingExactly(
                                 batchProcessAttributes("testBatchTopic")),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
-    assertProcessMetricsWithConsumedMessages(
-        testing(),
-        "io.opentelemetry.vertx-kafka-client-3.6",
-        "testBatchTopic",
-        hasConsumerGroup() ? "test" : null,
-        null,
-        1,
-        2,
-        null);
     assertProcessDurationMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
-        2,
+        3,
         null);
-    // batch and per-record process operations produce separate duration points
-    assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
+    // all of the records come from the same partition, so the batch process operation and the
+    // per-record process operations share a single duration point
+    assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 1);
     // the per-record process operations must not also count the two deliveries the batch process
     // operation already counted
     assertTotalConsumedMessages(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
@@ -190,15 +181,6 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                             .hasAttributesSatisfyingExactly(
                                 withErrorType(batchProcessAttributes("testBatchTopic"))),
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
-    assertProcessMetricsWithConsumedMessages(
-        testing(),
-        "io.opentelemetry.vertx-kafka-client-3.6",
-        "testBatchTopic",
-        hasConsumerGroup() ? "test" : null,
-        null,
-        1,
-        1,
-        IllegalArgumentException.class.getName());
     assertProcessDurationMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricPointCounts;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,15 +118,19 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
                     span -> span.hasName("batch consumer").hasParent(trace.getSpan(0))));
     // all of the records come from the same partition, so the batch process operation and the
     // per-record process operations share a single duration point
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
         3,
+        2,
         null);
     assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 1);
+    // the batch process operation must not also count the two deliveries the per-record process
+    // operations already counted
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
   }
 
   @Order(2)
@@ -186,14 +192,16 @@ public abstract class AbstractBatchRecordsNoReceiveTelemetryVertxKafkaTest
         "0",
         1,
         IllegalArgumentException.class.getName());
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
         1,
+        1,
         null);
     assertProcessMetricPointCounts(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 2);
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.vertx-kafka-client-3.6", 1);
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
@@ -8,7 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricPointCounts;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -195,13 +197,22 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
 
   private void assertBatchMetrics(long messageCount, String errorType) {
     String group = hasConsumerGroup() ? "test" : null;
-    // receive telemetry is enabled here, so the receive operation records poll duration
-    assertReceiveDurationMetrics(
-        testing(), "io.opentelemetry.kafka-clients-0.11", "testBatchTopic", group, "0", 1, null);
+    // receive telemetry is enabled here, so the receive operation records poll duration and owns
+    // the consumed messages count
+    assertReceiveMetrics(
+        testing(),
+        "io.opentelemetry.kafka-clients-0.11",
+        "testBatchTopic",
+        group,
+        "0",
+        1,
+        messageCount,
+        null);
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.kafka-clients-0.11", messageCount);
     if (errorType == null) {
       // all of the records come from the same partition, so the batch process operation and the
       // per-record process operations share a single duration point
-      assertProcessDurationMetrics(
+      assertProcessMetrics(
           testing(),
           "io.opentelemetry.vertx-kafka-client-3.6",
           "testBatchTopic",
@@ -213,7 +224,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
       return;
     }
     // the failed batch process operation gets a duration point of its own through error.type
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",
@@ -221,7 +232,7 @@ public abstract class AbstractBatchRecordsVertxKafkaTest extends AbstractVertxKa
         "0",
         1,
         errorType);
-    assertProcessDurationMetrics(
+    assertProcessMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testBatchTopic",

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractBatchRecordsVertxKafkaTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricPointCounts;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,12 +67,13 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                       }
                     },
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testSingleTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
+        1,
         1,
         null);
   }
@@ -109,12 +110,13 @@ public abstract class AbstractSingleRecordNoReceiveTelemetryVertxKafkaTest
                       }
                     },
                     span -> span.hasName("consumer").hasParent(trace.getSpan(2))));
-    assertProcessDurationMetrics(
+    assertProcessMetricsWithConsumedMessages(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testSingleTopic",
         hasConsumerGroup() ? "test" : null,
         "0",
+        1,
         1,
         IllegalArgumentException.class.getName());
   }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/kafka/AbstractSingleRecordVertxKafkaTest.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.javaagent.instrumentation.vertx.kafka;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
-import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -206,10 +206,18 @@ public abstract class AbstractSingleRecordVertxKafkaTest extends AbstractVertxKa
 
   private void assertSingleMetrics(String errorType) {
     String group = hasConsumerGroup() ? "test" : null;
-    // the receive operation records poll duration whether or not it produced a receive span
-    assertReceiveDurationMetrics(
-        testing(), "io.opentelemetry.kafka-clients-0.11", "testSingleTopic", group, "0", 1, null);
-    assertProcessDurationMetrics(
+    // the receive operation records poll duration and consumed messages under stable semconv,
+    // whether or not it produced a receive span
+    assertReceiveMetrics(
+        testing(),
+        "io.opentelemetry.kafka-clients-0.11",
+        "testSingleTopic",
+        group,
+        "0",
+        1,
+        1,
+        null);
+    assertProcessMetrics(
         testing(),
         "io.opentelemetry.vertx-kafka-client-3.6",
         "testSingleTopic",

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 
 public final class KafkaMessagingMetricsAssertions {
@@ -74,6 +75,36 @@ public final class KafkaMessagingMetricsAssertions {
         errorType);
   }
 
+  public static void assertReceiveMetrics(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      String group,
+      String partition,
+      long operationCount,
+      long messageCount,
+      String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoNewMetrics(testing, instrumentationName);
+      return;
+    }
+
+    assertReceiveDurationMetrics(
+        testing, instrumentationName, destination, group, partition, operationCount, errorType);
+    assertCounter(
+        testing,
+        instrumentationName,
+        CONSUMED_MESSAGES,
+        "Number of messages that were delivered to the application.",
+        "poll",
+        destination,
+        group,
+        partition,
+        messageCount,
+        errorType);
+    assertDeprecatedMetricsAbsent(testing);
+  }
+
   public static void assertReceiveDurationMetrics(
       InstrumentationExtension testing,
       String instrumentationName,
@@ -101,6 +132,62 @@ public final class KafkaMessagingMetricsAssertions {
         errorType);
     assertMetricAbsent(testing, instrumentationName, CONSUMED_MESSAGES);
     assertDeprecatedMetricsAbsent(testing);
+  }
+
+  /**
+   * Asserts the process operation's duration metric, and that the process operation never records
+   * the consumed messages count. That count is owned by the receive operation.
+   */
+  public static void assertProcessMetrics(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      String group,
+      String partition,
+      long operationCount,
+      String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoNewMetrics(testing, instrumentationName);
+      return;
+    }
+
+    assertProcessDurationMetrics(
+        testing, instrumentationName, destination, group, partition, operationCount, errorType);
+    assertNoProcessConsumedMessages(testing, instrumentationName);
+  }
+
+  /**
+   * Asserts the process operation's duration metric, and that the process operation also records
+   * the consumed messages count. That happens when no receive operation runs for the consumer, so
+   * the process operation is the only operation that can report the delivery.
+   */
+  public static void assertProcessMetricsWithConsumedMessages(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      String group,
+      String partition,
+      long operationCount,
+      long messageCount,
+      String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoNewMetrics(testing, instrumentationName);
+      return;
+    }
+
+    assertProcessDurationMetrics(
+        testing, instrumentationName, destination, group, partition, operationCount, errorType);
+    assertCounter(
+        testing,
+        instrumentationName,
+        CONSUMED_MESSAGES,
+        "Number of messages that were delivered to the application.",
+        "process",
+        destination,
+        group,
+        partition,
+        messageCount,
+        errorType);
   }
 
   public static void assertProcessDurationMetrics(
@@ -161,6 +248,30 @@ public final class KafkaMessagingMetricsAssertions {
             metrics.satisfiesExactly(
                 metric ->
                     assertThat(metric.getHistogramData().getPoints()).hasSize(durationPointCount)));
+  }
+
+  /**
+   * Asserts that the given number of messages was consumed in total, summed over every attribute
+   * combination. Since the consumed messages count must be reported exactly once per delivery, this
+   * catches a delivery being counted by more than one operation.
+   */
+  public static void assertTotalConsumedMessages(
+      InstrumentationExtension testing, String instrumentationName, long total) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoNewMetrics(testing, instrumentationName);
+      return;
+    }
+    testing.waitAndAssertMetrics(
+        instrumentationName,
+        CONSUMED_MESSAGES,
+        metrics ->
+            metrics.satisfiesExactly(
+                metric ->
+                    assertThat(
+                            metric.getLongSumData().getPoints().stream()
+                                .mapToLong(LongPointData::getValue)
+                                .sum())
+                        .isEqualTo(total)));
   }
 
   private static void assertDuration(
@@ -268,6 +379,20 @@ public final class KafkaMessagingMetricsAssertions {
             metric -> metric.getInstrumentationScopeInfo().getName().equals(instrumentationName))
         .extracting(MetricData::getName)
         .doesNotContain(metricName);
+  }
+
+  private static void assertNoProcessConsumedMessages(
+      InstrumentationExtension testing, String instrumentationName) {
+    assertThat(testing.metrics())
+        .filteredOn(
+            metric ->
+                metric.getInstrumentationScopeInfo().getName().equals(instrumentationName)
+                    && metric.getName().equals(CONSUMED_MESSAGES))
+        .flatExtracting(metric -> metric.getLongSumData().getPoints())
+        .allSatisfy(
+            point ->
+                assertThat(point.getAttributes().get(stringKey("messaging.operation.name")))
+                    .isNotEqualTo("process"));
   }
 
   private static void assertDeprecatedMetricsAbsent(InstrumentationExtension testing) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
@@ -91,6 +91,23 @@ public final class KafkaMessagingMetricsAssertions {
 
     assertReceiveDurationMetrics(
         testing, instrumentationName, destination, group, partition, operationCount, errorType);
+    assertConsumedMessagesMetrics(
+        testing, instrumentationName, destination, group, partition, messageCount, errorType);
+  }
+
+  public static void assertConsumedMessagesMetrics(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      String group,
+      String partition,
+      long messageCount,
+      String errorType) {
+    if (!emitStableMessagingSemconv()) {
+      assertNoNewMetrics(testing, instrumentationName);
+      return;
+    }
+
     assertCounter(
         testing,
         instrumentationName,
@@ -130,7 +147,6 @@ public final class KafkaMessagingMetricsAssertions {
         partition,
         operationCount,
         errorType);
-    assertMetricAbsent(testing, instrumentationName, CONSUMED_MESSAGES);
     assertDeprecatedMetricsAbsent(testing);
   }
 


### PR DESCRIPTION
Kafka instrumentation now records `messaging.client.consumed.messages`. The metric is emitted only when stable messaging semantic conventions are enabled.

A single poll can be observed by both a receive operation and the process operations for its records. The receive operation reports the count when one runs, and the process operations report it otherwise. That also covers push-based delivery such as listener callbacks, where no receive operation runs.

Each record is counted once, no matter how many operations see it.
