### PR TITLE
Fix duplicate MessageListener wrapping in Pulsar instrumentation

### DIFF
--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/MessageListenerInstrumentation.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/MessageListenerInstrumentation.java
@@ -49,7 +49,10 @@ class MessageListenerInstrumentation implements TypeInstrumentation {
     public static MessageListener<?> after(
         @Advice.This ConsumerConfigurationData<?> data,
         @Advice.Return(typing = Assigner.Typing.DYNAMIC) MessageListener<?> listener) {
-      return listener == null ? null : new MessageListenerWrapper<>(listener);
+      if (listener == null || listener instanceof MessageListenerWrapper) {
+        return listener;
+      }
+      return new MessageListenerWrapper<>(listener);
     }
   }
 

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -1261,6 +1261,7 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     conf.setMessageListener(originalListener);
 
     MessageListener<String> wrapped1 = conf.getMessageListener();
+    conf.setMessageListener(wrapped1);
     MessageListener<String> wrapped2 = conf.getMessageListener();
 
     assertThat(wrapped1).isInstanceOf(MessageListenerInstrumentation.MessageListenerWrapper.class);

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -1252,4 +1252,18 @@ class PulsarClientTest extends AbstractPulsarClientTest {
                         .hasKind(SpanKind.PRODUCER)
                         .hasParent(trace.getSpan(0))));
   }
+
+  @Test
+  void testMessageListenerNotWrappedMultipleTimes() {
+    org.apache.pulsar.client.impl.conf.ConsumerConfigurationData<String> conf =
+        new org.apache.pulsar.client.impl.conf.ConsumerConfigurationData<>();
+    MessageListener<String> originalListener = (consumer, msg) -> {};
+    conf.setMessageListener(originalListener);
+
+    MessageListener<String> wrapped1 = conf.getMessageListener();
+    MessageListener<String> wrapped2 = conf.getMessageListener();
+
+    assertThat(wrapped1).isInstanceOf(MessageListenerInstrumentation.MessageListenerWrapper.class);
+    assertThat(wrapped2).isSameAs(wrapped1);
+  }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -1264,7 +1264,12 @@ class PulsarClientTest extends AbstractPulsarClientTest {
     conf.setMessageListener(wrapped1);
     MessageListener<String> wrapped2 = conf.getMessageListener();
 
-    assertThat(wrapped1).isInstanceOf(MessageListenerInstrumentation.MessageListenerWrapper.class);
+    // MessageListenerInstrumentation.MessageListenerWrapper is a javaagent helper class isolated
+    // from this test's classloader, so it can't be referenced directly (.class would throw
+    // NoClassDefFoundError); compare by name instead.
+    assertThat(wrapped1.getClass().getName())
+        .isEqualTo(
+            "io.opentelemetry.javaagent.instrumentation.pulsar.v2_8.MessageListenerInstrumentation$MessageListenerWrapper");
     assertThat(wrapped2).isSameAs(wrapped1);
   }
 }

--- a/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
+++ b/instrumentation/pulsar/pulsar-2.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pulsar/v2_8/PulsarClientTest.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.junit.jupiter.api.Test;
 
 class PulsarClientTest extends AbstractPulsarClientTest {
@@ -1255,8 +1256,7 @@ class PulsarClientTest extends AbstractPulsarClientTest {
 
   @Test
   void testMessageListenerNotWrappedMultipleTimes() {
-    org.apache.pulsar.client.impl.conf.ConsumerConfigurationData<String> conf =
-        new org.apache.pulsar.client.impl.conf.ConsumerConfigurationData<>();
+    ConsumerConfigurationData<String> conf = new ConsumerConfigurationData<>();
     MessageListener<String> originalListener = (consumer, msg) -> {};
     conf.setMessageListener(originalListener);
 


### PR DESCRIPTION
Stops Pulsar consumers from reporting duplicate nested `process` spans for one message.

`MessageListenerInstrumentation` wraps whatever `ConsumerConfigurationData.getMessageListener()` returns. It now skips a listener that is already a `MessageListenerWrapper`.

The double wrap only happens when something writes the getter's result back into the configuration. Spring for Apache Pulsar does, in `ConsumerBuilderConfigurationUtil`, to restore the `@JsonIgnore` fields that `ConsumerBuilder.loadConf` nulls out:

1. Spring reads the listener. The advice returns a wrapper.
2. Spring sets that wrapper back on the builder, which stores it in the configuration.
3. Pulsar reads the listener to dispatch a message. The advice wraps the wrapper.

Plain Pulsar usage never reaches step 2, so the configuration keeps the original listener and each read wraps it once.

Fixes #19698
