### PR TITLE
Return Iterable instead of Collection for header names

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -34,8 +34,8 @@ Comparing source compatibility of opentelemetry-instrumentation-api-2.31.0-SNAPS
 ***  MODIFIED INTERFACE: PUBLIC ABSTRACT io.opentelemetry.instrumentation.api.semconv.http.HttpCommonAttributesGetter  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	GENERIC TEMPLATES: === REQUEST:java.lang.Object, === RESPONSE:java.lang.Object
-	+++  NEW METHOD: PUBLIC(+) java.util.Collection<java.lang.String> getHttpRequestHeaderNames(java.lang.Object)
-	+++  NEW METHOD: PUBLIC(+) java.util.Collection<java.lang.String> getHttpResponseHeaderNames(java.lang.Object, java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) java.lang.Iterable<java.lang.String> getHttpRequestHeaderNames(java.lang.Object)
+	+++  NEW METHOD: PUBLIC(+) java.lang.Iterable<java.lang.String> getHttpResponseHeaderNames(java.lang.Object, java.lang.Object)
 ***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesExtractorBuilder  (not serializable)
 	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 	GENERIC TEMPLATES: === REQUEST:java.lang.Object, === RESPONSE:java.lang.Object

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesGetter.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static java.util.Collections.emptyList;
 
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -94,7 +93,7 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
   }
 
   /**
-   * Extracts the names of all headers present on the request, or an empty collection if there were
+   * Extracts the names of all headers present on the request, or an empty iterable if there were
    * none.
    *
    * <p>This is used to resolve header selectors that cannot be turned into a list of exact header
@@ -103,13 +102,13 @@ public interface MessagingAttributesGetter<REQUEST, RESPONSE> {
    * String)} alone. To preserve compatibility with existing implementations, overriding this method
    * is optional until 3.0.
    *
-   * <p>Implementations of this method <b>must not</b> return a null value; an empty collection
-   * should be returned instead. The returned collection is only read, so implementations may return
-   * a view over the underlying header names as long as that view cannot change while the returned
-   * collection is being read.
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty iterable should
+   * be returned instead. The returned iterable is only read, so implementations may return a view
+   * over the underlying header names as long as that view cannot change while the returned iterable
+   * is being read.
    */
   // TODO: remove the default implementation and make this required to implement in 3.0
-  default Collection<String> getMessageHeaderNames(REQUEST request) {
+  default Iterable<String> getMessageHeaderNames(REQUEST request) {
     return emptyList();
   }
 }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/CapturedHttpHeaders.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/CapturedHttpHeaders.java
@@ -101,7 +101,7 @@ final class CapturedHttpHeaders {
   }
 
   /** Returns the lowercase names of the captured headers among {@code enumeratedNames}. */
-  Collection<String> matchingNames(Collection<String> enumeratedNames) {
+  Collection<String> matchingNames(Iterable<String> enumeratedNames) {
     Set<String> names = new LinkedHashSet<>(exactNames);
     for (String name : enumeratedNames) {
       String lowercased = lowercase(name);

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesGetter.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpCommonAttributesGetter.java
@@ -10,7 +10,6 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -39,20 +38,20 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
   List<String> getHttpRequestHeader(REQUEST request, String name);
 
   /**
-   * Returns the names of all headers present on the request, or an empty collection if they cannot
-   * be enumerated.
+   * Returns the names of all headers present on the request, or an empty iterable if they cannot be
+   * enumerated.
    *
    * <p>This is only called when the configured request header selector uses wildcard patterns or
    * only excluded patterns, in which case the header names to capture cannot be known in advance.
    * Instrumentations that do not implement this method only support selectors that list header
    * names literally.
    *
-   * <p>Implementations of this method <b>must not</b> return a null value; an empty collection
-   * should be returned instead.
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty iterable should
+   * be returned instead.
    *
    * @since 2.31.0
    */
-  default Collection<String> getHttpRequestHeaderNames(REQUEST request) {
+  default Iterable<String> getHttpRequestHeaderNames(REQUEST request) {
     return emptyList();
   }
 
@@ -81,7 +80,7 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
   List<String> getHttpResponseHeader(REQUEST request, RESPONSE response, String name);
 
   /**
-   * Returns the names of all headers present on the response, or an empty collection if they cannot
+   * Returns the names of all headers present on the response, or an empty iterable if they cannot
    * be enumerated.
    *
    * <p>This is only called when the configured response header selector uses wildcard patterns or
@@ -92,12 +91,12 @@ public interface HttpCommonAttributesGetter<REQUEST, RESPONSE> {
    * <p>This is called from {@link Instrumenter#end(Context, Object, Object, Throwable)}, only when
    * {@code response} is non-{@code null}.
    *
-   * <p>Implementations of this method <b>must not</b> return a null value; an empty collection
-   * should be returned instead.
+   * <p>Implementations of this method <b>must not</b> return a null value; an empty iterable should
+   * be returned instead.
    *
    * @since 2.31.0
    */
-  default Collection<String> getHttpResponseHeaderNames(REQUEST request, RESPONSE response) {
+  default Iterable<String> getHttpResponseHeaderNames(REQUEST request, RESPONSE response) {
     return emptyList();
   }
 

--- a/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletHeaderSelectorTest.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletHeaderSelectorTest.java
@@ -28,6 +28,7 @@ import io.opentelemetry.instrumentation.servlet.v3_0.internal.Servlet3Accessor;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.ArrayList;
 import java.util.List;
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
@@ -87,6 +88,25 @@ class ServletHeaderSelectorTest {
         .doesNotContainKeys(
             stringArrayKey("http.request.header.x-secret"),
             stringArrayKey("http.response.header.x-secret"));
+  }
+
+  @Test
+  void requestHeaderNamesAreReiterable() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeaderNames())
+        .thenAnswer(invocation -> enumeration(asList("X-Test-Request", "X-Secret")));
+
+    Iterable<String> headerNames = Servlet3Accessor.INSTANCE.getRequestHeaderNames(request);
+
+    // ServletRequestGetter.keys() hands this iterable to a TextMapGetter, and a propagator may read
+    // it more than once
+    List<String> firstPass = new ArrayList<>();
+    headerNames.forEach(firstPass::add);
+    List<String> secondPass = new ArrayList<>();
+    headerNames.forEach(secondPass::add);
+
+    assertThat(firstPass).containsExactly("X-Test-Request", "X-Secret");
+    assertThat(secondPass).isEqualTo(firstPass);
   }
 
   @SuppressWarnings("deprecation") // testing deprecated API

--- a/instrumentation/servlet/servlet-5.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/internal/Servlet5Accessor.java
+++ b/instrumentation/servlet/servlet-5.0/library/src/main/java/io/opentelemetry/instrumentation/servlet/v5_0/internal/Servlet5Accessor.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.servlet.v5_0.internal;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
+import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import io.opentelemetry.instrumentation.servlet.common.internal.ServletAccessor;
 import io.opentelemetry.instrumentation.servlet.common.internal.ServletAsyncListener;
 import jakarta.servlet.AsyncEvent;
@@ -107,9 +108,8 @@ public class Servlet5Accessor implements ServletAccessor<HttpServletRequest, Htt
   }
 
   @Override
-  public Collection<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
-    Enumeration<String> names = httpServletRequest.getHeaderNames();
-    return names == null ? emptyList() : Collections.list(names);
+  public Iterable<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
+    return () -> EnumerationUtil.asIterator(httpServletRequest.getHeaderNames());
   }
 
   @Override

--- a/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/ServletHeaderSelectorTest.java
+++ b/instrumentation/servlet/servlet-5.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v5_0/ServletHeaderSelectorTest.java
@@ -31,6 +31,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -87,6 +88,25 @@ class ServletHeaderSelectorTest {
         .doesNotContainKeys(
             stringArrayKey("http.request.header.x-secret"),
             stringArrayKey("http.response.header.x-secret"));
+  }
+
+  @Test
+  void requestHeaderNamesAreReiterable() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeaderNames())
+        .thenAnswer(invocation -> enumeration(asList("X-Test-Request", "X-Secret")));
+
+    Iterable<String> headerNames = Servlet5Accessor.INSTANCE.getRequestHeaderNames(request);
+
+    // ServletRequestGetter.keys() hands this iterable to a TextMapGetter, and a propagator may read
+    // it more than once
+    List<String> firstPass = new ArrayList<>();
+    headerNames.forEach(firstPass::add);
+    List<String> secondPass = new ArrayList<>();
+    headerNames.forEach(secondPass::add);
+
+    assertThat(firstPass).containsExactly("X-Test-Request", "X-Secret");
+    assertThat(secondPass).isEqualTo(firstPass);
   }
 
   @SuppressWarnings("deprecation") // testing deprecated API

--- a/instrumentation/servlet/servlet-common-javax/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/javax/JavaxServletAccessor.java
+++ b/instrumentation/servlet/servlet-common-javax/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/javax/JavaxServletAccessor.java
@@ -8,9 +8,9 @@ package io.opentelemetry.instrumentation.servlet.common.javax;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
+import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import io.opentelemetry.instrumentation.servlet.common.internal.ServletAccessor;
 import java.security.Principal;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -84,10 +84,12 @@ public abstract class JavaxServletAccessor<R> implements ServletAccessor<HttpSer
   }
 
   @Override
-  public Collection<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
-    @SuppressWarnings("unchecked") // servlet api uses Enumeration without generic type
-    Enumeration<String> names = httpServletRequest.getHeaderNames();
-    return names == null ? emptyList() : Collections.list(names);
+  public Iterable<String> getRequestHeaderNames(HttpServletRequest httpServletRequest) {
+    return () -> {
+      @SuppressWarnings("unchecked") // servlet api uses Enumeration without generic type
+      Enumeration<String> names = httpServletRequest.getHeaderNames();
+      return EnumerationUtil.asIterator(names);
+    };
   }
 
   @Override

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletAccessor.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletAccessor.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.servlet.common.internal;
 import static java.util.Collections.emptyList;
 
 import java.security.Principal;
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -60,7 +59,7 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
 
   List<String> getRequestHeaderValues(REQUEST request, String name);
 
-  Collection<String> getRequestHeaderNames(REQUEST request);
+  Iterable<String> getRequestHeaderNames(REQUEST request);
 
   Iterable<String> getRequestParameterNames(REQUEST request);
 
@@ -82,10 +81,10 @@ public interface ServletAccessor<REQUEST, RESPONSE> {
   List<String> getResponseHeaderValues(RESPONSE response, String name);
 
   /**
-   * Returns the names of the headers set on the response, or an empty collection when the Servlet
-   * API version does not allow enumerating them, which is the case before Servlet 3.0.
+   * Returns the names of the headers set on the response, or an empty iterable when the Servlet API
+   * version does not allow enumerating them, which is the case before Servlet 3.0.
    */
-  default Collection<String> getResponseHeaderNames(RESPONSE response) {
+  default Iterable<String> getResponseHeaderNames(RESPONSE response) {
     return emptyList();
   }
 

--- a/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletHttpAttributesGetter.java
+++ b/instrumentation/servlet/servlet-common/library/src/main/java/io/opentelemetry/instrumentation/servlet/common/internal/ServletHttpAttributesGetter.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.servlet.common.internal;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -54,8 +53,7 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
   }
 
   @Override
-  public Collection<String> getHttpRequestHeaderNames(
-      ServletRequestContext<REQUEST> requestContext) {
+  public Iterable<String> getHttpRequestHeaderNames(ServletRequestContext<REQUEST> requestContext) {
     return accessor.getRequestHeaderNames(requestContext.request());
   }
 
@@ -97,7 +95,7 @@ public class ServletHttpAttributesGetter<REQUEST, RESPONSE>
   }
 
   @Override
-  public Collection<String> getHttpResponseHeaderNames(
+  public Iterable<String> getHttpResponseHeaderNames(
       ServletRequestContext<REQUEST> requestContext,
       ServletResponseContext<RESPONSE> responseContext) {
     RESPONSE response = responseContext.response();

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/SpringWebMvcHttpAttributesGetter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.spring.webmvc.v5_3;
 
 import static java.util.Collections.emptyList;
 
+import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,9 +33,8 @@ class SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public Collection<String> getHttpRequestHeaderNames(HttpServletRequest request) {
-    Enumeration<String> headerNames = request.getHeaderNames();
-    return headerNames == null ? emptyList() : Collections.list(headerNames);
+  public Iterable<String> getHttpRequestHeaderNames(HttpServletRequest request) {
+    return () -> EnumerationUtil.asIterator(request.getHeaderNames());
   }
 
   @Override

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/main/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/SpringWebMvcHttpAttributesGetter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.spring.webmvc.v6_0;
 
 import static java.util.Collections.emptyList;
 
+import io.opentelemetry.instrumentation.api.internal.EnumerationUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerAttributesGetter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,9 +34,8 @@ final class SpringWebMvcHttpAttributesGetter
   }
 
   @Override
-  public Collection<String> getHttpRequestHeaderNames(HttpServletRequest request) {
-    Enumeration<String> headerNames = request.getHeaderNames();
-    return headerNames == null ? emptyList() : Collections.list(headerNames);
+  public Iterable<String> getHttpRequestHeaderNames(HttpServletRequest request) {
+    return () -> EnumerationUtil.asIterator(request.getHeaderNames());
   }
 
   @Override


### PR DESCRIPTION
The attributes getters that enumerate header names now return `Iterable<String>` instead of `Collection<String>`. This lets an instrumentation hand back a lazy view over the headers it already has, instead of copying every header name into a new list on each request.

```java
// old
default Collection<String> getHttpRequestHeaderNames(REQUEST request);
default Collection<String> getHttpResponseHeaderNames(REQUEST request, RESPONSE response);
default Collection<String> getMessageHeaderNames(REQUEST request);

// new
default Iterable<String> getHttpRequestHeaderNames(REQUEST request);
default Iterable<String> getHttpResponseHeaderNames(REQUEST request, RESPONSE response);
default Iterable<String> getMessageHeaderNames(REQUEST request);
```

All three methods are unreleased, so nothing breaks for existing users either: they land in 2.31.0, and the api baseline is 2.30.0.

Answers https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19604#discussion_r3803645962.