### PR TITLE
Fall back to exception class name for MongoDB client-side errors

### DIFF
--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetter.java
@@ -158,7 +158,14 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
   public String getErrorType(
       CommandStartedEvent request, @Nullable Void response, @Nullable Throwable error) {
     if (error instanceof MongoException) {
-      return Integer.toString(((MongoException) error).getCode());
+      // MongoException.getCode() only returns a real server error code (a positive value) when the
+      // exception came from a server command error. For client-side exceptions the driver uses
+      // negative sentinels (e.g. -2, -3, -4), which are meaningless as an error.type. Returning
+      // null in that case lets the shared extractor fall back to the exception class name.
+      int code = ((MongoException) error).getCode();
+      if (code > 0) {
+        return Integer.toString(code);
+      }
     }
     return null;
   }

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
@@ -9,13 +9,21 @@ import static io.opentelemetry.instrumentation.mongo.v3_1.internal.MongoInstrume
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
+import com.mongodb.MongoException;
+import com.mongodb.MongoSocketException;
+import com.mongodb.ServerAddress;
+import java.util.stream.Stream;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class MongoDbAttributesGetterTest {
 
@@ -89,6 +97,31 @@ class MongoDbAttributesGetterTest {
     // This can vary because of different whitespace for different MongoDB versions
     assertThat(normalized)
         .isIn("{\"cmd\": \"c\", \"f1\": [\"?\", \"?", "{\"cmd\": \"c\", \"f1\": [\"?\",");
+  }
+
+  @ParameterizedTest
+  @MethodSource("errorTypes")
+  void getErrorTypeReturnsServerCodeOrFallsBack(Throwable error, String expectedErrorType) {
+    MongoDbAttributesGetter getter =
+        new MongoDbAttributesGetter(true, DEFAULT_MAX_NORMALIZED_QUERY_LENGTH);
+
+    assertThat(getter.getErrorType(null, null, error)).isEqualTo(expectedErrorType);
+  }
+
+  private static Stream<Arguments> errorTypes() {
+    return Stream.of(
+        argumentSet("server error code", new MongoException(11000, "duplicate key"), "11000"),
+        argumentSet("client message sentinel (-3)", new MongoException("boom"), null),
+        argumentSet(
+            "client message-and-cause sentinel (-4)",
+            new MongoException("boom", new RuntimeException()),
+            null),
+        argumentSet(
+            "socket exception sentinel (-2)",
+            new MongoSocketException("boom", new ServerAddress()),
+            null),
+        argumentSet("non-mongo exception", new IllegalStateException("boom"), null),
+        argumentSet("no error", null, null));
   }
 
   private static String sanitizeQueryAcrossVersions(

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
@@ -111,6 +111,7 @@ class MongoDbAttributesGetterTest {
   private static Stream<Arguments> errorTypes() {
     return Stream.of(
         argumentSet("server error code", new MongoException(11000, "duplicate key"), "11000"),
+        argumentSet("zero code falls back", new MongoException(0, "boom"), null),
         argumentSet("client message sentinel (-3)", new MongoException("boom"), null),
         argumentSet(
             "client message-and-cause sentinel (-4)",


### PR DESCRIPTION
MongoDB instrumentation set the stable `error.type` attribute from `MongoException.getCode()`, but that code is a real server error code only when the exception came from a server command error. For client-side failures the driver assigns negative sentinel codes, so a socket failure or a server-selection timeout reported an `error.type` of `-2`, `-3`, or `-4`, which tells a user nothing.

The getter now returns the code only when it is positive, so the shared extractor falls back to the exception's canonical class name. A socket read timeout reports `com.mongodb.MongoSocketReadTimeoutException` instead of `-2`, while a genuine server code such as `11000` is unchanged. Because `error.type` is also a dimension of the `db.client.operation.duration` histogram, existing time series that carried the sentinel codes now carry exception class names.
