### PR TITLE
Emit db.operation.name for Couchbase 2.x query spans in stable-only mode

### DIFF
--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -51,6 +51,9 @@ public abstract class CouchbaseRequestInfo {
     SqlQuery sqlQueryWithSummary =
         emitStableDatabaseSemconv() ? CouchbaseQuerySanitizer.analyzeWithSummary(query) : null;
     String operation = sqlQuery != null ? sqlQuery.getOperationName() : null;
+    if (operation == null && sqlQueryWithSummary != null) {
+      operation = sqlQueryWithSummary.getOperationName();
+    }
     return new AutoValue_CouchbaseRequestInfo(
         bucket, sqlQuery, sqlQueryWithSummary, operation, false);
   }

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -318,9 +318,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
                             equalTo(maybeStable(DB_NAME), bucketCouchbase.name()),
-                            equalTo(
-                                maybeStable(DB_OPERATION),
-                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(maybeStable(DB_OPERATION), "SELECT"),
                             satisfies(
                                 maybeStable(DB_STATEMENT), val -> val.startsWith("SELECT mockrow")),
                             equalTo(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -225,9 +225,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
                             equalTo(maybeStable(DB_NAME), bucketCouchbase.name()),
-                            equalTo(
-                                maybeStable(DB_OPERATION),
-                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(maybeStable(DB_OPERATION), "SELECT"),
                             satisfies(
                                 maybeStable(DB_STATEMENT), val -> val.startsWith("SELECT mockrow")),
                             equalTo(


### PR DESCRIPTION
Couchbase 2.x query spans were missing `db.operation.name` when an application opted into stable database semantic conventions only, with `otel.semconv-stability.opt-in=database`. N1QL, analytics, and statement queries all lost the value. Dual mode, `database/dup`, and the default legacy mode were unaffected.

The same value is a dimension on the `db.client.operation.duration` metric, so stable-only users will now see `db.operation.name` on that metric for query spans where it was previously absent. That changes how those series are grouped.

View and spatial-view queries still carry no operation name in any mode, and span names are unchanged.
