### PR TITLE
Don't count redelivered Kafka messages again after a failed process operation

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -65,7 +65,11 @@ public class KafkaConsumerTelemetry {
   public <K, V> Context buildAndFinishSpan(
       ConsumerRecords<K, V> records, Consumer<K, V> consumer, Timer timer) {
     return buildAndFinishSpan(
-        records, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer), timer);
+        records,
+        KafkaUtil.getConsumerGroup(consumer),
+        KafkaUtil.getClientId(consumer),
+        KafkaUtil.getDeliveryIdentity(consumer),
+        timer);
   }
 
   @Nullable
@@ -74,11 +78,22 @@ public class KafkaConsumerTelemetry {
       @Nullable String consumerGroup,
       @Nullable String clientId,
       Timer timer) {
+    return buildAndFinishSpan(records, consumerGroup, clientId, null, timer);
+  }
+
+  @Nullable
+  public <K, V> Context buildAndFinishSpan(
+      ConsumerRecords<K, V> records,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity,
+      Timer timer) {
     if (records.isEmpty()) {
       return null;
     }
     Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
-    KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumerGroup, clientId);
+    KafkaReceiveRequest request =
+        KafkaReceiveRequest.create(records, consumerGroup, clientId, deliveryIdentity);
     Context receiveContext = null;
     boolean receiveOperationStarted = false;
     if (consumerReceiveInstrumenter.shouldStart(parentContext, request)) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -12,6 +12,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.DeliveryTracker;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
@@ -73,7 +74,7 @@ public class KafkaConsumerTelemetry {
         records,
         KafkaUtil.getConsumerGroup(consumer),
         KafkaUtil.getClientId(consumer),
-        KafkaUtil.getDeliveryIdentity(consumer),
+        KafkaUtil.getDeliveryTracker(consumer),
         timer);
   }
 
@@ -91,14 +92,14 @@ public class KafkaConsumerTelemetry {
       ConsumerRecords<K, V> records,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity,
+      @Nullable DeliveryTracker deliveryTracker,
       Timer timer) {
     if (records.isEmpty()) {
       return null;
     }
     Context parentContext = KafkaConsumerContextUtil.withoutLeakedProcessSpan(Context.current());
     KafkaReceiveRequest request =
-        KafkaReceiveRequest.create(records, consumerGroup, clientId, deliveryIdentity);
+        KafkaReceiveRequest.create(records, consumerGroup, clientId, deliveryTracker);
     Context receiveContext = null;
     boolean receiveOperationStarted = false;
     if (consumerReceiveInstrumenter.shouldStart(parentContext, request)) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/KafkaConsumerTelemetry.java
@@ -54,11 +54,16 @@ public class KafkaConsumerTelemetry {
     for (TopicPartition partition : consumerRecords.partitions()) {
       List<ConsumerRecord<K, V>> list = consumerRecords.records(partition);
       if (list != null && !list.isEmpty()) {
+        for (ConsumerRecord<K, V> record : list) {
+          KafkaConsumerContextUtil.set(record, consumerContext);
+        }
         list = TracingList.wrap(list, consumerProcessInstrumenter, () -> true, consumerContext);
       }
       records.put(partition, list);
     }
-    return new ConsumerRecords<>(records);
+    ConsumerRecords<K, V> tracedRecords = new ConsumerRecords<>(records);
+    KafkaConsumerContextUtil.set(tracedRecords, consumerContext);
+    return tracedRecords;
   }
 
   @Nullable

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptor.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.kafkaclients.v2_6.internal;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.internal.Timer;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.DeliveryTracker;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import java.util.Map;
@@ -35,7 +36,7 @@ public class OpenTelemetryConsumerInterceptor<K, V> implements ConsumerIntercept
   @Nullable private String clientId;
   // this interceptor instance is bound to a single consumer, so it can identify deliveries from
   // that consumer across polls
-  private final Object deliveryIdentity = new Object();
+  private final DeliveryTracker deliveryTracker = new DeliveryTracker();
 
   @Override
   @CanIgnoreReturnValue
@@ -47,12 +48,12 @@ public class OpenTelemetryConsumerInterceptor<K, V> implements ConsumerIntercept
     Timer timer = Timer.start();
     Context receiveContext =
         consumerTelemetry.buildAndFinishSpan(
-            records, consumerGroup, clientId, deliveryIdentity, timer);
+            records, consumerGroup, clientId, deliveryTracker, timer);
     if (receiveContext == null) {
       receiveContext = Context.current();
     }
     KafkaConsumerContext consumerContext =
-        KafkaConsumerContextUtil.create(receiveContext, consumerGroup, clientId, deliveryIdentity);
+        KafkaConsumerContextUtil.create(receiveContext, consumerGroup, clientId, deliveryTracker);
     return consumerTelemetry.addTracing(records, consumerContext);
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/internal/OpenTelemetryConsumerInterceptor.java
@@ -33,6 +33,9 @@ public class OpenTelemetryConsumerInterceptor<K, V> implements ConsumerIntercept
   @Nullable private KafkaConsumerTelemetry consumerTelemetry;
   @Nullable private String consumerGroup;
   @Nullable private String clientId;
+  // this interceptor instance is bound to a single consumer, so it can identify deliveries from
+  // that consumer across polls
+  private final Object deliveryIdentity = new Object();
 
   @Override
   @CanIgnoreReturnValue
@@ -43,12 +46,13 @@ public class OpenTelemetryConsumerInterceptor<K, V> implements ConsumerIntercept
     // timer should be started before fetching ConsumerRecords, but there is no callback for that
     Timer timer = Timer.start();
     Context receiveContext =
-        consumerTelemetry.buildAndFinishSpan(records, consumerGroup, clientId, timer);
+        consumerTelemetry.buildAndFinishSpan(
+            records, consumerGroup, clientId, deliveryIdentity, timer);
     if (receiveContext == null) {
       receiveContext = Context.current();
     }
     KafkaConsumerContext consumerContext =
-        KafkaConsumerContextUtil.create(receiveContext, consumerGroup, clientId);
+        KafkaConsumerContextUtil.create(receiveContext, consumerGroup, clientId, deliveryIdentity);
     return consumerTelemetry.addTracing(records, consumerContext);
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/AbstractInterceptorsTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMess
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSentMessagesMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
@@ -140,6 +141,7 @@ abstract class AbstractInterceptorsTest extends KafkaClientBaseTest {
       assertProcessMetricsWithConsumedMessages(
           testing, instrumentationName, SHARED_TOPIC, "test", "0", 1, 1, null);
     }
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
   }
 
   void assertTraces() {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -49,6 +49,7 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.DeliveryTracker;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
@@ -80,7 +81,7 @@ class WrapperTest extends AbstractWrapperTest {
             .createConsumerProcessInstrumenter();
     Context parentContext = Context.root();
     KafkaConsumerContext consumerContext =
-        KafkaConsumerContextUtil.create(parentContext, "group", "client", new Object());
+        KafkaConsumerContextUtil.create(parentContext, "group", "client", new DeliveryTracker());
     KafkaProcessRequest failedRequest =
         KafkaProcessRequest.create(
             consumerContext, new ConsumerRecord<>("unwrapped", 0, 1, "key", "value"));
@@ -89,15 +90,11 @@ class WrapperTest extends AbstractWrapperTest {
     Context failedContext = instrumenter.start(parentContext, failedRequest);
     instrumenter.end(failedContext, failedRequest, null, error);
 
-    Instrumenter<KafkaProcessRequest, Void> retryInstrumenter =
-        new KafkaInstrumenterFactory(testing.getOpenTelemetry(), instrumentationName)
-            .setMessagingReceiveTelemetryEnabled(true)
-            .createConsumerProcessInstrumenter();
     KafkaProcessRequest retryRequest =
         KafkaProcessRequest.create(
             consumerContext, new ConsumerRecord<>("unwrapped", 0, 1, "key", "value"));
-    Context retryContext = retryInstrumenter.start(parentContext, retryRequest);
-    retryInstrumenter.end(retryContext, retryRequest, null, null);
+    Context retryContext = instrumenter.start(parentContext, retryRequest);
+    instrumenter.end(retryContext, retryRequest, null, null);
 
     String errorType = RuntimeException.class.getName();
     assertProcessMetricsWithConsumedMessages(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -11,7 +11,9 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSign
 import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetricsWithConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertSendMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
@@ -37,6 +39,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +47,12 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContext;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
 import io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
@@ -53,12 +62,45 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class WrapperTest extends AbstractWrapperTest {
+
+  @Test
+  void processCountsRetriedDeliveryOnceWhenConfiguredReceiveOperationDidNotRun() {
+    assumeTrue(emitStableMessagingSemconv());
+    String instrumentationName = "test-kafka-unwrapped-consumer";
+    Instrumenter<KafkaProcessRequest, Void> instrumenter =
+        new KafkaInstrumenterFactory(testing.getOpenTelemetry(), instrumentationName)
+            .setMessagingReceiveTelemetryEnabled(true)
+            .createConsumerProcessInstrumenter();
+    Context parentContext = Context.root();
+    KafkaConsumerContext consumerContext =
+        KafkaConsumerContextUtil.create(parentContext, "group", "client", new Object());
+    KafkaProcessRequest failedRequest =
+        KafkaProcessRequest.create(
+            consumerContext, new ConsumerRecord<>("unwrapped", 0, 1, "key", "value"));
+    RuntimeException error = new RuntimeException("test");
+
+    Context failedContext = instrumenter.start(parentContext, failedRequest);
+    instrumenter.end(failedContext, failedRequest, null, error);
+
+    KafkaProcessRequest retryRequest =
+        KafkaProcessRequest.create(
+            consumerContext, new ConsumerRecord<>("unwrapped", 0, 1, "key", "value"));
+    Context retryContext = instrumenter.start(parentContext, retryRequest);
+    instrumenter.end(retryContext, retryRequest, null, null);
+
+    String errorType = RuntimeException.class.getName();
+    assertProcessMetricsWithConsumedMessages(
+        testing, instrumentationName, "unwrapped", "group", "0", 1, 1, errorType);
+    assertProcessDurationMetrics(testing, instrumentationName, "unwrapped", "group", "0", 1, null);
+    assertTotalConsumedMessages(testing, instrumentationName, 1);
+  }
 
   @Override
   void configure(KafkaTelemetryBuilder builder) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -89,11 +89,15 @@ class WrapperTest extends AbstractWrapperTest {
     Context failedContext = instrumenter.start(parentContext, failedRequest);
     instrumenter.end(failedContext, failedRequest, null, error);
 
+    Instrumenter<KafkaProcessRequest, Void> retryInstrumenter =
+        new KafkaInstrumenterFactory(testing.getOpenTelemetry(), instrumentationName)
+            .setMessagingReceiveTelemetryEnabled(true)
+            .createConsumerProcessInstrumenter();
     KafkaProcessRequest retryRequest =
         KafkaProcessRequest.create(
             consumerContext, new ConsumerRecord<>("unwrapped", 0, 1, "key", "value"));
-    Context retryContext = instrumenter.start(parentContext, retryRequest);
-    instrumenter.end(retryContext, retryRequest, null, null);
+    Context retryContext = retryInstrumenter.start(parentContext, retryRequest);
+    retryInstrumenter.end(retryContext, retryRequest, null, null);
 
     String errorType = RuntimeException.class.getName();
     assertProcessMetricsWithConsumedMessages(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -132,6 +132,36 @@ class WrapperTest extends AbstractWrapperTest {
     assertTotalConsumedMessages(testing, instrumentationName, batchSize);
   }
 
+  @Test
+  void batchProcessDoesNotTreatMissingOffsetAsFailed() {
+    assumeTrue(emitStableMessagingSemconv());
+    String instrumentationName = "test-kafka-sparse-batch";
+    Instrumenter<KafkaReceiveRequest, Void> instrumenter =
+        new KafkaInstrumenterFactory(testing.getOpenTelemetry(), instrumentationName)
+            .createBatchProcessInstrumenter();
+    DeliveryTracker deliveryTracker = new DeliveryTracker();
+
+    ConsumerRecords<String, String> failedRecords = records("sparse-batch", 10L, 12L);
+    KafkaReceiveRequest failedRequest =
+        KafkaReceiveRequest.create(failedRecords, "group", "client", deliveryTracker);
+    Context failedContext = instrumenter.start(Context.root(), failedRequest);
+    instrumenter.end(failedContext, failedRequest, null, new RuntimeException("test"));
+
+    ConsumerRecords<String, String> missingOffsetRecords = records("sparse-batch", 11L);
+    KafkaReceiveRequest missingOffsetRequest =
+        KafkaReceiveRequest.create(missingOffsetRecords, "group", "client", deliveryTracker);
+    Context missingOffsetContext = instrumenter.start(Context.root(), missingOffsetRequest);
+    instrumenter.end(missingOffsetContext, missingOffsetRequest, null, null);
+
+    ConsumerRecords<String, String> retryRecords = records("sparse-batch", 10L, 12L);
+    KafkaReceiveRequest retryRequest =
+        KafkaReceiveRequest.create(retryRecords, "group", "client", deliveryTracker);
+    Context retryContext = instrumenter.start(Context.root(), retryRequest);
+    instrumenter.end(retryContext, retryRequest, null, null);
+
+    assertTotalConsumedMessages(testing, instrumentationName, 3);
+  }
+
   @Override
   void configure(KafkaTelemetryBuilder builder) {
     builder.setMessagingReceiveTelemetryEnabled(true);
@@ -242,6 +272,15 @@ class WrapperTest extends AbstractWrapperTest {
   private static ConsumerRecords<String, String> records(String topic, int count) {
     List<ConsumerRecord<String, String>> records = new ArrayList<>();
     for (int offset = 0; offset < count; offset++) {
+      records.add(new ConsumerRecord<>(topic, 0, offset, "key", "value"));
+    }
+    TopicPartition partition = new TopicPartition(topic, 0);
+    return new ConsumerRecords<>(singletonMap(partition, records));
+  }
+
+  private static ConsumerRecords<String, String> records(String topic, long... offsets) {
+    List<ConsumerRecord<String, String>> records = new ArrayList<>();
+    for (long offset : offsets) {
       records.add(new ConsumerRecord<>(topic, 0, offset, "key", "value"));
     }
     TopicPartition partition = new TopicPartition(topic, 0);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test/java/io/opentelemetry/instrumentation/kafkaclients/v2_6/WrapperTest.java
@@ -37,6 +37,7 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -54,6 +55,7 @@ import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.Kafka
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaConsumerContextUtil;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaInstrumenterFactory;
 import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaProcessRequest;
+import io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal.KafkaReceiveRequest;
 import io.opentelemetry.instrumentation.testing.junit.message.MessageHeaderUtil;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.LinkData;
@@ -64,6 +66,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Test;
@@ -101,6 +105,31 @@ class WrapperTest extends AbstractWrapperTest {
         testing, instrumentationName, "unwrapped", "group", "0", 1, 1, errorType);
     assertProcessDurationMetrics(testing, instrumentationName, "unwrapped", "group", "0", 1, null);
     assertTotalConsumedMessages(testing, instrumentationName, 1);
+  }
+
+  @Test
+  void batchProcessCountsLargeRetriedDeliveryOnce() {
+    assumeTrue(emitStableMessagingSemconv());
+    String instrumentationName = "test-kafka-large-batch";
+    Instrumenter<KafkaReceiveRequest, Void> instrumenter =
+        new KafkaInstrumenterFactory(testing.getOpenTelemetry(), instrumentationName)
+            .createBatchProcessInstrumenter();
+    DeliveryTracker deliveryTracker = new DeliveryTracker();
+    int batchSize = 1025;
+
+    ConsumerRecords<String, String> failedRecords = records("large-batch", batchSize);
+    KafkaReceiveRequest failedRequest =
+        KafkaReceiveRequest.create(failedRecords, "group", "client", deliveryTracker);
+    Context failedContext = instrumenter.start(Context.root(), failedRequest);
+    instrumenter.end(failedContext, failedRequest, null, new RuntimeException("test"));
+
+    ConsumerRecords<String, String> retryRecords = records("large-batch", batchSize);
+    KafkaReceiveRequest retryRequest =
+        KafkaReceiveRequest.create(retryRecords, "group", "client", deliveryTracker);
+    Context retryContext = instrumenter.start(Context.root(), retryRequest);
+    instrumenter.end(retryContext, retryRequest, null, null);
+
+    assertTotalConsumedMessages(testing, instrumentationName, batchSize);
   }
 
   @Override
@@ -208,6 +237,15 @@ class WrapperTest extends AbstractWrapperTest {
 
   private static LinkData batchRecordLink(SpanContext producerSpanContext, long offset) {
     return LinkData.create(producerSpanContext, Attributes.of(MESSAGING_KAFKA_OFFSET, offset));
+  }
+
+  private static ConsumerRecords<String, String> records(String topic, int count) {
+    List<ConsumerRecord<String, String>> records = new ArrayList<>();
+    for (int offset = 0; offset < count; offset++) {
+      records.add(new ConsumerRecord<>(topic, 0, offset, "key", "value"));
+    }
+    TopicPartition partition = new TopicPartition(topic, 0);
+    return new ConsumerRecords<>(singletonMap(partition, records));
   }
 
   protected static List<AttributeAssertion> sendAttributes(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractKafkaConsumerRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractKafkaConsumerRequest.java
@@ -11,10 +11,15 @@ abstract class AbstractKafkaConsumerRequest {
 
   @Nullable private final String consumerGroup;
   @Nullable private final String clientId;
+  @Nullable private final Object deliveryIdentity;
 
-  AbstractKafkaConsumerRequest(@Nullable String consumerGroup, @Nullable String clientId) {
+  AbstractKafkaConsumerRequest(
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
     this.consumerGroup = consumerGroup;
     this.clientId = clientId;
+    this.deliveryIdentity = deliveryIdentity;
   }
 
   @Nullable
@@ -25,6 +30,17 @@ abstract class AbstractKafkaConsumerRequest {
   @Nullable
   public String getClientId() {
     return clientId;
+  }
+
+  /**
+   * Returns the object that identifies the source of this delivery, or {@code null} if it is
+   * unknown. This must be stable across redeliveries of the same records, e.g. a token bound to the
+   * lifetime of the {@code Consumer}, so that a retried delivery can be recognized instead of being
+   * counted again.
+   */
+  @Nullable
+  Object getDeliveryIdentity() {
+    return deliveryIdentity;
   }
 
   @Nullable

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractKafkaConsumerRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/AbstractKafkaConsumerRequest.java
@@ -11,15 +11,15 @@ abstract class AbstractKafkaConsumerRequest {
 
   @Nullable private final String consumerGroup;
   @Nullable private final String clientId;
-  @Nullable private final Object deliveryIdentity;
+  @Nullable private final DeliveryTracker deliveryTracker;
 
   AbstractKafkaConsumerRequest(
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
+      @Nullable DeliveryTracker deliveryTracker) {
     this.consumerGroup = consumerGroup;
     this.clientId = clientId;
-    this.deliveryIdentity = deliveryIdentity;
+    this.deliveryTracker = deliveryTracker;
   }
 
   @Nullable
@@ -33,14 +33,12 @@ abstract class AbstractKafkaConsumerRequest {
   }
 
   /**
-   * Returns the object that identifies the source of this delivery, or {@code null} if it is
-   * unknown. This must be stable across redeliveries of the same records, e.g. a token bound to the
-   * lifetime of the {@code Consumer}, so that a retried delivery can be recognized instead of being
-   * counted again.
+   * Returns the tracker of the consumer that produced this delivery, or {@code null} if it is
+   * unknown. Without a tracker a redelivery cannot be recognized, and is counted again.
    */
   @Nullable
-  Object getDeliveryIdentity() {
-    return deliveryIdentity;
+  DeliveryTracker getDeliveryTracker() {
+    return deliveryTracker;
   }
 
   @Nullable

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -142,21 +143,36 @@ public class DeliveryTracker {
     }
 
     private static PendingFailure create(List<DeliveryKey> deliveryKeys) {
-      Map<TopicPartition, OffsetRange> boundsByPartition = new HashMap<>();
+      Map<TopicPartition, List<Long>> offsetsByPartition = new HashMap<>();
       for (DeliveryKey deliveryKey : deliveryKeys) {
-        OffsetRange range = boundsByPartition.get(deliveryKey.topicPartition);
-        if (range == null) {
-          boundsByPartition.put(
-              deliveryKey.topicPartition, new OffsetRange(deliveryKey.offset, deliveryKey.offset));
-        } else {
-          range.include(deliveryKey.offset);
+        List<Long> offsets = offsetsByPartition.get(deliveryKey.topicPartition);
+        if (offsets == null) {
+          offsets = new ArrayList<>();
+          offsetsByPartition.put(deliveryKey.topicPartition, offsets);
         }
+        offsets.add(deliveryKey.offset);
       }
 
       Map<TopicPartition, List<OffsetRange>> rangesByPartition = new HashMap<>();
-      for (Map.Entry<TopicPartition, OffsetRange> entry : boundsByPartition.entrySet()) {
+      for (Map.Entry<TopicPartition, List<Long>> entry : offsetsByPartition.entrySet()) {
+        List<Long> offsets = entry.getValue();
+        Collections.sort(offsets);
         List<OffsetRange> ranges = new ArrayList<>();
-        ranges.add(entry.getValue());
+        for (long offset : offsets) {
+          if (ranges.isEmpty()) {
+            ranges.add(new OffsetRange(offset, offset));
+            continue;
+          }
+          OffsetRange range = ranges.get(ranges.size() - 1);
+          if (offset == range.end) {
+            continue;
+          }
+          if (range.end != Long.MAX_VALUE && offset == range.end + 1) {
+            range.end = offset;
+          } else {
+            ranges.add(new OffsetRange(offset, offset));
+          }
+        }
         rangesByPartition.put(entry.getKey(), ranges);
       }
       return new PendingFailure(rangesByPartition);
@@ -216,11 +232,6 @@ public class DeliveryTracker {
     private OffsetRange(long start, long end) {
       this.start = start;
       this.end = end;
-    }
-
-    private void include(long offset) {
-      start = Math.min(start, offset);
-      end = Math.max(end, offset);
     }
 
     private boolean contains(long offset) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import java.util.List;
 
 /**
  * Identifies the source of a delivery and remembers which of its deliveries a process operation
@@ -28,18 +29,51 @@ public class DeliveryTracker {
   private static final int MAX_PENDING_FAILED_DELIVERIES = 1024;
 
   // bounded so that a consumer that never recovers cannot grow this without limit
-  private final Cache<String, Boolean> pendingFailedDeliveries =
+  private final Cache<String, Object> pendingFailedDeliveries =
       Cache.bounded(MAX_PENDING_FAILED_DELIVERIES);
 
-  boolean isPendingFailed(String deliveryKey) {
+  synchronized boolean isPendingFailed(String deliveryKey) {
     return pendingFailedDeliveries.get(deliveryKey) != null;
   }
 
-  void setPendingFailed(String deliveryKey, boolean pendingFailed) {
-    if (pendingFailed) {
-      pendingFailedDeliveries.put(deliveryKey, true);
-    } else {
-      pendingFailedDeliveries.remove(deliveryKey);
+  synchronized DeliveryState start(List<String> deliveryKeys) {
+    Object[] pendingFailures = new Object[deliveryKeys.size()];
+    for (int i = 0; i < deliveryKeys.size(); i++) {
+      pendingFailures[i] = pendingFailedDeliveries.get(deliveryKeys.get(i));
+    }
+    return new DeliveryState(this, deliveryKeys, pendingFailures);
+  }
+
+  private synchronized void end(DeliveryState state, boolean successful) {
+    for (int i = 0; i < state.deliveryKeys.size(); i++) {
+      String deliveryKey = state.deliveryKeys.get(i);
+      if (!successful) {
+        pendingFailedDeliveries.put(deliveryKey, new Object());
+      } else if (state.pendingFailures[i] != null
+          && state.pendingFailures[i] == pendingFailedDeliveries.get(deliveryKey)) {
+        pendingFailedDeliveries.remove(deliveryKey);
+      }
+    }
+  }
+
+  static final class DeliveryState {
+    private final DeliveryTracker deliveryTracker;
+    private final List<String> deliveryKeys;
+    private final Object[] pendingFailures;
+
+    private DeliveryState(
+        DeliveryTracker deliveryTracker, List<String> deliveryKeys, Object[] pendingFailures) {
+      this.deliveryTracker = deliveryTracker;
+      this.deliveryKeys = deliveryKeys;
+      this.pendingFailures = pendingFailures;
+    }
+
+    boolean wasPendingFailed(int index) {
+      return pendingFailures[index] != null;
+    }
+
+    void end(boolean successful) {
+      deliveryTracker.end(this, successful);
     }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
@@ -5,8 +5,16 @@
 
 package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 
-import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * Identifies the source of a delivery and remembers which of its deliveries a process operation
@@ -26,43 +34,91 @@ import java.util.List;
  */
 public class DeliveryTracker {
 
-  private static final int MAX_PENDING_FAILED_DELIVERIES = 1024;
+  private static final int MAX_PENDING_FAILED_OPERATIONS = 1024;
 
   // bounded so that a consumer that never recovers cannot grow this without limit
-  private final Cache<String, Object> pendingFailedDeliveries =
-      Cache.bounded(MAX_PENDING_FAILED_DELIVERIES);
+  private final Deque<PendingFailure> pendingFailures = new ArrayDeque<>();
 
-  synchronized boolean isPendingFailed(String deliveryKey) {
-    return pendingFailedDeliveries.get(deliveryKey) != null;
+  synchronized boolean isPendingFailed(DeliveryKey deliveryKey) {
+    return findPendingFailure(deliveryKey) != null;
   }
 
-  synchronized DeliveryState start(List<String> deliveryKeys) {
-    Object[] pendingFailures = new Object[deliveryKeys.size()];
+  synchronized DeliveryState start(List<DeliveryKey> deliveryKeys) {
+    PendingFailure[] pendingFailures = new PendingFailure[deliveryKeys.size()];
     for (int i = 0; i < deliveryKeys.size(); i++) {
-      pendingFailures[i] = pendingFailedDeliveries.get(deliveryKeys.get(i));
+      pendingFailures[i] = findPendingFailure(deliveryKeys.get(i));
     }
     return new DeliveryState(this, deliveryKeys, pendingFailures);
   }
 
   private synchronized void end(DeliveryState state, boolean successful) {
-    for (int i = 0; i < state.deliveryKeys.size(); i++) {
-      String deliveryKey = state.deliveryKeys.get(i);
-      if (!successful) {
-        pendingFailedDeliveries.put(deliveryKey, new Object());
-      } else if (state.pendingFailures[i] != null
-          && state.pendingFailures[i] == pendingFailedDeliveries.get(deliveryKey)) {
-        pendingFailedDeliveries.remove(deliveryKey);
+    if (!successful) {
+      removePendingFailures(state.deliveryKeys);
+      PendingFailure pendingFailure = PendingFailure.create(state.deliveryKeys);
+      if (pendingFailure.isEmpty()) {
+        return;
       }
+      pendingFailures.addFirst(pendingFailure);
+      if (pendingFailures.size() > MAX_PENDING_FAILED_OPERATIONS) {
+        pendingFailures.removeLast();
+      }
+      return;
+    }
+
+    for (int i = 0; i < state.deliveryKeys.size(); i++) {
+      DeliveryKey deliveryKey = state.deliveryKeys.get(i);
+      PendingFailure pendingFailure = state.pendingFailures[i];
+      if (pendingFailure != null && pendingFailure == findPendingFailure(deliveryKey)) {
+        pendingFailure.remove(deliveryKey);
+        if (pendingFailure.isEmpty()) {
+          pendingFailures.remove(pendingFailure);
+        }
+      }
+    }
+  }
+
+  @Nullable
+  private PendingFailure findPendingFailure(DeliveryKey deliveryKey) {
+    for (PendingFailure pendingFailure : pendingFailures) {
+      if (pendingFailure.contains(deliveryKey)) {
+        return pendingFailure;
+      }
+    }
+    return null;
+  }
+
+  private void removePendingFailures(List<DeliveryKey> deliveryKeys) {
+    Iterator<PendingFailure> iterator = pendingFailures.iterator();
+    while (iterator.hasNext()) {
+      PendingFailure pendingFailure = iterator.next();
+      for (DeliveryKey deliveryKey : deliveryKeys) {
+        pendingFailure.remove(deliveryKey);
+      }
+      if (pendingFailure.isEmpty()) {
+        iterator.remove();
+      }
+    }
+  }
+
+  static final class DeliveryKey {
+    private final TopicPartition topicPartition;
+    private final long offset;
+
+    DeliveryKey(String topic, int partition, long offset) {
+      this.topicPartition = new TopicPartition(topic, partition);
+      this.offset = offset;
     }
   }
 
   static final class DeliveryState {
     private final DeliveryTracker deliveryTracker;
-    private final List<String> deliveryKeys;
-    private final Object[] pendingFailures;
+    private final List<DeliveryKey> deliveryKeys;
+    private final PendingFailure[] pendingFailures;
 
     private DeliveryState(
-        DeliveryTracker deliveryTracker, List<String> deliveryKeys, Object[] pendingFailures) {
+        DeliveryTracker deliveryTracker,
+        List<DeliveryKey> deliveryKeys,
+        PendingFailure[] pendingFailures) {
       this.deliveryTracker = deliveryTracker;
       this.deliveryKeys = deliveryKeys;
       this.pendingFailures = pendingFailures;
@@ -74,6 +130,101 @@ public class DeliveryTracker {
 
     void end(boolean successful) {
       deliveryTracker.end(this, successful);
+    }
+  }
+
+  /** Stores one failed operation as offset ranges, so its batch size does not affect capacity. */
+  private static final class PendingFailure {
+    private final Map<TopicPartition, List<OffsetRange>> rangesByPartition;
+
+    private PendingFailure(Map<TopicPartition, List<OffsetRange>> rangesByPartition) {
+      this.rangesByPartition = rangesByPartition;
+    }
+
+    private static PendingFailure create(List<DeliveryKey> deliveryKeys) {
+      Map<TopicPartition, OffsetRange> boundsByPartition = new HashMap<>();
+      for (DeliveryKey deliveryKey : deliveryKeys) {
+        OffsetRange range = boundsByPartition.get(deliveryKey.topicPartition);
+        if (range == null) {
+          boundsByPartition.put(
+              deliveryKey.topicPartition, new OffsetRange(deliveryKey.offset, deliveryKey.offset));
+        } else {
+          range.include(deliveryKey.offset);
+        }
+      }
+
+      Map<TopicPartition, List<OffsetRange>> rangesByPartition = new HashMap<>();
+      for (Map.Entry<TopicPartition, OffsetRange> entry : boundsByPartition.entrySet()) {
+        List<OffsetRange> ranges = new ArrayList<>();
+        ranges.add(entry.getValue());
+        rangesByPartition.put(entry.getKey(), ranges);
+      }
+      return new PendingFailure(rangesByPartition);
+    }
+
+    private boolean contains(DeliveryKey deliveryKey) {
+      List<OffsetRange> ranges = rangesByPartition.get(deliveryKey.topicPartition);
+      if (ranges == null) {
+        return false;
+      }
+      for (OffsetRange range : ranges) {
+        if (range.contains(deliveryKey.offset)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private void remove(DeliveryKey deliveryKey) {
+      List<OffsetRange> ranges = rangesByPartition.get(deliveryKey.topicPartition);
+      if (ranges == null) {
+        return;
+      }
+      ListIterator<OffsetRange> iterator = ranges.listIterator();
+      while (iterator.hasNext()) {
+        OffsetRange range = iterator.next();
+        if (!range.contains(deliveryKey.offset)) {
+          continue;
+        }
+        if (range.start == range.end) {
+          iterator.remove();
+        } else if (deliveryKey.offset == range.start) {
+          range.start++;
+        } else if (deliveryKey.offset == range.end) {
+          range.end--;
+        } else {
+          long end = range.end;
+          range.end = deliveryKey.offset - 1;
+          iterator.add(new OffsetRange(deliveryKey.offset + 1, end));
+        }
+        if (ranges.isEmpty()) {
+          rangesByPartition.remove(deliveryKey.topicPartition);
+        }
+        return;
+      }
+    }
+
+    private boolean isEmpty() {
+      return rangesByPartition.isEmpty();
+    }
+  }
+
+  private static final class OffsetRange {
+    private long start;
+    private long end;
+
+    private OffsetRange(long start, long end) {
+      this.start = start;
+      this.end = end;
+    }
+
+    private void include(long offset) {
+      start = Math.min(start, offset);
+      end = Math.max(end, offset);
+    }
+
+    private boolean contains(long offset) {
+      return offset >= start && offset <= end;
     }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/DeliveryTracker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
+
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+
+/**
+ * Identifies the source of a delivery and remembers which of its deliveries a process operation
+ * failed to handle.
+ *
+ * <p>When a process operation fails and the consumer seeks back to the failed offset, the same
+ * record is delivered again. A failed delivery stays pending here until a later process operation
+ * for it succeeds, so that {@code messaging.client.consumed.messages} does not count the redelivery
+ * as a newly consumed message.
+ *
+ * <p>One tracker belongs to one consumer and is stable for the lifetime of that consumer, so that
+ * two consumers reading the same offset are tracked independently. It does not reference the
+ * consumer, so attaching it to consumer records does not keep the consumer alive.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class DeliveryTracker {
+
+  private static final int MAX_PENDING_FAILED_DELIVERIES = 1024;
+
+  // bounded so that a consumer that never recovers cannot grow this without limit
+  private final Cache<String, Boolean> pendingFailedDeliveries =
+      Cache.bounded(MAX_PENDING_FAILED_DELIVERIES);
+
+  boolean isPendingFailed(String deliveryKey) {
+    return pendingFailedDeliveries.get(deliveryKey) != null;
+  }
+
+  void setPendingFailed(String deliveryKey, boolean pendingFailed) {
+    if (pendingFailed) {
+      pendingFailedDeliveries.put(deliveryKey, true);
+    } else {
+      pendingFailedDeliveries.remove(deliveryKey);
+    }
+  }
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaBatchProcessSpanLinksExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaBatchProcessSpanLinksExtractor.java
@@ -41,7 +41,7 @@ final class KafkaBatchProcessSpanLinksExtractor implements SpanLinksExtractor<Ka
                 record,
                 request.getConsumerGroup(),
                 request.getClientId(),
-                request.getDeliveryIdentity()));
+                request.getDeliveryTracker()));
       }
       return;
     }
@@ -53,7 +53,7 @@ final class KafkaBatchProcessSpanLinksExtractor implements SpanLinksExtractor<Ka
               record,
               request.getConsumerGroup(),
               request.getClientId(),
-              request.getDeliveryIdentity());
+              request.getDeliveryTracker());
       Context extracted = propagator.extract(Context.root(), processRequest, recordGetter);
       spanLinks.addLink(
           Span.fromContext(extracted).getSpanContext(), attributes.getLinkAttributes(record));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaBatchProcessSpanLinksExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaBatchProcessSpanLinksExtractor.java
@@ -37,7 +37,11 @@ final class KafkaBatchProcessSpanLinksExtractor implements SpanLinksExtractor<Ka
         singleRecordLinkExtractor.extract(
             spanLinks,
             parentContext,
-            KafkaProcessRequest.create(record, request.getConsumerGroup(), request.getClientId()));
+            KafkaProcessRequest.create(
+                record,
+                request.getConsumerGroup(),
+                request.getClientId(),
+                request.getDeliveryIdentity()));
       }
       return;
     }
@@ -45,7 +49,11 @@ final class KafkaBatchProcessSpanLinksExtractor implements SpanLinksExtractor<Ka
     KafkaBatchRecordAttributes attributes = request.getBatchRecordAttributes();
     for (ConsumerRecord<?, ?> record : request.getRecords()) {
       KafkaProcessRequest processRequest =
-          KafkaProcessRequest.create(record, request.getConsumerGroup(), request.getClientId());
+          KafkaProcessRequest.create(
+              record,
+              request.getConsumerGroup(),
+              request.getClientId(),
+              request.getDeliveryIdentity());
       Context extracted = propagator.extract(Context.root(), processRequest, recordGetter);
       spanLinks.addLink(
           Span.fromContext(extracted).getSpanContext(), attributes.getLinkAttributes(record));

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContext.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContext.java
@@ -20,8 +20,8 @@ public abstract class KafkaConsumerContext {
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    return new AutoValue_KafkaConsumerContext(context, consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    return new AutoValue_KafkaConsumerContext(context, consumerGroup, clientId, deliveryTracker);
   }
 
   @Nullable
@@ -34,5 +34,5 @@ public abstract class KafkaConsumerContext {
   abstract String getClientId();
 
   @Nullable
-  abstract Object getDeliveryIdentity();
+  abstract DeliveryTracker getDeliveryTracker();
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContext.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContext.java
@@ -17,8 +17,11 @@ import javax.annotation.Nullable;
 public abstract class KafkaConsumerContext {
 
   static KafkaConsumerContext create(
-      @Nullable Context context, @Nullable String consumerGroup, @Nullable String clientId) {
-    return new AutoValue_KafkaConsumerContext(context, consumerGroup, clientId);
+      @Nullable Context context,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    return new AutoValue_KafkaConsumerContext(context, consumerGroup, clientId, deliveryIdentity);
   }
 
   @Nullable
@@ -29,4 +32,7 @@ public abstract class KafkaConsumerContext {
 
   @Nullable
   abstract String getClientId();
+
+  @Nullable
+  abstract Object getDeliveryIdentity();
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -31,12 +31,12 @@ public final class KafkaConsumerContextUtil {
   // class as field type
   private static final VirtualField<ConsumerRecord<?, ?>, Context> recordContextField =
       VirtualField.find(ConsumerRecord.class, Context.class);
-  private static final VirtualField<ConsumerRecord<?, ?>, String[]> recordConsumerInfoField =
-      VirtualField.find(ConsumerRecord.class, String[].class);
+  private static final VirtualField<ConsumerRecord<?, ?>, Object[]> recordConsumerInfoField =
+      VirtualField.find(ConsumerRecord.class, Object[].class);
   private static final VirtualField<ConsumerRecords<?, ?>, Context> recordsContextField =
       VirtualField.find(ConsumerRecords.class, Context.class);
-  private static final VirtualField<ConsumerRecords<?, ?>, String[]> recordsConsumerInfoField =
-      VirtualField.find(ConsumerRecords.class, String[].class);
+  private static final VirtualField<ConsumerRecords<?, ?>, Object[]> recordsConsumerInfoField =
+      VirtualField.find(ConsumerRecords.class, Object[].class);
   private static final VirtualField<ConsumerRecord<?, ?>, Boolean> recordCountedField =
       VirtualField.find(ConsumerRecord.class, Boolean.class);
 
@@ -90,33 +90,44 @@ public final class KafkaConsumerContextUtil {
     Context receiveContext = recordContextField.get(records);
     String consumerGroup = null;
     String clientId = null;
-    String[] consumerInfo = recordConsumerInfoField.get(records);
+    Object deliveryIdentity = null;
+    Object[] consumerInfo = recordConsumerInfoField.get(records);
     if (consumerInfo != null) {
-      consumerGroup = consumerInfo[0];
-      clientId = consumerInfo[1];
+      consumerGroup = (String) consumerInfo[0];
+      clientId = (String) consumerInfo[1];
+      deliveryIdentity = consumerInfo[2];
     }
-    return create(receiveContext, consumerGroup, clientId);
+    return create(receiveContext, consumerGroup, clientId, deliveryIdentity);
   }
 
   public static KafkaConsumerContext get(ConsumerRecords<?, ?> records) {
     Context receiveContext = recordsContextField.get(records);
     String consumerGroup = null;
     String clientId = null;
-    String[] consumerInfo = recordsConsumerInfoField.get(records);
+    Object deliveryIdentity = null;
+    Object[] consumerInfo = recordsConsumerInfoField.get(records);
     if (consumerInfo != null) {
-      consumerGroup = consumerInfo[0];
-      clientId = consumerInfo[1];
+      consumerGroup = (String) consumerInfo[0];
+      clientId = (String) consumerInfo[1];
+      deliveryIdentity = consumerInfo[2];
     }
-    return create(receiveContext, consumerGroup, clientId);
+    return create(receiveContext, consumerGroup, clientId, deliveryIdentity);
   }
 
   public static KafkaConsumerContext create(@Nullable Context context, Consumer<?, ?> consumer) {
-    return create(context, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
+    return create(
+        context,
+        KafkaUtil.getConsumerGroup(consumer),
+        KafkaUtil.getClientId(consumer),
+        KafkaUtil.getDeliveryIdentity(consumer));
   }
 
   public static KafkaConsumerContext create(
-      @Nullable Context context, @Nullable String consumerGroup, @Nullable String clientId) {
-    return KafkaConsumerContext.create(context, consumerGroup, clientId);
+      @Nullable Context context,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    return KafkaConsumerContext.create(context, consumerGroup, clientId, deliveryIdentity);
   }
 
   public static void set(ConsumerRecord<?, ?> record, KafkaConsumerContext consumerContext) {
@@ -124,16 +135,18 @@ public final class KafkaConsumerContextUtil {
         record,
         consumerContext.getContext(),
         consumerContext.getConsumerGroup(),
-        consumerContext.getClientId());
+        consumerContext.getClientId(),
+        consumerContext.getDeliveryIdentity());
   }
 
   private static void set(
       ConsumerRecord<?, ?> record,
       @Nullable Context context,
       @Nullable String consumerGroup,
-      @Nullable String clientId) {
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
     recordContextField.set(record, context);
-    recordConsumerInfoField.set(record, new String[] {consumerGroup, clientId});
+    recordConsumerInfoField.set(record, new Object[] {consumerGroup, clientId, deliveryIdentity});
   }
 
   public static void set(ConsumerRecords<?, ?> records, KafkaConsumerContext consumerContext) {
@@ -141,16 +154,18 @@ public final class KafkaConsumerContextUtil {
         records,
         consumerContext.getContext(),
         consumerContext.getConsumerGroup(),
-        consumerContext.getClientId());
+        consumerContext.getClientId(),
+        consumerContext.getDeliveryIdentity());
   }
 
   private static void set(
       ConsumerRecords<?, ?> records,
       @Nullable Context context,
       @Nullable String consumerGroup,
-      @Nullable String clientId) {
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
     recordsContextField.set(records, context);
-    recordsConsumerInfoField.set(records, new String[] {consumerGroup, clientId});
+    recordsConsumerInfoField.set(records, new Object[] {consumerGroup, clientId, deliveryIdentity});
   }
 
   public static void copy(ConsumerRecord<?, ?> from, ConsumerRecord<?, ?> to) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -86,30 +86,48 @@ public final class KafkaConsumerContextUtil {
     return true;
   }
 
-  public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {
-    Context receiveContext = recordContextField.get(records);
+  public static KafkaConsumerContext get(ConsumerRecord<?, ?> record) {
+    return get(record, null);
+  }
+
+  public static KafkaConsumerContext get(
+      ConsumerRecord<?, ?> record, @Nullable Consumer<?, ?> consumer) {
+    Context receiveContext = recordContextField.get(record);
+    Object[] consumerInfo = recordConsumerInfoField.get(record);
+    return createWithFallback(receiveContext, consumerInfo, consumer);
+  }
+
+  public static KafkaConsumerContext get(ConsumerRecords<?, ?> records) {
+    return get(records, null);
+  }
+
+  public static KafkaConsumerContext get(
+      ConsumerRecords<?, ?> records, @Nullable Consumer<?, ?> consumer) {
+    Context receiveContext = recordsContextField.get(records);
+    Object[] consumerInfo = recordsConsumerInfoField.get(records);
+    return createWithFallback(receiveContext, consumerInfo, consumer);
+  }
+
+  private static KafkaConsumerContext createWithFallback(
+      @Nullable Context receiveContext,
+      @Nullable Object[] consumerInfo,
+      @Nullable Consumer<?, ?> consumer) {
     String consumerGroup = null;
     String clientId = null;
     Object deliveryIdentity = null;
-    Object[] consumerInfo = recordConsumerInfoField.get(records);
     if (consumerInfo != null) {
       consumerGroup = (String) consumerInfo[0];
       clientId = (String) consumerInfo[1];
       deliveryIdentity = consumerInfo[2];
     }
-    return create(receiveContext, consumerGroup, clientId, deliveryIdentity);
-  }
-
-  public static KafkaConsumerContext get(ConsumerRecords<?, ?> records) {
-    Context receiveContext = recordsContextField.get(records);
-    String consumerGroup = null;
-    String clientId = null;
-    Object deliveryIdentity = null;
-    Object[] consumerInfo = recordsConsumerInfoField.get(records);
-    if (consumerInfo != null) {
-      consumerGroup = (String) consumerInfo[0];
-      clientId = (String) consumerInfo[1];
-      deliveryIdentity = consumerInfo[2];
+    if (consumerGroup == null) {
+      consumerGroup = KafkaUtil.getConsumerGroup(consumer);
+    }
+    if (clientId == null) {
+      clientId = KafkaUtil.getClientId(consumer);
+    }
+    if (deliveryIdentity == null) {
+      deliveryIdentity = KafkaUtil.getDeliveryIdentity(consumer);
     }
     return create(receiveContext, consumerGroup, clientId, deliveryIdentity);
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -114,11 +114,11 @@ public final class KafkaConsumerContextUtil {
       @Nullable Consumer<?, ?> consumer) {
     String consumerGroup = null;
     String clientId = null;
-    Object deliveryIdentity = null;
+    DeliveryTracker deliveryTracker = null;
     if (consumerInfo != null) {
       consumerGroup = (String) consumerInfo[0];
       clientId = (String) consumerInfo[1];
-      deliveryIdentity = consumerInfo[2];
+      deliveryTracker = (DeliveryTracker) consumerInfo[2];
     }
     if (consumerGroup == null) {
       consumerGroup = KafkaUtil.getConsumerGroup(consumer);
@@ -126,10 +126,10 @@ public final class KafkaConsumerContextUtil {
     if (clientId == null) {
       clientId = KafkaUtil.getClientId(consumer);
     }
-    if (deliveryIdentity == null) {
-      deliveryIdentity = KafkaUtil.getDeliveryIdentity(consumer);
+    if (deliveryTracker == null) {
+      deliveryTracker = KafkaUtil.getDeliveryTracker(consumer);
     }
-    return create(receiveContext, consumerGroup, clientId, deliveryIdentity);
+    return create(receiveContext, consumerGroup, clientId, deliveryTracker);
   }
 
   public static KafkaConsumerContext create(@Nullable Context context, Consumer<?, ?> consumer) {
@@ -137,15 +137,15 @@ public final class KafkaConsumerContextUtil {
         context,
         KafkaUtil.getConsumerGroup(consumer),
         KafkaUtil.getClientId(consumer),
-        KafkaUtil.getDeliveryIdentity(consumer));
+        KafkaUtil.getDeliveryTracker(consumer));
   }
 
   public static KafkaConsumerContext create(
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    return KafkaConsumerContext.create(context, consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    return KafkaConsumerContext.create(context, consumerGroup, clientId, deliveryTracker);
   }
 
   public static void set(ConsumerRecord<?, ?> record, KafkaConsumerContext consumerContext) {
@@ -154,7 +154,7 @@ public final class KafkaConsumerContextUtil {
         consumerContext.getContext(),
         consumerContext.getConsumerGroup(),
         consumerContext.getClientId(),
-        consumerContext.getDeliveryIdentity());
+        consumerContext.getDeliveryTracker());
   }
 
   private static void set(
@@ -162,9 +162,9 @@ public final class KafkaConsumerContextUtil {
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
+      @Nullable DeliveryTracker deliveryTracker) {
     recordContextField.set(record, context);
-    recordConsumerInfoField.set(record, new Object[] {consumerGroup, clientId, deliveryIdentity});
+    recordConsumerInfoField.set(record, new Object[] {consumerGroup, clientId, deliveryTracker});
   }
 
   public static void set(ConsumerRecords<?, ?> records, KafkaConsumerContext consumerContext) {
@@ -173,7 +173,7 @@ public final class KafkaConsumerContextUtil {
         consumerContext.getContext(),
         consumerContext.getConsumerGroup(),
         consumerContext.getClientId(),
-        consumerContext.getDeliveryIdentity());
+        consumerContext.getDeliveryTracker());
   }
 
   private static void set(
@@ -181,9 +181,9 @@ public final class KafkaConsumerContextUtil {
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
+      @Nullable DeliveryTracker deliveryTracker) {
     recordsContextField.set(records, context);
-    recordsConsumerInfoField.set(records, new Object[] {consumerGroup, clientId, deliveryIdentity});
+    recordsConsumerInfoField.set(records, new Object[] {consumerGroup, clientId, deliveryTracker});
   }
 
   public static void copy(ConsumerRecord<?, ?> from, ConsumerRecord<?, ?> to) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -293,7 +293,7 @@ public final class KafkaInstrumenterFactory {
       Context context,
       AbstractKafkaConsumerRequest request,
       ConsumerRecord<?, ?> delivery,
-      List<String> deliveryKeys) {
+      List<DeliveryTracker.DeliveryKey> deliveryKeys) {
     DeliveryTracker deliveryTracker = request.getDeliveryTracker();
     DeliveryTracker.DeliveryState deliveryState = startDeliveryState(deliveryTracker, deliveryKeys);
     long consumedMessagesCount =
@@ -308,7 +308,7 @@ public final class KafkaInstrumenterFactory {
       Context context,
       AbstractKafkaConsumerRequest request,
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
-      List<String> deliveryKeys) {
+      List<DeliveryTracker.DeliveryKey> deliveryKeys) {
     DeliveryTracker deliveryTracker = request.getDeliveryTracker();
     DeliveryTracker.DeliveryState deliveryState = startDeliveryState(deliveryTracker, deliveryKeys);
     long consumedMessagesCount =
@@ -321,7 +321,7 @@ public final class KafkaInstrumenterFactory {
 
   @Nullable
   private static DeliveryTracker.DeliveryState startDeliveryState(
-      @Nullable DeliveryTracker deliveryTracker, List<String> deliveryKeys) {
+      @Nullable DeliveryTracker deliveryTracker, List<DeliveryTracker.DeliveryKey> deliveryKeys) {
     return deliveryTracker == null ? null : deliveryTracker.start(deliveryKeys);
   }
 
@@ -370,7 +370,7 @@ public final class KafkaInstrumenterFactory {
 
   private static long countConsumedMessages(
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
-      List<String> deliveryKeys,
+      List<DeliveryTracker.DeliveryKey> deliveryKeys,
       @Nullable DeliveryTracker deliveryTracker) {
     long consumedMessagesCount = 0;
     int index = 0;
@@ -389,7 +389,7 @@ public final class KafkaInstrumenterFactory {
    * recognized.
    */
   private static boolean isPendingFailed(
-      @Nullable DeliveryTracker deliveryTracker, String deliveryKey) {
+      @Nullable DeliveryTracker deliveryTracker, DeliveryTracker.DeliveryKey deliveryKey) {
     return deliveryTracker != null && deliveryTracker.isPendingFailed(deliveryKey);
   }
 
@@ -397,12 +397,12 @@ public final class KafkaInstrumenterFactory {
     state.end(successful);
   }
 
-  private static List<String> deliveryKeys(KafkaProcessRequest request) {
+  private static List<DeliveryTracker.DeliveryKey> deliveryKeys(KafkaProcessRequest request) {
     return singletonList(deliveryKey(request.getRecord()));
   }
 
-  private static List<String> deliveryKeys(KafkaReceiveRequest request) {
-    List<String> keys = new ArrayList<>();
+  private static List<DeliveryTracker.DeliveryKey> deliveryKeys(KafkaReceiveRequest request) {
+    List<DeliveryTracker.DeliveryKey> keys = new ArrayList<>();
     for (ConsumerRecord<?, ?> record : request.getRecords()) {
       keys.add(deliveryKey(record));
     }
@@ -413,8 +413,8 @@ public final class KafkaInstrumenterFactory {
    * Returns a key that tells deliveries apart. A {@link DeliveryTracker} belongs to one consumer,
    * so the topic, partition and offset are enough to identify a delivery within it.
    */
-  private static String deliveryKey(ConsumerRecord<?, ?> record) {
-    return record.topic() + ':' + record.partition() + ':' + record.offset();
+  private static DeliveryTracker.DeliveryKey deliveryKey(ConsumerRecord<?, ?> record) {
+    return new DeliveryTracker.DeliveryKey(record.topic(), record.partition(), record.offset());
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
@@ -270,10 +269,6 @@ public final class KafkaInstrumenterFactory {
    * not counted by a receive operation. Semantic conventions require the counter to be reported
    * once per message delivery, including push-based dispatch such as listener callbacks, which have
    * no receive operation.
-   *
-   * <p>The count is deduplicated per individual {@link ConsumerRecord}, so that a batch process
-   * operation and the per-record process operations of the same delivery, which both run in some
-   * frameworks, together count each record exactly once.
    */
   private void addConsumedMessagesIfNoReceiveOperation(
       InstrumenterBuilder<KafkaProcessRequest, Void> builder) {
@@ -283,6 +278,18 @@ public final class KafkaInstrumenterFactory {
               (context, request, startAttributes) ->
                   startDeliveryTracking(
                       context, request, request.getRecord(), deliveryKeys(request)))
+          .addOperationMetrics(consumedMessagesMetrics);
+    }
+  }
+
+  private void addBatchConsumedMessagesIfNoReceiveOperation(
+      InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
+    if (emitStableMessagingSemconv()) {
+      builder
+          .addContextCustomizer(
+              (context, request, startAttributes) ->
+                  startBatchDeliveryTracking(
+                      context, request, request.getRecords(), deliveryKeys(request)))
           .addOperationMetrics(consumedMessagesMetrics);
     }
   }
@@ -305,17 +312,35 @@ public final class KafkaInstrumenterFactory {
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
+  private Context startBatchDeliveryTracking(
+      Context context,
+      AbstractKafkaConsumerRequest request,
+      Iterable<? extends ConsumerRecord<?, ?>> deliveries,
+      List<String> deliveryKeys) {
+    Cache<String, Boolean> deliveryPendingFailedDeliveries =
+        pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
+    long consumedMessagesCount =
+        KafkaConsumerContextUtil.hasReceiveOperation(context)
+            ? 0
+            : countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries);
+    return context
+        .with(
+            CONSUMED_MESSAGES_DELIVERY_STATE,
+            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+        .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+  }
+
   private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
     builder
         .addContextCustomizer(
             (context, request, startAttributes) -> {
-              ConsumerRecords<?, ?> delivery = request.getRecords();
+              Iterable<? extends ConsumerRecord<?, ?>> deliveries = request.getRecords();
               List<String> deliveryKeys = deliveryKeys(request);
               Cache<String, Boolean> deliveryPendingFailedDeliveries =
-                  pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
+                  pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
               return context.with(
                   CONSUMED_MESSAGES_COUNT_KEY,
-                  countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries));
+                  countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries));
             })
         .addOperationMetrics(consumedMessagesMetrics);
   }
@@ -338,7 +363,7 @@ public final class KafkaInstrumenterFactory {
   }
 
   private static long countConsumedMessages(
-      ConsumerRecords<?, ?> deliveries,
+      Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys,
       Cache<String, Boolean> deliveryPendingFailedDeliveries) {
     long consumedMessagesCount = 0;
@@ -418,6 +443,7 @@ public final class KafkaInstrumenterFactory {
                     openTelemetry.getPropagators().getTextMapPropagator()))
             .addOperationMetrics(MessagingProcessMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
+    addBatchConsumedMessagesIfNoReceiveOperation(builder);
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -287,18 +287,6 @@ public final class KafkaInstrumenterFactory {
     }
   }
 
-  private void addBatchConsumedMessagesIfNoReceiveOperation(
-      InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
-    if (emitStableMessagingSemconv()) {
-      builder
-          .addContextCustomizer(
-              (context, request, startAttributes) ->
-                  startBatchDeliveryTracking(
-                      context, request, request.getRecords(), deliveryKeys(request)))
-          .addOperationMetrics(consumedMessagesMetrics);
-    }
-  }
-
   private Context startDeliveryTracking(
       Context context,
       AbstractKafkaConsumerRequest request,
@@ -310,24 +298,6 @@ public final class KafkaInstrumenterFactory {
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
             : countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries);
-    return context
-        .with(
-            CONSUMED_MESSAGES_DELIVERY_STATE,
-            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
-        .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
-  }
-
-  private Context startBatchDeliveryTracking(
-      Context context,
-      AbstractKafkaConsumerRequest request,
-      ConsumerRecords<?, ?> deliveries,
-      List<String> deliveryKeys) {
-    Cache<String, Boolean> deliveryPendingFailedDeliveries =
-        pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
-    long consumedMessagesCount =
-        KafkaConsumerContextUtil.hasReceiveOperation(context)
-            ? 0
-            : countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries);
     return context
         .with(
             CONSUMED_MESSAGES_DELIVERY_STATE,
@@ -448,7 +418,6 @@ public final class KafkaInstrumenterFactory {
                     openTelemetry.getPropagators().getTextMapPropagator()))
             .addOperationMetrics(MessagingProcessMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
-    addBatchConsumedMessagesIfNoReceiveOperation(builder);
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -35,8 +35,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import io.opentelemetry.instrumentation.api.internal.cache.Cache;
-import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -52,7 +50,6 @@ public final class KafkaInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String POLL_OPERATION_NAME = "poll";
   private static final String PROCESS_OPERATION_NAME = "process";
-  private static final int MAX_PENDING_FAILED_DELIVERIES = 1024;
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
@@ -62,8 +59,6 @@ public final class KafkaInstrumenterFactory {
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
   private static final ContextKey<DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =
       ContextKey.named("opentelemetry-kafka-consumed-messages-delivery");
-  private static final VirtualField<OpenTelemetry, DeliveryTracker> DELIVERY_TRACKER_FIELD =
-      VirtualField.find(OpenTelemetry.class, DeliveryTracker.class);
   private static final OperationMetrics consumedMessagesMetrics =
       meter -> {
         OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
@@ -95,7 +90,6 @@ public final class KafkaInstrumenterFactory {
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
-  private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private IncludeExclude headers = IncludeExclude.builder().build();
   private boolean captureExperimentalSpanAttributes = false;
@@ -104,8 +98,6 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
     this.instrumentationName = instrumentationName;
-    DeliveryTracker deliveryTracker = getDeliveryTracker(openTelemetry);
-    pendingFailedDeliveries = deliveryTracker.pendingFailedDeliveries;
   }
 
   @CanIgnoreReturnValue
@@ -272,7 +264,7 @@ public final class KafkaInstrumenterFactory {
    * once per message delivery, including push-based dispatch such as listener callbacks, which have
    * no receive operation.
    */
-  private void addConsumedMessagesIfNoReceiveOperation(
+  private static void addConsumedMessagesIfNoReceiveOperation(
       InstrumenterBuilder<KafkaProcessRequest, Void> builder) {
     if (emitStableMessagingSemconv()) {
       builder
@@ -284,7 +276,7 @@ public final class KafkaInstrumenterFactory {
     }
   }
 
-  private void addBatchConsumedMessagesIfNoReceiveOperation(
+  private static void addBatchConsumedMessagesIfNoReceiveOperation(
       InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
     if (emitStableMessagingSemconv()) {
       builder
@@ -296,96 +288,74 @@ public final class KafkaInstrumenterFactory {
     }
   }
 
-  private Context startDeliveryTracking(
+  private static Context startDeliveryTracking(
       Context context,
       AbstractKafkaConsumerRequest request,
       ConsumerRecord<?, ?> delivery,
       List<String> deliveryKeys) {
-    Cache<String, Boolean> deliveryPendingFailedDeliveries =
-        pendingFailedDeliveries(request.getDeliveryIdentity());
+    DeliveryTracker deliveryTracker = request.getDeliveryTracker();
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
-            : countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries);
-    return withDeliveryState(context, deliveryKeys, deliveryPendingFailedDeliveries)
+            : countConsumedMessages(delivery, deliveryKeys, deliveryTracker);
+    return withDeliveryState(context, deliveryKeys, deliveryTracker)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
-  private Context startBatchDeliveryTracking(
+  private static Context startBatchDeliveryTracking(
       Context context,
       AbstractKafkaConsumerRequest request,
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys) {
-    Cache<String, Boolean> deliveryPendingFailedDeliveries =
-        pendingFailedDeliveries(request.getDeliveryIdentity());
+    DeliveryTracker deliveryTracker = request.getDeliveryTracker();
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
-            : countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries);
-    return withDeliveryState(context, deliveryKeys, deliveryPendingFailedDeliveries)
+            : countConsumedMessages(deliveries, deliveryKeys, deliveryTracker);
+    return withDeliveryState(context, deliveryKeys, deliveryTracker)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
   private static Context withDeliveryState(
-      Context context,
-      List<String> deliveryKeys,
-      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
-    if (deliveryPendingFailedDeliveries == null) {
+      Context context, List<String> deliveryKeys, @Nullable DeliveryTracker deliveryTracker) {
+    if (deliveryTracker == null) {
       return context;
     }
     return context.with(
-        CONSUMED_MESSAGES_DELIVERY_STATE,
-        new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries));
+        CONSUMED_MESSAGES_DELIVERY_STATE, new DeliveryState(deliveryKeys, deliveryTracker));
   }
 
-  private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
+  private static void addReceiveConsumedMessages(
+      InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
     builder
         .addContextCustomizer(
-            (context, request, startAttributes) -> {
-              Iterable<? extends ConsumerRecord<?, ?>> deliveries = request.getRecords();
-              List<String> deliveryKeys = deliveryKeys(request);
-              Cache<String, Boolean> deliveryPendingFailedDeliveries =
-                  pendingFailedDeliveries(request.getDeliveryIdentity());
-              return context.with(
-                  CONSUMED_MESSAGES_COUNT_KEY,
-                  countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries));
-            })
+            (context, request, startAttributes) ->
+                context.with(
+                    CONSUMED_MESSAGES_COUNT_KEY,
+                    countConsumedMessages(
+                        request.getRecords(), deliveryKeys(request), request.getDeliveryTracker())))
         .addOperationMetrics(consumedMessagesMetrics);
-  }
-
-  /**
-   * Returns the pending-failed deliveries of the consumer that produced the delivery, or {@code
-   * null} if the delivery has no identity. Without an identity a redelivery cannot be recognized,
-   * so tracking it would only allocate state that is never read again.
-   */
-  @Nullable
-  private Cache<String, Boolean> pendingFailedDeliveries(@Nullable Object deliveryIdentity) {
-    if (deliveryIdentity == null) {
-      return null;
-    }
-    return pendingFailedDeliveries.computeIfAbsent(
-        deliveryIdentity, unused -> Cache.bounded(MAX_PENDING_FAILED_DELIVERIES));
   }
 
   private static long countConsumedMessages(
       ConsumerRecord<?, ?> delivery,
       List<String> deliveryKeys,
-      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+      @Nullable DeliveryTracker deliveryTracker) {
     if (!KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)) {
       return 0;
     }
-    return isPendingFailed(deliveryPendingFailedDeliveries, deliveryKeys.get(0)) ? 0 : 1;
+    return isPendingFailed(deliveryTracker, deliveryKeys.get(0)) ? 0 : 1;
   }
 
   private static long countConsumedMessages(
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys,
-      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+      @Nullable DeliveryTracker deliveryTracker) {
     long consumedMessagesCount = 0;
     int index = 0;
     for (ConsumerRecord<?, ?> delivery : deliveries) {
       if (KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)
-          && !isPendingFailed(deliveryPendingFailedDeliveries, deliveryKeys.get(index))) {
+          && !isPendingFailed(deliveryTracker, deliveryKeys.get(index))) {
         consumedMessagesCount++;
       }
       index++;
@@ -393,57 +363,39 @@ public final class KafkaInstrumenterFactory {
     return consumedMessagesCount;
   }
 
+  /**
+   * A delivery with no tracker is always counted, because without a tracker a redelivery cannot be
+   * recognized.
+   */
   private static boolean isPendingFailed(
-      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries, String deliveryKey) {
-    return deliveryPendingFailedDeliveries != null
-        && deliveryPendingFailedDeliveries.get(deliveryKey) != null;
+      @Nullable DeliveryTracker deliveryTracker, String deliveryKey) {
+    return deliveryTracker != null && deliveryTracker.isPendingFailed(deliveryKey);
   }
 
   private static void endDeliveryTracking(DeliveryState state, boolean successful) {
     for (String deliveryKey : state.deliveryKeys) {
-      if (successful) {
-        state.pendingFailedDeliveries.remove(deliveryKey);
-      } else {
-        state.pendingFailedDeliveries.put(deliveryKey, true);
-      }
+      state.deliveryTracker.setPendingFailed(deliveryKey, !successful);
     }
   }
 
   private static List<String> deliveryKeys(KafkaProcessRequest request) {
-    return deliveryKeys(request, singletonList(request.getRecord()));
+    return singletonList(deliveryKey(request.getRecord()));
   }
 
   private static List<String> deliveryKeys(KafkaReceiveRequest request) {
-    return deliveryKeys(request, request.getRecords());
-  }
-
-  private static List<String> deliveryKeys(
-      AbstractKafkaConsumerRequest request, Iterable<? extends ConsumerRecord<?, ?>> records) {
     List<String> keys = new ArrayList<>();
-    for (ConsumerRecord<?, ?> record : records) {
-      keys.add(deliveryKey(request.getConsumerGroup(), request.getClientId(), record));
+    for (ConsumerRecord<?, ?> record : request.getRecords()) {
+      keys.add(deliveryKey(record));
     }
     return keys;
   }
 
-  private static String deliveryKey(
-      @Nullable String consumerGroup, @Nullable String clientId, ConsumerRecord<?, ?> record) {
-    StringBuilder key = new StringBuilder();
-    appendKeyPart(key, consumerGroup);
-    appendKeyPart(key, clientId);
-    String topic = record.topic();
-    return key.append(topic.length())
-        .append(':')
-        .append(topic)
-        .append(':')
-        .append(record.partition())
-        .append(':')
-        .append(record.offset())
-        .toString();
-  }
-
-  private static void appendKeyPart(StringBuilder key, @Nullable String value) {
-    key.append(value == null ? -1 : value.length()).append(':').append(value).append('|');
+  /**
+   * Returns a key that tells deliveries apart. A {@link DeliveryTracker} belongs to one consumer,
+   * so the topic, partition and offset are enough to identify a delivery within it.
+   */
+  private static String deliveryKey(ConsumerRecord<?, ?> record) {
+    return record.topic() + ':' + record.partition() + ':' + record.offset();
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
@@ -469,22 +421,6 @@ public final class KafkaInstrumenterFactory {
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
-  private static DeliveryTracker getDeliveryTracker(OpenTelemetry openTelemetry) {
-    DeliveryTracker deliveryTracker = DELIVERY_TRACKER_FIELD.get(openTelemetry);
-    if (deliveryTracker != null) {
-      return deliveryTracker;
-    }
-
-    synchronized (DELIVERY_TRACKER_FIELD) {
-      deliveryTracker = DELIVERY_TRACKER_FIELD.get(openTelemetry);
-      if (deliveryTracker == null) {
-        deliveryTracker = new DeliveryTracker();
-        DELIVERY_TRACKER_FIELD.set(openTelemetry, deliveryTracker);
-      }
-      return deliveryTracker;
-    }
-  }
-
   private static Attributes withConsumedMessagesCount(
       Attributes attributes, long consumedMessagesCount) {
     return attributes.toBuilder().put(MESSAGING_BATCH_MESSAGE_COUNT, consumedMessagesCount).build();
@@ -503,16 +439,11 @@ public final class KafkaInstrumenterFactory {
 
   private static final class DeliveryState {
     private final List<String> deliveryKeys;
-    private final Cache<String, Boolean> pendingFailedDeliveries;
+    private final DeliveryTracker deliveryTracker;
 
-    private DeliveryState(
-        List<String> deliveryKeys, Cache<String, Boolean> pendingFailedDeliveries) {
+    private DeliveryState(List<String> deliveryKeys, DeliveryTracker deliveryTracker) {
       this.deliveryKeys = deliveryKeys;
-      this.pendingFailedDeliveries = pendingFailedDeliveries;
+      this.deliveryTracker = deliveryTracker;
     }
-  }
-
-  private static class DeliveryTracker {
-    private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries = Cache.weak();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingReceiveExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -53,8 +54,6 @@ public final class KafkaInstrumenterFactory {
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
-  // copied from ErrorAttributes
-  private static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
   private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
   private static final ContextKey<DeliveryTracker.DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -300,15 +300,12 @@ public final class KafkaInstrumenterFactory {
       ConsumerRecord<?, ?> delivery,
       List<String> deliveryKeys) {
     Cache<String, Boolean> deliveryPendingFailedDeliveries =
-        pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
+        pendingFailedDeliveries(request.getDeliveryIdentity());
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
             : countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries);
-    return context
-        .with(
-            CONSUMED_MESSAGES_DELIVERY_STATE,
-            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+    return withDeliveryState(context, deliveryKeys, deliveryPendingFailedDeliveries)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
@@ -318,16 +315,25 @@ public final class KafkaInstrumenterFactory {
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys) {
     Cache<String, Boolean> deliveryPendingFailedDeliveries =
-        pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
+        pendingFailedDeliveries(request.getDeliveryIdentity());
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
             : countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries);
-    return context
-        .with(
-            CONSUMED_MESSAGES_DELIVERY_STATE,
-            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+    return withDeliveryState(context, deliveryKeys, deliveryPendingFailedDeliveries)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+  }
+
+  private static Context withDeliveryState(
+      Context context,
+      List<String> deliveryKeys,
+      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+    if (deliveryPendingFailedDeliveries == null) {
+      return context;
+    }
+    return context.with(
+        CONSUMED_MESSAGES_DELIVERY_STATE,
+        new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries));
   }
 
   private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
@@ -337,7 +343,7 @@ public final class KafkaInstrumenterFactory {
               Iterable<? extends ConsumerRecord<?, ?>> deliveries = request.getRecords();
               List<String> deliveryKeys = deliveryKeys(request);
               Cache<String, Boolean> deliveryPendingFailedDeliveries =
-                  pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
+                  pendingFailedDeliveries(request.getDeliveryIdentity());
               return context.with(
                   CONSUMED_MESSAGES_COUNT_KEY,
                   countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries));
@@ -345,37 +351,50 @@ public final class KafkaInstrumenterFactory {
         .addOperationMetrics(consumedMessagesMetrics);
   }
 
-  private Cache<String, Boolean> pendingFailedDeliveries(
-      @Nullable Object deliveryIdentity, Object delivery) {
+  /**
+   * Returns the pending-failed deliveries of the consumer that produced the delivery, or {@code
+   * null} if the delivery has no identity. Without an identity a redelivery cannot be recognized,
+   * so tracking it would only allocate state that is never read again.
+   */
+  @Nullable
+  private Cache<String, Boolean> pendingFailedDeliveries(@Nullable Object deliveryIdentity) {
+    if (deliveryIdentity == null) {
+      return null;
+    }
     return pendingFailedDeliveries.computeIfAbsent(
-        deliveryIdentity != null ? deliveryIdentity : delivery,
-        unused -> Cache.bounded(MAX_PENDING_FAILED_DELIVERIES));
+        deliveryIdentity, unused -> Cache.bounded(MAX_PENDING_FAILED_DELIVERIES));
   }
 
   private static long countConsumedMessages(
       ConsumerRecord<?, ?> delivery,
       List<String> deliveryKeys,
-      Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
     if (!KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)) {
       return 0;
     }
-    return deliveryPendingFailedDeliveries.get(deliveryKeys.get(0)) == null ? 1 : 0;
+    return isPendingFailed(deliveryPendingFailedDeliveries, deliveryKeys.get(0)) ? 0 : 1;
   }
 
   private static long countConsumedMessages(
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys,
-      Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries) {
     long consumedMessagesCount = 0;
     int index = 0;
     for (ConsumerRecord<?, ?> delivery : deliveries) {
       if (KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)
-          && deliveryPendingFailedDeliveries.get(deliveryKeys.get(index)) == null) {
+          && !isPendingFailed(deliveryPendingFailedDeliveries, deliveryKeys.get(index))) {
         consumedMessagesCount++;
       }
       index++;
     }
     return consumedMessagesCount;
+  }
+
+  private static boolean isPendingFailed(
+      @Nullable Cache<String, Boolean> deliveryPendingFailedDeliveries, String deliveryKey) {
+    return deliveryPendingFailedDeliveries != null
+        && deliveryPendingFailedDeliveries.get(deliveryKey) != null;
   }
 
   private static void endDeliveryTracking(DeliveryState state, boolean successful) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -280,32 +280,66 @@ public final class KafkaInstrumenterFactory {
     if (emitStableMessagingSemconv()) {
       builder
           .addContextCustomizer(
-              (context, request, startAttributes) -> {
-                Object delivery = request.getRecord();
-                List<String> deliveryKeys = deliveryKeys(request);
-                Cache<String, Boolean> deliveryPendingFailedDeliveries =
-                    pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
-                long consumedMessagesCount =
-                    KafkaConsumerContextUtil.hasReceiveOperation(context)
-                        ? 0
-                        : countConsumedMessages(
-                            delivery, deliveryKeys, deliveryPendingFailedDeliveries);
-                return context
-                    .with(
-                        CONSUMED_MESSAGES_DELIVERY_STATE,
-                        new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
-                    .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
-              })
+              (context, request, startAttributes) ->
+                  startDeliveryTracking(
+                      context, request, request.getRecord(), deliveryKeys(request)))
           .addOperationMetrics(consumedMessagesMetrics);
     }
   }
 
-  private static void addReceiveConsumedMessages(
+  private void addBatchConsumedMessagesIfNoReceiveOperation(
       InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
+    if (emitStableMessagingSemconv()) {
+      builder
+          .addContextCustomizer(
+              (context, request, startAttributes) ->
+                  startBatchDeliveryTracking(
+                      context, request, request.getRecords(), deliveryKeys(request)))
+          .addOperationMetrics(consumedMessagesMetrics);
+    }
+  }
+
+  private Context startDeliveryTracking(
+      Context context,
+      AbstractKafkaConsumerRequest request,
+      ConsumerRecord<?, ?> delivery,
+      List<String> deliveryKeys) {
+    Cache<String, Boolean> deliveryPendingFailedDeliveries =
+        pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
+    long consumedMessagesCount =
+        KafkaConsumerContextUtil.hasReceiveOperation(context)
+            ? 0
+            : countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries);
+    return context
+        .with(
+            CONSUMED_MESSAGES_DELIVERY_STATE,
+            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+        .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+  }
+
+  private Context startBatchDeliveryTracking(
+      Context context,
+      AbstractKafkaConsumerRequest request,
+      ConsumerRecords<?, ?> deliveries,
+      List<String> deliveryKeys) {
+    Cache<String, Boolean> deliveryPendingFailedDeliveries =
+        pendingFailedDeliveries(request.getDeliveryIdentity(), deliveries);
+    long consumedMessagesCount =
+        KafkaConsumerContextUtil.hasReceiveOperation(context)
+            ? 0
+            : countConsumedMessages(deliveries, deliveryKeys, deliveryPendingFailedDeliveries);
+    return context
+        .with(
+            CONSUMED_MESSAGES_DELIVERY_STATE,
+            new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+        .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+  }
+
+  private void addReceiveConsumedMessages(InstrumenterBuilder<KafkaReceiveRequest, Void> builder) {
     builder
         .addContextCustomizer(
             (context, request, startAttributes) -> {
-              Object delivery = request.getRecords();
+              ConsumerRecords<?, ?> delivery = request.getRecords();
               List<String> deliveryKeys = deliveryKeys(request);
               Cache<String, Boolean> deliveryPendingFailedDeliveries =
                   pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
@@ -414,6 +448,7 @@ public final class KafkaInstrumenterFactory {
                     openTelemetry.getPropagators().getTextMapPropagator()))
             .addOperationMetrics(MessagingProcessMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
+    addBatchConsumedMessagesIfNoReceiveOperation(builder);
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -36,6 +36,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -61,7 +62,8 @@ public final class KafkaInstrumenterFactory {
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
   private static final ContextKey<DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =
       ContextKey.named("opentelemetry-kafka-consumed-messages-delivery");
-  private static final Cache<OpenTelemetry, DeliveryTracker> deliveryTrackers = Cache.weak();
+  private static final VirtualField<OpenTelemetry, DeliveryTracker> DELIVERY_TRACKER_FIELD =
+      VirtualField.find(OpenTelemetry.class, DeliveryTracker.class);
   private static final OperationMetrics consumedMessagesMetrics =
       meter -> {
         OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
@@ -468,7 +470,19 @@ public final class KafkaInstrumenterFactory {
   }
 
   private static DeliveryTracker getDeliveryTracker(OpenTelemetry openTelemetry) {
-    return deliveryTrackers.computeIfAbsent(openTelemetry, unused -> new DeliveryTracker());
+    DeliveryTracker deliveryTracker = DELIVERY_TRACKER_FIELD.get(openTelemetry);
+    if (deliveryTracker != null) {
+      return deliveryTracker;
+    }
+
+    synchronized (DELIVERY_TRACKER_FIELD) {
+      deliveryTracker = DELIVERY_TRACKER_FIELD.get(openTelemetry);
+      if (deliveryTracker == null) {
+        deliveryTracker = new DeliveryTracker();
+        DELIVERY_TRACKER_FIELD.set(openTelemetry, deliveryTracker);
+      }
+      return deliveryTracker;
+    }
   }
 
   private static Attributes withConsumedMessagesCount(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.OpenTelemetry;
@@ -34,7 +35,10 @@ import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationListener;
 import io.opentelemetry.instrumentation.api.instrumenter.OperationMetrics;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
-import java.util.function.ToLongFunction;
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -48,11 +52,17 @@ public final class KafkaInstrumenterFactory {
   private static final String SEND_OPERATION_NAME = "send";
   private static final String POLL_OPERATION_NAME = "poll";
   private static final String PROCESS_OPERATION_NAME = "process";
+  private static final int MAX_PENDING_FAILED_DELIVERIES = 1024;
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
       AttributeKey.longKey("messaging.batch.message_count");
+  // copied from ErrorAttributes
+  private static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
   private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
+  private static final ContextKey<DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =
+      ContextKey.named("opentelemetry-kafka-consumed-messages-delivery");
+  private static final Cache<OpenTelemetry, DeliveryTracker> deliveryTrackers = Cache.weak();
   private static final OperationMetrics consumedMessagesMetrics =
       meter -> {
         OperationListener delegate = MessagingConsumerMetrics.getConsumedMessages().create(meter);
@@ -74,12 +84,17 @@ public final class KafkaInstrumenterFactory {
                   withConsumedMessagesCount(endAttributes, consumedMessagesCount),
                   endNanos);
             }
+            DeliveryState deliveryState = context.get(CONSUMED_MESSAGES_DELIVERY_STATE);
+            if (deliveryState != null) {
+              endDeliveryTracking(deliveryState, endAttributes.get(ERROR_TYPE) == null);
+            }
           }
         };
       };
 
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
+  private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.getDefault();
   private IncludeExclude headers = IncludeExclude.builder().build();
   private boolean captureExperimentalSpanAttributes = false;
@@ -88,6 +103,8 @@ public final class KafkaInstrumenterFactory {
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
     this.instrumentationName = instrumentationName;
+    DeliveryTracker deliveryTracker = getDeliveryTracker(openTelemetry);
+    pendingFailedDeliveries = deliveryTracker.pendingFailedDeliveries;
   }
 
   @CanIgnoreReturnValue
@@ -234,8 +251,7 @@ public final class KafkaInstrumenterFactory {
     if (captureExperimentalSpanAttributes) {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
-    addConsumedMessagesIfNoReceiveOperation(
-        builder, request -> countConsumedMessages(request.getRecord()));
+    addConsumedMessagesIfNoReceiveOperation(builder);
     setMessagingProcessExceptionEventExtractor(builder);
 
     return MessagingProcessInstrumenterFactory.create(
@@ -259,17 +275,26 @@ public final class KafkaInstrumenterFactory {
    * operation and the per-record process operations of the same delivery, which both run in some
    * frameworks, together count each record exactly once.
    */
-  private static <REQUEST> void addConsumedMessagesIfNoReceiveOperation(
-      InstrumenterBuilder<REQUEST, Void> builder, ToLongFunction<REQUEST> messageCounter) {
+  private void addConsumedMessagesIfNoReceiveOperation(
+      InstrumenterBuilder<KafkaProcessRequest, Void> builder) {
     if (emitStableMessagingSemconv()) {
       builder
           .addContextCustomizer(
               (context, request, startAttributes) -> {
+                Object delivery = request.getRecord();
+                List<String> deliveryKeys = deliveryKeys(request);
+                Cache<String, Boolean> deliveryPendingFailedDeliveries =
+                    pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
                 long consumedMessagesCount =
                     KafkaConsumerContextUtil.hasReceiveOperation(context)
                         ? 0
-                        : messageCounter.applyAsLong(request);
-                return context.with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
+                        : countConsumedMessages(
+                            delivery, deliveryKeys, deliveryPendingFailedDeliveries);
+                return context
+                    .with(
+                        CONSUMED_MESSAGES_DELIVERY_STATE,
+                        new DeliveryState(deliveryKeys, deliveryPendingFailedDeliveries))
+                    .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
               })
           .addOperationMetrics(consumedMessagesMetrics);
     }
@@ -280,27 +305,95 @@ public final class KafkaInstrumenterFactory {
     builder
         .addContextCustomizer(
             (context, request, startAttributes) -> {
+              Object delivery = request.getRecords();
+              List<String> deliveryKeys = deliveryKeys(request);
+              Cache<String, Boolean> deliveryPendingFailedDeliveries =
+                  pendingFailedDeliveries(request.getDeliveryIdentity(), delivery);
               return context.with(
-                  CONSUMED_MESSAGES_COUNT_KEY, countConsumedMessages(request.getRecords()));
+                  CONSUMED_MESSAGES_COUNT_KEY,
+                  countConsumedMessages(delivery, deliveryKeys, deliveryPendingFailedDeliveries));
             })
         .addOperationMetrics(consumedMessagesMetrics);
   }
 
-  /**
-   * Returns {@code 1} the first time the given record is seen, and {@code 0} afterwards, so that
-   * operations that observe the same record do not count it twice.
-   */
-  private static long countConsumedMessages(ConsumerRecord<?, ?> record) {
-    return KafkaConsumerContextUtil.markConsumedMessageCounted(record) ? 1 : 0;
+  private Cache<String, Boolean> pendingFailedDeliveries(
+      @Nullable Object deliveryIdentity, Object delivery) {
+    return pendingFailedDeliveries.computeIfAbsent(
+        deliveryIdentity != null ? deliveryIdentity : delivery,
+        unused -> Cache.bounded(MAX_PENDING_FAILED_DELIVERIES));
   }
 
-  /** Counts the records of a batch individually, so that they can be deduplicated one by one. */
-  private static long countConsumedMessages(ConsumerRecords<?, ?> records) {
+  private static long countConsumedMessages(
+      ConsumerRecord<?, ?> delivery,
+      List<String> deliveryKeys,
+      Cache<String, Boolean> deliveryPendingFailedDeliveries) {
+    if (!KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)) {
+      return 0;
+    }
+    return deliveryPendingFailedDeliveries.get(deliveryKeys.get(0)) == null ? 1 : 0;
+  }
+
+  private static long countConsumedMessages(
+      ConsumerRecords<?, ?> deliveries,
+      List<String> deliveryKeys,
+      Cache<String, Boolean> deliveryPendingFailedDeliveries) {
     long consumedMessagesCount = 0;
-    for (ConsumerRecord<?, ?> record : records) {
-      consumedMessagesCount += countConsumedMessages(record);
+    int index = 0;
+    for (ConsumerRecord<?, ?> delivery : deliveries) {
+      if (KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)
+          && deliveryPendingFailedDeliveries.get(deliveryKeys.get(index)) == null) {
+        consumedMessagesCount++;
+      }
+      index++;
     }
     return consumedMessagesCount;
+  }
+
+  private static void endDeliveryTracking(DeliveryState state, boolean successful) {
+    for (String deliveryKey : state.deliveryKeys) {
+      if (successful) {
+        state.pendingFailedDeliveries.remove(deliveryKey);
+      } else {
+        state.pendingFailedDeliveries.put(deliveryKey, true);
+      }
+    }
+  }
+
+  private static List<String> deliveryKeys(KafkaProcessRequest request) {
+    return deliveryKeys(request, singletonList(request.getRecord()));
+  }
+
+  private static List<String> deliveryKeys(KafkaReceiveRequest request) {
+    return deliveryKeys(request, request.getRecords());
+  }
+
+  private static List<String> deliveryKeys(
+      AbstractKafkaConsumerRequest request, Iterable<? extends ConsumerRecord<?, ?>> records) {
+    List<String> keys = new ArrayList<>();
+    for (ConsumerRecord<?, ?> record : records) {
+      keys.add(deliveryKey(request.getConsumerGroup(), request.getClientId(), record));
+    }
+    return keys;
+  }
+
+  private static String deliveryKey(
+      @Nullable String consumerGroup, @Nullable String clientId, ConsumerRecord<?, ?> record) {
+    StringBuilder key = new StringBuilder();
+    appendKeyPart(key, consumerGroup);
+    appendKeyPart(key, clientId);
+    String topic = record.topic();
+    return key.append(topic.length())
+        .append(':')
+        .append(topic)
+        .append(':')
+        .append(record.partition())
+        .append(':')
+        .append(record.offset())
+        .toString();
+  }
+
+  private static void appendKeyPart(StringBuilder key, @Nullable String value) {
+    key.append(value == null ? -1 : value.length()).append(':').append(value).append('|');
   }
 
   public Instrumenter<KafkaReceiveRequest, Void> createBatchProcessInstrumenter() {
@@ -321,10 +414,27 @@ public final class KafkaInstrumenterFactory {
                     openTelemetry.getPropagators().getTextMapPropagator()))
             .addOperationMetrics(MessagingProcessMetrics.get())
             .setErrorCauseExtractor(errorCauseExtractor);
-    addConsumedMessagesIfNoReceiveOperation(
-        builder, request -> countConsumedMessages(request.getRecords()));
     setMessagingProcessExceptionEventExtractor(builder);
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
+  }
+
+  private static final class DeliveryState {
+    private final List<String> deliveryKeys;
+    private final Cache<String, Boolean> pendingFailedDeliveries;
+
+    private DeliveryState(
+        List<String> deliveryKeys, Cache<String, Boolean> pendingFailedDeliveries) {
+      this.deliveryKeys = deliveryKeys;
+      this.pendingFailedDeliveries = pendingFailedDeliveries;
+    }
+  }
+
+  private static class DeliveryTracker {
+    private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries = Cache.weak();
+  }
+
+  private static DeliveryTracker getDeliveryTracker(OpenTelemetry openTelemetry) {
+    return deliveryTrackers.computeIfAbsent(openTelemetry, unused -> new DeliveryTracker());
   }
 
   private static Attributes withConsumedMessagesCount(

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -57,7 +57,7 @@ public final class KafkaInstrumenterFactory {
   private static final AttributeKey<String> ERROR_TYPE = AttributeKey.stringKey("error.type");
   private static final ContextKey<Long> CONSUMED_MESSAGES_COUNT_KEY =
       ContextKey.named("opentelemetry-kafka-consumed-messages-count");
-  private static final ContextKey<DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =
+  private static final ContextKey<DeliveryTracker.DeliveryState> CONSUMED_MESSAGES_DELIVERY_STATE =
       ContextKey.named("opentelemetry-kafka-consumed-messages-delivery");
   private static final OperationMetrics consumedMessagesMetrics =
       meter -> {
@@ -80,7 +80,8 @@ public final class KafkaInstrumenterFactory {
                   withConsumedMessagesCount(endAttributes, consumedMessagesCount),
                   endNanos);
             }
-            DeliveryState deliveryState = context.get(CONSUMED_MESSAGES_DELIVERY_STATE);
+            DeliveryTracker.DeliveryState deliveryState =
+                context.get(CONSUMED_MESSAGES_DELIVERY_STATE);
             if (deliveryState != null) {
               endDeliveryTracking(deliveryState, endAttributes.get(ERROR_TYPE) == null);
             }
@@ -294,11 +295,12 @@ public final class KafkaInstrumenterFactory {
       ConsumerRecord<?, ?> delivery,
       List<String> deliveryKeys) {
     DeliveryTracker deliveryTracker = request.getDeliveryTracker();
+    DeliveryTracker.DeliveryState deliveryState = startDeliveryState(deliveryTracker, deliveryKeys);
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
-            : countConsumedMessages(delivery, deliveryKeys, deliveryTracker);
-    return withDeliveryState(context, deliveryKeys, deliveryTracker)
+            : countConsumedMessages(delivery, deliveryState);
+    return withDeliveryState(context, deliveryState)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
@@ -308,21 +310,27 @@ public final class KafkaInstrumenterFactory {
       Iterable<? extends ConsumerRecord<?, ?>> deliveries,
       List<String> deliveryKeys) {
     DeliveryTracker deliveryTracker = request.getDeliveryTracker();
+    DeliveryTracker.DeliveryState deliveryState = startDeliveryState(deliveryTracker, deliveryKeys);
     long consumedMessagesCount =
         KafkaConsumerContextUtil.hasReceiveOperation(context)
             ? 0
-            : countConsumedMessages(deliveries, deliveryKeys, deliveryTracker);
-    return withDeliveryState(context, deliveryKeys, deliveryTracker)
+            : countConsumedMessages(deliveries, deliveryState);
+    return withDeliveryState(context, deliveryState)
         .with(CONSUMED_MESSAGES_COUNT_KEY, consumedMessagesCount);
   }
 
+  @Nullable
+  private static DeliveryTracker.DeliveryState startDeliveryState(
+      @Nullable DeliveryTracker deliveryTracker, List<String> deliveryKeys) {
+    return deliveryTracker == null ? null : deliveryTracker.start(deliveryKeys);
+  }
+
   private static Context withDeliveryState(
-      Context context, List<String> deliveryKeys, @Nullable DeliveryTracker deliveryTracker) {
-    if (deliveryTracker == null) {
+      Context context, @Nullable DeliveryTracker.DeliveryState deliveryState) {
+    if (deliveryState == null) {
       return context;
     }
-    return context.with(
-        CONSUMED_MESSAGES_DELIVERY_STATE, new DeliveryState(deliveryKeys, deliveryTracker));
+    return context.with(CONSUMED_MESSAGES_DELIVERY_STATE, deliveryState);
   }
 
   private static void addReceiveConsumedMessages(
@@ -338,13 +346,26 @@ public final class KafkaInstrumenterFactory {
   }
 
   private static long countConsumedMessages(
-      ConsumerRecord<?, ?> delivery,
-      List<String> deliveryKeys,
-      @Nullable DeliveryTracker deliveryTracker) {
+      ConsumerRecord<?, ?> delivery, @Nullable DeliveryTracker.DeliveryState deliveryState) {
     if (!KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)) {
       return 0;
     }
-    return isPendingFailed(deliveryTracker, deliveryKeys.get(0)) ? 0 : 1;
+    return deliveryState != null && deliveryState.wasPendingFailed(0) ? 0 : 1;
+  }
+
+  private static long countConsumedMessages(
+      Iterable<? extends ConsumerRecord<?, ?>> deliveries,
+      @Nullable DeliveryTracker.DeliveryState deliveryState) {
+    long consumedMessagesCount = 0;
+    int index = 0;
+    for (ConsumerRecord<?, ?> delivery : deliveries) {
+      if (KafkaConsumerContextUtil.markConsumedMessageCounted(delivery)
+          && (deliveryState == null || !deliveryState.wasPendingFailed(index))) {
+        consumedMessagesCount++;
+      }
+      index++;
+    }
+    return consumedMessagesCount;
   }
 
   private static long countConsumedMessages(
@@ -372,10 +393,8 @@ public final class KafkaInstrumenterFactory {
     return deliveryTracker != null && deliveryTracker.isPendingFailed(deliveryKey);
   }
 
-  private static void endDeliveryTracking(DeliveryState state, boolean successful) {
-    for (String deliveryKey : state.deliveryKeys) {
-      state.deliveryTracker.setPendingFailed(deliveryKey, !successful);
-    }
+  private static void endDeliveryTracking(DeliveryTracker.DeliveryState state, boolean successful) {
+    state.end(successful);
   }
 
   private static List<String> deliveryKeys(KafkaProcessRequest request) {
@@ -435,15 +454,5 @@ public final class KafkaInstrumenterFactory {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
         .setHeaders(headers)
         .build();
-  }
-
-  private static final class DeliveryState {
-    private final List<String> deliveryKeys;
-    private final DeliveryTracker deliveryTracker;
-
-    private DeliveryState(List<String> deliveryKeys, DeliveryTracker deliveryTracker) {
-      this.deliveryKeys = deliveryKeys;
-      this.deliveryTracker = deliveryTracker;
-    }
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaInstrumenterFactory.java
@@ -467,21 +467,6 @@ public final class KafkaInstrumenterFactory {
     return builder.buildInstrumenter(SpanKindExtractor.alwaysConsumer());
   }
 
-  private static final class DeliveryState {
-    private final List<String> deliveryKeys;
-    private final Cache<String, Boolean> pendingFailedDeliveries;
-
-    private DeliveryState(
-        List<String> deliveryKeys, Cache<String, Boolean> pendingFailedDeliveries) {
-      this.deliveryKeys = deliveryKeys;
-      this.pendingFailedDeliveries = pendingFailedDeliveries;
-    }
-  }
-
-  private static class DeliveryTracker {
-    private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries = Cache.weak();
-  }
-
   private static DeliveryTracker getDeliveryTracker(OpenTelemetry openTelemetry) {
     return deliveryTrackers.computeIfAbsent(openTelemetry, unused -> new DeliveryTracker());
   }
@@ -500,5 +485,20 @@ public final class KafkaInstrumenterFactory {
     return MessagingAttributesExtractor.builder(getter, operationType, operationName)
         .setHeaders(headers)
         .build();
+  }
+
+  private static final class DeliveryState {
+    private final List<String> deliveryKeys;
+    private final Cache<String, Boolean> pendingFailedDeliveries;
+
+    private DeliveryState(
+        List<String> deliveryKeys, Cache<String, Boolean> pendingFailedDeliveries) {
+      this.deliveryKeys = deliveryKeys;
+      this.pendingFailedDeliveries = pendingFailedDeliveries;
+    }
+  }
+
+  private static class DeliveryTracker {
+    private final Cache<Object, Cache<String, Boolean>> pendingFailedDeliveries = Cache.weak();
   }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProcessRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProcessRequest.java
@@ -23,7 +23,7 @@ public class KafkaProcessRequest extends AbstractKafkaConsumerRequest {
         record,
         KafkaUtil.getConsumerGroup(consumer),
         KafkaUtil.getClientId(consumer),
-        KafkaUtil.getDeliveryIdentity(consumer));
+        KafkaUtil.getDeliveryTracker(consumer));
   }
 
   public static KafkaProcessRequest create(
@@ -32,7 +32,7 @@ public class KafkaProcessRequest extends AbstractKafkaConsumerRequest {
         record,
         consumerContext.getConsumerGroup(),
         consumerContext.getClientId(),
-        consumerContext.getDeliveryIdentity());
+        consumerContext.getDeliveryTracker());
   }
 
   public static KafkaProcessRequest create(
@@ -44,8 +44,8 @@ public class KafkaProcessRequest extends AbstractKafkaConsumerRequest {
       ConsumerRecord<?, ?> record,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    return new KafkaProcessRequest(record, consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    return new KafkaProcessRequest(record, consumerGroup, clientId, deliveryTracker);
   }
 
   public KafkaProcessRequest(
@@ -57,8 +57,8 @@ public class KafkaProcessRequest extends AbstractKafkaConsumerRequest {
       ConsumerRecord<?, ?> record,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    super(consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    super(consumerGroup, clientId, deliveryTracker);
     this.record = record;
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProcessRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaProcessRequest.java
@@ -19,22 +19,46 @@ public class KafkaProcessRequest extends AbstractKafkaConsumerRequest {
 
   public static KafkaProcessRequest create(
       ConsumerRecord<?, ?> record, @Nullable Consumer<?, ?> consumer) {
-    return create(record, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
+    return create(
+        record,
+        KafkaUtil.getConsumerGroup(consumer),
+        KafkaUtil.getClientId(consumer),
+        KafkaUtil.getDeliveryIdentity(consumer));
   }
 
   public static KafkaProcessRequest create(
       KafkaConsumerContext consumerContext, ConsumerRecord<?, ?> record) {
-    return create(record, consumerContext.getConsumerGroup(), consumerContext.getClientId());
+    return create(
+        record,
+        consumerContext.getConsumerGroup(),
+        consumerContext.getClientId(),
+        consumerContext.getDeliveryIdentity());
   }
 
   public static KafkaProcessRequest create(
       ConsumerRecord<?, ?> record, @Nullable String consumerGroup, @Nullable String clientId) {
-    return new KafkaProcessRequest(record, consumerGroup, clientId);
+    return create(record, consumerGroup, clientId, null);
+  }
+
+  static KafkaProcessRequest create(
+      ConsumerRecord<?, ?> record,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    return new KafkaProcessRequest(record, consumerGroup, clientId, deliveryIdentity);
   }
 
   public KafkaProcessRequest(
       ConsumerRecord<?, ?> record, @Nullable String consumerGroup, @Nullable String clientId) {
-    super(consumerGroup, clientId);
+    this(record, consumerGroup, clientId, null);
+  }
+
+  private KafkaProcessRequest(
+      ConsumerRecord<?, ?> record,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    super(consumerGroup, clientId, deliveryIdentity);
     this.record = record;
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveRequest.java
@@ -24,7 +24,7 @@ public class KafkaReceiveRequest extends AbstractKafkaConsumerRequest {
         records,
         KafkaUtil.getConsumerGroup(consumer),
         KafkaUtil.getClientId(consumer),
-        KafkaUtil.getDeliveryIdentity(consumer));
+        KafkaUtil.getDeliveryTracker(consumer));
   }
 
   public static KafkaReceiveRequest create(
@@ -33,7 +33,7 @@ public class KafkaReceiveRequest extends AbstractKafkaConsumerRequest {
         records,
         consumerContext.getConsumerGroup(),
         consumerContext.getClientId(),
-        consumerContext.getDeliveryIdentity());
+        consumerContext.getDeliveryTracker());
   }
 
   public static KafkaReceiveRequest create(
@@ -45,16 +45,16 @@ public class KafkaReceiveRequest extends AbstractKafkaConsumerRequest {
       ConsumerRecords<?, ?> records,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    return new KafkaReceiveRequest(records, consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    return new KafkaReceiveRequest(records, consumerGroup, clientId, deliveryTracker);
   }
 
   private KafkaReceiveRequest(
       ConsumerRecords<?, ?> records,
       @Nullable String consumerGroup,
       @Nullable String clientId,
-      @Nullable Object deliveryIdentity) {
-    super(consumerGroup, clientId, deliveryIdentity);
+      @Nullable DeliveryTracker deliveryTracker) {
+    super(consumerGroup, clientId, deliveryTracker);
     this.records = records;
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveRequest.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaReceiveRequest.java
@@ -20,22 +20,41 @@ public class KafkaReceiveRequest extends AbstractKafkaConsumerRequest {
 
   public static KafkaReceiveRequest create(
       ConsumerRecords<?, ?> records, @Nullable Consumer<?, ?> consumer) {
-    return create(records, KafkaUtil.getConsumerGroup(consumer), KafkaUtil.getClientId(consumer));
+    return create(
+        records,
+        KafkaUtil.getConsumerGroup(consumer),
+        KafkaUtil.getClientId(consumer),
+        KafkaUtil.getDeliveryIdentity(consumer));
   }
 
   public static KafkaReceiveRequest create(
       KafkaConsumerContext consumerContext, ConsumerRecords<?, ?> records) {
-    return create(records, consumerContext.getConsumerGroup(), consumerContext.getClientId());
+    return create(
+        records,
+        consumerContext.getConsumerGroup(),
+        consumerContext.getClientId(),
+        consumerContext.getDeliveryIdentity());
   }
 
   public static KafkaReceiveRequest create(
       ConsumerRecords<?, ?> records, @Nullable String consumerGroup, @Nullable String clientId) {
-    return new KafkaReceiveRequest(records, consumerGroup, clientId);
+    return create(records, consumerGroup, clientId, null);
+  }
+
+  public static KafkaReceiveRequest create(
+      ConsumerRecords<?, ?> records,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    return new KafkaReceiveRequest(records, consumerGroup, clientId, deliveryIdentity);
   }
 
   private KafkaReceiveRequest(
-      ConsumerRecords<?, ?> records, @Nullable String consumerGroup, @Nullable String clientId) {
-    super(consumerGroup, clientId);
+      ConsumerRecords<?, ?> records,
+      @Nullable String consumerGroup,
+      @Nullable String clientId,
+      @Nullable Object deliveryIdentity) {
+    super(consumerGroup, clientId, deliveryIdentity);
     this.records = records;
   }
 

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.joining;
 
+import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -37,6 +38,8 @@ public final class KafkaUtil {
 
   private static final VirtualField<Consumer<?, ?>, Map<String, String>> consumerInfoField =
       VirtualField.find(Consumer.class, Map.class);
+
+  private static final Cache<Consumer<?, ?>, Object> deliveryIdentities = Cache.weak();
 
   private static final MethodHandle GET_GROUP_METADATA;
   private static final MethodHandle GET_GROUP_ID;
@@ -82,6 +85,19 @@ public final class KafkaUtil {
   @Nullable
   public static String getClientId(@Nullable Consumer<?, ?> consumer) {
     return getConsumerInfo(consumer).get(CLIENT_ID);
+  }
+
+  /**
+   * Returns a token that identifies deliveries from the given consumer. The token is stable for the
+   * lifetime of the consumer, so that a redelivery can be recognized, but it does not reference the
+   * consumer, so that attaching it to consumer records does not keep the consumer alive.
+   */
+  @Nullable
+  public static Object getDeliveryIdentity(@Nullable Consumer<?, ?> consumer) {
+    if (consumer == null) {
+      return null;
+    }
+    return deliveryIdentities.computeIfAbsent(consumer, unused -> new Object());
   }
 
   private static Map<String, String> getConsumerInfo(@Nullable Consumer<?, ?> consumer) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.kafkaclients.common.v0_11.internal;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.joining;
 
-import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -38,8 +37,8 @@ public final class KafkaUtil {
 
   private static final VirtualField<Consumer<?, ?>, Map<String, String>> consumerInfoField =
       VirtualField.find(Consumer.class, Map.class);
-
-  private static final Cache<Consumer<?, ?>, Object> deliveryIdentities = Cache.weak();
+  private static final VirtualField<Consumer<?, ?>, DeliveryTracker> deliveryTrackerField =
+      VirtualField.find(Consumer.class, DeliveryTracker.class);
 
   private static final MethodHandle GET_GROUP_METADATA;
   private static final MethodHandle GET_GROUP_ID;
@@ -88,16 +87,20 @@ public final class KafkaUtil {
   }
 
   /**
-   * Returns a token that identifies deliveries from the given consumer. The token is stable for the
-   * lifetime of the consumer, so that a redelivery can be recognized, but it does not reference the
-   * consumer, so that attaching it to consumer records does not keep the consumer alive.
+   * Returns the {@link DeliveryTracker} of the given consumer, creating it if it does not exist.
    */
   @Nullable
-  public static Object getDeliveryIdentity(@Nullable Consumer<?, ?> consumer) {
+  public static DeliveryTracker getDeliveryTracker(@Nullable Consumer<?, ?> consumer) {
     if (consumer == null) {
       return null;
     }
-    return deliveryIdentities.computeIfAbsent(consumer, unused -> new Object());
+    DeliveryTracker deliveryTracker = deliveryTrackerField.get(consumer);
+    if (deliveryTracker == null) {
+      // a Kafka consumer does not support multi-threaded access, so this does not have to be atomic
+      deliveryTracker = new DeliveryTracker();
+      deliveryTrackerField.set(consumer, deliveryTracker);
+    }
+    return deliveryTracker;
   }
 
   private static Map<String, String> getConsumerInfo(@Nullable Consumer<?, ?> consumer) {

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/ListenerConsumerInstrumentation.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/ListenerConsumerInstrumentation.java
@@ -90,12 +90,12 @@ class ListenerConsumerInstrumentation implements TypeInstrumentation {
 
       @Nullable
       public static AdviceScope start(ConsumerRecords<?, ?> records, Consumer<?, ?> consumer) {
-        KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(records);
+        KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(records, consumer);
         Context receiveContext = consumerContext.getContext();
 
         // use the receive CONSUMER span as parent if it's available
         Context parentContext = receiveContext != null ? receiveContext : Context.current();
-        KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
+        KafkaReceiveRequest request = KafkaReceiveRequest.create(consumerContext, records);
 
         if (!batchProcessInstrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -557,7 +557,6 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         receiveCount,
-        1,
         null);
     assertProcessMetrics(
         testing,
@@ -587,7 +586,6 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         receiveCount,
-        1,
         null);
     assertProcessMetrics(
         testing,

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -557,7 +557,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         receiveCount,
-        receiveCount,
+        1,
         null);
     assertProcessMetrics(
         testing,

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -10,7 +10,9 @@ import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertProcessMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveDurationMetrics;
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertReceiveMetrics;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -556,7 +558,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "testSingleListener",
         "0",
         receiveCount,
-        receiveCount,
+        1,
         null);
     assertProcessMetrics(
         testing,
@@ -578,15 +580,15 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
 
   private static void assertBatchFailureMetrics() {
     int receiveCount = testLatestDeps() ? 1 : 3;
-    assertReceiveMetrics(
+    assertReceiveDurationMetrics(
         testing,
         "io.opentelemetry.kafka-clients-0.11",
         "testBatchTopic",
         "testBatchListener",
         "0",
         receiveCount,
-        receiveCount,
         null);
+    assertTotalConsumedMessages(testing, "io.opentelemetry.kafka-clients-0.11", 1);
     assertProcessMetrics(
         testing,
         "io.opentelemetry.spring-kafka-2.7",

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -557,6 +557,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         receiveCount,
+        receiveCount,
         null);
     assertProcessMetrics(
         testing,
@@ -584,6 +585,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "testBatchTopic",
         "testBatchListener",
         "0",
+        receiveCount,
         receiveCount,
         receiveCount,
         null);

--- a/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spring/kafka/v2_7/SpringKafkaTest.java
@@ -587,7 +587,7 @@ class SpringKafkaTest extends AbstractSpringKafkaTest {
         "0",
         receiveCount,
         receiveCount,
-        receiveCount,
+        1,
         null);
     assertProcessMetrics(
         testing,

--- a/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
+++ b/instrumentation/spring/spring-kafka-2.7/library/build.gradle.kts
@@ -28,9 +28,25 @@ dependencies {
   }
 }
 
-tasks.test {
-  usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
-  systemProperty("testLatestDeps", otelProps.testLatestDeps)
+tasks {
+  test {
+    usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    systemProperty("testLatestDeps", otelProps.testLatestDeps)
+  }
+
+  val testMessagingPreview = register<Test>("testMessagingPreview") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("SpringKafkaInterceptorDeliveryTest")
+    }
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  check {
+    dependsOn(testMessagingPreview)
+  }
 }
 
 // spring 6 (which spring-kafka 3.+ uses) requires java 17

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
@@ -38,9 +38,10 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
 
   @Override
   public ConsumerRecords<K, V> intercept(ConsumerRecords<K, V> records, Consumer<K, V> consumer) {
-    Context parentContext = getParentContext(records);
+    KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(records, consumer);
+    Context parentContext = getParentContext(consumerContext);
 
-    KafkaReceiveRequest request = KafkaReceiveRequest.create(records, consumer);
+    KafkaReceiveRequest request = KafkaReceiveRequest.create(consumerContext, records);
     if (batchProcessInstrumenter.shouldStart(parentContext, request) && !skipProcessing(records)) {
       Context context = batchProcessInstrumenter.start(parentContext, request);
       Scope scope = context.makeCurrent();
@@ -61,8 +62,7 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
     return reference != null && reference.get() == records;
   }
 
-  private static Context getParentContext(ConsumerRecords<?, ?> records) {
-    KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(records);
+  private static Context getParentContext(KafkaConsumerContext consumerContext) {
     Context receiveContext = consumerContext.getContext();
 
     // use the receive CONSUMER span as parent if it's available

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
@@ -50,9 +50,10 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
   }
 
   private void start(ConsumerRecord<K, V> record, @Nullable Consumer<K, V> consumer) {
-    Context parentContext = getParentContext(record);
+    KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(record, consumer);
+    Context parentContext = getParentContext(consumerContext);
 
-    KafkaProcessRequest request = KafkaProcessRequest.create(record, consumer);
+    KafkaProcessRequest request = KafkaProcessRequest.create(consumerContext, record);
     if (processInstrumenter.shouldStart(parentContext, request)) {
       Context context = processInstrumenter.start(parentContext, request);
       Scope scope = context.makeCurrent();
@@ -60,8 +61,7 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
     }
   }
 
-  private static Context getParentContext(ConsumerRecord<?, ?> record) {
-    KafkaConsumerContext consumerContext = KafkaConsumerContextUtil.get(record);
+  private static Context getParentContext(KafkaConsumerContext consumerContext) {
     Context receiveContext = consumerContext.getContext();
 
     // use the receive CONSUMER span as parent if it's available

--- a/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.kafka.v2_7;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.internal.OpenTelemetryConsumerInterceptor;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.kafka.listener.BatchInterceptor;
+import org.springframework.kafka.listener.RecordInterceptor;
+
+class SpringKafkaInterceptorDeliveryTest {
+
+  private static final String KAFKA_INSTRUMENTATION_NAME = "io.opentelemetry.kafka-clients-2.6";
+  private static final String TOPIC = "test";
+  private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
+
+  @Test
+  void batchRetriesUseInterceptorDeliveryIdentity() {
+    assumeTrue(emitStableMessagingSemconv());
+    OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor = consumerInterceptor();
+    BatchInterceptor<String, String> springInterceptor =
+        SpringKafkaTelemetry.create(testing.getOpenTelemetry()).createBatchInterceptor();
+    Consumer<String, String> consumer = consumer();
+
+    for (int attempt = 0; attempt < 3; attempt++) {
+      ConsumerRecords<String, String> records = consumerInterceptor.onConsume(records());
+      springInterceptor.intercept(records, consumer);
+      if (attempt < 2) {
+        springInterceptor.failure(records, failure(), consumer);
+      } else {
+        springInterceptor.success(records, consumer);
+      }
+    }
+
+    assertTotalConsumedMessages(testing, KAFKA_INSTRUMENTATION_NAME, 1);
+  }
+
+  @Test
+  void recordRetriesUseInterceptorDeliveryIdentity() {
+    assumeTrue(emitStableMessagingSemconv());
+    OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor = consumerInterceptor();
+    RecordInterceptor<String, String> springInterceptor =
+        SpringKafkaTelemetry.create(testing.getOpenTelemetry()).createRecordInterceptor();
+    Consumer<String, String> consumer = consumer();
+
+    for (int attempt = 0; attempt < 3; attempt++) {
+      ConsumerRecord<String, String> record =
+          consumerInterceptor.onConsume(records()).records(PARTITION).get(0);
+      springInterceptor.intercept(record, consumer);
+      if (attempt < 2) {
+        springInterceptor.failure(record, failure(), consumer);
+      } else {
+        springInterceptor.success(record, consumer);
+      }
+    }
+
+    assertTotalConsumedMessages(testing, KAFKA_INSTRUMENTATION_NAME, 1);
+  }
+
+  private static OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor() {
+    KafkaTelemetry kafkaTelemetry =
+        KafkaTelemetry.builder(testing.getOpenTelemetry())
+            .setMessagingReceiveTelemetryEnabled(true)
+            .build();
+    Map<String, Object> config = new HashMap<>();
+    config.put(ConsumerConfig.GROUP_ID_CONFIG, "group");
+    config.put(ConsumerConfig.CLIENT_ID_CONFIG, "client");
+    config.putAll(kafkaTelemetry.consumerInterceptorConfigProperties());
+    OpenTelemetryConsumerInterceptor<String, String> interceptor =
+        new OpenTelemetryConsumerInterceptor<>();
+    interceptor.configure(config);
+    return interceptor;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Consumer<String, String> consumer() {
+    return mock(Consumer.class);
+  }
+
+  private static IllegalArgumentException failure() {
+    return new IllegalArgumentException("failure");
+  }
+
+  private static ConsumerRecords<String, String> records() {
+    ConsumerRecord<String, String> record =
+        new ConsumerRecord<>(TOPIC, PARTITION.partition(), 1, "key", "value");
+    return new ConsumerRecords<>(singletonMap(PARTITION, singletonList(record)));
+  }
+}

--- a/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
@@ -38,7 +38,7 @@ class SpringKafkaInterceptorDeliveryTest {
   static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @Test
-  void batchRetriesUseInterceptorDeliveryIdentity() {
+  void batchRetriesUseInterceptorDeliveryTracker() {
     assumeTrue(emitStableMessagingSemconv());
     OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor = consumerInterceptor();
     BatchInterceptor<String, String> springInterceptor =
@@ -59,7 +59,7 @@ class SpringKafkaInterceptorDeliveryTest {
   }
 
   @Test
-  void recordRetriesUseInterceptorDeliveryIdentity() {
+  void recordRetriesUseInterceptorDeliveryTracker() {
     assumeTrue(emitStableMessagingSemconv());
     OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor = consumerInterceptor();
     RecordInterceptor<String, String> springInterceptor =

--- a/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/test/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/SpringKafkaInterceptorDeliveryTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.messaging.KafkaMessagingMetricsAssertions.assertTotalConsumedMessages;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
@@ -17,6 +18,7 @@ import io.opentelemetry.instrumentation.kafkaclients.v2_6.internal.OpenTelemetry
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -59,7 +61,7 @@ class SpringKafkaInterceptorDeliveryTest {
   }
 
   @Test
-  void recordRetriesUseInterceptorDeliveryTracker() {
+  void overlappingRecordRetriesUseInterceptorDeliveryTracker() {
     assumeTrue(emitStableMessagingSemconv());
     OpenTelemetryConsumerInterceptor<String, String> consumerInterceptor = consumerInterceptor();
     RecordInterceptor<String, String> springInterceptor =
@@ -67,14 +69,16 @@ class SpringKafkaInterceptorDeliveryTest {
     Consumer<String, String> consumer = consumer();
 
     for (int attempt = 0; attempt < 3; attempt++) {
-      ConsumerRecord<String, String> record =
-          consumerInterceptor.onConsume(records()).records(PARTITION).get(0);
+      Iterator<ConsumerRecord<String, String>> iterator =
+          consumerInterceptor.onConsume(records()).iterator();
+      ConsumerRecord<String, String> record = iterator.next();
       springInterceptor.intercept(record, consumer);
       if (attempt < 2) {
         springInterceptor.failure(record, failure(), consumer);
       } else {
         springInterceptor.success(record, consumer);
       }
+      assertThat(iterator.hasNext()).isFalse();
     }
 
     assertTotalConsumedMessages(testing, KAFKA_INSTRUMENTATION_NAME, 1);

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -201,6 +201,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
         "0",
         1,
         null);
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.spring-kafka-2.7", 1);
   }
 
   @Test

--- a/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
+++ b/instrumentation/spring/spring-kafka-2.7/testing/src/main/java/io/opentelemetry/testing/AbstractSpringKafkaNoReceiveTelemetryTest.java
@@ -352,6 +352,7 @@ public abstract class AbstractSpringKafkaNoReceiveTelemetryTest extends Abstract
           1,
           null);
     }
+    assertTotalConsumedMessages(testing(), "io.opentelemetry.spring-kafka-2.7", 1);
   }
 
   private static List<AttributeAssertion> sendAttributes(String topic, String messageKey) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/messaging/KafkaMessagingMetricsAssertions.java
@@ -89,7 +89,7 @@ public final class KafkaMessagingMetricsAssertions {
       return;
     }
 
-    assertReceiveDurationMetrics(
+    assertReceiveDuration(
         testing, instrumentationName, destination, group, partition, operationCount, errorType);
     assertConsumedMessagesMetrics(
         testing, instrumentationName, destination, group, partition, messageCount, errorType);
@@ -135,6 +135,19 @@ public final class KafkaMessagingMetricsAssertions {
       return;
     }
 
+    assertReceiveDuration(
+        testing, instrumentationName, destination, group, partition, operationCount, errorType);
+    assertDeprecatedMetricsAbsent(testing);
+  }
+
+  private static void assertReceiveDuration(
+      InstrumentationExtension testing,
+      String instrumentationName,
+      String destination,
+      String group,
+      String partition,
+      long operationCount,
+      String errorType) {
     assertDuration(
         testing,
         instrumentationName,
@@ -147,7 +160,6 @@ public final class KafkaMessagingMetricsAssertions {
         partition,
         operationCount,
         errorType);
-    assertDeprecatedMetricsAbsent(testing);
   }
 
   /**


### PR DESCRIPTION
When a process operation fails and the consumer seeks back to the failed offset, the same record is delivered again. `messaging.client.consumed.messages` counted every redelivery as a newly consumed message, so a record that failed twice before succeeding was reported as three consumed messages.

The instrumentation now remembers a failed delivery until a later process operation for it succeeds, and does not count its redeliveries.

That state lives in a delivery tracker that belongs to one consumer, so two consumers reading the same offset are tracked independently. Within a tracker, the topic, partition, and offset identify a delivery.

A tracker keeps at most 1024 failed operations. A consumer that keeps failing forgets its oldest failures, so their redeliveries are counted again.
