### PR TITLE
Emit Redis default database index in lettuce and vertx-redis-client

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceConnectAttributesExtractor.java
@@ -33,13 +33,12 @@ final class LettuceConnectAttributesExtractor implements AttributesExtractor<Red
     }
 
     int database = redisUri.getDatabase();
-    if (database != 0) {
-      if (emitStableDatabaseSemconv()) {
-        attributes.put(DB_NAMESPACE, String.valueOf(database));
-      }
-      if (emitOldDatabaseSemconv()) {
-        attributes.put(DB_REDIS_DATABASE_INDEX, (long) database);
-      }
+    if (emitStableDatabaseSemconv()) {
+      attributes.put(DB_NAMESPACE, String.valueOf(database));
+    }
+    // Old semconv output is deliberately left unchanged: it still drops the default database 0.
+    if (emitOldDatabaseSemconv() && database != 0) {
+      attributes.put(DB_REDIS_DATABASE_INDEX, (long) database);
     }
   }
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -11,11 +11,13 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.ExperimentalHelper.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static java.util.Arrays.asList;
@@ -164,6 +166,8 @@ class LettuceAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 
@@ -196,6 +200,8 @@ class LettuceAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, incorrectPort),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
@@ -10,11 +10,13 @@ import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsT
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -136,6 +138,8 @@ class LettuceSyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 
@@ -163,6 +167,8 @@ class LettuceSyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, incorrectPort),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceConnectAttributesExtractor.java
@@ -33,13 +33,12 @@ final class LettuceConnectAttributesExtractor implements AttributesExtractor<Red
     }
 
     int database = redisUri.getDatabase();
-    if (database != 0) {
-      if (emitStableDatabaseSemconv()) {
-        attributes.put(DB_NAMESPACE, String.valueOf(database));
-      }
-      if (emitOldDatabaseSemconv()) {
-        attributes.put(DB_REDIS_DATABASE_INDEX, (long) database);
-      }
+    if (emitStableDatabaseSemconv()) {
+      attributes.put(DB_NAMESPACE, String.valueOf(database));
+    }
+    // Old semconv output is deliberately left unchanged: it still drops the default database 0.
+    if (emitOldDatabaseSemconv() && database != 0) {
+      attributes.put(DB_REDIS_DATABASE_INDEX, (long) database);
     }
   }
 

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceAsyncClientTest.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServ
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v5_0.ExperimentalHelper.experimental;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
@@ -20,6 +21,7 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
@@ -139,6 +141,8 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 
@@ -174,6 +178,8 @@ class LettuceAsyncClientTest extends AbstractLettuceClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, incorrectPort),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))
                         .hasEventsSatisfyingExactly(
                             event ->

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSyncClientTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
@@ -19,6 +20,7 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_REDIS_DATABASE_INDEX;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
@@ -106,6 +108,8 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))));
   }
 
@@ -132,6 +136,8 @@ class LettuceSyncClientTest extends AbstractLettuceClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, incorrectPort),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(maybeStablePeerService(), "test-peer-service"))
                         .hasEventsSatisfyingExactly(
                             event ->

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientAttributesGetter.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientAttributesGetter.java
@@ -30,8 +30,7 @@ class VertxRedisClientAttributesGetter
   @Nullable
   public String getDbNamespace(VertxRedisClientRequest request) {
     if (emitStableDatabaseSemconv()) {
-      Long databaseIndex = request.getDatabaseIndex();
-      return databaseIndex == null ? null : String.valueOf(databaseIndex);
+      return request.getDatabaseNamespace();
     }
     return null;
   }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientRequest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientRequest.java
@@ -98,6 +98,18 @@ class VertxRedisClientRequest {
   }
 
   @Nullable
+  String getDatabaseNamespace() {
+    if (redisUri == null) {
+      return null;
+    }
+    // A connection string without an explicit database connects to Redis database 0, the server
+    // default. The Vert.x client itself reports "0" in this case (see its CommandReporter), so we
+    // report 0 for the stable db.namespace rather than dropping the attribute.
+    Integer select = redisUri.select();
+    return select != null ? String.valueOf(select) : "0";
+  }
+
+  @Nullable
   String getConnectionString() {
     return null;
   }

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.vertx.redisclient.v4_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
@@ -142,7 +143,18 @@ class VertxRedisClientTest {
                     span.hasName(emitStableDatabaseSemconv() ? "SET " + host + ":" + port : "SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            defaultDatabaseSpanAttributes("SET", "SET foo ?"))));
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            // old semconv output is unchanged: the default database 0 is not
+                            // reported
+                            equalTo(DB_REDIS_DATABASE_INDEX, null),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(maybeStablePeerService(), "test-peer-service"),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip))));
 
     assertDurationMetric(
         testing,
@@ -393,37 +405,6 @@ class VertxRedisClientTest {
         equalTo(DB_STATEMENT, queryText),
         equalTo(DB_OPERATION, operationName),
         equalTo(DB_REDIS_DATABASE_INDEX, 1),
-        equalTo(SERVER_ADDRESS, host),
-        equalTo(SERVER_PORT, port),
-        equalTo(maybeStablePeerService(), "test-peer-service"),
-        equalTo(NETWORK_PEER_PORT, port),
-        equalTo(NETWORK_PEER_ADDRESS, ip)
-      };
-    }
-  }
-
-  private static AttributeAssertion[] defaultDatabaseSpanAttributes(
-      String operationName, String queryText) {
-    // not testing database/dup
-    if (emitStableDatabaseSemconv()) {
-      return new AttributeAssertion[] {
-        equalTo(DB_SYSTEM_NAME, REDIS),
-        equalTo(DB_QUERY_TEXT, queryText),
-        equalTo(DB_OPERATION_NAME, operationName),
-        equalTo(DB_NAMESPACE, "0"),
-        equalTo(SERVER_ADDRESS, host),
-        equalTo(SERVER_PORT, port),
-        equalTo(maybeStablePeerService(), "test-peer-service"),
-        equalTo(NETWORK_PEER_PORT, port),
-        equalTo(NETWORK_PEER_ADDRESS, ip)
-      };
-    } else {
-      return new AttributeAssertion[] {
-        equalTo(DB_SYSTEM, REDIS),
-        equalTo(DB_STATEMENT, queryText),
-        equalTo(DB_OPERATION, operationName),
-        // old semconv output is unchanged: the default database 0 is not reported
-        equalTo(DB_REDIS_DATABASE_INDEX, null),
         equalTo(SERVER_ADDRESS, host),
         equalTo(SERVER_PORT, port),
         equalTo(maybeStablePeerService(), "test-peer-service"),

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -147,8 +147,6 @@ class VertxRedisClientTest {
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
-                            // old semconv output is unchanged: the default database 0 is not
-                            // reported
                             equalTo(DB_REDIS_DATABASE_INDEX, null),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientTest.java
@@ -74,6 +74,8 @@ class VertxRedisClientTest {
   private static Redis client;
   private static RedisConnection connection;
   private static RedisAPI redis;
+  private static Redis defaultDbClient;
+  private static RedisAPI defaultDbRedis;
 
   @BeforeAll
   static void setup() throws Exception {
@@ -91,6 +93,14 @@ class VertxRedisClientTest {
     connection = client.connect().toCompletionStage().toCompletableFuture().get(30, SECONDS);
     redis = RedisAPI.api(connection);
     cleanup.deferAfterAll(redis::close);
+
+    // a connection string without a database index connects to the default database 0
+    defaultDbClient = Redis.createClient(vertx, "redis://" + host + ":" + port);
+    cleanup.deferAfterAll(defaultDbClient::close);
+    RedisConnection defaultDbConnection =
+        defaultDbClient.connect().toCompletionStage().toCompletableFuture().get(30, SECONDS);
+    defaultDbRedis = RedisAPI.api(defaultDbConnection);
+    cleanup.deferAfterAll(defaultDbRedis::close);
   }
 
   @Test
@@ -104,6 +114,35 @@ class VertxRedisClientTest {
                     span.hasName(emitStableDatabaseSemconv() ? "SET " + host + ":" + port : "SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(redisSpanAttributes("SET", "SET foo ?"))));
+
+    assertDurationMetric(
+        testing,
+        "io.opentelemetry.vertx-redis-client-4.0",
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_NAMESPACE,
+        SERVER_ADDRESS,
+        SERVER_PORT,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT);
+  }
+
+  @Test
+  void setCommandOnDefaultDatabase() throws Exception {
+    defaultDbRedis
+        .set(asList("foo", "bar"))
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + host + ":" + port : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            defaultDatabaseSpanAttributes("SET", "SET foo ?"))));
 
     assertDurationMetric(
         testing,
@@ -354,6 +393,37 @@ class VertxRedisClientTest {
         equalTo(DB_STATEMENT, queryText),
         equalTo(DB_OPERATION, operationName),
         equalTo(DB_REDIS_DATABASE_INDEX, 1),
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
+        equalTo(maybeStablePeerService(), "test-peer-service"),
+        equalTo(NETWORK_PEER_PORT, port),
+        equalTo(NETWORK_PEER_ADDRESS, ip)
+      };
+    }
+  }
+
+  private static AttributeAssertion[] defaultDatabaseSpanAttributes(
+      String operationName, String queryText) {
+    // not testing database/dup
+    if (emitStableDatabaseSemconv()) {
+      return new AttributeAssertion[] {
+        equalTo(DB_SYSTEM_NAME, REDIS),
+        equalTo(DB_QUERY_TEXT, queryText),
+        equalTo(DB_OPERATION_NAME, operationName),
+        equalTo(DB_NAMESPACE, "0"),
+        equalTo(SERVER_ADDRESS, host),
+        equalTo(SERVER_PORT, port),
+        equalTo(maybeStablePeerService(), "test-peer-service"),
+        equalTo(NETWORK_PEER_PORT, port),
+        equalTo(NETWORK_PEER_ADDRESS, ip)
+      };
+    } else {
+      return new AttributeAssertion[] {
+        equalTo(DB_SYSTEM, REDIS),
+        equalTo(DB_STATEMENT, queryText),
+        equalTo(DB_OPERATION, operationName),
+        // old semconv output is unchanged: the default database 0 is not reported
+        equalTo(DB_REDIS_DATABASE_INDEX, null),
         equalTo(SERVER_ADDRESS, host),
         equalTo(SERVER_PORT, port),
         equalTo(maybeStablePeerService(), "test-peer-service"),


### PR DESCRIPTION
Lettuce and the Vert.x Redis client dropped the stable `db.namespace` attribute when the client was on Redis database 0. Database 0 is the server default, so the attribute was missing for almost every connection, and a default-database connection looked the same as one whose database was unknown. Both now report `db.namespace` as `0`, which is what the jedis instrumentation already does.

Old semantic convention output does not change. The legacy `db.redis.database_index` still omits database 0.

### Where it lands

For lettuce 4.0 and 5.0 this only affects `CONNECT` spans, which are off by default and turned on with `otel.instrumentation.lettuce.connection-telemetry.enabled=true`. Those spans carry no metrics.

For the Vert.x Redis client it affects every command span whose connection string names no database, such as `redis://localhost:6379`.

### Metrics

`db.namespace` is a dimension of `db.client.operation.duration`, and the Vert.x instrumentation records that histogram. A default-database client now adds `db.namespace="0"` where it previously had no such dimension, so existing series for those clients split. Old semconv output is unaffected, because `db.redis.database_index` is never a metric dimension.

### Runtime SELECT

The agent does not track a `SELECT` issued at runtime, so it reports the database from the connection string. That limit already applied to a connection string that names a database. It now applies to the default database too: a connection that starts on database 0 and then runs `SELECT 1` reports `db.namespace` as `0` rather than reporting nothing.
