### PR TITLE
Fix HBase db.collection.name to drop the namespace prefix

### DIFF
--- a/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/common/HbaseAttributesGetter.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/common/HbaseAttributesGetter.java
@@ -29,7 +29,7 @@ final class HbaseAttributesGetter implements DbClientAttributesGetter<HbaseReque
   @Override
   public String getDbCollectionName(HbaseRequest hbaseRequest) {
     TableName tableName = hbaseRequest.getTableName();
-    return tableName == null ? null : tableName.getNameAsString();
+    return tableName == null ? null : tableName.getQualifierAsString();
   }
 
   @Nullable

--- a/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
@@ -304,7 +304,12 @@ public abstract class AbstractHbaseTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(GET + " " + TABLE_NAME.getNameAsString())
+                        span.hasName(
+                                GET
+                                    + " "
+                                    + (emitStableDatabaseSemconv()
+                                        ? TABLE_NAME.getQualifierAsString()
+                                        : TABLE_NAME.getNameAsString()))
                             .hasKind(SpanKind.CLIENT)
                             .hasStatus(StatusData.error())
                             .hasAttributesSatisfyingExactly(
@@ -320,7 +325,7 @@ public abstract class AbstractHbaseTest {
                                 equalTo(
                                     DB_COLLECTION_NAME,
                                     emitStableDatabaseSemconv()
-                                        ? TABLE_NAME.getNameAsString()
+                                        ? TABLE_NAME.getQualifierAsString()
                                         : null),
                                 equalTo(SERVER_ADDRESS, hostname),
                                 equalTo(SERVER_PORT, REGION_SERVER_PORT),
@@ -605,7 +610,12 @@ public abstract class AbstractHbaseTest {
       TableName table, String operation, int port, boolean hasTable, Long batchSize) {
     String spanName;
     if (hasTable) {
-      spanName = operation + " " + table.getNameAsString();
+      spanName =
+          operation
+              + " "
+              + (emitStableDatabaseSemconv()
+                  ? table.getQualifierAsString()
+                  : table.getNameAsString());
     } else if (emitStableDatabaseSemconv()) {
       spanName = operation + " " + hostname + ":" + port;
     } else {
@@ -645,7 +655,7 @@ public abstract class AbstractHbaseTest {
 
   private static String dbCollectionName(TableName table, boolean hasTable) {
     if (hasTable && emitStableDatabaseSemconv()) {
-      return table.getNameAsString();
+      return table.getQualifierAsString();
     }
     return null;
   }


### PR DESCRIPTION
HBase reported the table namespace twice. For a table outside the default namespace, `db.namespace` carried the namespace and `db.collection.name` carried the namespace-qualified name. `db.collection.name` now carries only the bare table name.

For the table `ot_test:eleven_test_table`, a span now reports `db.namespace=ot_test` and `db.collection.name=eleven_test_table`, instead of `db.collection.name=ot_test:eleven_test_table`. Tables in the default namespace are unaffected.

In stable database semantic conventions mode the span name comes from the collection name, so `Get ot_test:eleven_test_table` becomes `Get eleven_test_table`. The default (legacy) mode is unchanged. `db.collection.name` is also a `db.client.operation.duration` dimension, so those time series shift too.
