### PR TITLE
Report the real Redis command as db.operation.name in rediscala

### DIFF
--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -30,6 +30,12 @@ final class RediscalaAttributesGetter implements DbClientAttributesGetter<Redisc
 
   @Override
   public String getDbOperationName(RediscalaRequest request) {
+    return request.getStableOperationName();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation") // old database semconv still use db.operation
+  public String getDbOperation(RediscalaRequest request) {
     return request.getOperationName();
   }
 

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -7,8 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
 import static java.util.Arrays.asList;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import javax.annotation.Nullable;
 import redis.Operation;
 import redis.RedisCommand;
@@ -17,8 +19,14 @@ import scala.collection.immutable.Queue;
 
 class RediscalaRequest {
 
-  // Redis commands that are split into a container command and a subcommand, e.g. CONFIG GET.
-  // Rediscala names the command class after both tokens, e.g. ConfigGet.
+  // Command classes that rediscala names after something other than the command it sends, either
+  // because the name also covers an option, e.g. ZrangeWithscores sends ZRANGE ... WITHSCORES, or
+  // because the class name does not start with the container command, e.g. SenMasters sends
+  // SENTINEL MASTERS.
+  private static final Map<String, String> COMMAND_NAMES = commandNames();
+
+  // Redis commands that take a subcommand, e.g. CONFIG GET. Rediscala names the command class
+  // after both tokens, e.g. ConfigGet.
   private static final List<String> CONTAINER_COMMANDS =
       asList(
           "ACL", "CLIENT", "CLUSTER", "COMMAND", "CONFIG", "DEBUG", "LATENCY", "MEMORY", "OBJECT",
@@ -110,7 +118,19 @@ class RediscalaRequest {
 
   private static String operationName(RedisCommand<?, ?> command, boolean stable) {
     String name = command.getClass().getSimpleName().toUpperCase(Locale.ROOT);
-    return stable ? containerCommand(name) : name;
+    return stable ? stableOperationName(name) : name;
+  }
+
+  private static String stableOperationName(String className) {
+    // commands without arguments are scala objects, whose class name ends with $
+    String name =
+        className.endsWith("$") ? className.substring(0, className.length() - 1) : className;
+
+    String commandName = COMMAND_NAMES.get(name);
+    if (commandName != null) {
+      return commandName;
+    }
+    return containerCommand(name);
   }
 
   private static String containerCommand(String name) {
@@ -120,5 +140,29 @@ class RediscalaRequest {
       }
     }
     return name;
+  }
+
+  private static Map<String, String> commandNames() {
+    Map<String, String> names = new HashMap<>();
+    names.put("BITCOUNTRANGE", "BITCOUNT");
+    names.put("EXISTSMANY", "EXISTS");
+    names.put("GEORADIUSBYMEMBERWITHOPT", "GEORADIUSBYMEMBER");
+    names.put("RENAMEX", "RENAMENX");
+    names.put("SENGETMASTERADDR", "SENTINEL");
+    names.put("SENMASTERFAILOVER", "SENTINEL");
+    names.put("SENMASTERINFO", "SENTINEL");
+    names.put("SENMASTERS", "SENTINEL");
+    names.put("SENRESETMASTER", "SENTINEL");
+    names.put("SENSLAVES", "SENTINEL");
+    names.put("SLAVEOFNOONE", "SLAVEOF");
+    names.put("SORTSTORE", "SORT");
+    names.put("SRANDMEMBERS", "SRANDMEMBER");
+    names.put("ZINTERSTOREWEIGHTED", "ZINTERSTORE");
+    names.put("ZRANGEBYSCOREWITHSCORES", "ZRANGEBYSCORE");
+    names.put("ZRANGEWITHSCORES", "ZRANGE");
+    names.put("ZREVRANGEBYSCOREWITHSCORES", "ZREVRANGEBYSCORE");
+    names.put("ZREVRANGEWITHSCORES", "ZREVRANGE");
+    names.put("ZUNIONSTOREWEIGHTED", "ZUNIONSTORE");
+    return names;
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
+import static java.util.Arrays.asList;
+
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import redis.Operation;
@@ -13,28 +16,48 @@ import scala.collection.Iterator;
 import scala.collection.immutable.Queue;
 
 class RediscalaRequest {
+
+  // Redis commands that are split into a container command and a subcommand, e.g. CONFIG GET.
+  // Rediscala names the command class after both tokens, e.g. ConfigGet.
+  private static final List<String> CONTAINER_COMMANDS =
+      asList(
+          "ACL", "CLIENT", "CLUSTER", "COMMAND", "CONFIG", "DEBUG", "LATENCY", "MEMORY", "OBJECT",
+          "PUBSUB", "SCRIPT", "SLOWLOG", "XGROUP", "XINFO");
+
   private final String operationName;
+  private final String stableOperationName;
   @Nullable private final Long batchSize;
   @Nullable private final String host;
   @Nullable private final Integer port;
 
   static RediscalaRequest create(
       RedisCommand<?, ?> command, @Nullable String host, @Nullable Integer port) {
-    return new RediscalaRequest(operationName(command), null, host, port);
+    return new RediscalaRequest(
+        operationName(command, /* stable= */ false),
+        operationName(command, /* stable= */ true),
+        null,
+        host,
+        port);
   }
 
   static RediscalaRequest createTransaction(
       Queue<Operation<?, ?>> operations, @Nullable String host, @Nullable Integer port) {
     return new RediscalaRequest(
-        transactionOperationName(operations), batchSize(operations), host, port);
+        transactionOperationName(operations, /* stable= */ false),
+        transactionOperationName(operations, /* stable= */ true),
+        batchSize(operations),
+        host,
+        port);
   }
 
   private RediscalaRequest(
       String operationName,
+      String stableOperationName,
       @Nullable Long batchSize,
       @Nullable String host,
       @Nullable Integer port) {
     this.operationName = operationName;
+    this.stableOperationName = stableOperationName;
     this.batchSize = batchSize;
     this.host = host;
     this.port = port;
@@ -42,6 +65,10 @@ class RediscalaRequest {
 
   String getOperationName() {
     return operationName;
+  }
+
+  String getStableOperationName() {
+    return stableOperationName;
   }
 
   @Nullable
@@ -59,15 +86,16 @@ class RediscalaRequest {
     return port;
   }
 
-  private static String transactionOperationName(Queue<Operation<?, ?>> operations) {
+  private static String transactionOperationName(
+      Queue<Operation<?, ?>> operations, boolean stable) {
     if (operations.isEmpty()) {
       return "MULTI";
     }
 
     Iterator<Operation<?, ?>> iterator = operations.iterator();
-    String operationName = operationName(iterator.next().redisCommand());
+    String operationName = operationName(iterator.next().redisCommand(), stable);
     while (iterator.hasNext()) {
-      if (!operationName.equals(operationName(iterator.next().redisCommand()))) {
+      if (!operationName.equals(operationName(iterator.next().redisCommand(), stable))) {
         return "MULTI";
       }
     }
@@ -80,7 +108,17 @@ class RediscalaRequest {
     return size != 1 ? (long) size : null;
   }
 
-  private static String operationName(RedisCommand<?, ?> command) {
-    return command.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+  private static String operationName(RedisCommand<?, ?> command, boolean stable) {
+    String name = command.getClass().getSimpleName().toUpperCase(Locale.ROOT);
+    return stable ? containerCommand(name) : name;
+  }
+
+  private static String containerCommand(String name) {
+    for (String container : CONTAINER_COMMANDS) {
+      if (name.length() > container.length() && name.startsWith(container)) {
+        return container;
+      }
+    }
+    return name;
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -245,6 +245,37 @@ class RediscalaClientTest {
     assertCommandSpan("PUBLISH")
   }
 
+  @Test def testCommandWithOption(): Unit = {
+    val value = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] =
+          redisClient.zrangeWithscores[String]("sorted-set", 0, -1)
+      }
+    )
+
+    Await.result(value, Duration.apply("3 second"))
+
+    // ZrangeWithscores sends ZRANGE with the WITHSCORES option
+    assertCommandSpan(
+      if (emitStableDatabaseSemconv()) "ZRANGE" else "ZRANGEWITHSCORES"
+    )
+  }
+
+  @Test def testCommandWithoutArguments(): Unit = {
+    val value = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] = redisClient.ping()
+      }
+    )
+
+    Await.result(value, Duration.apply("3 second"))
+
+    // commands without arguments are scala objects, whose class name ends with $
+    assertCommandSpan(if (emitStableDatabaseSemconv()) "PING" else "PING$")
+  }
+
   private def assertCommandSpan(operationName: String): Unit =
     testing.waitAndAssertTraces(new Consumer[TraceAssert] {
       override def accept(trace: TraceAssert): Unit =

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -214,6 +214,63 @@ class RediscalaClientTest {
     })
   }
 
+  @Test def testContainerCommand(): Unit = {
+    val value = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] = redisClient.configGet("maxmemory")
+      }
+    )
+
+    Await.result(value, Duration.apply("3 second"))
+
+    // CONFIG GET is a container command, so the stable operation name is only the container token
+    assertCommandSpan(
+      if (emitStableDatabaseSemconv()) "CONFIG" else "CONFIGGET"
+    )
+  }
+
+  @Test def testSingleTokenCommand(): Unit = {
+    val value = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] =
+          redisClient.publish("channel", "message")
+      }
+    )
+
+    Await.result(value, Duration.apply("3 second"))
+
+    // PUBLISH is a single command, so it is reported unchanged in both modes
+    assertCommandSpan("PUBLISH")
+  }
+
+  private def assertCommandSpan(operationName: String): Unit =
+    testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+      override def accept(trace: TraceAssert): Unit =
+        trace.hasSpansSatisfyingExactly(
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span.hasName("parent").hasNoParent
+            }
+          },
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span
+                .hasName(spanName(operationName))
+                .hasKind(CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                  equalTo(maybeStable(DB_OPERATION), operationName),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port)
+                )
+            }
+          }
+        )
+    })
+
   @ParameterizedTest
   @MethodSource(Array("transactionScenarios"))
   def testTransaction(scenario: BatchScenario): Unit = {

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -377,6 +377,20 @@ class RediscalaClientTest {
         )
       ),
       Arguments.argumentSet(
+        "twoSameStableOperation",
+        BatchScenario(
+          commands = Seq(
+            _.zrange[String]("transaction-same-stable", 0, -1),
+            _.zrangeWithscores[String]("transaction-same-stable", 0, -1)
+          ),
+          // Zrange and ZrangeWithscores both send ZRANGE, so they group together only when the
+          // stable operation name is used
+          operationName =
+            if (emitStableDatabaseSemconv()) "MULTI ZRANGE" else "MULTI",
+          batchSize = 2L
+        )
+      ),
+      Arguments.argumentSet(
         "twoDifferentOperations",
         BatchScenario(
           commands = Seq(


### PR DESCRIPTION
Under the stable database semantic conventions, rediscala reported the command's JVM class name as `db.operation.name` and in the span name. That name is often not the command sent to Redis, so a single command could split into several `db.client.operation.duration` series, some named after strings no Redis server accepts.

- `CONFIG GET` reported `CONFIGGET`, now `CONFIG`
- `ZrangeWithscores` reported `ZRANGEWITHSCORES`, now `ZRANGE`, so it shares a series with plain `Zrange`
- `SenMasters` reported `SENMASTERS`, now `SENTINEL`
- `PING` reported `PING$`, now `PING`

The old conventions are unchanged. `db.operation` and the old span name still report `CONFIGGET`, `ZRANGEWITHSCORES` and `PING$`.

### How the name is derived

The name comes from the command's class name. First strip a trailing `$`, which commands without arguments have because they are Scala objects. Then look the name up in a map of the classes rediscala misnames. Finally, shorten it to a container command such as `CONFIG` when the name starts with one and is longer, which leaves single-token commands such as `EVALSHA` and `PUBLISH` untouched.

The name cannot come from the encoded request. `RedisCommand.encodedRequest()` returns `akka.util.ByteString` in `com.github.etaty:rediscala_2.11:1.8.0` and `org.apache.pekko.util.ByteString` in `io.github.rediscala:rediscala_2.13:1.17.0`, and the muzzle block declares both, so referencing that method could not pass muzzle across the supported range.