### PR TITLE
Emit db.redis.database_index on lettuce 5.1 command spans under old semconv

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.lettuce.v5_1;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import javax.annotation.Nullable;
+
+final class LettuceDbAttributesExtractor
+    implements AttributesExtractor<LettuceRequest, LettuceResponse> {
+
+  // copied from DbIncubatingAttributes
+  private static final AttributeKey<Long> DB_REDIS_DATABASE_INDEX =
+      AttributeKey.longKey("db.redis.database_index");
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, LettuceRequest request) {
+    if (emitOldDatabaseSemconv()) {
+      attributes.put(DB_REDIS_DATABASE_INDEX, request.getDatabaseIndex());
+    }
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      LettuceRequest request,
+      @Nullable LettuceResponse response,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceTelemetryBuilder.java
@@ -77,6 +77,7 @@ public final class LettuceTelemetryBuilder {
                 INSTRUMENTATION_NAME,
                 DbClientSpanNameExtractor.create(spanNameAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
+            .addAttributesExtractor(new LettuceDbAttributesExtractor())
             .addOperationMetrics(DbClientMetrics.get())
             .setSpanStatusExtractor(
                 (spanStatusBuilder, request, response, error) -> {

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractorTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.lettuce.v5_1;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
+import org.junit.jupiter.api.Test;
+
+// lettuce reports the Redis database index only from 6.5.0 through 7.0.x (through its db.namespace
+// tracing tag); the tag is gone again by 7.1.0. So neither the pinned 5.1.0 nor latest deps
+// populates it on a real command span, and these tests drive the extractor directly to cover the
+// legacy attribute across semconv modes.
+class LettuceDbAttributesExtractorTest {
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+  void emitsLegacyDatabaseIndexOnlyUnderOldSemconv() {
+    LettuceRequest request = new LettuceRequest(RedisCommandSanitizer.create(true));
+    request.setDatabaseIndex(1);
+
+    AttributesBuilder builder = Attributes.builder();
+    new LettuceDbAttributesExtractor().onStart(builder, Context.root(), request);
+    Attributes attributes = builder.build();
+
+    if (emitOldDatabaseSemconv()) {
+      assertThat(attributes).hasSize(1).containsEntry(DB_REDIS_DATABASE_INDEX, 1L);
+    } else {
+      assertThat(attributes).isEmpty();
+    }
+  }
+
+  @Test
+  void doesNotEmitWhenDatabaseIndexAbsent() {
+    LettuceRequest request = new LettuceRequest(RedisCommandSanitizer.create(true));
+
+    AttributesBuilder builder = Attributes.builder();
+    new LettuceDbAttributesExtractor().onStart(builder, Context.root(), request);
+
+    assertThat(builder.build()).isEmpty();
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractorTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/test/java/io/opentelemetry/instrumentation/lettuce/v5_1/LettuceDbAttributesExtractorTest.java
@@ -6,45 +6,59 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.REDIS;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
+import io.lettuce.core.tracing.Tracer;
+import io.lettuce.core.tracing.Tracing;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 // lettuce reports the Redis database index only from 6.5.0 through 7.0.x (through its db.namespace
 // tracing tag); the tag is gone again by 7.1.0. So neither the pinned 5.1.0 nor latest deps
-// populates it on a real command span, and these tests drive the extractor directly to cover the
-// legacy attribute across semconv modes.
+// populates it on a real command span.
 class LettuceDbAttributesExtractorTest {
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = LibraryInstrumentationExtension.create();
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @Test
-  void emitsLegacyDatabaseIndexOnlyUnderOldSemconv() {
-    LettuceRequest request = new LettuceRequest(RedisCommandSanitizer.create(true));
-    request.setDatabaseIndex(1);
+  void emitsLegacyDatabaseIndexFromTracingTagOnlyUnderOldSemconv() {
+    Tracing tracing = LettuceTelemetry.create(testing.getOpenTelemetry()).createTracing();
+    Tracer.Span span =
+        tracing
+            .getTracerProvider()
+            .getTracer()
+            .nextSpan()
+            .name("GET")
+            .tag("db.namespace", "1")
+            .start();
+    span.finish();
 
-    AttributesBuilder builder = Attributes.builder();
-    new LettuceDbAttributesExtractor().onStart(builder, Context.root(), request);
-    Attributes attributes = builder.build();
-
-    if (emitOldDatabaseSemconv()) {
-      assertThat(attributes).hasSize(1).containsEntry(DB_REDIS_DATABASE_INDEX, 1L);
-    } else {
-      assertThat(attributes).isEmpty();
-    }
-  }
-
-  @Test
-  void doesNotEmitWhenDatabaseIndexAbsent() {
-    LettuceRequest request = new LettuceRequest(RedisCommandSanitizer.create(true));
-
-    AttributesBuilder builder = Attributes.builder();
-    new LettuceDbAttributesExtractor().onStart(builder, Context.root(), request);
-
-    assertThat(builder.build()).isEmpty();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                spanData ->
+                    spanData
+                        .hasName("GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_NAME), "1"),
+                            equalTo(maybeStable(DB_STATEMENT), "GET"),
+                            equalTo(maybeStable(DB_OPERATION), "GET"),
+                            equalTo(
+                                DB_REDIS_DATABASE_INDEX, emitOldDatabaseSemconv() ? 1L : null))));
   }
 }


### PR DESCRIPTION
The Lettuce 5.1 library instrumentation records the Redis database index as stable `db.namespace`, but command spans omit the legacy `db.redis.database_index` under old semantic conventions. This change emits the legacy attribute when old database semantic conventions are enabled, which makes command spans consistent with Lettuce connect spans.

In old-only mode, database index `1` now produces `db.redis.database_index=1` alongside the existing old database attributes. Stable mode remains unchanged with `db.namespace=1`. The `database/dup` mode emits both forms.

Lettuce emits the `db.namespace` tracing tag only in versions 6.5.0 through 7.0.x, outside the pinned and latest dependency test versions. A focused library test therefore creates a command span through `LettuceTelemetry.createTracing()`, applies the tag directly, and verifies the complete old and stable attribute sets. This covers tag parsing and builder wiring without adding a Lettuce version matrix.
