### PR TITLE
Honor query sanitization configuration in influxdb-2.4

### DIFF
--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -74,7 +74,6 @@ tasks {
     filter {
       includeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
     }
-    include("**/InfluxDbQuerySanitizationDisabledTest.*")
     systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false")
     jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
   }
@@ -86,7 +85,6 @@ tasks {
     filter {
       includeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
     }
-    include("**/InfluxDbQuerySanitizationDisabledTest.*")
     systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false")
     jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
     jvmArgs("-Dotel.semconv-stability.opt-in=database")

--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -78,6 +78,18 @@ tasks {
     jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
   }
 
+  val testQuerySanitizationEnabledOverride = register<Test>("testQuerySanitizationEnabledOverride") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("InfluxDbClientTest.testQueryWithTwoArguments")
+    }
+    systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false,otel.instrumentation.influxdb.query-sanitization.enabled=true")
+    jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
+    jvmArgs("-Dotel.instrumentation.influxdb.query-sanitization.enabled=true")
+  }
+
   val testQuerySanitizationDisabledStableSemconv = register<Test>("testQuerySanitizationDisabledStableSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -91,6 +103,6 @@ tasks {
   }
 
   check {
-    dependsOn(testStableSemconv, testQuerySanitizationDisabled, testQuerySanitizationDisabledStableSemconv)
+    dependsOn(testStableSemconv, testQuerySanitizationDisabled, testQuerySanitizationDisabledStableSemconv, testQuerySanitizationEnabledOverride)
   }
 }

--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -50,15 +50,49 @@ tasks {
     }
   }
 
+  test {
+    filter {
+      excludeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
+    }
+  }
+
   val testStableSemconv = register<Test>("testStableSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
 
+    filter {
+      excludeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
+    }
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database")
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
+  val testQuerySanitizationDisabled = register<Test>("testQuerySanitizationDisabled") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
+    }
+    include("**/InfluxDbQuerySanitizationDisabledTest.*")
+    systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
+  }
+
+  val testQuerySanitizationDisabledStableSemconv = register<Test>("testQuerySanitizationDisabledStableSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
+    }
+    include("**/InfluxDbQuerySanitizationDisabledTest.*")
+    systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false")
+    jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
   check {
-    dependsOn(testStableSemconv)
+    dependsOn(testStableSemconv, testQuerySanitizationDisabled, testQuerySanitizationDisabledStableSemconv)
   }
 }

--- a/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
+++ b/instrumentation/influxdb-2.4/javaagent/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
     filter {
       includeTestsMatching("InfluxDbQuerySanitizationDisabledTest")
     }
-    systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false")
+    systemProperty("metadataConfig", "otel.instrumentation.common.db.query-sanitization.enabled=false,otel.semconv-stability.opt-in=database")
     jvmArgs("-Dotel.instrumentation.common.db.query-sanitization.enabled=false")
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }

--- a/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbSingletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.influxdb.v2_4;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
@@ -35,6 +36,8 @@ public class InfluxDbSingletons {
             .addAttributesExtractor(
                 SqlClientAttributesExtractor.builder(queryAttributesGetter)
                     .setTableAttribute(null)
+                    .setQuerySanitizationEnabled(
+                        DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "influxdb"))
                     .build())
             .addOperationMetrics(DbClientMetrics.get());
     setDbClientExceptionEventExtractor(queryBuilder);

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbQuerySanitizationDisabledTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbQuerySanitizationDisabledTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
 
-// ignore using deprecated createDatabase and deleteDatabase methods warning.
+// using deprecated InfluxDB and semconv APIs
 @SuppressWarnings("deprecation")
 @TestInstance(Lifecycle.PER_CLASS)
 class InfluxDbQuerySanitizationDisabledTest {

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbQuerySanitizationDisabledTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbQuerySanitizationDisabledTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.influxdb.v2_4;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_QUERY_SUMMARY;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.INFLUXDB;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.Query;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.GenericContainer;
+
+// ignore using deprecated createDatabase and deleteDatabase methods warning.
+@SuppressWarnings("deprecation")
+@TestInstance(Lifecycle.PER_CLASS)
+class InfluxDbQuerySanitizationDisabledTest {
+
+  @RegisterExtension
+  private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @RegisterExtension
+  private static final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  private static final GenericContainer<?> influxDbServer =
+      new GenericContainer<>("influxdb:1.8.10-alpine").withExposedPorts(8086);
+
+  private static InfluxDB influxDb;
+
+  private static final String DATABASE_NAME = "mydb";
+
+  private static String host;
+
+  private static int port;
+
+  @BeforeAll
+  void setup() {
+    cleanup.deferAfterAll(influxDbServer::stop);
+    influxDbServer.start();
+    port = influxDbServer.getMappedPort(8086);
+    host = influxDbServer.getHost();
+    String serverUrl = "http://" + host + ":" + port + "/";
+    influxDb = InfluxDBFactory.connect(serverUrl, "root", "root");
+    cleanup.deferAfterAll(influxDb);
+    influxDb.createDatabase(DATABASE_NAME);
+    cleanup.deferAfterAll(() -> influxDb.deleteDatabase(DATABASE_NAME));
+  }
+
+  @Test
+  void testQueryIsNotSanitized() {
+    Query query = new Query("SELECT * FROM cpu_load where test1 = 'influxDb'", DATABASE_NAME);
+    influxDb.query(query, MILLISECONDS);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT cpu_load"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), INFLUXDB),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                "SELECT * FROM cpu_load where test1 = 'influxDb'"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "SELECT cpu_load" : null))));
+  }
+}

--- a/instrumentation/influxdb-2.4/metadata.yaml
+++ b/instrumentation/influxdb-2.4/metadata.yaml
@@ -5,4 +5,11 @@ semantic_conventions:
   - DATABASE_CLIENT_METRICS
 library_link: https://github.com/influxdata/influxdb-java
 configurations:
+  - name: otel.instrumentation.influxdb.query-sanitization.enabled
+    declarative_name: java.influxdb.query_sanitization.enabled
+    description: >
+      Enables query sanitization for InfluxDB queries. Takes precedence over
+      otel.instrumentation.common.db.query-sanitization.enabled.
+    type: boolean
+    default: true
   - ref: common.db.query-sanitization.enabled


### PR DESCRIPTION
The influxdb-2.4 module documented `otel.instrumentation.common.db.query-sanitization.enabled` but never read it, so InfluxDB queries stayed sanitized even when users turned sanitization off.

Both the common property and a new per-module property now work:

```properties
otel.instrumentation.common.db.query-sanitization.enabled=false
otel.instrumentation.influxdb.query-sanitization.enabled=false
```

The per-module property wins over the common one. Declarative config spells it `java.influxdb.query_sanitization.enabled`.

Users who never set the flag see no change, because sanitization stays on by default. Users who set it to `false` now get the raw query in `db.statement` and `db.query.text`, in both old and stable semconv modes. Only the query text changes. `db.operation`, `db.query.summary` and span names come from a separate analyzer that always sanitizes.
