### PR TITLE
Use a shared header selector constant in the HTTP base tests

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.3/library/src/test/java/io/opentelemetry/instrumentation/apachehttpclient/v4_3/ApacheHttpClientTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.apachehttpclient.v4_3;
 
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -33,7 +32,7 @@ class ApacheHttpClientTest extends AbstractApacheHttpClientTest {
         ApacheHttpClientTelemetry.builder(testing.getOpenTelemetry())
             // keeps coverage of the deprecated exact-name setter
             .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-            .setResponseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+            .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
             .build()
             .createHttpClientBuilder();
     RequestConfig.Builder requestConfigBuilder =

--- a/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/test/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientTest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-5.2/library/src/test/java/io/opentelemetry/instrumentation/apachehttpclient/v5_2/ApacheHttpClientTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.apachehttpclient.v5_2;
 
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -37,7 +36,7 @@ class ApacheHttpClientTest extends AbstractApacheHttpClientTest {
         ApacheHttpClientTelemetry.builder(testing.getOpenTelemetry())
             // keeps coverage of the deprecated exact-name setter
             .setCapturedRequestHeaders(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-            .setResponseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+            .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
             .build()
             .createHttpClientBuilder();
     builder.setDefaultRequestConfig(RequestConfig.custom().setMaxRedirects(2).build());

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpClientTest.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
-import static java.util.Collections.singletonList;
-
 import com.linecorp.armeria.client.WebClientBuilder;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -24,14 +21,8 @@ class ArmeriaHttpClientTest extends AbstractArmeriaHttpClientTest {
   protected WebClientBuilder configureClient(WebClientBuilder clientBuilder) {
     return clientBuilder.decorator(
         ArmeriaClientTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
-                    .build())
+            .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
             .build()
             .createDecorator());
   }

--- a/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.java
+++ b/instrumentation/armeria/armeria-1.3/library/src/test/java/io/opentelemetry/instrumentation/armeria/v1_3/ArmeriaHttpServerTest.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.instrumentation.armeria.v1_3;
 
-import static java.util.Collections.singletonList;
-
 import com.linecorp.armeria.server.ServerBuilder;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -24,14 +21,8 @@ class ArmeriaHttpServerTest extends AbstractArmeriaHttpServerTest {
   protected ServerBuilder configureServer(ServerBuilder sb) {
     return sb.decorator(
         ArmeriaServerTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
-                    .build())
+            .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
             .build()
             .createDecorator());
   }

--- a/instrumentation/helidon-4.3/library/src/test/java/io/opentelemetry/instrumentation/helidon/v4_3/HelidonServerTest.java
+++ b/instrumentation/helidon-4.3/library/src/test/java/io/opentelemetry/instrumentation/helidon/v4_3/HelidonServerTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.helidon.v4_3;
 import static java.util.Collections.singletonList;
 
 import io.helidon.webserver.http.HttpRouting;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -26,7 +25,7 @@ class HelidonServerTest extends AbstractHelidonTest {
         HelidonTelemetry.builder(testing.getOpenTelemetry())
             // keeps coverage of the deprecated exact-name setter
             .setCapturedRequestHeaders(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-            .setResponseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
             .build();
     routing.addFilter(feature.createFilter());
   }

--- a/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
+++ b/instrumentation/java-http-client/library/src/test/java/io/opentelemetry/instrumentation/javahttpclient/JavaHttpClientTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.javahttpclient;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -23,14 +22,8 @@ class JavaHttpClientTest {
     @Override
     protected HttpClient configureHttpClient(HttpClient httpClient) {
       return JavaHttpClientTelemetry.builder(testing.getOpenTelemetry())
-          .setRequestHeaders(
-              IncludeExclude.builder()
-                  .setIncluded(AbstractHttpClientTest.TEST_REQUEST_HEADER)
-                  .build())
-          .setResponseHeaders(
-              IncludeExclude.builder()
-                  .setIncluded(AbstractHttpClientTest.TEST_RESPONSE_HEADER)
-                  .build())
+          .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+          .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
           .build()
           .wrap(httpClient);
     }

--- a/instrumentation/java-http-server/library/src/test/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerTest.java
+++ b/instrumentation/java-http-server/library/src/test/java/io/opentelemetry/instrumentation/javahttpserver/JavaHttpServerTest.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.javahttpserver;
 
 import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpContext;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -23,14 +22,8 @@ class JavaHttpServerTest extends AbstractJavaHttpServerTest {
   protected void configureContexts(List<HttpContext> contexts) {
     Filter filter =
         JavaHttpServerTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(AbstractHttpServerTest.TEST_REQUEST_HEADER)
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(AbstractHttpServerTest.TEST_RESPONSE_HEADER)
-                    .build())
+            .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
             .build()
             .createFilter();
     contexts.forEach(ctx -> ctx.getFilters().add(filter));

--- a/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12LibraryTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-12.0/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v12_0/JettyHttpClient12LibraryTest.java
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.jetty.httpclient.v12_0;
 
-import static java.util.Collections.singletonList;
-
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -24,14 +21,8 @@ class JettyHttpClient12LibraryTest extends AbstractJettyClient12Test {
   @Override
   protected HttpClient createStandardClient() {
     return JettyClientTelemetry.builder(testing.getOpenTelemetry())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
-                .build())
+        .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
         .build()
         .createHttpClient();
   }

--- a/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.java
+++ b/instrumentation/jetty-httpclient/jetty-httpclient-9.2/library/src/test/java/io/opentelemetry/instrumentation/jetty/httpclient/v9_2/JettyHttpClient9LibraryTest.java
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.jetty.httpclient.v9_2;
 
-import static java.util.Collections.singletonList;
-
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -23,14 +20,8 @@ class JettyHttpClient9LibraryTest extends AbstractJettyClient9Test {
   @Override
   protected HttpClient createStandardClient() {
     return JettyClientTelemetry.builder(testing.getOpenTelemetry())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(singletonList(AbstractHttpClientTest.TEST_REQUEST_HEADER))
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(singletonList(AbstractHttpClientTest.TEST_RESPONSE_HEADER))
-                .build())
+        .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
         .build()
         .createHttpClient();
   }

--- a/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorTestUtil.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorTestUtil.kt
@@ -7,15 +7,14 @@ package io.opentelemetry.instrumentation.ktor.v1_0
 
 import io.ktor.application.*
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.instrumentation.api.config.IncludeExclude
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest
 
 internal object KtorTestUtil {
   fun installOpenTelemetry(application: Application, openTelemetry: OpenTelemetry) {
     application.install(KtorServerTelemetry) {
       setOpenTelemetry(openTelemetry)
-      // the wildcard patterns exercise capturing headers by name enumeration
-      setRequestHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
-      setResponseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+      setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+      setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
     }
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpClientTest.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.ktor.v2_0
 
 import io.ktor.client.*
-import io.opentelemetry.instrumentation.api.config.IncludeExclude
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -21,9 +21,8 @@ class KtorHttpClientTest : AbstractKtorHttpClientTest() {
   override fun HttpClientConfig<*>.installTracing() {
     install(KtorClientTelemetry) {
       setOpenTelemetry(testingExtension.openTelemetry)
-      // the wildcard patterns exercise capturing headers by name enumeration
-      requestHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
-      responseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+      requestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+      responseHeaders(AbstractHttpClientTest.TEST_HEADERS)
     }
   }
 }

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorTestUtil.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorTestUtil.kt
@@ -7,15 +7,14 @@ package io.opentelemetry.instrumentation.ktor.v2_0
 
 import io.ktor.server.application.*
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.instrumentation.api.config.IncludeExclude
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest
 
 internal object KtorTestUtil {
   fun installOpenTelemetry(application: Application, openTelemetry: OpenTelemetry) {
     application.install(KtorServerTelemetry) {
       setOpenTelemetry(openTelemetry)
-      // the wildcard patterns exercise capturing headers by name enumeration
-      requestHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
-      responseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+      requestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+      responseHeaders(AbstractHttpServerTest.TEST_HEADERS)
     }
   }
 }

--- a/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpClientTest.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.instrumentation.ktor.v3_0
 
 import io.ktor.client.*
-import io.opentelemetry.instrumentation.api.config.IncludeExclude
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -21,9 +21,8 @@ class KtorHttpClientTest : AbstractKtorHttpClientTest() {
   override fun HttpClientConfig<*>.installTracing() {
     install(KtorClientTelemetry) {
       setOpenTelemetry(testingExtension.openTelemetry)
-      // the wildcard patterns exercise capturing headers by name enumeration
-      requestHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
-      responseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+      requestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+      responseHeaders(AbstractHttpClientTest.TEST_HEADERS)
     }
   }
 }

--- a/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-3.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v3_0/KtorHttpServerTest.kt
@@ -9,8 +9,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
 import io.ktor.server.application.hooks.CallFailed
 import io.ktor.server.response.respondText
-import io.opentelemetry.instrumentation.api.config.IncludeExclude
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -29,9 +29,8 @@ class KtorHttpServerTest : AbstractKtorHttpServerTest() {
     application.apply {
       install(KtorServerTelemetry) {
         setOpenTelemetry(testing.openTelemetry)
-        // the wildcard patterns exercise capturing headers by name enumeration
-        requestHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
-        responseHeaders(IncludeExclude.builder().setIncluded("X-Test-*").build())
+        requestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+        responseHeaders(AbstractHttpServerTest.TEST_HEADERS)
       }
 
       install(createRouteScopedPlugin("Failure handler, that can mask exceptions if exception handling is in the wrong phase", ServerEndpoint.EXCEPTION.path, {}) {

--- a/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
+++ b/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ClientTest.java
@@ -5,20 +5,16 @@
 
 package io.opentelemetry.instrumentation.netty.v4_1;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest.TEST_HEADERS;
 
 import io.netty.channel.Channel;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class Netty41ClientTest extends AbstractNetty41ClientTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forLibrary();

--- a/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ServerTest.java
+++ b/instrumentation/netty/netty-4.1/library/src/test/java/io/opentelemetry/instrumentation/netty/v4_1/Netty41ServerTest.java
@@ -5,19 +5,15 @@
 
 package io.opentelemetry.instrumentation.netty.v4_1;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.TEST_HEADERS;
 
 import io.netty.channel.ChannelPipeline;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
 import io.opentelemetry.testing.internal.io.netty.handler.codec.http.HttpServerCodec;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class Netty41ServerTest extends AbstractNetty41ServerTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forLibrary();

--- a/instrumentation/okhttp/okhttp-3.0/library/src/http2Test/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Http2Test.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/http2Test/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Http2Test.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.okhttp.v3_0;
 
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -26,14 +25,8 @@ class OkHttp3Http2Test extends AbstractOkHttp3Test {
   public Call.Factory createCallFactory(OkHttpClient.Builder clientBuilder) {
     clientBuilder.protocols(singletonList(Protocol.H2_PRIOR_KNOWLEDGE));
     return OkHttpTelemetry.builder(testing.getOpenTelemetry())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpClientTest.TEST_REQUEST_HEADER)
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpClientTest.TEST_RESPONSE_HEADER)
-                .build())
+        .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
         .build()
         .createCallFactory(clientBuilder.build());
   }

--- a/instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Test.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/okhttp/v3_0/OkHttp3Test.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.okhttp.v3_0;
 
 import static java.util.Collections.singletonList;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -25,14 +24,8 @@ class OkHttp3Test extends AbstractOkHttp3Test {
   public Call.Factory createCallFactory(OkHttpClient.Builder clientBuilder) {
     clientBuilder.protocols(singletonList(Protocol.HTTP_1_1));
     return OkHttpTelemetry.builder(testing.getOpenTelemetry())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpClientTest.TEST_REQUEST_HEADER)
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpClientTest.TEST_RESPONSE_HEADER)
-                .build())
+        .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
         .build()
         .createCallFactory(clientBuilder.build());
   }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/RatpackHttpClientTest.java
@@ -5,9 +5,8 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest.TEST_HEADERS;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,9 +15,6 @@ import ratpack.http.client.HttpClient;
 import ratpack.http.client.HttpClientSpec;
 
 class RatpackHttpClientTest extends AbstractRatpackHttpClientTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forLibrary();

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackAsyncHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackAsyncHttpServerTest.java
@@ -5,9 +5,8 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7.server;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.TEST_HEADERS;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.ratpack.server.AbstractRatpackAsyncHttpServerTest;
 import io.opentelemetry.instrumentation.ratpack.v1_7.RatpackServerTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -17,9 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import ratpack.server.RatpackServerSpec;
 
 class RatpackAsyncHttpServerTest extends AbstractRatpackAsyncHttpServerTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forLibrary();

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackForkedHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackForkedHttpServerTest.java
@@ -5,9 +5,8 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7.server;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.TEST_HEADERS;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.ratpack.server.AbstractRatpackForkedHttpServerTest;
 import io.opentelemetry.instrumentation.ratpack.v1_7.RatpackServerTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -17,9 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import ratpack.server.RatpackServerSpec;
 
 class RatpackForkedHttpServerTest extends AbstractRatpackForkedHttpServerTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forLibrary();

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackHttpServerTest.java
@@ -5,9 +5,8 @@
 
 package io.opentelemetry.instrumentation.ratpack.v1_7.server;
 
-import static java.util.Collections.singletonList;
+import static io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest.TEST_HEADERS;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.ratpack.server.AbstractRatpackHttpServerTest;
 import io.opentelemetry.instrumentation.ratpack.v1_7.RatpackServerTelemetry;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -17,9 +16,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import ratpack.server.RatpackServerSpec;
 
 class RatpackHttpServerTest extends AbstractRatpackHttpServerTest {
-
-  private static final IncludeExclude TEST_HEADERS =
-      IncludeExclude.builder().setIncluded(singletonList("x-test-*")).build();
 
   @RegisterExtension
   static final InstrumentationExtension testing = HttpServerInstrumentationExtension.forLibrary();

--- a/instrumentation/restlet/restlet-1.1/library/src/test/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletServerTest.java
+++ b/instrumentation/restlet/restlet-1.1/library/src/test/java/io/opentelemetry/instrumentation/restlet/v1_1/RestletServerTest.java
@@ -5,10 +5,7 @@
 
 package io.opentelemetry.instrumentation.restlet.v1_1;
 
-import static java.util.Collections.singletonList;
-
 import com.noelios.restlet.StatusFilter;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -25,14 +22,8 @@ class RestletServerTest extends AbstractRestletServerTest {
   protected Restlet wrapRestlet(Restlet restlet, String path) {
     RestletTelemetry telemetry =
         RestletTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
-                    .build())
+            .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
             .build();
 
     Filter tracingFilter = telemetry.createFilter(path);

--- a/instrumentation/restlet/restlet-2.0/library/src/test/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletServerTest.java
+++ b/instrumentation/restlet/restlet-2.0/library/src/test/java/io/opentelemetry/instrumentation/restlet/v2_0/RestletServerTest.java
@@ -5,9 +5,6 @@
 
 package io.opentelemetry.instrumentation.restlet.v2_0;
 
-import static java.util.Collections.singletonList;
-
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension;
@@ -26,14 +23,8 @@ class RestletServerTest extends AbstractRestletServerTest {
   protected Restlet wrapRestlet(Restlet restlet, String path) {
     RestletTelemetry telemetry =
         RestletTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
-                    .build())
+            .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
             .build();
 
     Filter tracingFilter = telemetry.createFilter(path);

--- a/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTestUtil.java
+++ b/instrumentation/servlet/servlet-3.0/library/src/test/java/io/opentelemetry/instrumentation/servlet/v3_0/ServletTestUtil.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.servlet.v3_0;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.servlet.v3_0.internal.Experimental;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import javax.servlet.Filter;
@@ -22,14 +21,8 @@ public class ServletTestUtil {
   public static Filter newFilter(OpenTelemetry openTelemetry) {
     ServletTelemetryBuilder builder =
         ServletTelemetry.builder(openTelemetry)
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_REQUEST_HEADER))
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(singletonList(AbstractHttpServerTest.TEST_RESPONSE_HEADER))
-                    .build());
+            .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS);
     Experimental.setCaptureRequestParameters(builder, singletonList("test-parameter"));
     Experimental.setTraceIdRequestAttributeEnabled(builder, true);
     return builder.build().createFilter();

--- a/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
+++ b/instrumentation/spring/spring-web/spring-web-3.1/library/src/test/java/io/opentelemetry/instrumentation/spring/web/v3_1/SpringWebInstrumentationTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSIO
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
@@ -45,14 +44,8 @@ class SpringWebInstrumentationTest extends AbstractHttpClientTest<HttpEntity<Str
         .getInterceptors()
         .add(
             SpringWebTelemetry.builder(testing.getOpenTelemetry())
-                .setRequestHeaders(
-                    IncludeExclude.builder()
-                        .setIncluded(AbstractHttpClientTest.TEST_REQUEST_HEADER)
-                        .build())
-                .setResponseHeaders(
-                    IncludeExclude.builder()
-                        .setIncluded(AbstractHttpClientTest.TEST_RESPONSE_HEADER)
-                        .build())
+                .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+                .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
                 .build()
                 .createInterceptor());
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientInstrumentationTest.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/SpringWebfluxClientInstrumentationTest.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.instrumentation.spring.webflux.v5_3;
 
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.spring.webflux.client.AbstractSpringWebfluxClientInstrumentationTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
@@ -23,14 +22,8 @@ class SpringWebfluxClientInstrumentationTest
   protected WebClient.Builder instrument(WebClient.Builder builder) {
     SpringWebfluxClientTelemetry instrumentation =
         SpringWebfluxClientTelemetry.builder(testing.getOpenTelemetry())
-            .setRequestHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(AbstractHttpClientTest.TEST_REQUEST_HEADER)
-                    .build())
-            .setResponseHeaders(
-                IncludeExclude.builder()
-                    .setIncluded(AbstractHttpClientTest.TEST_RESPONSE_HEADER)
-                    .build())
+            .setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)
+            .setResponseHeaders(AbstractHttpClientTest.TEST_HEADERS)
             .build();
     return builder.filters(instrumentation::addFilterAndRegisterReactorHook);
   }

--- a/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
+++ b/instrumentation/spring/spring-webflux/spring-webflux-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webflux/v5_3/TestWebfluxSpringBootApp.java
@@ -16,7 +16,6 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint.SUCCESS;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import java.net.URI;
 import java.util.Properties;
@@ -54,14 +53,8 @@ class TestWebfluxSpringBootApp {
   @Bean
   WebFilter telemetryFilter() {
     return SpringWebfluxServerTelemetry.builder(GlobalOpenTelemetry.get())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_REQUEST_HEADER)
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_RESPONSE_HEADER)
-                .build())
+        .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
         .build()
         .createWebFilterAndRegisterReactorHook();
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/TestWebSpringBootApp.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-5.3/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v5_3/TestWebSpringBootApp.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import java.util.Properties;
@@ -56,14 +55,8 @@ class TestWebSpringBootApp {
   @Bean
   Filter telemetryFilter() {
     return SpringWebMvcTelemetry.builder(GlobalOpenTelemetry.get())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_REQUEST_HEADER)
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_RESPONSE_HEADER)
-                .build())
+        .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
         .build()
         .createServletFilter();
   }

--- a/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/TestWebSpringBootApp.java
+++ b/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/library/src/test/java/io/opentelemetry/instrumentation/spring/webmvc/v6_0/TestWebSpringBootApp.java
@@ -18,7 +18,6 @@ import static io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpServerTest;
 import io.opentelemetry.instrumentation.testing.junit.http.ServerEndpoint;
 import jakarta.servlet.Filter;
@@ -56,14 +55,8 @@ class TestWebSpringBootApp {
   @Bean
   Filter telemetryFilter() {
     return SpringWebMvcTelemetry.builder(GlobalOpenTelemetry.get())
-        .setRequestHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_REQUEST_HEADER)
-                .build())
-        .setResponseHeaders(
-            IncludeExclude.builder()
-                .setIncluded(AbstractHttpServerTest.TEST_RESPONSE_HEADER)
-                .build())
+        .setRequestHeaders(AbstractHttpServerTest.TEST_HEADERS)
+        .setResponseHeaders(AbstractHttpServerTest.TEST_HEADERS)
         .build()
         .createServletFilter();
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpClientTest.java
@@ -47,6 +47,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner;
@@ -87,6 +88,13 @@ public abstract class AbstractHttpClientTest<REQUEST> implements HttpClientTypeA
   public static final Duration READ_TIMEOUT = Duration.ofSeconds(2);
   public static final String TEST_REQUEST_HEADER = "X-Test-Request";
   public static final String TEST_RESPONSE_HEADER = "X-Test-Response";
+
+  /**
+   * Header selector that the shared client tests configure. The wildcard pattern makes the tests
+   * exercise capturing headers by name enumeration.
+   */
+  public static final IncludeExclude TEST_HEADERS =
+      IncludeExclude.builder().setIncluded("X-Test-*").build();
 
   static final String BASIC_AUTH_KEY = "custom-authorization-header";
   static final String BASIC_AUTH_VAL = "plain text auth token";

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -61,6 +61,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.testing.GlobalTraceUtil;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
@@ -129,6 +130,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerUsingTest<SERVER> {
   public static final String TEST_REQUEST_HEADER = "X-Test-Request";
   public static final String TEST_RESPONSE_HEADER = "X-Test-Response";
+
+  /**
+   * Header selector that the shared server tests configure. The wildcard pattern makes the tests
+   * exercise capturing headers by name enumeration.
+   */
+  public static final IncludeExclude TEST_HEADERS =
+      IncludeExclude.builder().setIncluded("X-Test-*").build();
 
   private final HttpServerTestOptions options = new HttpServerTestOptions();
 


### PR DESCRIPTION
The library instrumentation tests each built their own `IncludeExclude` header selector inline, and the eight pull requests that added them drifted apart: some matched the exact header names, some matched `x-test-*`, some `X-Test-*`, and some passed `setIncluded(x)` while others passed `setIncluded(singletonList(x))`. This adds one `TEST_HEADERS` constant to `AbstractHttpClientTest` and `AbstractHttpServerTest` and uses it at every call site, so the base tests all configure header capture the same way.

```java
public static final IncludeExclude TEST_HEADERS =
    IncludeExclude.builder().setIncluded("X-Test-*").build();
```

Call sites now read `.setRequestHeaders(AbstractHttpClientTest.TEST_HEADERS)` instead of an inline builder, and the per-class `TEST_HEADERS` constants in the Netty and Ratpack tests are gone.

One constant covers both directions because `X-Test-Request` and `X-Test-Response` both match `X-Test-*`, so a request/response pair would be two public constants holding the same value.

The pattern is a wildcard rather than the exact names on purpose. A wildcard makes the shared base test exercise `getHttpRequestHeaderNames` and `getHttpResponseHeaderNames` across its whole matrix, including redirects, error responses, and concurrency, which an exact name never does.

Answers https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19606#discussion_r3803665941.