### PR TITLE
Emit stable db.namespace in redisson-3.17

### DIFF
--- a/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_0/RedisConnectionInstrumentation.java
@@ -51,7 +51,8 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
       public static AdviceScope start(RedisConnection connection, Object arg) {
         InetSocketAddress remoteAddress =
             (InetSocketAddress) connection.getChannel().remoteAddress();
-        RedissonRequest request = RedissonRequest.create(remoteAddress, arg);
+        // the redisson 3.0 client API does not expose the database index
+        RedissonRequest request = RedissonRequest.create(remoteAddress, arg, null);
         PromiseWrapper<?> promise = request.getPromiseWrapper();
         if (promise == null) {
           return null;

--- a/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
+++ b/instrumentation/redisson/redisson-3.17/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedisConnectionInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.redisson.v3_17;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.javaagent.instrumentation.redisson.v3_17.RedissonSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -20,6 +21,8 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.redisson.client.RedisClient;
+import org.redisson.client.RedisClientConfig;
 import org.redisson.client.RedisConnection;
 
 class RedisConnectionInstrumentation implements TypeInstrumentation {
@@ -52,7 +55,8 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         Context parentContext = Context.current();
         InetSocketAddress remoteAddress =
             (InetSocketAddress) connection.getChannel().remoteAddress();
-        RedissonRequest request = RedissonRequest.create(remoteAddress, arg);
+        RedissonRequest request =
+            RedissonRequest.create(remoteAddress, arg, databaseIndex(connection));
         PromiseWrapper<?> promise = request.getPromiseWrapper();
         if (promise == null) {
           return null;
@@ -67,6 +71,19 @@ class RedisConnectionInstrumentation implements TypeInstrumentation {
         promise.setEndOperationListener(
             new EndOperationListener<>(instrumenter(), context, request));
         return new AdviceScope(request, context, scope);
+      }
+
+      @Nullable
+      private static Long databaseIndex(RedisConnection connection) {
+        if (!emitStableDatabaseSemconv()) {
+          return null;
+        }
+        RedisClient client = connection.getRedisClient();
+        if (client == null) {
+          return null;
+        }
+        RedisClientConfig config = client.getConfig();
+        return config != null ? (long) config.getDatabase() : null;
       }
 
       public void end(@Nullable Throwable throwable) {

--- a/instrumentation/redisson/redisson-3.17/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-3.17/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedissonAsyncClientTest.java
@@ -13,4 +13,9 @@ class RedissonAsyncClientTest extends AbstractRedissonAsyncClientTest {
   protected boolean useRedisProtocol() {
     return true;
   }
+
+  @Override
+  protected boolean hasDatabaseIndex() {
+    return true;
+  }
 }

--- a/instrumentation/redisson/redisson-3.17/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedissonClientTest.java
+++ b/instrumentation/redisson/redisson-3.17/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/redisson/v3_17/RedissonClientTest.java
@@ -19,4 +19,9 @@ class RedissonClientTest extends AbstractRedissonClientTest {
   protected boolean lockHas3Traces() {
     return testLatestDeps();
   }
+
+  @Override
+  protected boolean hasDatabaseIndex() {
+    return true;
+  }
 }

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonDbAttributesGetter.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonDbAttributesGetter.java
@@ -10,7 +10,7 @@ import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIn
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
-final class RedissonDbAttributesGetter implements DbClientAttributesGetter<RedissonRequest, Void> {
+class RedissonDbAttributesGetter implements DbClientAttributesGetter<RedissonRequest, Void> {
 
   @Override
   public String getDbSystemName(RedissonRequest request) {
@@ -20,6 +20,13 @@ final class RedissonDbAttributesGetter implements DbClientAttributesGetter<Redis
   @Nullable
   @Override
   public String getDbNamespace(RedissonRequest request) {
+    Long databaseIndex = request.getDatabaseIndex();
+    return databaseIndex != null ? String.valueOf(databaseIndex) : null;
+  }
+
+  @Nullable
+  @Override
+  public String getDbName(RedissonRequest request) {
     return null;
   }
 

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonInstrumenterFactory.java
@@ -14,17 +14,28 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNam
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
+import javax.annotation.Nullable;
 
 public class RedissonInstrumenterFactory {
 
   public static Instrumenter<RedissonRequest, Void> createInstrumenter(String instrumentationName) {
     RedissonDbAttributesGetter dbAttributesGetter = new RedissonDbAttributesGetter();
+    // Redis semantic conventions don't follow the regular pattern of adding db.namespace to the
+    // span name.
+    RedissonDbAttributesGetter spanNameAttributesGetter =
+        new RedissonDbAttributesGetter() {
+          @Nullable
+          @Override
+          public String getDbNamespace(RedissonRequest request) {
+            return null;
+          }
+        };
 
     InstrumenterBuilder<RedissonRequest, Void> builder =
         Instrumenter.<RedissonRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 instrumentationName,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
+                DbClientSpanNameExtractor.create(spanNameAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
             .addOperationMetrics(DbClientMetrics.get());
     setDbClientExceptionEventExtractor(builder);

--- a/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
+++ b/instrumentation/redisson/redisson-common-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/common/v3_0/RedissonRequest.java
@@ -74,14 +74,22 @@ public abstract class RedissonRequest {
     }
   }
 
-  public static RedissonRequest create(@Nullable InetSocketAddress address, Object command) {
-    return new AutoValue_RedissonRequest(address, command);
+  /**
+   * Creates a request. The database index is resolved by the version specific instrumentation,
+   * because the redisson 3.0 client API does not expose it.
+   */
+  public static RedissonRequest create(
+      @Nullable InetSocketAddress address, Object command, @Nullable Long databaseIndex) {
+    return new AutoValue_RedissonRequest(address, command, databaseIndex);
   }
 
   @Nullable
   public abstract InetSocketAddress getAddress();
 
   public abstract Object getCommand();
+
+  @Nullable
+  public abstract Long getDatabaseIndex();
 
   @Nullable
   public String getOperationName() {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanKind;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
@@ -39,6 +40,7 @@ import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -151,6 +153,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"))));
   }
@@ -187,6 +190,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SADD set1 ?"),
                             equalTo(maybeStable(DB_OPERATION), "SADD"))
                         .hasParent(trace.getSpan(0)),
@@ -261,6 +265,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
@@ -283,6 +288,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
@@ -296,6 +302,7 @@ public abstract class AbstractRedissonAsyncClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "EXEC"),
                             equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0)),
@@ -304,6 +311,16 @@ public abstract class AbstractRedissonAsyncClientTest {
 
   protected boolean useRedisProtocol() {
     return testLatestDeps();
+  }
+
+  /** Whether the instrumented redisson version can report the Redis database index. */
+  protected boolean hasDatabaseIndex() {
+    return false;
+  }
+
+  @Nullable
+  private String dbNamespace() {
+    return emitStableDatabaseSemconv() && hasDatabaseIndex() ? "0" : null;
   }
 
   private static class MyCallable implements Serializable, Callable<Object> {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonAsyncClientTest.java
@@ -40,7 +40,6 @@ import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -318,7 +317,6 @@ public abstract class AbstractRedissonAsyncClientTest {
     return false;
   }
 
-  @Nullable
   private String dbNamespace() {
     return emitStableDatabaseSemconv() && hasDatabaseIndex() ? "0" : null;
   }

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.or
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
@@ -29,10 +30,12 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -47,6 +50,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -113,6 +117,15 @@ public abstract class AbstractRedissonClientTest {
 
   @BeforeEach
   void setup(TestInfo testInfo) throws InvocationTargetException, IllegalAccessException {
+    // the stringCommandLazyConnection test case simulates reconnection during Redis command
+    // execution, which needs an empty idle connection pool
+    Integer connectionMinimumIdleSize = testInfo.getTags().contains(TEST_RECONNECT) ? 0 : null;
+    redisson = Redisson.create(createConfig(0, connectionMinimumIdleSize));
+    testing.clearData();
+  }
+
+  private Config createConfig(int database, @Nullable Integer connectionMinimumIdleSize)
+      throws InvocationTargetException, IllegalAccessException {
     String newAddress = address;
     if (useRedisProtocol()) {
       // Newer versions of redisson require scheme, older versions forbid it
@@ -129,11 +142,9 @@ public abstract class AbstractRedissonClientTest {
     SingleServerConfig singleServerConfig = config.useSingleServer();
     singleServerConfig.setAddress(newAddress);
     singleServerConfig.setTimeout(30_000);
-    if (testInfo.getTags().contains(TEST_RECONNECT)) {
-      // When verifying the stringCommandLazyConnection test case, simulate reconnection during
-      // Redis
-      // command execution.
-      singleServerConfig.setConnectionMinimumIdleSize(0);
+    singleServerConfig.setDatabase(database);
+    if (connectionMinimumIdleSize != null) {
+      singleServerConfig.setConnectionMinimumIdleSize(connectionMinimumIdleSize);
     }
     try {
       // disable connection ping if it exists
@@ -144,8 +155,7 @@ public abstract class AbstractRedissonClientTest {
     } catch (NoSuchMethodException ignored) {
       // ignored
     }
-    redisson = Redisson.create(config);
-    testing.clearData();
+    return config;
   }
 
   @AfterEach
@@ -180,6 +190,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET")),
                 span ->
@@ -193,6 +204,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "GET foo"),
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
@@ -216,19 +228,54 @@ public abstract class AbstractRedissonClientTest {
                           equalTo(SERVER_ADDRESS, host),
                           equalTo(SERVER_PORT, port),
                           equalTo(maybeStable(DB_SYSTEM), REDIS),
+                          equalTo(DB_NAMESPACE, dbNamespace()),
                           equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                           equalTo(maybeStable(DB_OPERATION), "SET")));
         });
 
+    List<AttributeKey<?>> expectedKeys =
+        new ArrayList<>(
+            asList(
+                DB_SYSTEM_NAME,
+                DB_OPERATION_NAME,
+                NETWORK_PEER_PORT,
+                NETWORK_PEER_ADDRESS,
+                SERVER_PORT,
+                SERVER_ADDRESS));
+    if (hasDatabaseIndex()) {
+      expectedKeys.add(DB_NAMESPACE);
+    }
     assertDurationMetric(
-        testing,
-        instrumentationName.get(),
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        NETWORK_PEER_PORT,
-        NETWORK_PEER_ADDRESS,
-        SERVER_PORT,
-        SERVER_ADDRESS);
+        testing, instrumentationName.get(), expectedKeys.toArray(new AttributeKey<?>[0]));
+  }
+
+  @Test
+  void configuredDatabaseIndex() throws InvocationTargetException, IllegalAccessException {
+    RedissonClient databaseOne = Redisson.create(createConfig(1, null));
+    try {
+      testing.clearData();
+      RBucket<String> keyObject = databaseOne.getBucket("foo");
+      keyObject.set("bar");
+
+      testing.waitAndAssertTraces(
+          trace ->
+              trace.hasSpansSatisfyingExactly(
+                  span ->
+                      span.hasName(emitStableDatabaseSemconv() ? "SET " + address : "SET")
+                          .hasKind(CLIENT)
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null),
+                              equalTo(NETWORK_PEER_ADDRESS, ip),
+                              equalTo(NETWORK_PEER_PORT, port),
+                              equalTo(SERVER_ADDRESS, host),
+                              equalTo(SERVER_PORT, port),
+                              equalTo(maybeStable(DB_SYSTEM), REDIS),
+                              equalTo(DB_NAMESPACE, dbNamespace("1")),
+                              equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
+                              equalTo(maybeStable(DB_OPERATION), "SET"))));
+    } finally {
+      databaseOne.shutdown();
+    }
   }
 
   @Test
@@ -252,6 +299,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"))),
         trace ->
@@ -266,6 +314,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "GET foo"),
                             equalTo(maybeStable(DB_OPERATION), "GET"))));
   }
@@ -303,6 +352,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv()
@@ -390,6 +440,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "PIPELINE SET" : null),
@@ -438,6 +489,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(
                                 DB_OPERATION_NAME,
                                 emitStableDatabaseSemconv() ? "MULTI SET" : null),
@@ -460,6 +512,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SET batch2 ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"))
                         .hasParent(trace.getSpan(0)),
@@ -473,6 +526,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "EXEC"),
                             equalTo(maybeStable(DB_OPERATION), "EXEC"))
                         .hasParent(trace.getSpan(0))));
@@ -497,6 +551,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "RPUSH list1 ?"),
                             equalTo(maybeStable(DB_OPERATION), "RPUSH"))
                         .hasNoParent()));
@@ -524,6 +579,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 String.format("EVAL %s 1 map1 ? ?", script)),
@@ -540,6 +596,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "HGET map1 key1"),
                             equalTo(maybeStable(DB_OPERATION), "HGET"))));
   }
@@ -563,6 +620,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "SADD set1 ?"),
                             equalTo(maybeStable(DB_OPERATION), "SADD"))));
   }
@@ -592,6 +650,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "ZADD sort_set1 ? ? ? ? ? ?"),
                             equalTo(maybeStable(DB_OPERATION), "ZADD"))));
   }
@@ -620,6 +679,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_STATEMENT), "INCR AtomicLong"),
                             equalTo(maybeStable(DB_OPERATION), "INCR"))));
   }
@@ -648,6 +708,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_OPERATION), "EVAL"),
                             satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("EVAL")))));
     traceAsserts.add(
@@ -663,6 +724,7 @@ public abstract class AbstractRedissonClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, dbNamespace()),
                             equalTo(maybeStable(DB_OPERATION), "EVAL"),
                             satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("EVAL")))));
     if (lockHas3Traces()) {
@@ -679,6 +741,7 @@ public abstract class AbstractRedissonClientTest {
                               equalTo(SERVER_ADDRESS, host),
                               equalTo(SERVER_PORT, port),
                               equalTo(maybeStable(DB_SYSTEM), REDIS),
+                              equalTo(DB_NAMESPACE, dbNamespace()),
                               equalTo(maybeStable(DB_OPERATION), "DEL"),
                               satisfies(maybeStable(DB_STATEMENT), val -> val.startsWith("DEL")))));
     }
@@ -692,6 +755,21 @@ public abstract class AbstractRedissonClientTest {
 
   protected boolean lockHas3Traces() {
     return false;
+  }
+
+  /** Whether the instrumented redisson version can report the Redis database index. */
+  protected boolean hasDatabaseIndex() {
+    return false;
+  }
+
+  @Nullable
+  private String dbNamespace() {
+    return dbNamespace("0");
+  }
+
+  @Nullable
+  private String dbNamespace(String databaseIndex) {
+    return emitStableDatabaseSemconv() && hasDatabaseIndex() ? databaseIndex : null;
   }
 
   protected RBatch createBatch(RedissonClient redisson) {

--- a/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
+++ b/instrumentation/redisson/redisson-common-3.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/redisson/AbstractRedissonClientTest.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
@@ -124,7 +123,7 @@ public abstract class AbstractRedissonClientTest {
     testing.clearData();
   }
 
-  private Config createConfig(int database, @Nullable Integer connectionMinimumIdleSize)
+  private Config createConfig(int database, Integer connectionMinimumIdleSize)
       throws InvocationTargetException, IllegalAccessException {
     String newAddress = address;
     if (useRedisProtocol()) {
@@ -762,12 +761,10 @@ public abstract class AbstractRedissonClientTest {
     return false;
   }
 
-  @Nullable
   private String dbNamespace() {
     return dbNamespace("0");
   }
 
-  @Nullable
   private String dbNamespace(String databaseIndex) {
     return emitStableDatabaseSemconv() && hasDatabaseIndex() ? databaseIndex : null;
   }


### PR DESCRIPTION
redisson-3.17 spans now report the stable `db.namespace` attribute, set to the Redis database index the client is configured with. A span for database `1` used to look identical to one on the default database. The default database now reports `0` rather than omitting the attribute. jedis-4.0 and lettuce-5.1 already work this way.

redisson-3.0 still omits `db.namespace`. The index comes from `RedisClient.getConfig()`, which redisson added later in the 3.x line, so a module that supports 3.0.0 cannot reach it. The versions at the top of that module's range, up to 3.16.x, do expose it.

Old semantic convention output does not change, and neither do span names. Like the other Redis instrumentations, redisson leaves the namespace out of the span name, so a command on database `1` is still named `SET localhost:6379`.

`db.namespace` is a dimension of `db.client.operation.duration`, so existing redisson-3.17 series gain that dimension under the stable database semconv.