### PR TITLE
Group Renovate minor updates with patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,7 @@
 
     {
       // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -24,6 +25,10 @@
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry**',
+        '!open-telemetry/**',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,10 +16,11 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
-      groupName: 'all patch versions',
+      // group all patch and minor updates into a single weekly PR
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
+        'minor',
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
@@ -42,6 +43,9 @@
       // gh-aw updates need a dedicated branch so CI can regenerate their workflow lockfiles
       matchPackageNames: [
         'github/gh-aw',
+      ],
+      schedule: [
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
       groupName: 'gh-aw',
     },


### PR DESCRIPTION
Renovate's weekly group now covers minor updates as well as patch updates, so a minor release no longer opens its own pull request the moment it ships. This repo had 37 ungrouped Renovate pull requests in the last 90 days, nearly all single minor bumps. Checkstyle alone accounted for five, 13.5 through 13.9.

OpenTelemetry artifacts are excluded and keep landing individually and immediately, which is what dogfooding and cascaded releases need. The exclusion is written without a colon so it covers every OpenTelemetry group id, including `io.opentelemetry.proto` and `io.opentelemetry.semconv`. The pre-existing rule that disables `io.opentelemetry:**` only covers the bare group id, because that colon has to match literally.

`github/gh-aw` keeps its own branch, because CI regenerates the workflow lockfiles there, but it now follows the same weekly schedule instead of arriving on its own timing.

Major updates still get their own pull request. This matches what opentelemetry-java already does.
