### PR TITLE
Derive OpenSearch REST db.operation.name from request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
   `PUT my-index/_doc/?` by default. Set
   `otel.instrumentation.opensearch.query-sanitization.enabled=false` to restore the raw value.
   ([#19671](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19671))
+- The OpenSearch REST instrumentation now derives the stable `db.operation.name`, span name, and
+  `db.client.operation.duration` operation dimension from the request path instead of the HTTP
+  method. For example, `GET _cluster/health` now reports `cluster.health` instead of `GET`. Update
+  dashboards and alerts that filter stable telemetry by `GET`, `POST`, or `PUT` to use operation
+  names such as `search`, `index`, or `cluster.health`. Legacy semantic conventions still use the
+  HTTP method.
+  ([#19695](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19695))
 
 ### 🚫 Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,6 @@
   `PUT my-index/_doc/?` by default. Set
   `otel.instrumentation.opensearch.query-sanitization.enabled=false` to restore the raw value.
   ([#19671](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19671))
-- The OpenSearch REST instrumentation now derives the stable `db.operation.name`, span name, and
-  `db.client.operation.duration` operation dimension from the request path instead of the HTTP
-  method. For example, `GET _cluster/health` now reports `cluster.health` instead of `GET`. Update
-  dashboards and alerts that filter stable telemetry by `GET`, `POST`, or `PUT` to use operation
-  names such as `search`, `index`, or `cluster.health`. Legacy semantic conventions still use the
-  HTTP method.
-  ([#19695](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19695))
 
 ### 🚫 Deprecations
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/build.gradle.kts
@@ -4,4 +4,7 @@ plugins {
 
 dependencies {
   testImplementation(project(":instrumentation:opensearch:opensearch-rest-common-1.0:javaagent"))
+  // getterFallsBackToHttpMethodWhenNoRouteMatches instantiates OpenSearchRestAttributesGetter,
+  // which implements DbClientAttributesGetter from this module.
+  testImplementation(project(":instrumentation-api-incubator"))
 }

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -169,6 +169,14 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void nodeInfoMetricRouteMasksNodeIdAndKeepsMetric() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/nodeA/os"))
+        .isEqualTo("nodes.info");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA/os"))
+        .isEqualTo("_nodes/?/os");
+  }
+
+  @Test
   void globalNamedAliasRouteMasksAliasName() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_alias/customer-alias"))
         .isEqualTo("indices.get_alias");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -271,6 +271,12 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void getTermvectorsWithoutIdDerivesOperationName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "test-index/_termvectors"))
+        .isEqualTo("termvectors");
+  }
+
+  @Test
   void parameterizedClusterRoutesDeriveOperationsAndMaskNodeId() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_cluster/state/metadata/test-index"))
         .isEqualTo("cluster.state");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -210,6 +210,19 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void parameterizedClusterRoutesDeriveOperationsAndMaskNodeId() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_cluster/state/metadata/test-index"))
+        .isEqualTo("cluster.state");
+    assertThat(
+            OpenSearchEndpointMap.maskPathParameters("GET", "_cluster/state/metadata/test-index"))
+        .isEqualTo("_cluster/state/metadata/test-index");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_cluster/stats/nodes/nodeA"))
+        .isEqualTo("cluster.stats");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_cluster/stats/nodes/nodeA"))
+        .isEqualTo("_cluster/stats/nodes/?");
+  }
+
+  @Test
   void masksIdBearingSegmentAndKeepsStructureIntact() {
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
         .isEqualTo("test-index/_doc/?");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -193,6 +193,13 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void getFlushRoutesDeriveOperationName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_flush")).isEqualTo("indices.flush");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "test-index/_flush"))
+        .isEqualTo("indices.flush");
+  }
+
+  @Test
   void masksIdBearingSegmentAndKeepsStructureIntact() {
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
         .isEqualTo("test-index/_doc/?");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -177,6 +177,14 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void getAnalyzeRoutesDeriveOperationName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_analyze"))
+        .isEqualTo("indices.analyze");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "test-index/_analyze"))
+        .isEqualTo("indices.analyze");
+  }
+
+  @Test
   void masksIdBearingSegmentAndKeepsStructureIntact() {
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
         .isEqualTo("test-index/_doc/?");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -185,6 +185,16 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void postAliasRoutesDeriveOperationNameAndMaskAlias() {
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "test-index/_alias/customer-alias"))
+        .isEqualTo("indices.put_alias");
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "test-index/_aliases/customer-alias"))
+        .isEqualTo("indices.put_alias");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("POST", "test-index/_alias/customer-alias"))
+        .isEqualTo("test-index/_alias/?");
+  }
+
+  @Test
   void getAnalyzeRoutesDeriveOperationName() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_analyze"))
         .isEqualTo("indices.analyze");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -165,6 +165,31 @@ class OpenSearchEndpointMapTest {
             "my-index/my-type/_termvectors"));
   }
 
+  @ParameterizedTest
+  @MethodSource("collidingTypedApiRoutes")
+  void typedApiRoutesTakePrecedenceOverDocumentCatchAll(
+      String method, String path, String operationName) {
+    assertThat(OpenSearchEndpointMap.getOperationName(method, path)).isEqualTo(operationName);
+    assertThat(OpenSearchEndpointMap.maskPathParameters(method, path)).isEqualTo(path);
+  }
+
+  private static Stream<Arguments> collidingTypedApiRoutes() {
+    return Stream.of(
+        argumentSet("search", "GET", "my-index/my-type/_search", "search"),
+        argumentSet("multi-get", "POST", "my-index/my-type/_mget", "mget"),
+        argumentSet("put mapping", "PUT", "my-index/my-type/_mapping", "indices.put_mapping"),
+        argumentSet(
+            "delete by query", "POST", "my-index/my-type/_delete_by_query", "delete_by_query"));
+  }
+
+  @Test
+  void legacyTypedDocumentRouteAcceptsUnderscorePrefixedId() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "my-index/my-type/_document-id"))
+        .isEqualTo("get");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "my-index/my-type/_document-id"))
+        .isEqualTo("my-index/my-type/?");
+  }
+
   @Test
   void pinsScrollRouteOperationNames() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_search/scroll")).isEqualTo("scroll");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -170,6 +170,12 @@ class OpenSearchEndpointMapTest {
 
   @Test
   void nodeInfoMetricRouteMasksNodeIdAndKeepsMetric() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/os,jvm"))
+        .isEqualTo("nodes.info");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/os,jvm"))
+        .isEqualTo("_nodes/os,jvm");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA"))
+        .isEqualTo("_nodes/?");
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/nodeA/os"))
         .isEqualTo("nodes.info");
     assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA/os"))
@@ -309,7 +315,9 @@ class OpenSearchEndpointMapTest {
     StringBuilder result = new StringBuilder();
     for (String segment : split(template)) {
       result.append('/');
-      if (isParameter(segment)) {
+      if ("{node_info_metric}".equals(segment)) {
+        result.append("os");
+      } else if (isParameter(segment)) {
         // a value that starts with a letter, so it satisfies both the strict
         // {index}/{type} regex ([^_/][^/]*) and the general parameter regex
         result.append('x').append(segment, 1, segment.length() - 1);

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -242,6 +242,10 @@ class OpenSearchEndpointMapTest {
         .isEqualTo("nodes.info");
     assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/os,jvm"))
         .isEqualTo("_nodes/os,jvm");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/indices"))
+        .isEqualTo("_nodes/indices");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/aggregations"))
+        .isEqualTo("_nodes/aggregations");
     assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA"))
         .isEqualTo("_nodes/?");
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/nodeA/os"))

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchEndpointMapTest {
+
+  // ---------------------------------------------------------------------------
+  // Property tests over the whole table. These catch a malformed template, a
+  // typo in a placeholder, or a structural-versus-parameter misclassification
+  // anywhere in the registrations, including routes no spot check would list.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void everyRouteResolvesToItsOwnOperationName() {
+    forEachRoute(
+        (method, route) -> {
+          assertThat(route.getOperationName())
+              .as("operation name for %s %s", method, route.getTemplate())
+              .isNotEmpty();
+
+          String concretePath = concretePath(route.getTemplate());
+          assertThat(OpenSearchEndpointMap.getOperationName(method, concretePath))
+              .as("%s %s resolves to its registered operation name", method, concretePath)
+              .isEqualTo(route.getOperationName());
+        });
+  }
+
+  @Test
+  void everyRouteMasksParametersAndKeepsStructure() {
+    forEachRoute(
+        (method, route) -> {
+          String concretePath = concretePath(route.getTemplate());
+          String masked = OpenSearchEndpointMap.maskPathParameters(method, concretePath);
+          assertThat(masked).as("%s %s produces a masked path", method, concretePath).isNotNull();
+
+          List<String> segments = split(concretePath);
+          List<String> maskedSegments = split(masked);
+          assertThat(maskedSegments)
+              .as("masking preserves the segment count for %s", concretePath)
+              .hasSameSizeAs(segments);
+
+          List<String> templateSegments = split(route.getTemplate());
+          for (int i = 0; i < templateSegments.size(); i++) {
+            String templateSegment = templateSegments.get(i);
+            if (isParameter(templateSegment) && !isStructural(route, templateSegment)) {
+              assertThat(maskedSegments.get(i))
+                  .as("path parameter %s is masked in %s", templateSegment, concretePath)
+                  .isEqualTo("?");
+            } else {
+              assertThat(maskedSegments.get(i))
+                  .as("structural segment %s is preserved in %s", templateSegment, concretePath)
+                  .isEqualTo(segments.get(i));
+            }
+          }
+        });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Targeted cases for behavior a property test cannot express.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void unmappedRouteHasNoOperationName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_totally/unknown/thing")).isNull();
+    assertThat(OpenSearchEndpointMap.getOperationName("PATCH", "_search")).isNull();
+  }
+
+  @Test
+  void getterFallsBackToHttpMethodWhenNoRouteMatches() {
+    OpenSearchRestAttributesGetter getter = new OpenSearchRestAttributesGetter(true);
+    OpenSearchRestRequest request = OpenSearchRestRequest.create("GET", "_totally/unknown/thing");
+    assertThat(getter.getDbOperationName(request)).isEqualTo("GET");
+  }
+
+  @Test
+  void samePathResolvesDifferentlyByMethod() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "test-index/_doc/1")).isEqualTo("get");
+    assertThat(OpenSearchEndpointMap.getOperationName("DELETE", "test-index/_doc/1"))
+        .isEqualTo("delete");
+    assertThat(OpenSearchEndpointMap.getOperationName("PUT", "test-index/_doc/1"))
+        .isEqualTo("index");
+    // HEAD registers /{index}/_doc/{id} as exists, but not /{index}/_create/{id}
+    assertThat(OpenSearchEndpointMap.getOperationName("HEAD", "test-index/_create/1")).isNull();
+  }
+
+  @Test
+  void pinsScrollRouteOperationNames() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_search/scroll")).isEqualTo("scroll");
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "_search/scroll"))
+        .isEqualTo("scroll");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_search/scroll/abc123"))
+        .isEqualTo("scroll");
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "_search/scroll/abc123"))
+        .isEqualTo("scroll");
+    assertThat(OpenSearchEndpointMap.getOperationName("DELETE", "_search/scroll/abc123"))
+        .isEqualTo("clear_scroll");
+  }
+
+  @Test
+  void masksIdBearingSegmentAndKeepsStructureIntact() {
+    assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
+        .isEqualTo("test-index/_doc/?");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_search/scroll/abc123"))
+        .isEqualTo("_search/scroll/?");
+    // legacy typed document route: mask the id, keep index and type as structure
+    assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "my-index/my-type/999"))
+        .isEqualTo("my-index/my-type/?");
+    // a structural-only path carries no id to mask
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "test-index/_search"))
+        .isEqualTo("test-index/_search");
+  }
+
+  @Test
+  void unmatchedPathHasNothingToMask() {
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_totally/unknown/thing")).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sanitizer seam: query-string masking and keyword fallback.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void masksQueryParameterValuesButKeepsNames() {
+    // regression: the query string used to be re-appended verbatim, leaking routing=abc
+    assertThat(OpenSearchEndpointSanitizer.sanitize("GET", "my-index/_doc/12345?routing=abc"))
+        .isEqualTo("my-index/_doc/??routing=?");
+    assertThat(
+            OpenSearchEndpointSanitizer.sanitize(
+                "GET", "my-index/_doc/12345?routing=abc&refresh=true"))
+        .isEqualTo("my-index/_doc/??routing=?&refresh=?");
+    // a query on a search path (never id-masked) still has its values masked
+    assertThat(OpenSearchEndpointSanitizer.sanitize("GET", "my-index/_search?q=secret"))
+        .isEqualTo("my-index/_search?q=?");
+  }
+
+  @Test
+  void bothScrollSpellingsMaskTheScrollId() {
+    // path form: the id is a path segment
+    assertThat(OpenSearchEndpointSanitizer.sanitize("GET", "_search/scroll/DXF1ZXJ5QW5k"))
+        .isEqualTo("_search/scroll/?");
+    // query form (the canonical call): the id is a query parameter value
+    assertThat(OpenSearchEndpointSanitizer.sanitize("GET", "_search/scroll?scroll_id=DXF1ZXJ5QW5k"))
+        .isEqualTo("_search/scroll?scroll_id=?");
+  }
+
+  @Test
+  void keywordFallbackMasksIdAndQueryValuesForUnmappedPath() {
+    assertThat(OpenSearchEndpointSanitizer.sanitize("GET", "my-index/_doc/12345/_unknown?x=y"))
+        .isEqualTo("my-index/_doc/?/_unknown?x=?");
+  }
+
+  @Test
+  void underscorePrefixedPathIsNotSwallowedByTypedRoute() {
+    // {index}/{type} compile to [^_/][^/]*, so a reserved _-prefixed first segment cannot match the
+    // generic /{index}/{type}/{id} route (GET -> "get"). Pin it: _nodes/nodeA/stats resolves to
+    // nodes.stats, not the legacy typed "get" route.
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/nodeA/stats"))
+        .isEqualTo("nodes.stats");
+    // and its masking keeps the structural keywords, masking only the {node_id}
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA/stats"))
+        .isEqualTo("_nodes/?/stats");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private interface RouteConsumer {
+    void accept(String method, OpenSearchEndpointRoute route);
+  }
+
+  private static void forEachRoute(RouteConsumer consumer) {
+    for (Map.Entry<String, List<OpenSearchEndpointRoute>> entry :
+        OpenSearchEndpointMap.getRoutesByMethod().entrySet()) {
+      for (OpenSearchEndpointRoute route : entry.getValue()) {
+        consumer.accept(entry.getKey(), route);
+      }
+    }
+  }
+
+  /** Turns a template such as {@code /{index}/_doc/{id}} into a concrete path. */
+  private static String concretePath(String template) {
+    StringBuilder result = new StringBuilder();
+    for (String segment : split(template)) {
+      result.append('/');
+      if (isParameter(segment)) {
+        // a value that starts with a letter, so it satisfies both the strict
+        // {index}/{type} regex ([^_/][^/]*) and the general parameter regex
+        result.append('x').append(segment, 1, segment.length() - 1);
+      } else {
+        result.append(segment);
+      }
+    }
+    return result.toString();
+  }
+
+  private static boolean isParameter(String segment) {
+    return segment.startsWith("{") && segment.endsWith("}");
+  }
+
+  private static boolean isStructural(OpenSearchEndpointRoute route, String templateSegment) {
+    String name = templateSegment.substring(1, templateSegment.length() - 1);
+    return route.isStructuralGroup(name.replace("_", "0"));
+  }
+
+  private static List<String> split(String path) {
+    String trimmed = path.startsWith("/") ? path.substring(1) : path;
+    return asList(trimmed.split("/", -1));
+  }
+}

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -102,6 +102,14 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void legacyTypedPutRouteDerivesIndexOperationAndMasksOnlyId() {
+    assertThat(OpenSearchEndpointMap.getOperationName("PUT", "my-index/my-type/999"))
+        .isEqualTo("index");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "my-index/my-type/999"))
+        .isEqualTo("my-index/my-type/?");
+  }
+
+  @Test
   void pinsScrollRouteOperationNames() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_search/scroll")).isEqualTo("scroll");
     assertThat(OpenSearchEndpointMap.getOperationName("POST", "_search/scroll"))
@@ -120,9 +128,6 @@ class OpenSearchEndpointMapTest {
         .isEqualTo("test-index/_doc/?");
     assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_search/scroll/abc123"))
         .isEqualTo("_search/scroll/?");
-    // legacy typed document route: mask the id, keep index and type as structure
-    assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "my-index/my-type/999"))
-        .isEqualTo("my-index/my-type/?");
     // a structural-only path carries no id to mask
     assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "test-index/_search"))
         .isEqualTo("test-index/_search");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -25,17 +25,14 @@ class OpenSearchEndpointMapTest {
     int visited =
         forEachRoute(
             (method, route) -> {
-              assertThat(route.getOperationName())
-                  .as("operation name for %s %s", method, route.getTemplate())
-                  .isNotEmpty();
+              assertThat(route.getOperationName()).isNotEmpty();
 
               String concretePath = concretePath(route.getTemplate());
               assertThat(OpenSearchEndpointMap.getOperationName(method, concretePath))
-                  .as("%s %s resolves to its registered operation name", method, concretePath)
                   .isEqualTo(route.getOperationName());
             });
     // guard against a vacuous pass: an emptied or gutted table must fail here
-    assertThat(visited).as("route table is populated").isGreaterThanOrEqualTo(40);
+    assertThat(visited).isGreaterThanOrEqualTo(40);
   }
 
   @Test
@@ -45,32 +42,24 @@ class OpenSearchEndpointMapTest {
             (method, route) -> {
               String concretePath = concretePath(route.getTemplate());
               String masked = OpenSearchEndpointMap.maskPathParameters(method, concretePath);
-              assertThat(masked)
-                  .as("%s %s produces a masked path", method, concretePath)
-                  .isNotNull();
+              assertThat(masked).isNotNull();
 
               List<String> segments = split(concretePath);
               List<String> maskedSegments = split(masked);
-              assertThat(maskedSegments)
-                  .as("masking preserves the segment count for %s", concretePath)
-                  .hasSameSizeAs(segments);
+              assertThat(maskedSegments).hasSameSizeAs(segments);
 
               List<String> templateSegments = split(route.getTemplate());
               for (int i = 0; i < templateSegments.size(); i++) {
                 String templateSegment = templateSegments.get(i);
                 if (isParameter(templateSegment) && !isStructural(route, templateSegment)) {
-                  assertThat(maskedSegments.get(i))
-                      .as("path parameter %s is masked in %s", templateSegment, concretePath)
-                      .isEqualTo("?");
+                  assertThat(maskedSegments.get(i)).isEqualTo("?");
                 } else {
-                  assertThat(maskedSegments.get(i))
-                      .as("structural segment %s is preserved in %s", templateSegment, concretePath)
-                      .isEqualTo(segments.get(i));
+                  assertThat(maskedSegments.get(i)).isEqualTo(segments.get(i));
                 }
               }
             });
     // guard against a vacuous pass: an emptied or gutted table must fail here
-    assertThat(visited).as("route table is populated").isGreaterThanOrEqualTo(40);
+    assertThat(visited).isGreaterThanOrEqualTo(40);
   }
 
   // ---------------------------------------------------------------------------

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -7,10 +7,15 @@ package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OpenSearchEndpointMapTest {
 
@@ -98,6 +103,42 @@ class OpenSearchEndpointMapTest {
         .isEqualTo("index");
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "my-index/my-type/999"))
         .isEqualTo("my-index/my-type/?");
+  }
+
+  @ParameterizedTest
+  @MethodSource("legacyTypedSuffixRoutes")
+  void legacyTypedSuffixRoutesDeriveOperationsAndMaskIds(
+      String method, String path, String operationName, String maskedPath) {
+    assertThat(OpenSearchEndpointMap.getOperationName(method, path)).isEqualTo(operationName);
+    assertThat(OpenSearchEndpointMap.maskPathParameters(method, path)).isEqualTo(maskedPath);
+  }
+
+  private static Stream<Arguments> legacyTypedSuffixRoutes() {
+    return Stream.of(
+        argumentSet(
+            "create",
+            "PUT",
+            "my-index/my-type/999/_create",
+            "create",
+            "my-index/my-type/?/_create"),
+        argumentSet(
+            "update",
+            "POST",
+            "my-index/my-type/999/_update",
+            "update",
+            "my-index/my-type/?/_update"),
+        argumentSet(
+            "termvectors with id",
+            "GET",
+            "my-index/my-type/999/_termvectors",
+            "termvectors",
+            "my-index/my-type/?/_termvectors"),
+        argumentSet(
+            "termvectors without id",
+            "POST",
+            "my-index/my-type/_termvectors",
+            "termvectors",
+            "my-index/my-type/_termvectors"));
   }
 
   @Test

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -128,6 +128,14 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void globalNamedAliasRouteMasksAliasName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_alias/customer-alias"))
+        .isEqualTo("indices.get_alias");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_alias/customer-alias"))
+        .isEqualTo("_alias/?");
+  }
+
+  @Test
   void masksIdBearingSegmentAndKeepsStructureIntact() {
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
         .isEqualTo("test-index/_doc/?");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -22,47 +22,55 @@ class OpenSearchEndpointMapTest {
 
   @Test
   void everyRouteResolvesToItsOwnOperationName() {
-    forEachRoute(
-        (method, route) -> {
-          assertThat(route.getOperationName())
-              .as("operation name for %s %s", method, route.getTemplate())
-              .isNotEmpty();
+    int visited =
+        forEachRoute(
+            (method, route) -> {
+              assertThat(route.getOperationName())
+                  .as("operation name for %s %s", method, route.getTemplate())
+                  .isNotEmpty();
 
-          String concretePath = concretePath(route.getTemplate());
-          assertThat(OpenSearchEndpointMap.getOperationName(method, concretePath))
-              .as("%s %s resolves to its registered operation name", method, concretePath)
-              .isEqualTo(route.getOperationName());
-        });
+              String concretePath = concretePath(route.getTemplate());
+              assertThat(OpenSearchEndpointMap.getOperationName(method, concretePath))
+                  .as("%s %s resolves to its registered operation name", method, concretePath)
+                  .isEqualTo(route.getOperationName());
+            });
+    // guard against a vacuous pass: an emptied or gutted table must fail here
+    assertThat(visited).as("route table is populated").isGreaterThanOrEqualTo(40);
   }
 
   @Test
   void everyRouteMasksParametersAndKeepsStructure() {
-    forEachRoute(
-        (method, route) -> {
-          String concretePath = concretePath(route.getTemplate());
-          String masked = OpenSearchEndpointMap.maskPathParameters(method, concretePath);
-          assertThat(masked).as("%s %s produces a masked path", method, concretePath).isNotNull();
+    int visited =
+        forEachRoute(
+            (method, route) -> {
+              String concretePath = concretePath(route.getTemplate());
+              String masked = OpenSearchEndpointMap.maskPathParameters(method, concretePath);
+              assertThat(masked)
+                  .as("%s %s produces a masked path", method, concretePath)
+                  .isNotNull();
 
-          List<String> segments = split(concretePath);
-          List<String> maskedSegments = split(masked);
-          assertThat(maskedSegments)
-              .as("masking preserves the segment count for %s", concretePath)
-              .hasSameSizeAs(segments);
+              List<String> segments = split(concretePath);
+              List<String> maskedSegments = split(masked);
+              assertThat(maskedSegments)
+                  .as("masking preserves the segment count for %s", concretePath)
+                  .hasSameSizeAs(segments);
 
-          List<String> templateSegments = split(route.getTemplate());
-          for (int i = 0; i < templateSegments.size(); i++) {
-            String templateSegment = templateSegments.get(i);
-            if (isParameter(templateSegment) && !isStructural(route, templateSegment)) {
-              assertThat(maskedSegments.get(i))
-                  .as("path parameter %s is masked in %s", templateSegment, concretePath)
-                  .isEqualTo("?");
-            } else {
-              assertThat(maskedSegments.get(i))
-                  .as("structural segment %s is preserved in %s", templateSegment, concretePath)
-                  .isEqualTo(segments.get(i));
-            }
-          }
-        });
+              List<String> templateSegments = split(route.getTemplate());
+              for (int i = 0; i < templateSegments.size(); i++) {
+                String templateSegment = templateSegments.get(i);
+                if (isParameter(templateSegment) && !isStructural(route, templateSegment)) {
+                  assertThat(maskedSegments.get(i))
+                      .as("path parameter %s is masked in %s", templateSegment, concretePath)
+                      .isEqualTo("?");
+                } else {
+                  assertThat(maskedSegments.get(i))
+                      .as("structural segment %s is preserved in %s", templateSegment, concretePath)
+                      .isEqualTo(segments.get(i));
+                }
+              }
+            });
+    // guard against a vacuous pass: an emptied or gutted table must fail here
+    assertThat(visited).as("route table is populated").isGreaterThanOrEqualTo(40);
   }
 
   // ---------------------------------------------------------------------------
@@ -179,13 +187,16 @@ class OpenSearchEndpointMapTest {
     void accept(String method, OpenSearchEndpointRoute route);
   }
 
-  private static void forEachRoute(RouteConsumer consumer) {
+  private static int forEachRoute(RouteConsumer consumer) {
+    int visited = 0;
     for (Map.Entry<String, List<OpenSearchEndpointRoute>> entry :
         OpenSearchEndpointMap.getRoutesByMethod().entrySet()) {
       for (OpenSearchEndpointRoute route : entry.getValue()) {
         consumer.accept(entry.getKey(), route);
+        visited++;
       }
     }
+    return visited;
   }
 
   /** Turns a template such as {@code /{index}/_doc/{id}} into a concrete path. */

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -128,6 +128,30 @@ class OpenSearchEndpointMapTest {
             "update",
             "my-index/my-type/?/_update"),
         argumentSet(
+            "get source",
+            "GET",
+            "my-index/my-type/999/_source",
+            "get_source",
+            "my-index/my-type/?/_source"),
+        argumentSet(
+            "exists source",
+            "HEAD",
+            "my-index/my-type/999/_source",
+            "exists_source",
+            "my-index/my-type/?/_source"),
+        argumentSet(
+            "explain with GET",
+            "GET",
+            "my-index/my-type/999/_explain",
+            "explain",
+            "my-index/my-type/?/_explain"),
+        argumentSet(
+            "explain with POST",
+            "POST",
+            "my-index/my-type/999/_explain",
+            "explain",
+            "my-index/my-type/?/_explain"),
+        argumentSet(
             "termvectors with id",
             "GET",
             "my-index/my-type/999/_termvectors",

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -271,6 +271,15 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void allIndexExpressionMatchesWithoutAdmittingReservedApiSegments() {
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_all/_settings"))
+        .isEqualTo("indices.get_settings");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_all/_settings"))
+        .isEqualTo("_all/_settings");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_search/_settings")).isNull();
+  }
+
+  @Test
   void getTermvectorsWithoutIdDerivesOperationName() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "test-index/_termvectors"))
         .isEqualTo("termvectors");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -250,6 +250,12 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void postPutMappingRouteDerivesOperationName() {
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "test-index/_mapping"))
+        .isEqualTo("indices.put_mapping");
+  }
+
+  @Test
   void getAnalyzeRoutesDeriveOperationName() {
     assertThat(OpenSearchEndpointMap.getOperationName("GET", "_analyze"))
         .isEqualTo("indices.analyze");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -86,6 +86,8 @@ class OpenSearchEndpointMapTest {
         .isEqualTo("delete");
     assertThat(OpenSearchEndpointMap.getOperationName("PUT", "test-index/_doc/1"))
         .isEqualTo("index");
+    assertThat(OpenSearchEndpointMap.getOperationName("POST", "test-index/_doc/1"))
+        .isEqualTo("index");
     // HEAD registers /{index}/_doc/{id} as exists, but not /{index}/_create/{id}
     assertThat(OpenSearchEndpointMap.getOperationName("HEAD", "test-index/_create/1")).isNull();
   }

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -114,6 +114,20 @@ class OpenSearchEndpointMapTest {
   }
 
   @Test
+  void nodeStatsRoutesMaskNodeIdAndKeepMetricSelectors() {
+    assertThat(
+            OpenSearchEndpointMap.getOperationName("GET", "_nodes/nodeA/stats/indices/fielddata"))
+        .isEqualTo("nodes.stats");
+    assertThat(
+            OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/nodeA/stats/indices/fielddata"))
+        .isEqualTo("_nodes/?/stats/indices/fielddata");
+    assertThat(OpenSearchEndpointMap.getOperationName("GET", "_nodes/stats/_all"))
+        .isEqualTo("nodes.stats");
+    assertThat(OpenSearchEndpointMap.maskPathParameters("GET", "_nodes/stats/_all"))
+        .isEqualTo("_nodes/stats/_all");
+  }
+
+  @Test
   void masksIdBearingSegmentAndKeepsStructureIntact() {
     assertThat(OpenSearchEndpointMap.maskPathParameters("PUT", "test-index/_doc/12345"))
         .isEqualTo("test-index/_doc/?");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMapTest.java
@@ -97,6 +97,25 @@ class OpenSearchEndpointMapTest {
     assertThat(OpenSearchEndpointMap.getOperationName("HEAD", "test-index/_create/1")).isNull();
   }
 
+  @ParameterizedTest
+  @MethodSource("typelessMultiDocumentRoutes")
+  void typelessMultiDocumentRoutesDeriveOperations(
+      String method, String path, String operationName) {
+    assertThat(OpenSearchEndpointMap.getOperationName(method, path)).isEqualTo(operationName);
+  }
+
+  private static Stream<Arguments> typelessMultiDocumentRoutes() {
+    return Stream.of(
+        argumentSet("delete by query", "POST", "my-index/_delete_by_query", "delete_by_query"),
+        argumentSet("update by query", "POST", "my-index/_update_by_query", "update_by_query"),
+        argumentSet("global mtermvectors with GET", "GET", "_mtermvectors", "mtermvectors"),
+        argumentSet("global mtermvectors with POST", "POST", "_mtermvectors", "mtermvectors"),
+        argumentSet(
+            "indexed mtermvectors with GET", "GET", "my-index/_mtermvectors", "mtermvectors"),
+        argumentSet(
+            "indexed mtermvectors with POST", "POST", "my-index/_mtermvectors", "mtermvectors"));
+  }
+
   @Test
   void legacyTypedPutRouteDerivesIndexOperationAndMasksOnlyId() {
     assertThat(OpenSearchEndpointMap.getOperationName("PUT", "my-index/my-type/999"))

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizerTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizerTest.java
@@ -17,8 +17,8 @@ class OpenSearchEndpointSanitizerTest {
 
   @ParameterizedTest
   @MethodSource("endpoints")
-  void sanitize(String endpoint, String expected) {
-    assertThat(OpenSearchEndpointSanitizer.sanitize(endpoint)).isEqualTo(expected);
+  void sanitizeByKeyword(String endpoint, String expected) {
+    assertThat(OpenSearchEndpointSanitizer.sanitizeByKeyword(endpoint)).isEqualTo(expected);
   }
 
   private static Stream<Arguments> endpoints() {
@@ -42,7 +42,8 @@ class OpenSearchEndpointSanitizerTest {
         arguments("test-index/_update_by_query", "test-index/_update_by_query"),
         arguments("test-index/_doc", "test-index/_doc"),
         arguments("test-index/_doc/", "test-index/_doc/"),
-        // the legacy typed document route carries no keyword, so it is left intact
+        // the legacy typed document route carries no keyword, so the fallback leaves it intact.
+        // The route table masks its id instead, which OpenSearchEndpointMapTest pins.
         arguments("test-index/test-type/12345", "test-index/test-type/12345"),
         arguments("", ""));
   }

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -119,6 +119,10 @@ final class OpenSearchEndpointMap {
     put(map, "POST", "mget", "/_mget", "/{index}/_mget");
     put(map, "GET", "msearch", "/_msearch", "/{index}/_msearch");
     put(map, "POST", "msearch", "/_msearch", "/{index}/_msearch");
+    put(map, "GET", "mtermvectors", "/_mtermvectors", "/{index}/_mtermvectors");
+    put(map, "POST", "mtermvectors", "/_mtermvectors", "/{index}/_mtermvectors");
+    put(map, "POST", "delete_by_query", "/{index}/_delete_by_query");
+    put(map, "POST", "update_by_query", "/{index}/_update_by_query");
 
     // search and count
     put(map, "GET", "search", "/_search", "/{index}/_search");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -139,6 +139,7 @@ final class OpenSearchEndpointMap {
     put(map, "POST", "indices.refresh", "/_refresh", "/{index}/_refresh");
     put(map, "GET", "indices.refresh", "/_refresh", "/{index}/_refresh");
     put(map, "POST", "indices.flush", "/_flush", "/{index}/_flush");
+    put(map, "GET", "indices.flush", "/_flush", "/{index}/_flush");
     put(map, "POST", "indices.open", "/{index}/_open");
     put(map, "POST", "indices.close", "/{index}/_close");
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -39,17 +39,21 @@ final class OpenSearchEndpointMap {
     return route != null ? route.getOperationName() : null;
   }
 
+  /** Exposes every registered route so a test can assert invariants across the whole table. */
+  static Map<String, List<OpenSearchEndpointRoute>> getRoutesByMethod() {
+    return Collections.unmodifiableMap(ROUTES_BY_METHOD);
+  }
+
   /**
    * Masks the path parameters of the matching route, so {@code my-index/_doc/12345} becomes {@code
-   * my-index/_doc/?} while index names stay intact. Returns {@code null} when no route matches.
+   * my-index/_doc/?} while index names stay intact. The {@code endpoint} must be a path with no
+   * query string; the caller masks any query separately. Returns {@code null} when no route
+   * matches.
    */
   @Nullable
   static String maskPathParameters(String method, String endpoint) {
-    int queryIdx = endpoint.indexOf('?');
-    String rawPath = queryIdx >= 0 ? endpoint.substring(0, queryIdx) : endpoint;
-    String query = queryIdx >= 0 ? endpoint.substring(queryIdx) : "";
-    boolean hadLeadingSlash = rawPath.startsWith("/");
-    String normalizedPath = hadLeadingSlash ? rawPath : "/" + rawPath;
+    boolean hadLeadingSlash = endpoint.startsWith("/");
+    String normalizedPath = hadLeadingSlash ? endpoint : "/" + endpoint;
 
     OpenSearchEndpointRoute route = findRoute(method, normalizedPath);
     if (route == null) {
@@ -62,7 +66,7 @@ final class OpenSearchEndpointMap {
     if (!hadLeadingSlash) {
       maskedPath = maskedPath.substring(1);
     }
-    return maskedPath + query;
+    return maskedPath;
   }
 
   @Nullable
@@ -160,8 +164,8 @@ final class OpenSearchEndpointMap {
     put(map, "GET", "cluster.stats", "/_cluster/stats");
     put(map, "GET", "cluster.get_settings", "/_cluster/settings");
     put(map, "PUT", "cluster.put_settings", "/_cluster/settings");
-    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}");
     put(map, "GET", "nodes.stats", "/_nodes/stats", "/_nodes/{node_id}/stats");
+    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}");
 
     // cat API
     put(map, "GET", "cat.indices", "/_cat/indices", "/_cat/indices/{index}");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -163,6 +163,7 @@ final class OpenSearchEndpointMap {
         "/{index}/_alias/{name}",
         "/{index}/_aliases/{name}");
     put(map, "POST", "indices.update_aliases", "/_aliases");
+    put(map, "GET", "indices.analyze", "/_analyze", "/{index}/_analyze");
     put(map, "POST", "indices.analyze", "/_analyze", "/{index}/_analyze");
 
     // cluster and node health

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -145,6 +145,7 @@ final class OpenSearchEndpointMap {
 
     // mapping, settings and alias management
     put(map, "PUT", "indices.put_mapping", "/{index}/_mapping");
+    put(map, "POST", "indices.put_mapping", "/{index}/_mapping");
     put(map, "GET", "indices.get_mapping", "/_mapping", "/{index}/_mapping");
     put(map, "PUT", "indices.put_settings", "/_settings", "/{index}/_settings");
     put(map, "GET", "indices.get_settings", "/_settings", "/{index}/_settings");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -212,6 +212,28 @@ final class OpenSearchEndpointMap {
 
     // legacy typed document routes (/{index}/{type}/{id}); listed last so keyword routes such as
     // /{index}/_doc/{id} match first. The type is treated as endpoint structure, the id is masked.
+    // Typed API routes that collide with the three-segment document route must come first.
+    put(map, "PUT", "bulk", "/{index}/{type}/_bulk");
+    put(map, "POST", "bulk", "/{index}/{type}/_bulk");
+    put(map, "GET", "count", "/{index}/{type}/_count");
+    put(map, "POST", "count", "/{index}/{type}/_count");
+    put(map, "POST", "delete_by_query", "/{index}/{type}/_delete_by_query");
+    put(map, "PUT", "indices.put_mapping", "/{index}/{type}/_mapping", "/{index}/{type}/_mappings");
+    put(
+        map,
+        "POST",
+        "indices.put_mapping",
+        "/{index}/{type}/_mapping",
+        "/{index}/{type}/_mappings");
+    put(map, "GET", "mget", "/{index}/{type}/_mget");
+    put(map, "POST", "mget", "/{index}/{type}/_mget");
+    put(map, "GET", "msearch", "/{index}/{type}/_msearch");
+    put(map, "POST", "msearch", "/{index}/{type}/_msearch");
+    put(map, "GET", "mtermvectors", "/{index}/{type}/_mtermvectors");
+    put(map, "POST", "mtermvectors", "/{index}/{type}/_mtermvectors");
+    put(map, "GET", "search", "/{index}/{type}/_search");
+    put(map, "POST", "search", "/{index}/{type}/_search");
+    put(map, "POST", "update_by_query", "/{index}/{type}/_update_by_query");
     put(map, "PUT", "create", "/{index}/{type}/{id}/_create");
     put(map, "POST", "create", "/{index}/{type}/{id}/_create");
     put(map, "POST", "update", "/{index}/{type}/{id}/_update");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -196,6 +196,21 @@ final class OpenSearchEndpointMap {
 
     // legacy typed document routes (/{index}/{type}/{id}); listed last so keyword routes such as
     // /{index}/_doc/{id} match first. The type is treated as endpoint structure, the id is masked.
+    put(map, "PUT", "create", "/{index}/{type}/{id}/_create");
+    put(map, "POST", "create", "/{index}/{type}/{id}/_create");
+    put(map, "POST", "update", "/{index}/{type}/{id}/_update");
+    put(
+        map,
+        "GET",
+        "termvectors",
+        "/{index}/{type}/{id}/_termvectors",
+        "/{index}/{type}/_termvectors");
+    put(
+        map,
+        "POST",
+        "termvectors",
+        "/{index}/{type}/{id}/_termvectors",
+        "/{index}/{type}/_termvectors");
     put(map, "PUT", "index", "/{index}/{type}/{id}");
     put(map, "POST", "index", "/{index}/{type}/{id}", "/{index}/{type}");
     put(map, "GET", "get", "/{index}/{type}/{id}");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -182,7 +182,7 @@ final class OpenSearchEndpointMap {
         "/_nodes/{node_id}/stats/{metric}",
         "/_nodes/stats/{metric}/{index_metric}",
         "/_nodes/{node_id}/stats/{metric}/{index_metric}");
-    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}");
+    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}", "/_nodes/{node_id}/{metric}");
 
     // cat API
     put(map, "GET", "cat.indices", "/_cat/indices", "/_cat/indices/{index}");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -121,8 +121,9 @@ final class OpenSearchEndpointMap {
     put(map, "POST", "search", "/_search", "/{index}/_search");
     put(map, "GET", "count", "/_count", "/{index}/_count");
     put(map, "POST", "count", "/_count", "/{index}/_count");
-    put(map, "POST", "search.scroll", "/_search/scroll");
-    put(map, "DELETE", "clear_scroll", "/_search/scroll");
+    put(map, "GET", "scroll", "/_search/scroll", "/_search/scroll/{scroll_id}");
+    put(map, "POST", "scroll", "/_search/scroll", "/_search/scroll/{scroll_id}");
+    put(map, "DELETE", "clear_scroll", "/_search/scroll", "/_search/scroll/{scroll_id}");
     put(map, "GET", "field_caps", "/_field_caps", "/{index}/_field_caps");
     put(map, "POST", "field_caps", "/_field_caps", "/{index}/_field_caps");
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -164,7 +164,16 @@ final class OpenSearchEndpointMap {
     put(map, "GET", "cluster.stats", "/_cluster/stats");
     put(map, "GET", "cluster.get_settings", "/_cluster/settings");
     put(map, "PUT", "cluster.put_settings", "/_cluster/settings");
-    put(map, "GET", "nodes.stats", "/_nodes/stats", "/_nodes/{node_id}/stats");
+    put(
+        map,
+        "GET",
+        "nodes.stats",
+        "/_nodes/stats",
+        "/_nodes/{node_id}/stats",
+        "/_nodes/stats/{metric}",
+        "/_nodes/{node_id}/stats/{metric}",
+        "/_nodes/stats/{metric}/{index_metric}",
+        "/_nodes/{node_id}/stats/{metric}/{index_metric}");
     put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}");
 
     // cat API

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -190,7 +190,14 @@ final class OpenSearchEndpointMap {
         "/_nodes/{node_id}/stats/{metric}",
         "/_nodes/stats/{metric}/{index_metric}",
         "/_nodes/{node_id}/stats/{metric}/{index_metric}");
-    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}", "/_nodes/{node_id}/{metric}");
+    put(
+        map,
+        "GET",
+        "nodes.info",
+        "/_nodes",
+        "/_nodes/{node_info_metric}",
+        "/_nodes/{node_id}",
+        "/_nodes/{node_id}/{metric}");
 
     // cat API
     put(map, "GET", "cat.indices", "/_cat/indices", "/_cat/indices/{index}");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -109,7 +109,7 @@ final class OpenSearchEndpointMap {
     put(map, "HEAD", "exists_source", "/{index}/_source/{id}");
     put(map, "GET", "explain", "/{index}/_explain/{id}");
     put(map, "POST", "explain", "/{index}/_explain/{id}");
-    put(map, "GET", "termvectors", "/{index}/_termvectors/{id}");
+    put(map, "GET", "termvectors", "/{index}/_termvectors/{id}", "/{index}/_termvectors");
     put(map, "POST", "termvectors", "/{index}/_termvectors/{id}", "/{index}/_termvectors");
 
     // bulk and multi-document routes

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -215,6 +215,10 @@ final class OpenSearchEndpointMap {
     put(map, "PUT", "create", "/{index}/{type}/{id}/_create");
     put(map, "POST", "create", "/{index}/{type}/{id}/_create");
     put(map, "POST", "update", "/{index}/{type}/{id}/_update");
+    put(map, "GET", "get_source", "/{index}/{type}/{id}/_source");
+    put(map, "HEAD", "exists_source", "/{index}/{type}/{id}/_source");
+    put(map, "GET", "explain", "/{index}/{type}/{id}/_explain");
+    put(map, "POST", "explain", "/{index}/{type}/{id}/_explain");
     put(
         map,
         "GET",

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -100,7 +100,7 @@ final class OpenSearchEndpointMap {
     put(map, "PUT", "create", "/{index}/_create/{id}");
     put(map, "POST", "create", "/{index}/_create/{id}");
     put(map, "PUT", "index", "/{index}/_doc/{id}");
-    put(map, "POST", "index", "/{index}/_doc");
+    put(map, "POST", "index", "/{index}/_doc/{id}", "/{index}/_doc");
     put(map, "POST", "update", "/{index}/_update/{id}");
     put(map, "DELETE", "delete", "/{index}/_doc/{id}");
     put(map, "GET", "get", "/{index}/_doc/{id}");

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -170,8 +170,14 @@ final class OpenSearchEndpointMap {
 
     // cluster and node health
     put(map, "GET", "cluster.health", "/_cluster/health", "/_cluster/health/{index}");
-    put(map, "GET", "cluster.state", "/_cluster/state");
-    put(map, "GET", "cluster.stats", "/_cluster/stats");
+    put(
+        map,
+        "GET",
+        "cluster.state",
+        "/_cluster/state",
+        "/_cluster/state/{metric}",
+        "/_cluster/state/{metric}/{index}");
+    put(map, "GET", "cluster.stats", "/_cluster/stats", "/_cluster/stats/nodes/{node_id}");
     put(map, "GET", "cluster.get_settings", "/_cluster/settings");
     put(map, "PUT", "cluster.put_settings", "/_cluster/settings");
     put(

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -147,7 +147,14 @@ final class OpenSearchEndpointMap {
     put(map, "GET", "indices.get_mapping", "/_mapping", "/{index}/_mapping");
     put(map, "PUT", "indices.put_settings", "/_settings", "/{index}/_settings");
     put(map, "GET", "indices.get_settings", "/_settings", "/{index}/_settings");
-    put(map, "GET", "indices.get_alias", "/_alias", "/{index}/_alias", "/{index}/_alias/{name}");
+    put(
+        map,
+        "GET",
+        "indices.get_alias",
+        "/_alias",
+        "/_alias/{name}",
+        "/{index}/_alias",
+        "/{index}/_alias/{name}");
     put(map, "PUT", "indices.put_alias", "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
     put(
         map,

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A focused route table mapping an OpenSearch REST request (HTTP method and path) to an operation
+ * name such as {@code index}, {@code search} or {@code cluster.health}, plus the path parameters
+ * that name identifies.
+ *
+ * <p>OpenSearch forked Elasticsearch 7.10, so the path templates match those the Elasticsearch
+ * instrumentation uses in {@code ElasticsearchEndpointMap}. Unlike Elasticsearch, an OpenSearch
+ * REST request carries no endpoint id, so the operation has to be derived from the raw path here.
+ * This table covers the common OpenSearch REST endpoints rather than every route; an unmatched
+ * request yields {@code null} and the caller falls back to the HTTP method.
+ *
+ * <p>Within each HTTP method the routes are ordered from most specific to most general, because the
+ * first matching route wins. This ordering is what lets {@code /{index}/_doc/{id}} be told apart
+ * from the two-level structural path {@code /{index}/_doc}.
+ */
+final class OpenSearchEndpointMap {
+
+  private static final String MASKED_VALUE = "?";
+
+  private static final Map<String, List<OpenSearchEndpointRoute>> ROUTES_BY_METHOD = buildRoutes();
+
+  @Nullable
+  static String getOperationName(String method, String endpoint) {
+    OpenSearchEndpointRoute route = findRoute(method, endpoint);
+    return route != null ? route.getOperationName() : null;
+  }
+
+  /**
+   * Masks the path parameters of the matching route, so {@code my-index/_doc/12345} becomes {@code
+   * my-index/_doc/?} while index names stay intact. Returns {@code null} when no route matches.
+   */
+  @Nullable
+  static String maskPathParameters(String method, String endpoint) {
+    int queryIdx = endpoint.indexOf('?');
+    String rawPath = queryIdx >= 0 ? endpoint.substring(0, queryIdx) : endpoint;
+    String query = queryIdx >= 0 ? endpoint.substring(queryIdx) : "";
+    boolean hadLeadingSlash = rawPath.startsWith("/");
+    String normalizedPath = hadLeadingSlash ? rawPath : "/" + rawPath;
+
+    OpenSearchEndpointRoute route = findRoute(method, normalizedPath);
+    if (route == null) {
+      return null;
+    }
+    String maskedPath = route.maskPathParameters(normalizedPath, MASKED_VALUE);
+    if (maskedPath == null) {
+      return null;
+    }
+    if (!hadLeadingSlash) {
+      maskedPath = maskedPath.substring(1);
+    }
+    return maskedPath + query;
+  }
+
+  @Nullable
+  private static OpenSearchEndpointRoute findRoute(String method, String endpoint) {
+    List<OpenSearchEndpointRoute> routes = ROUTES_BY_METHOD.get(method);
+    if (routes == null) {
+      return null;
+    }
+    String path = pathOnly(endpoint);
+    for (OpenSearchEndpointRoute route : routes) {
+      if (route.matches(path)) {
+        return route;
+      }
+    }
+    return null;
+  }
+
+  private static String pathOnly(String endpoint) {
+    int queryIdx = endpoint.indexOf('?');
+    String path = queryIdx >= 0 ? endpoint.substring(0, queryIdx) : endpoint;
+    if (!path.startsWith("/")) {
+      path = "/" + path;
+    }
+    return path;
+  }
+
+  private static Map<String, List<OpenSearchEndpointRoute>> buildRoutes() {
+    Map<String, List<OpenSearchEndpointRoute>> map = new HashMap<>();
+
+    // single-document routes
+    put(map, "PUT", "create", "/{index}/_create/{id}");
+    put(map, "POST", "create", "/{index}/_create/{id}");
+    put(map, "PUT", "index", "/{index}/_doc/{id}");
+    put(map, "POST", "index", "/{index}/_doc");
+    put(map, "POST", "update", "/{index}/_update/{id}");
+    put(map, "DELETE", "delete", "/{index}/_doc/{id}");
+    put(map, "GET", "get", "/{index}/_doc/{id}");
+    put(map, "HEAD", "exists", "/{index}/_doc/{id}");
+    put(map, "GET", "get_source", "/{index}/_source/{id}");
+    put(map, "HEAD", "exists_source", "/{index}/_source/{id}");
+    put(map, "GET", "explain", "/{index}/_explain/{id}");
+    put(map, "POST", "explain", "/{index}/_explain/{id}");
+    put(map, "GET", "termvectors", "/{index}/_termvectors/{id}");
+    put(map, "POST", "termvectors", "/{index}/_termvectors/{id}", "/{index}/_termvectors");
+
+    // bulk and multi-document routes
+    put(map, "POST", "bulk", "/_bulk", "/{index}/_bulk");
+    put(map, "PUT", "bulk", "/_bulk", "/{index}/_bulk");
+    put(map, "GET", "mget", "/_mget", "/{index}/_mget");
+    put(map, "POST", "mget", "/_mget", "/{index}/_mget");
+    put(map, "GET", "msearch", "/_msearch", "/{index}/_msearch");
+    put(map, "POST", "msearch", "/_msearch", "/{index}/_msearch");
+
+    // search and count
+    put(map, "GET", "search", "/_search", "/{index}/_search");
+    put(map, "POST", "search", "/_search", "/{index}/_search");
+    put(map, "GET", "count", "/_count", "/{index}/_count");
+    put(map, "POST", "count", "/_count", "/{index}/_count");
+    put(map, "POST", "search.scroll", "/_search/scroll");
+    put(map, "DELETE", "clear_scroll", "/_search/scroll");
+    put(map, "GET", "field_caps", "/_field_caps", "/{index}/_field_caps");
+    put(map, "POST", "field_caps", "/_field_caps", "/{index}/_field_caps");
+
+    // index management
+    put(map, "PUT", "indices.create", "/{index}");
+    put(map, "DELETE", "indices.delete", "/{index}");
+    put(map, "GET", "indices.get", "/{index}");
+    put(map, "HEAD", "indices.exists", "/{index}");
+    put(map, "POST", "indices.refresh", "/_refresh", "/{index}/_refresh");
+    put(map, "GET", "indices.refresh", "/_refresh", "/{index}/_refresh");
+    put(map, "POST", "indices.flush", "/_flush", "/{index}/_flush");
+    put(map, "POST", "indices.open", "/{index}/_open");
+    put(map, "POST", "indices.close", "/{index}/_close");
+
+    // mapping, settings and alias management
+    put(map, "PUT", "indices.put_mapping", "/{index}/_mapping");
+    put(map, "GET", "indices.get_mapping", "/_mapping", "/{index}/_mapping");
+    put(map, "PUT", "indices.put_settings", "/_settings", "/{index}/_settings");
+    put(map, "GET", "indices.get_settings", "/_settings", "/{index}/_settings");
+    put(map, "GET", "indices.get_alias", "/_alias", "/{index}/_alias", "/{index}/_alias/{name}");
+    put(map, "PUT", "indices.put_alias", "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
+    put(
+        map,
+        "DELETE",
+        "indices.delete_alias",
+        "/{index}/_alias/{name}",
+        "/{index}/_aliases/{name}");
+    put(map, "POST", "indices.update_aliases", "/_aliases");
+    put(map, "POST", "indices.analyze", "/_analyze", "/{index}/_analyze");
+
+    // cluster and node health
+    put(map, "GET", "cluster.health", "/_cluster/health", "/_cluster/health/{index}");
+    put(map, "GET", "cluster.state", "/_cluster/state");
+    put(map, "GET", "cluster.stats", "/_cluster/stats");
+    put(map, "GET", "cluster.get_settings", "/_cluster/settings");
+    put(map, "PUT", "cluster.put_settings", "/_cluster/settings");
+    put(map, "GET", "nodes.info", "/_nodes", "/_nodes/{node_id}");
+    put(map, "GET", "nodes.stats", "/_nodes/stats", "/_nodes/{node_id}/stats");
+
+    // cat API
+    put(map, "GET", "cat.indices", "/_cat/indices", "/_cat/indices/{index}");
+    put(map, "GET", "cat.health", "/_cat/health");
+    put(map, "GET", "cat.nodes", "/_cat/nodes");
+    put(map, "GET", "cat.shards", "/_cat/shards", "/_cat/shards/{index}");
+    put(map, "GET", "cat.aliases", "/_cat/aliases", "/_cat/aliases/{name}");
+
+    // top-level info and ping
+    put(map, "GET", "info", "/");
+    put(map, "HEAD", "ping", "/");
+
+    // legacy typed document routes (/{index}/{type}/{id}); listed last so keyword routes such as
+    // /{index}/_doc/{id} match first. The type is treated as endpoint structure, the id is masked.
+    put(map, "PUT", "index", "/{index}/{type}/{id}");
+    put(map, "POST", "index", "/{index}/{type}/{id}", "/{index}/{type}");
+    put(map, "GET", "get", "/{index}/{type}/{id}");
+    put(map, "DELETE", "delete", "/{index}/{type}/{id}");
+    put(map, "HEAD", "exists", "/{index}/{type}/{id}");
+
+    for (Map.Entry<String, List<OpenSearchEndpointRoute>> entry : map.entrySet()) {
+      entry.setValue(Collections.unmodifiableList(entry.getValue()));
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  private static void put(
+      Map<String, List<OpenSearchEndpointRoute>> map,
+      String method,
+      String operationName,
+      String... templates) {
+    List<OpenSearchEndpointRoute> routes = map.computeIfAbsent(method, unused -> new ArrayList<>());
+    for (String template : templates) {
+      routes.add(new OpenSearchEndpointRoute(operationName, template));
+    }
+  }
+
+  private OpenSearchEndpointMap() {}
+}

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointMap.java
@@ -157,6 +157,7 @@ final class OpenSearchEndpointMap {
         "/{index}/_alias",
         "/{index}/_alias/{name}");
     put(map, "PUT", "indices.put_alias", "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
+    put(map, "POST", "indices.put_alias", "/{index}/_alias/{name}", "/{index}/_aliases/{name}");
     put(
         map,
         "DELETE",

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -28,12 +28,14 @@ final class OpenSearchEndpointRoute {
   private static final Pattern PATH_PART_NAMES_PATTERN = Pattern.compile("\\{([^}]+)}");
 
   private final String operationName;
+  private final String template;
   private final Pattern pattern;
   private final List<String> pathPartNames;
   private final Set<String> structuralGroups;
 
   OpenSearchEndpointRoute(String operationName, String template) {
     this.operationName = operationName;
+    this.template = template;
     this.pattern = buildRegexPattern(template);
     this.pathPartNames = new ArrayList<>();
     this.structuralGroups = new HashSet<>();
@@ -50,6 +52,18 @@ final class OpenSearchEndpointRoute {
 
   String getOperationName() {
     return operationName;
+  }
+
+  String getTemplate() {
+    return template;
+  }
+
+  List<String> getPathPartNames() {
+    return pathPartNames;
+  }
+
+  boolean isStructuralGroup(String groupName) {
+    return structuralGroups.contains(groupName);
   }
 
   boolean matches(String path) {

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -26,6 +26,10 @@ final class OpenSearchEndpointRoute {
 
   private static final String UNDERSCORE_REPLACEMENT = "0";
   private static final Pattern PATH_PART_NAMES_PATTERN = Pattern.compile("\\{([^}]+)}");
+  private static final String NODE_INFO_METRIC =
+      "(?:settings|os|process|jvm|thread_pool|transport|http|plugins|ingest)";
+  private static final String NODE_INFO_METRIC_PATTERN =
+      NODE_INFO_METRIC + "(?:," + NODE_INFO_METRIC + ")*";
 
   private final String operationName;
   private final String template;
@@ -115,7 +119,7 @@ final class OpenSearchEndpointRoute {
       // parameter must not match a reserved path segment such as `_search` or `_doc`. This keeps a
       // generic template like /{index}/{type}/{id} from swallowing a keyword route such as
       // /{index}/_doc/{id}.
-      regex.append(isIndexOrType(groupName) ? ">[^_/][^/]*)" : ">[^/]+)");
+      regex.append('>').append(parameterPattern(groupName)).append(')');
 
       template = template.substring(endIndex + 1);
       startIdx = template.indexOf('{');
@@ -127,11 +131,19 @@ final class OpenSearchEndpointRoute {
     return Pattern.compile(regex.toString());
   }
 
+  private static String parameterPattern(String groupName) {
+    if ("node_info_metric".equals(groupName)) {
+      return NODE_INFO_METRIC_PATTERN;
+    }
+    return isIndexOrType(groupName) ? "[^_/][^/]*" : "[^/]+";
+  }
+
   private static boolean isStructural(String groupName) {
     return "index".equals(groupName)
         || "type".equals(groupName)
         || "metric".equals(groupName)
-        || "index_metric".equals(groupName);
+        || "index_metric".equals(groupName)
+        || "node_info_metric".equals(groupName);
   }
 
   private static boolean isIndexOrType(String groupName) {

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -27,7 +27,7 @@ final class OpenSearchEndpointRoute {
   private static final String UNDERSCORE_REPLACEMENT = "0";
   private static final Pattern PATH_PART_NAMES_PATTERN = Pattern.compile("\\{([^}]+)}");
   private static final String NODE_INFO_METRIC =
-      "(?:settings|os|process|jvm|thread_pool|transport|http|plugins|ingest)";
+      "(?:settings|os|process|jvm|thread_pool|transport|http|plugins|ingest|aggregations|indices)";
   private static final String NODE_INFO_METRIC_PATTERN =
       NODE_INFO_METRIC + "(?:," + NODE_INFO_METRIC + ")*";
 

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -85,7 +85,7 @@ final class OpenSearchEndpointRoute {
     for (int i = pathPartNames.size() - 1; i >= 0; i--) {
       String group = pathPartNames.get(i);
       if (structuralGroups.contains(group)) {
-        // index names and legacy mapping types are endpoint structure, not customer identifiers
+        // Preserve endpoint structure such as index names, mapping types, and metric selectors.
         continue;
       }
       result.replace(matcher.start(group), matcher.end(group), maskedValue);
@@ -115,7 +115,7 @@ final class OpenSearchEndpointRoute {
       // parameter must not match a reserved path segment such as `_search` or `_doc`. This keeps a
       // generic template like /{index}/{type}/{id} from swallowing a keyword route such as
       // /{index}/_doc/{id}.
-      regex.append(isStructural(groupName) ? ">[^_/][^/]*)" : ">[^/]+)");
+      regex.append(isIndexOrType(groupName) ? ">[^_/][^/]*)" : ">[^/]+)");
 
       template = template.substring(endIndex + 1);
       startIdx = template.indexOf('{');
@@ -128,6 +128,13 @@ final class OpenSearchEndpointRoute {
   }
 
   private static boolean isStructural(String groupName) {
+    return "index".equals(groupName)
+        || "type".equals(groupName)
+        || "metric".equals(groupName)
+        || "index_metric".equals(groupName);
+  }
+
+  private static boolean isIndexOrType(String groupName) {
     return "index".equals(groupName) || "type".equals(groupName);
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -115,10 +115,9 @@ final class OpenSearchEndpointRoute {
       String groupName = template.substring(startIdx + 1, endIndex);
       regex.append("(?<");
       regex.append(groupName.replace("_", UNDERSCORE_REPLACEMENT));
-      // An index name or a legacy mapping type cannot begin with `_`, so an {index} or {type}
-      // parameter must not match a reserved path segment such as `_search` or `_doc`. This keeps a
-      // generic template like /{index}/{type}/{id} from swallowing a keyword route such as
-      // /{index}/_doc/{id}.
+      // An index name or a legacy mapping type cannot begin with `_`, except for the `_all` index
+      // expression. Rejecting other reserved segments keeps a generic template like
+      // /{index}/{type}/{id} from swallowing a keyword route such as /{index}/_doc/{id}.
       regex.append('>').append(parameterPattern(groupName)).append(')');
 
       template = template.substring(endIndex + 1);
@@ -135,7 +134,10 @@ final class OpenSearchEndpointRoute {
     if ("node_info_metric".equals(groupName)) {
       return NODE_INFO_METRIC_PATTERN;
     }
-    return isIndexOrType(groupName) ? "[^_/][^/]*" : "[^/]+";
+    if ("index".equals(groupName)) {
+      return "(?:_all|[^_/][^/]*)";
+    }
+    return "type".equals(groupName) ? "[^_/][^/]*" : "[^/]+";
   }
 
   private static boolean isStructural(String groupName) {
@@ -144,9 +146,5 @@ final class OpenSearchEndpointRoute {
         || "metric".equals(groupName)
         || "index_metric".equals(groupName)
         || "node_info_metric".equals(groupName);
-  }
-
-  private static boolean isIndexOrType(String groupName) {
-    return "index".equals(groupName) || "type".equals(groupName);
   }
 }

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointRoute.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A single OpenSearch REST route. It pairs an operation name (such as {@code index} or {@code
+ * search}) with a parameterized path template (such as {@code /{index}/_doc/{id}}) and compiles the
+ * template into a regular expression with named capture groups for the path parameters.
+ *
+ * <p>Modeled on {@code ElasticsearchEndpointDefinition.Route} and its {@code EndpointPattern} in
+ * the Elasticsearch instrumentation, but kept entirely inside the OpenSearch module so it carries
+ * no cross-family dependency. Underscores in a capture group name are replaced with {@code 0} while
+ * building the regex, because a Java named capture group disallows underscores.
+ */
+final class OpenSearchEndpointRoute {
+
+  private static final String UNDERSCORE_REPLACEMENT = "0";
+  private static final Pattern PATH_PART_NAMES_PATTERN = Pattern.compile("\\{([^}]+)}");
+
+  private final String operationName;
+  private final Pattern pattern;
+  private final List<String> pathPartNames;
+  private final Set<String> structuralGroups;
+
+  OpenSearchEndpointRoute(String operationName, String template) {
+    this.operationName = operationName;
+    this.pattern = buildRegexPattern(template);
+    this.pathPartNames = new ArrayList<>();
+    this.structuralGroups = new HashSet<>();
+    Matcher matcher = PATH_PART_NAMES_PATTERN.matcher(template);
+    while (matcher.find()) {
+      String name = matcher.group(1);
+      String groupName = name.replace("_", UNDERSCORE_REPLACEMENT);
+      pathPartNames.add(groupName);
+      if (isStructural(name)) {
+        structuralGroups.add(groupName);
+      }
+    }
+  }
+
+  String getOperationName() {
+    return operationName;
+  }
+
+  boolean matches(String path) {
+    return pattern.matcher(path).matches();
+  }
+
+  /**
+   * Rebuilds the path with every path parameter segment replaced by {@code maskedValue}, keeping
+   * the endpoint structure (index names and API keywords) intact. Returns {@code null} when the
+   * path does not match this route.
+   */
+  String maskPathParameters(String path, String maskedValue) {
+    Matcher matcher = pattern.matcher(path);
+    if (!matcher.matches()) {
+      return null;
+    }
+    StringBuilder result = new StringBuilder(path);
+    // rewrite from the end so earlier group offsets stay valid
+    for (int i = pathPartNames.size() - 1; i >= 0; i--) {
+      String group = pathPartNames.get(i);
+      if (structuralGroups.contains(group)) {
+        // index names and legacy mapping types are endpoint structure, not customer identifiers
+        continue;
+      }
+      result.replace(matcher.start(group), matcher.end(group), maskedValue);
+    }
+    return result.toString();
+  }
+
+  /** Builds a regex pattern from the parameterized route template. */
+  private static Pattern buildRegexPattern(String template) {
+    StringBuilder regex = new StringBuilder();
+    regex.append('^');
+    int startIdx = template.indexOf('{');
+    while (startIdx >= 0) {
+      regex.append(template, 0, startIdx);
+
+      int endIndex = template.indexOf('}');
+      if (endIndex <= startIdx + 1) {
+        break;
+      }
+
+      // Append a named capture group. An underscore in the group name is replaced with `0`,
+      // because `_` is not allowed in a Java named capture group.
+      String groupName = template.substring(startIdx + 1, endIndex);
+      regex.append("(?<");
+      regex.append(groupName.replace("_", UNDERSCORE_REPLACEMENT));
+      // An index name or a legacy mapping type cannot begin with `_`, so an {index} or {type}
+      // parameter must not match a reserved path segment such as `_search` or `_doc`. This keeps a
+      // generic template like /{index}/{type}/{id} from swallowing a keyword route such as
+      // /{index}/_doc/{id}.
+      regex.append(isStructural(groupName) ? ">[^_/][^/]*)" : ">[^/]+)");
+
+      template = template.substring(endIndex + 1);
+      startIdx = template.indexOf('{');
+    }
+
+    regex.append(template);
+    regex.append('$');
+
+    return Pattern.compile(regex.toString());
+  }
+
+  private static boolean isStructural(String groupName) {
+    return "index".equals(groupName) || "type".equals(groupName);
+  }
+}

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
@@ -75,7 +75,12 @@ final class OpenSearchEndpointSanitizer {
     return result.toString();
   }
 
-  private static String sanitizeByKeyword(String endpoint) {
+  /**
+   * Fallback for paths the route table does not match. Package-private so {@link
+   * OpenSearchEndpointSanitizerTest} can pin the keyword contract directly, without depending on
+   * which paths happen to be absent from the route table.
+   */
+  static String sanitizeByKeyword(String endpoint) {
     String[] segments = endpoint.split("/", -1);
     String previous = null;
     for (int i = 0; i < segments.length; i++) {

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
@@ -37,11 +37,42 @@ final class OpenSearchEndpointSanitizer {
       new HashSet<>(asList("_doc", "_create", "_update", "_source", "_explain", "_termvectors"));
 
   static String sanitize(String method, String endpoint) {
-    String masked = OpenSearchEndpointMap.maskPathParameters(method, endpoint);
-    if (masked != null) {
-      return masked;
+    int queryIdx = endpoint.indexOf('?');
+    String path = queryIdx >= 0 ? endpoint.substring(0, queryIdx) : endpoint;
+    String query = queryIdx >= 0 ? endpoint.substring(queryIdx) : "";
+
+    String maskedPath = OpenSearchEndpointMap.maskPathParameters(method, path);
+    if (maskedPath == null) {
+      maskedPath = sanitizeByKeyword(path);
     }
-    return sanitizeByKeyword(endpoint);
+    return maskedPath + maskQueryValues(query);
+  }
+
+  /**
+   * Masks the value of every query parameter while keeping the parameter names, so {@code
+   * ?routing=abc&refresh=true} becomes {@code ?routing=?&refresh=?}. A query parameter value is
+   * customer-controlled just like a path id, so it must not appear in {@code db.query.text}.
+   */
+  private static String maskQueryValues(String query) {
+    if (query.isEmpty()) {
+      return query;
+    }
+    // query starts with '?'; keep it, then mask each name=value value
+    String[] params = query.substring(1).split("&", -1);
+    StringBuilder result = new StringBuilder("?");
+    for (int i = 0; i < params.length; i++) {
+      if (i > 0) {
+        result.append('&');
+      }
+      String param = params[i];
+      int eq = param.indexOf('=');
+      if (eq >= 0) {
+        result.append(param, 0, eq + 1).append(MASKED_VALUE);
+      } else {
+        result.append(param);
+      }
+    }
+    return result.toString();
   }
 
   private static String sanitizeByKeyword(String endpoint) {

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchEndpointSanitizer.java
@@ -16,15 +16,15 @@ import java.util.Set;
  * becomes {@code /my-index/_doc/?}.
  *
  * <p>This is the single seam for endpoint sanitization: {@link
- * OpenSearchRestAttributesGetter#getDbQueryText} is the only caller. It intentionally works from
- * the raw path string alone, because {@link OpenSearchRestRequest} carries no endpoint metadata. A
- * route-based replacement (a parameterized route table that masks exactly the path parameters) can
- * swap this implementation without touching the getter.
+ * OpenSearchRestAttributesGetter#getDbQueryText} is the only caller. It masks exactly the path
+ * parameters of the route that matches the request, using the same {@link OpenSearchEndpointMap}
+ * route table that derives the operation name. Legacy typed document routes such as {@code
+ * /{index}/{type}/{id}} are matched too, so their id is masked while the index and type stay as
+ * structure.
  *
- * <p>Masking is conservative: only the segment immediately following a known single-document
- * identifier keyword is masked. Identifier-bearing routes that carry no such keyword, such as the
- * legacy typed {@code /{index}/{type}/{id}} document route, are left intact to avoid masking
- * segments that are really endpoint structure.
+ * <p>When no route matches, masking falls back to the conservative keyword rule: only the segment
+ * immediately following a known single-document identifier keyword is masked, so an unknown path
+ * never has structural segments masked by mistake.
  */
 final class OpenSearchEndpointSanitizer {
 
@@ -32,11 +32,19 @@ final class OpenSearchEndpointSanitizer {
 
   // Path segments that are immediately followed by a single-document identifier, e.g.
   // /{index}/_doc/{id} or /{index}/_update/{id}. The following segment is customer-controlled, so
-  // it is masked.
+  // it is masked. Used only as a fallback when no route matches.
   private static final Set<String> idIntroducingSegments =
       new HashSet<>(asList("_doc", "_create", "_update", "_source", "_explain", "_termvectors"));
 
-  static String sanitize(String endpoint) {
+  static String sanitize(String method, String endpoint) {
+    String masked = OpenSearchEndpointMap.maskPathParameters(method, endpoint);
+    if (masked != null) {
+      return masked;
+    }
+    return sanitizeByKeyword(endpoint);
+  }
+
+  private static String sanitizeByKeyword(String endpoint) {
     String[] segments = endpoint.split("/", -1);
     String previous = null;
     for (int i = 0; i < segments.length; i++) {

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestAttributesGetter.java
@@ -36,14 +36,16 @@ final class OpenSearchRestAttributesGetter
   public String getDbQueryText(OpenSearchRestRequest request) {
     String endpoint = request.getEndpoint();
     if (querySanitizationEnabled) {
-      endpoint = OpenSearchEndpointSanitizer.sanitize(endpoint);
+      endpoint = OpenSearchEndpointSanitizer.sanitize(request.getMethod(), endpoint);
     }
     return request.getMethod() + " " + endpoint;
   }
 
   @Override
   public String getDbOperationName(OpenSearchRestRequest request) {
-    return request.getMethod();
+    String operationName =
+        OpenSearchEndpointMap.getOperationName(request.getMethod(), request.getEndpoint());
+    return operationName != null ? operationName : request.getMethod();
   }
 
   @Nullable

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/v1_0/OpenSearchRestAttributesGetter.java
@@ -48,6 +48,14 @@ final class OpenSearchRestAttributesGetter
     return operationName != null ? operationName : request.getMethod();
   }
 
+  @Override
+  @SuppressWarnings("deprecation") // old database semconv still use db.operation
+  public String getDbOperation(OpenSearchRestRequest request) {
+    // old semconv output is deliberately left unchanged: it still reports the HTTP method rather
+    // than the route-derived operation name
+    return request.getMethod();
+  }
+
   @Nullable
   @Override
   public String getErrorType(

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/AbstractOpenSearchRestTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/AbstractOpenSearchRestTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.rest.common;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
@@ -91,11 +92,13 @@ public abstract class AbstractOpenSearchRestTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("cluster.health")
+                        span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "cluster.health"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv() ? "cluster.health" : "GET"),
                                 equalTo(maybeStable(DB_STATEMENT), "GET _cluster/health")),
                     span ->
                         span.hasName("GET")
@@ -161,12 +164,14 @@ public abstract class AbstractOpenSearchRestTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("cluster.health")
+                        span.hasName(emitStableDatabaseSemconv() ? "cluster.health" : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "cluster.health"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv() ? "cluster.health" : "GET"),
                                 equalTo(maybeStable(DB_STATEMENT), "GET _cluster/health")),
                     span ->
                         span.hasName("GET")
@@ -211,11 +216,13 @@ public abstract class AbstractOpenSearchRestTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("index")
+                        span.hasName(emitStableDatabaseSemconv() ? "index" : "PUT")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "index"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    emitStableDatabaseSemconv() ? "index" : "PUT"),
                                 equalTo(maybeStable(DB_STATEMENT), expectedStatement)),
                     span ->
                         span.hasName("PUT")

--- a/instrumentation/opensearch/opensearch-rest-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/AbstractOpenSearchRestTest.java
+++ b/instrumentation/opensearch/opensearch-rest-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/rest/common/AbstractOpenSearchRestTest.java
@@ -91,11 +91,11 @@ public abstract class AbstractOpenSearchRestTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("GET")
+                        span.hasName("cluster.health")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_OPERATION), "cluster.health"),
                                 equalTo(maybeStable(DB_STATEMENT), "GET _cluster/health")),
                     span ->
                         span.hasName("GET")
@@ -161,12 +161,12 @@ public abstract class AbstractOpenSearchRestTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("GET")
+                        span.hasName("cluster.health")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_OPERATION), "cluster.health"),
                                 equalTo(maybeStable(DB_STATEMENT), "GET _cluster/health")),
                     span ->
                         span.hasName("GET")
@@ -211,11 +211,11 @@ public abstract class AbstractOpenSearchRestTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("PUT")
+                        span.hasName("index")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "PUT"),
+                                equalTo(maybeStable(DB_OPERATION), "index"),
                                 equalTo(maybeStable(DB_STATEMENT), expectedStatement)),
                     span ->
                         span.hasName("PUT")


### PR DESCRIPTION
`db.operation.name` for OpenSearch REST requests was the bare HTTP method, so every request reported `PUT`, `GET` or `POST` regardless of what it did. Under the stable database semantic conventions this attribute is meant to name the operation, not the transport verb, and `PUT` tells an operator nothing about whether a request created a document, updated a mapping or opened an index. This derives a real operation name from the request path.  `OpenSearchRestRequest` carries only the HTTP method and the raw path, with no endpoint metadata, so the name has to come from the path. This adds a small route table to the `opensearch-rest-common-1.0` javaagent module that matches a method and path template against the request and returns a name such as `index`, `search` or `cluster.health`. It is modeled on the Elasticsearch `ElasticsearchEndpointDefinition` matcher but lives entirely in the OpenSearch module, so there is no cross-family dependency. OpenSearch forked Elasticsearch 7.10, so the path templates match. When no route matches, the getter falls back to the HTTP method, so nothing regresses.  Within a method the routes are ordered from most specific to most general, and the first match wins, so this ordering is load-bearing. For example `/_nodes/stats` must stay registered ahead of `/_nodes/{node_id}`, because `{node_id}` is not a structural segment and would otherwise match `stats` and report `nodes.info`. Do not sort the table alphabetically.  This changes only the stable conventions. The old `db.operation` attribute and the old span name are deliberately left unchanged and still report the HTTP method, so `GET _cluster/health` keeps `db.operation=GET` and the span name `GET` under old semconv, while stable semconv gets `db.operation.name=cluster.health` and the span name `cluster.health`. Only the stable output moves.  Concretely, under stable semconv, for `GET _cluster/health` the operation name changes from `GET` to `cluster.health`, and for `PUT test-index/_doc/12345` it changes from `PUT` to `index`.  This is a metric change, not only a span attribute change. `db.operation.name` is one of the ten dimensions `DbClientMetricsAdvice` declares for the `db.client.operation.duration` histogram, alongside `db.system.name`, `db.collection.name`, `db.namespace`, `db.query.summary`, `error.type`, `network.peer.address`, `network.peer.port`, `server.address` and `server.port`. So existing time series that were split by `PUT`/`GET`/`POST` are now split by the operation name, and the old series stop and new ones begin.  The span name changes with it. On the generic database path `DbClientSpanNameExtractor` uses the query summary first, which OpenSearch does not implement, and then the operation name, so the stable span for `GET _cluster/health` is now named `cluster.health` rather than `GET`.  The same route table also masks `db.query.text`. #19671 masked only the segment after a known single-document keyword and deliberately left the legacy typed `/{index}/{type}/{id}` document route unmasked, because without a route table that route cannot be told apart from a real two-level path. With the route table the path parameters are known, so `OpenSearchEndpointSanitizer.sanitize` now masks exactly them and keeps index names as structure. Its seam is unchanged: `getDbQueryText` still calls `sanitize`, and only its internals changed. A path that matches no route still falls back to the previous keyword rule.  `db.query.text` now masks query parameter values too, keeping the parameter names, so `_search/scroll?scroll_id=DXF1ZXJ5...` becomes `_search/scroll?scroll_id=?` and `my-index/_doc/12345?routing=abc` becomes `my-index/_doc/??routing=?`. A query parameter value such as `routing` or `scroll_id` is customer-controlled like a path id, and #19671 blanked the whole trailing segment of a document route including its query string, so re-appending the query verbatim would have exposed a value it had removed. Both the route-based path and the keyword fallback go through the same query masking, so the two masking layers agree, and the path and query spellings of an id-bearing operation such as scroll now mask consistently. This masking applies to both the stable and the old query text, since #19671 already accepted that sanitization changes old output. 

This replaces #19674, which was closed and cannot be reopened because its branch was force-pushed. The commits are the same work, rebased onto the current head of the base branch.