### PR TITLE
Report Elasticsearch REST API names as db.operation.name in transport instrumentation

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
@@ -87,12 +87,13 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("findAll")),
                 span ->
-                    span.hasName("SearchAction")
+                    span.hasName(operationName("SearchAction", "search"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "SearchAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("SearchAction", "search")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("SearchAction")),
                             equalTo(
@@ -121,12 +122,12 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("index")),
                 span ->
-                    span.hasName("IndexAction")
+                    span.hasName(operationName("IndexAction", "index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(indexActionAssertions(201)),
                 span ->
-                    span.hasName("RefreshAction")
+                    span.hasName(operationName("RefreshAction", "indices.refresh"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(refreshActionAssertions())));
@@ -143,7 +144,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("findById")),
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(getActionAssertions(1))));
@@ -163,12 +164,12 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("index")),
                 span ->
-                    span.hasName("IndexAction")
+                    span.hasName(operationName("IndexAction", "index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(indexActionAssertions(200)),
                 span ->
-                    span.hasName("RefreshAction")
+                    span.hasName(operationName("RefreshAction", "indices.refresh"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(refreshActionAssertions())),
@@ -180,7 +181,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("findById")),
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(getActionAssertions(2))));
@@ -198,12 +199,13 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("deleteById")),
                 span ->
-                    span.hasName("DeleteAction")
+                    span.hasName(operationName("DeleteAction", "delete"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "DeleteAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("DeleteAction", "delete")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("DeleteAction")),
                             equalTo(
@@ -223,7 +225,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                             equalTo(
                                 longKey("elasticsearch.shard.replication.total"), experimental(2))),
                 span ->
-                    span.hasName("RefreshAction")
+                    span.hasName(operationName("RefreshAction", "indices.refresh"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(refreshActionAssertions())),
@@ -235,12 +237,13 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("findAll")),
                 span ->
-                    span.hasName("SearchAction")
+                    span.hasName(operationName("SearchAction", "search"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "SearchAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("SearchAction", "search")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("SearchAction")),
                             equalTo(
@@ -257,7 +260,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("IndexRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental("test-index")),
@@ -273,7 +276,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "RefreshAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("RefreshAction", "indices.refresh")),
             equalTo(stringKey("elasticsearch.action"), experimental("RefreshAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("RefreshRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental("test-index")),
@@ -286,7 +289,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "GetAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("GetAction", "get")),
             equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental("test-index")),

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringRepositoryTest.java
@@ -122,7 +122,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("index")),
                 span ->
-                    span.hasName(operationName("IndexAction", "index"))
+                    span.hasName("IndexAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(indexActionAssertions(201)),
@@ -164,7 +164,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertFunctionName("index")),
                 span ->
-                    span.hasName(operationName("IndexAction", "index"))
+                    span.hasName("IndexAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(indexActionAssertions(200)),
@@ -260,7 +260,7 @@ class Elasticsearch53SpringRepositoryTest extends ElasticsearchSpringTest {
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
+            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("IndexRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental("test-index")),

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -174,7 +174,7 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("RefreshAction")
+                    span.hasName(operationName("RefreshAction", "indices.refresh"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasStatus(StatusData.error())
@@ -224,12 +224,14 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("CreateIndexAction")
+                    span.hasName(operationName("CreateIndexAction", "indices.create"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "CreateIndexAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                operationName("CreateIndexAction", "indices.create")),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental("CreateIndexAction")),
@@ -242,12 +244,14 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("ClusterHealthAction")
+                    span.hasName(operationName("ClusterHealthAction", "cluster.health"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "ClusterHealthAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                operationName("ClusterHealthAction", "cluster.health")),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental("ClusterHealthAction")),
@@ -257,12 +261,13 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("SearchAction")
+                    span.hasName(operationName("SearchAction", "search"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "SearchAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("SearchAction", "search")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("SearchAction")),
                             equalTo(
@@ -276,12 +281,13 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("IndexAction")
+                    span.hasName(operationName("IndexAction", "index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
                             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
                             equalTo(
                                 stringKey("elasticsearch.request"), experimental("IndexRequest")),
@@ -305,7 +311,7 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("RefreshAction")
+                    span.hasName(operationName("RefreshAction", "indices.refresh"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -313,12 +319,13 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("SearchAction")
+                    span.hasName(operationName("SearchAction", "search"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "SearchAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("SearchAction", "search")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("SearchAction")),
                             equalTo(
@@ -335,7 +342,7 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "RefreshAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("RefreshAction", "indices.refresh")),
             equalTo(stringKey("elasticsearch.action"), experimental("RefreshAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("RefreshRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental(indexName))));
@@ -423,12 +430,13 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("SearchAction")
+                    span.hasName(operationName("SearchAction", "search"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "SearchAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("SearchAction", "search")),
                             equalTo(
                                 stringKey("elasticsearch.action"), experimental("SearchAction")),
                             equalTo(

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/Elasticsearch53SpringTemplateTest.java
@@ -281,13 +281,12 @@ class Elasticsearch53SpringTemplateTest extends ElasticsearchSpringTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(operationName("IndexAction", "index"))
+                    span.hasName("IndexAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(
-                                maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
+                            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
                             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
                             equalTo(
                                 stringKey("elasticsearch.request"), experimental("IndexRequest")),

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/ElasticsearchSpringTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/springdata/ElasticsearchSpringTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3.springdata;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
 abstract class ElasticsearchSpringTest {
   private static final boolean EXPERIMENTAL_ATTRIBUTES =
       Boolean.getBoolean("otel.instrumentation.elasticsearch.experimental-span-attributes");
@@ -21,5 +23,9 @@ abstract class ElasticsearchSpringTest {
       return null;
     }
     return value;
+  }
+
+  protected static String operationName(String actionClassName, String stableOperationName) {
+    return emitStableDatabaseSemconv() ? stableOperationName : actionClassName;
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
@@ -32,8 +32,9 @@ public class ElasticsearchTransportAttributesGetter
 
   @Override
   public String getDbOperationName(ElasticTransportRequest request) {
+    Class<?> actionClass = request.getAction().getClass();
     return ElasticsearchTransportOperationNames.operationName(
-        request.getAction().getClass().getSimpleName());
+        actionClass.getName(), actionClass.getSimpleName());
   }
 
   @Deprecated

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
@@ -32,6 +32,15 @@ public class ElasticsearchTransportAttributesGetter
 
   @Override
   public String getDbOperationName(ElasticTransportRequest request) {
+    return ElasticsearchTransportOperationNames.operationName(
+        request.getAction().getClass().getSimpleName());
+  }
+
+  @Deprecated
+  @Override
+  @SuppressWarnings("deprecation") // old database semconv still use db.operation
+  public String getDbOperation(ElasticTransportRequest request) {
+    // frozen: old semantic conventions keep reporting the action class name
     return request.getAction().getClass().getSimpleName();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maps Elasticsearch transport action classes to the Elasticsearch REST API names reported by the
+ * Elasticsearch REST and api-client instrumentations, so that the same logical operation gets the
+ * same {@code db.operation.name} no matter which client the application uses.
+ *
+ * <p>Actions that have no REST API equivalent, such as the internal persistent task and dangling
+ * index actions, are deliberately absent and keep their action class name.
+ */
+final class ElasticsearchTransportOperationNames {
+
+  private static final Map<String, String> OPERATION_NAMES = buildOperationNames();
+
+  /**
+   * Returns the Elasticsearch REST API name for the given action class simple name, falling back to
+   * the action class simple name when the action has no REST API equivalent.
+   */
+  static String operationName(String actionClassName) {
+    String operationName = OPERATION_NAMES.get(actionClassName);
+    return operationName != null ? operationName : actionClassName;
+  }
+
+  private static Map<String, String> buildOperationNames() {
+    Map<String, String> operationNames = new HashMap<>();
+    operationNames.put("AddIndexBlockAction", "indices.add_block");
+    operationNames.put("AddVotingConfigExclusionsAction", "cluster.post_voting_config_exclusions");
+    operationNames.put("AliasesExistAction", "indices.exists_alias");
+    operationNames.put("AnalyzeAction", "indices.analyze");
+    operationNames.put("AnalyzeIndexDiskUsageAction", "indices.disk_usage");
+    operationNames.put("AutoPutMappingAction", "indices.put_mapping");
+    operationNames.put("BulkAction", "bulk");
+    operationNames.put("CancelTasksAction", "tasks.cancel");
+    operationNames.put("CleanupRepositoryAction", "snapshot.cleanup_repository");
+    operationNames.put("ClearIndicesCacheAction", "indices.clear_cache");
+    operationNames.put("ClearScrollAction", "clear_scroll");
+    operationNames.put(
+        "ClearVotingConfigExclusionsAction", "cluster.delete_voting_config_exclusions");
+    operationNames.put("CloneSnapshotAction", "snapshot.clone");
+    operationNames.put("CloseIndexAction", "indices.close");
+    operationNames.put("ClosePointInTimeAction", "close_point_in_time");
+    operationNames.put("ClusterAllocationExplainAction", "cluster.allocation_explain");
+    operationNames.put("ClusterHealthAction", "cluster.health");
+    operationNames.put("ClusterRerouteAction", "cluster.reroute");
+    operationNames.put("ClusterSearchShardsAction", "search_shards");
+    operationNames.put("ClusterStateAction", "cluster.state");
+    operationNames.put("ClusterStatsAction", "cluster.stats");
+    operationNames.put("ClusterUpdateSettingsAction", "cluster.put_settings");
+    operationNames.put("CreateIndexAction", "indices.create");
+    operationNames.put("CreateSnapshotAction", "snapshot.create");
+    operationNames.put("DeleteAction", "delete");
+    operationNames.put("DeleteByQueryAction", "delete_by_query");
+    operationNames.put("DeleteComponentTemplateAction", "cluster.delete_component_template");
+    operationNames.put("DeleteComposableIndexTemplateAction", "indices.delete_index_template");
+    operationNames.put("DeleteDanglingIndexAction", "dangling_indices.delete_dangling_index");
+    operationNames.put("DeleteIndexAction", "indices.delete");
+    operationNames.put("DeleteIndexTemplateAction", "indices.delete_template");
+    operationNames.put("DeletePipelineAction", "ingest.delete_pipeline");
+    operationNames.put("DeleteRepositoryAction", "snapshot.delete_repository");
+    operationNames.put("DeleteSnapshotAction", "snapshot.delete");
+    operationNames.put("DeleteStoredScriptAction", "delete_script");
+    operationNames.put("ExplainAction", "explain");
+    operationNames.put("FieldCapabilitiesAction", "field_caps");
+    operationNames.put("FieldStatsAction", "field_stats");
+    operationNames.put("FieldUsageStatsAction", "indices.field_usage_stats");
+    operationNames.put("FlushAction", "indices.flush");
+    operationNames.put("ForceMergeAction", "indices.forcemerge");
+    operationNames.put("GetAction", "get");
+    operationNames.put("GetAliasesAction", "indices.get_alias");
+    operationNames.put("GetComponentTemplateAction", "cluster.get_component_template");
+    operationNames.put("GetComposableIndexTemplateAction", "indices.get_index_template");
+    operationNames.put("GetFeatureUpgradeStatusAction", "migration.get_feature_upgrade_status");
+    operationNames.put("GetFieldMappingsAction", "indices.get_field_mapping");
+    operationNames.put("GetIndexAction", "indices.get");
+    operationNames.put("GetIndexTemplatesAction", "indices.get_template");
+    operationNames.put("GetMappingsAction", "indices.get_mapping");
+    operationNames.put("GetPipelineAction", "ingest.get_pipeline");
+    operationNames.put("GetRepositoriesAction", "snapshot.get_repository");
+    operationNames.put("GetScriptContextAction", "get_script_context");
+    operationNames.put("GetScriptLanguageAction", "get_script_languages");
+    operationNames.put("GetSettingsAction", "indices.get_settings");
+    operationNames.put("GetSnapshotsAction", "snapshot.get");
+    operationNames.put("GetStoredScriptAction", "get_script");
+    operationNames.put("GetTaskAction", "tasks.get");
+    operationNames.put("ImportDanglingIndexAction", "dangling_indices.import_dangling_index");
+    operationNames.put("IndexAction", "index");
+    operationNames.put("IndicesAliasesAction", "indices.update_aliases");
+    operationNames.put("IndicesExistsAction", "indices.exists");
+    operationNames.put("IndicesSegmentsAction", "indices.segments");
+    operationNames.put("IndicesShardStoresAction", "indices.shard_stores");
+    operationNames.put("IndicesStatsAction", "indices.stats");
+    operationNames.put("ListDanglingIndicesAction", "dangling_indices.list_dangling_indices");
+    operationNames.put("ListTasksAction", "tasks.list");
+    operationNames.put("MainAction", "info");
+    operationNames.put("ModifyDataStreamsAction", "indices.modify_data_stream");
+    operationNames.put("MultiGetAction", "mget");
+    operationNames.put("MultiSearchAction", "msearch");
+    operationNames.put("MultiTermVectorsAction", "mtermvectors");
+    operationNames.put("NodesHotThreadsAction", "nodes.hot_threads");
+    operationNames.put("NodesInfoAction", "nodes.info");
+    operationNames.put("NodesReloadSecureSettingsAction", "nodes.reload_secure_settings");
+    operationNames.put("NodesStatsAction", "nodes.stats");
+    operationNames.put("NodesUsageAction", "nodes.usage");
+    operationNames.put("OpenIndexAction", "indices.open");
+    operationNames.put("OpenPointInTimeAction", "open_point_in_time");
+    operationNames.put("PendingClusterTasksAction", "cluster.pending_tasks");
+    operationNames.put("PostFeatureUpgradeAction", "migration.post_feature_upgrade");
+    operationNames.put("PutComponentTemplateAction", "cluster.put_component_template");
+    operationNames.put("PutComposableIndexTemplateAction", "indices.put_index_template");
+    operationNames.put("PutIndexTemplateAction", "indices.put_template");
+    operationNames.put("PutMappingAction", "indices.put_mapping");
+    operationNames.put("PutPipelineAction", "ingest.put_pipeline");
+    operationNames.put("PutRepositoryAction", "snapshot.create_repository");
+    operationNames.put("PutStoredScriptAction", "put_script");
+    operationNames.put("RecoveryAction", "indices.recovery");
+    operationNames.put("RefreshAction", "indices.refresh");
+    operationNames.put("ReindexAction", "reindex");
+    operationNames.put("RemoteInfoAction", "cluster.remote_info");
+    operationNames.put("ResetFeatureStateAction", "features.reset_features");
+    operationNames.put("ResizeAction", "indices.shrink");
+    operationNames.put("ResolveIndexAction", "indices.resolve_index");
+    operationNames.put("RestoreSnapshotAction", "snapshot.restore");
+    operationNames.put("RolloverAction", "indices.rollover");
+    operationNames.put("SearchAction", "search");
+    operationNames.put("SearchScrollAction", "scroll");
+    operationNames.put("ShrinkAction", "indices.shrink");
+    operationNames.put("SimulateIndexTemplateAction", "indices.simulate_index_template");
+    operationNames.put("SimulatePipelineAction", "ingest.simulate");
+    operationNames.put("SimulateTemplateAction", "indices.simulate_template");
+    operationNames.put("SnapshotsStatusAction", "snapshot.status");
+    operationNames.put("SnapshottableFeaturesAction", "features.get_features");
+    operationNames.put("SyncedFlushAction", "indices.flush_synced");
+    operationNames.put("TermVectorsAction", "termvectors");
+    operationNames.put("TypesExistsAction", "indices.exists_type");
+    operationNames.put("UpdateAction", "update");
+    operationNames.put("UpdateByQueryAction", "update_by_query");
+    operationNames.put("UpdateSettingsAction", "indices.put_settings");
+    operationNames.put("UpgradeAction", "indices.upgrade");
+    operationNames.put("UpgradeStatusAction", "indices.get_upgrade");
+    operationNames.put("ValidateQueryAction", "indices.validate_query");
+    operationNames.put("VerifyRepositoryAction", "snapshot.verify_repository");
+    return Collections.unmodifiableMap(operationNames);
+  }
+
+  private ElasticsearchTransportOperationNames() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -16,8 +16,8 @@ import java.util.Map;
  *
  * <p>The table is keyed on the action class simple name, which is the identifier this
  * instrumentation already reports for an action in the {@code elasticsearch.action} attribute.
- * Keying on the action classes themselves is not an option, because this module is shared across
- * Elasticsearch 5.0 to 7.17 and most of these classes are absent from some of those versions.
+ * Referring to the action classes themselves is not an option, because this module is shared across
+ * Elasticsearch 5.0 to 7.17 and many of these classes do not exist in every version in that range.
  *
  * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
  * equivalent, such as the internal persistent task actions and {@code AutoCreateAction}, or when it

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -14,9 +14,10 @@ import java.util.Map;
  * Elasticsearch REST and api-client instrumentations, so that the same logical operation gets the
  * same {@code db.operation.name} no matter which client the application uses.
  *
- * <p>Actions are keyed on the action class simple name because the packages holding these classes
- * moved between Elasticsearch 5.x, 6.x and 7.x, so a fully qualified name would not match across
- * the supported versions.
+ * <p>The table is keyed on the action class simple name, which is the identifier this
+ * instrumentation already reports for an action in the {@code elasticsearch.action} attribute.
+ * Keying on the action classes themselves is not an option, because this module is shared across
+ * Elasticsearch 5.0 to 7.17 and most of these classes are absent from some of those versions.
  *
  * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
  * equivalent, such as the internal persistent task actions and {@code AutoCreateAction}, or when it

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -22,9 +22,9 @@ import java.util.Map;
  * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
  * equivalent, such as the internal persistent task actions and {@code AutoCreateAction}, or when it
  * covers several REST APIs that the REST and api-client instrumentations report under different
- * names, such as {@code ResizeAction} covering shrink, split and clone. Reporting the action class
- * name is less specific than the REST API name, but it never attributes an operation to a REST API
- * the caller did not use.
+ * names, such as {@code IndexAction} covering index and create or {@code ResizeAction} covering
+ * shrink, split and clone. Reporting the action class name is less specific than the REST API name,
+ * but it never attributes an operation to a REST API the caller did not use.
  */
 final class ElasticsearchTransportOperationNames {
 
@@ -100,7 +100,6 @@ final class ElasticsearchTransportOperationNames {
     operationNames.put("GetStoredScriptAction", "get_script");
     operationNames.put("GetTaskAction", "tasks.get");
     operationNames.put("ImportDanglingIndexAction", "dangling_indices.import_dangling_index");
-    operationNames.put("IndexAction", "index");
     operationNames.put("IndicesAliasesAction", "indices.update_aliases");
     operationNames.put("IndicesExistsAction", "indices.exists");
     operationNames.put("IndicesSegmentsAction", "indices.segments");

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -19,11 +19,11 @@ import java.util.Map;
  * the supported versions.
  *
  * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
- * equivalent, such as the internal persistent task and dangling index actions, or when it covers
- * several REST APIs that the REST and api-client instrumentations report under different names,
- * such as {@code ResizeAction} covering shrink, split and clone. Reporting the action class name is
- * less specific than the REST API name, but it never attributes an operation to a REST API the
- * caller did not use.
+ * equivalent, such as the internal persistent task actions and {@code AutoCreateAction}, or when it
+ * covers several REST APIs that the REST and api-client instrumentations report under different
+ * names, such as {@code ResizeAction} covering shrink, split and clone. Reporting the action class
+ * name is less specific than the REST API name, but it never attributes an operation to a REST API
+ * the caller did not use.
  */
 final class ElasticsearchTransportOperationNames {
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -14,10 +14,10 @@ import java.util.Map;
  * Elasticsearch REST and api-client instrumentations, so that the same logical operation gets the
  * same {@code db.operation.name} no matter which client the application uses.
  *
- * <p>The table is keyed on the action class simple name, which is the identifier this
- * instrumentation already reports for an action in the {@code elasticsearch.action} attribute.
- * Referring to the action classes themselves is not an option, because this module is shared across
- * Elasticsearch 5.0 to 7.17 and many of these classes do not exist in every version in that range.
+ * <p>The table is keyed on the fully qualified action class name so that plugin actions cannot
+ * collide with built-in actions that have the same simple name. The names are stored as strings
+ * because this module is shared across Elasticsearch 5.0 to 7.17 and many of these classes do not
+ * exist in every version in that range.
  *
  * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
  * equivalent, such as the internal persistent task actions and {@code AutoCreateAction}, or when it
@@ -31,129 +31,275 @@ final class ElasticsearchTransportOperationNames {
   private static final Map<String, String> OPERATION_NAMES = buildOperationNames();
 
   /**
-   * Returns the Elasticsearch REST API name for the given action class simple name, falling back to
-   * the action class simple name when the action is not mapped.
+   * Returns the Elasticsearch REST API name for the given action class, falling back to its simple
+   * name when the action is not mapped.
    */
-  static String operationName(String actionClassName) {
+  static String operationName(String actionClassName, String actionClassSimpleName) {
     String operationName = OPERATION_NAMES.get(actionClassName);
-    return operationName != null ? operationName : actionClassName;
+    return operationName != null ? operationName : actionClassSimpleName;
   }
 
   private static Map<String, String> buildOperationNames() {
     Map<String, String> operationNames = new HashMap<>();
-    operationNames.put("AddIndexBlockAction", "indices.add_block");
-    operationNames.put("AddVotingConfigExclusionsAction", "cluster.post_voting_config_exclusions");
-    operationNames.put("AliasesExistAction", "indices.exists_alias");
-    operationNames.put("AnalyzeAction", "indices.analyze");
-    operationNames.put("AnalyzeIndexDiskUsageAction", "indices.disk_usage");
-    operationNames.put("BulkAction", "bulk");
-    operationNames.put("CancelTasksAction", "tasks.cancel");
-    operationNames.put("CleanupRepositoryAction", "snapshot.cleanup_repository");
-    operationNames.put("ClearIndicesCacheAction", "indices.clear_cache");
-    operationNames.put("ClearScrollAction", "clear_scroll");
     operationNames.put(
-        "ClearVotingConfigExclusionsAction", "cluster.delete_voting_config_exclusions");
-    operationNames.put("CloneSnapshotAction", "snapshot.clone");
-    operationNames.put("CloseIndexAction", "indices.close");
-    operationNames.put("ClosePointInTimeAction", "close_point_in_time");
-    operationNames.put("ClusterAllocationExplainAction", "cluster.allocation_explain");
-    operationNames.put("ClusterHealthAction", "cluster.health");
-    operationNames.put("ClusterRerouteAction", "cluster.reroute");
-    operationNames.put("ClusterSearchShardsAction", "search_shards");
-    operationNames.put("ClusterStateAction", "cluster.state");
-    operationNames.put("ClusterStatsAction", "cluster.stats");
-    operationNames.put("ClusterUpdateSettingsAction", "cluster.put_settings");
-    operationNames.put("CreateIndexAction", "indices.create");
-    operationNames.put("CreateSnapshotAction", "snapshot.create");
-    operationNames.put("DeleteAction", "delete");
-    operationNames.put("DeleteByQueryAction", "delete_by_query");
-    operationNames.put("DeleteComponentTemplateAction", "cluster.delete_component_template");
-    operationNames.put("DeleteComposableIndexTemplateAction", "indices.delete_index_template");
-    operationNames.put("DeleteDanglingIndexAction", "dangling_indices.delete_dangling_index");
-    operationNames.put("DeleteIndexAction", "indices.delete");
-    operationNames.put("DeleteIndexTemplateAction", "indices.delete_template");
-    operationNames.put("DeletePipelineAction", "ingest.delete_pipeline");
-    operationNames.put("DeleteRepositoryAction", "snapshot.delete_repository");
-    operationNames.put("DeleteSnapshotAction", "snapshot.delete");
-    operationNames.put("DeleteStoredScriptAction", "delete_script");
-    operationNames.put("ExplainAction", "explain");
-    operationNames.put("FieldCapabilitiesAction", "field_caps");
-    operationNames.put("FieldStatsAction", "field_stats");
-    operationNames.put("FieldUsageStatsAction", "indices.field_usage_stats");
-    operationNames.put("FlushAction", "indices.flush");
-    operationNames.put("ForceMergeAction", "indices.forcemerge");
-    operationNames.put("GetAction", "get");
-    operationNames.put("GetAliasesAction", "indices.get_alias");
-    operationNames.put("GetComponentTemplateAction", "cluster.get_component_template");
-    operationNames.put("GetComposableIndexTemplateAction", "indices.get_index_template");
-    operationNames.put("GetFeatureUpgradeStatusAction", "migration.get_feature_upgrade_status");
-    operationNames.put("GetFieldMappingsAction", "indices.get_field_mapping");
-    operationNames.put("GetIndexAction", "indices.get");
-    operationNames.put("GetIndexTemplatesAction", "indices.get_template");
-    operationNames.put("GetMappingsAction", "indices.get_mapping");
-    operationNames.put("GetPipelineAction", "ingest.get_pipeline");
-    operationNames.put("GetRepositoriesAction", "snapshot.get_repository");
-    operationNames.put("GetScriptContextAction", "get_script_context");
-    operationNames.put("GetScriptLanguageAction", "get_script_languages");
-    operationNames.put("GetSettingsAction", "indices.get_settings");
-    operationNames.put("GetSnapshotsAction", "snapshot.get");
-    operationNames.put("GetStoredScriptAction", "get_script");
-    operationNames.put("GetTaskAction", "tasks.get");
-    operationNames.put("ImportDanglingIndexAction", "dangling_indices.import_dangling_index");
-    operationNames.put("IndicesAliasesAction", "indices.update_aliases");
-    operationNames.put("IndicesExistsAction", "indices.exists");
-    operationNames.put("IndicesSegmentsAction", "indices.segments");
-    operationNames.put("IndicesShardStoresAction", "indices.shard_stores");
-    operationNames.put("IndicesStatsAction", "indices.stats");
-    operationNames.put("ListDanglingIndicesAction", "dangling_indices.list_dangling_indices");
-    operationNames.put("ListTasksAction", "tasks.list");
-    operationNames.put("MainAction", "info");
-    operationNames.put("ModifyDataStreamsAction", "indices.modify_data_stream");
-    operationNames.put("MultiGetAction", "mget");
-    operationNames.put("MultiSearchAction", "msearch");
-    operationNames.put("MultiTermVectorsAction", "mtermvectors");
-    operationNames.put("NodesHotThreadsAction", "nodes.hot_threads");
-    operationNames.put("NodesInfoAction", "nodes.info");
-    operationNames.put("NodesReloadSecureSettingsAction", "nodes.reload_secure_settings");
-    operationNames.put("NodesStatsAction", "nodes.stats");
-    operationNames.put("NodesUsageAction", "nodes.usage");
-    operationNames.put("OpenIndexAction", "indices.open");
-    operationNames.put("OpenPointInTimeAction", "open_point_in_time");
-    operationNames.put("PendingClusterTasksAction", "cluster.pending_tasks");
-    operationNames.put("PostFeatureUpgradeAction", "migration.post_feature_upgrade");
-    operationNames.put("PutComponentTemplateAction", "cluster.put_component_template");
-    operationNames.put("PutComposableIndexTemplateAction", "indices.put_index_template");
-    operationNames.put("PutIndexTemplateAction", "indices.put_template");
-    operationNames.put("PutMappingAction", "indices.put_mapping");
-    operationNames.put("PutPipelineAction", "ingest.put_pipeline");
-    operationNames.put("PutRepositoryAction", "snapshot.create_repository");
-    operationNames.put("PutStoredScriptAction", "put_script");
-    operationNames.put("RecoveryAction", "indices.recovery");
-    operationNames.put("RefreshAction", "indices.refresh");
-    operationNames.put("ReindexAction", "reindex");
-    operationNames.put("RemoteInfoAction", "cluster.remote_info");
-    operationNames.put("ResetFeatureStateAction", "features.reset_features");
-    operationNames.put("ResolveIndexAction", "indices.resolve_index");
-    operationNames.put("RestoreSnapshotAction", "snapshot.restore");
-    operationNames.put("RolloverAction", "indices.rollover");
-    operationNames.put("SearchAction", "search");
-    operationNames.put("SearchScrollAction", "scroll");
-    operationNames.put("ShrinkAction", "indices.shrink");
-    operationNames.put("SimulateIndexTemplateAction", "indices.simulate_index_template");
-    operationNames.put("SimulatePipelineAction", "ingest.simulate");
-    operationNames.put("SimulateTemplateAction", "indices.simulate_template");
-    operationNames.put("SnapshotsStatusAction", "snapshot.status");
-    operationNames.put("SnapshottableFeaturesAction", "features.get_features");
-    operationNames.put("SyncedFlushAction", "indices.flush_synced");
-    operationNames.put("TermVectorsAction", "termvectors");
-    operationNames.put("TypesExistsAction", "indices.exists_type");
-    operationNames.put("UpdateAction", "update");
-    operationNames.put("UpdateByQueryAction", "update_by_query");
-    operationNames.put("UpdateSettingsAction", "indices.put_settings");
-    operationNames.put("UpgradeAction", "indices.upgrade");
-    operationNames.put("UpgradeStatusAction", "indices.get_upgrade");
-    operationNames.put("ValidateQueryAction", "indices.validate_query");
-    operationNames.put("VerifyRepositoryAction", "snapshot.verify_repository");
+        "org.elasticsearch.action.admin.indices.readonly.AddIndexBlockAction", "indices.add_block");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsAction",
+        "cluster.post_voting_config_exclusions");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.alias.exists.AliasesExistAction",
+        "indices.exists_alias");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.analyze.AnalyzeAction", "indices.analyze");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.diskusage.AnalyzeIndexDiskUsageAction",
+        "indices.disk_usage");
+    operationNames.put("org.elasticsearch.action.bulk.BulkAction", "bulk");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksAction",
+        "tasks.cancel");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryAction",
+        "snapshot.cleanup_repository");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheAction",
+        "indices.clear_cache");
+    operationNames.put("org.elasticsearch.action.search.ClearScrollAction", "clear_scroll");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.configuration.ClearVotingConfigExclusionsAction",
+        "cluster.delete_voting_config_exclusions");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.clone.CloneSnapshotAction",
+        "snapshot.clone");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.close.CloseIndexAction", "indices.close");
+    operationNames.put(
+        "org.elasticsearch.action.search.ClosePointInTimeAction", "close_point_in_time");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainAction",
+        "cluster.allocation_explain");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.health.ClusterHealthAction", "cluster.health");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteAction", "cluster.reroute");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsAction", "search_shards");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.state.ClusterStateAction", "cluster.state");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.stats.ClusterStatsAction", "cluster.stats");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction",
+        "cluster.put_settings");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.create.CreateIndexAction", "indices.create");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction",
+        "snapshot.create");
+    operationNames.put("org.elasticsearch.action.delete.DeleteAction", "delete");
+    operationNames.put("org.elasticsearch.index.reindex.DeleteByQueryAction", "delete_by_query");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.delete.DeleteComponentTemplateAction",
+        "cluster.delete_component_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.delete.DeleteComposableIndexTemplateAction",
+        "indices.delete_index_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.dangling.delete.DeleteDanglingIndexAction",
+        "dangling_indices.delete_dangling_index");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.delete.DeleteIndexAction", "indices.delete");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateAction",
+        "indices.delete_template");
+    operationNames.put(
+        "org.elasticsearch.action.ingest.DeletePipelineAction", "ingest.delete_pipeline");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryAction",
+        "snapshot.delete_repository");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotAction",
+        "snapshot.delete");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.storedscripts.DeleteStoredScriptAction",
+        "delete_script");
+    operationNames.put("org.elasticsearch.action.explain.ExplainAction", "explain");
+    operationNames.put("org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction", "field_caps");
+    operationNames.put("org.elasticsearch.action.fieldstats.FieldStatsAction", "field_stats");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.stats.FieldUsageStatsAction",
+        "indices.field_usage_stats");
+    operationNames.put("org.elasticsearch.action.admin.indices.flush.FlushAction", "indices.flush");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.forcemerge.ForceMergeAction", "indices.forcemerge");
+    operationNames.put("org.elasticsearch.action.get.GetAction", "get");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction", "indices.get_alias");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.get.GetComponentTemplateAction",
+        "cluster.get_component_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.get.GetComposableIndexTemplateAction",
+        "indices.get_index_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.migration.GetFeatureUpgradeStatusAction",
+        "migration.get_feature_upgrade_status");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction",
+        "indices.get_field_mapping");
+    operationNames.put("org.elasticsearch.action.admin.indices.get.GetIndexAction", "indices.get");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction",
+        "indices.get_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.mapping.get.GetMappingsAction",
+        "indices.get_mapping");
+    operationNames.put("org.elasticsearch.action.ingest.GetPipelineAction", "ingest.get_pipeline");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction",
+        "snapshot.get_repository");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.storedscripts.GetScriptContextAction",
+        "get_script_context");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.storedscripts.GetScriptLanguageAction",
+        "get_script_languages");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction",
+        "indices.get_settings");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction", "snapshot.get");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptAction", "get_script");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction", "tasks.get");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.dangling.import_index.ImportDanglingIndexAction",
+        "dangling_indices.import_dangling_index");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction",
+        "indices.update_aliases");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsAction",
+        "indices.exists");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction",
+        "indices.segments");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.shards.IndicesShardStoresAction",
+        "indices.shard_stores");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.stats.IndicesStatsAction", "indices.stats");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.dangling.list.ListDanglingIndicesAction",
+        "dangling_indices.list_dangling_indices");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksAction", "tasks.list");
+    operationNames.put("org.elasticsearch.action.main.MainAction", "info");
+    operationNames.put(
+        "org.elasticsearch.action.datastreams.ModifyDataStreamsAction",
+        "indices.modify_data_stream");
+    operationNames.put("org.elasticsearch.action.get.MultiGetAction", "mget");
+    operationNames.put("org.elasticsearch.action.search.MultiSearchAction", "msearch");
+    operationNames.put(
+        "org.elasticsearch.action.termvectors.MultiTermVectorsAction", "mtermvectors");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsAction",
+        "nodes.hot_threads");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction", "nodes.info");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsAction",
+        "nodes.reload_secure_settings");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction", "nodes.stats");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.node.usage.NodesUsageAction", "nodes.usage");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.open.OpenIndexAction", "indices.open");
+    operationNames.put(
+        "org.elasticsearch.action.search.OpenPointInTimeAction", "open_point_in_time");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksAction",
+        "cluster.pending_tasks");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.migration.PostFeatureUpgradeAction",
+        "migration.post_feature_upgrade");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction",
+        "cluster.put_component_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction",
+        "indices.put_index_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction",
+        "indices.put_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction",
+        "indices.put_mapping");
+    operationNames.put("org.elasticsearch.action.ingest.PutPipelineAction", "ingest.put_pipeline");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction",
+        "snapshot.create_repository");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.storedscripts.PutStoredScriptAction", "put_script");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.recovery.RecoveryAction", "indices.recovery");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.refresh.RefreshAction", "indices.refresh");
+    operationNames.put("org.elasticsearch.index.reindex.ReindexAction", "reindex");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.remote.RemoteInfoAction", "cluster.remote_info");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateAction",
+        "features.reset_features");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction",
+        "indices.resolve_index");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotAction",
+        "snapshot.restore");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.rollover.RolloverAction", "indices.rollover");
+    operationNames.put("org.elasticsearch.action.search.SearchAction", "search");
+    operationNames.put("org.elasticsearch.action.search.SearchScrollAction", "scroll");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.shrink.ShrinkAction", "indices.shrink");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.post.SimulateIndexTemplateAction",
+        "indices.simulate_index_template");
+    operationNames.put("org.elasticsearch.action.ingest.SimulatePipelineAction", "ingest.simulate");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.template.post.SimulateTemplateAction",
+        "indices.simulate_template");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusAction",
+        "snapshot.status");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.snapshots.features.SnapshottableFeaturesAction",
+        "features.get_features");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.flush.SyncedFlushAction", "indices.flush_synced");
+    operationNames.put("org.elasticsearch.action.termvectors.TermVectorsAction", "termvectors");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.exists.types.TypesExistsAction",
+        "indices.exists_type");
+    operationNames.put("org.elasticsearch.action.update.UpdateAction", "update");
+    operationNames.put("org.elasticsearch.index.reindex.UpdateByQueryAction", "update_by_query");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsAction",
+        "indices.put_settings");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.upgrade.post.UpgradeAction", "indices.upgrade");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusAction",
+        "indices.get_upgrade");
+    operationNames.put(
+        "org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction",
+        "indices.validate_query");
+    operationNames.put(
+        "org.elasticsearch.action.admin.cluster.repositories.verify.VerifyRepositoryAction",
+        "snapshot.verify_repository");
     return Collections.unmodifiableMap(operationNames);
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportOperationNames.java
@@ -14,8 +14,16 @@ import java.util.Map;
  * Elasticsearch REST and api-client instrumentations, so that the same logical operation gets the
  * same {@code db.operation.name} no matter which client the application uses.
  *
- * <p>Actions that have no REST API equivalent, such as the internal persistent task and dangling
- * index actions, are deliberately absent and keep their action class name.
+ * <p>Actions are keyed on the action class simple name because the packages holding these classes
+ * moved between Elasticsearch 5.x, 6.x and 7.x, so a fully qualified name would not match across
+ * the supported versions.
+ *
+ * <p>An action is deliberately absent, and so keeps its action class name, when it has no REST API
+ * equivalent, such as the internal persistent task and dangling index actions, or when it covers
+ * several REST APIs that the REST and api-client instrumentations report under different names,
+ * such as {@code ResizeAction} covering shrink, split and clone. Reporting the action class name is
+ * less specific than the REST API name, but it never attributes an operation to a REST API the
+ * caller did not use.
  */
 final class ElasticsearchTransportOperationNames {
 
@@ -23,7 +31,7 @@ final class ElasticsearchTransportOperationNames {
 
   /**
    * Returns the Elasticsearch REST API name for the given action class simple name, falling back to
-   * the action class simple name when the action has no REST API equivalent.
+   * the action class simple name when the action is not mapped.
    */
   static String operationName(String actionClassName) {
     String operationName = OPERATION_NAMES.get(actionClassName);
@@ -37,7 +45,6 @@ final class ElasticsearchTransportOperationNames {
     operationNames.put("AliasesExistAction", "indices.exists_alias");
     operationNames.put("AnalyzeAction", "indices.analyze");
     operationNames.put("AnalyzeIndexDiskUsageAction", "indices.disk_usage");
-    operationNames.put("AutoPutMappingAction", "indices.put_mapping");
     operationNames.put("BulkAction", "bulk");
     operationNames.put("CancelTasksAction", "tasks.cancel");
     operationNames.put("CleanupRepositoryAction", "snapshot.cleanup_repository");
@@ -126,7 +133,6 @@ final class ElasticsearchTransportOperationNames {
     operationNames.put("ReindexAction", "reindex");
     operationNames.put("RemoteInfoAction", "cluster.remote_info");
     operationNames.put("ResetFeatureStateAction", "features.reset_features");
-    operationNames.put("ResizeAction", "indices.shrink");
     operationNames.put("ResolveIndexAction", "indices.resolve_index");
     operationNames.put("RestoreSnapshotAction", "snapshot.restore");
     operationNames.put("RolloverAction", "indices.rollover");

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +100,10 @@ abstract class AbstractElasticsearchClientTest {
       return null;
     }
     return value;
+  }
+
+  static String operationName(String actionClassName, String stableOperationName) {
+    return emitStableDatabaseSemconv() ? stableOperationName : actionClassName;
   }
 
   static class Result<RESPONSE> {

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
@@ -277,7 +277,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                                 longKey("elasticsearch.shard.replication.failed"), experimental(0)),
                             equalTo(
                                 longKey("elasticsearch.request.write.version"),
-                                hasWriteVersion() ? experimental(-3) : null))),
+                                hasWriteVersion() ? experimental(-4) : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
     assertThat(emptyResult.getIndex()).isEqualTo(indexName);
 
     IndexResponse createResult =
-        client.prepareIndex(indexName, indexType, id).setSource(emptyMap()).get();
+        client.prepareIndex(indexName, indexType, id).setSource(emptyMap()).setCreate(true).get();
     assertThat(createResult.getId()).isEqualTo(id);
     assertThat(createResult.getType()).isEqualTo(indexType);
     assertThat(createResult.getIndex()).isEqualTo(indexName);
@@ -252,13 +252,12 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(operationName("IndexAction", "index"))
+                    span.hasName("IndexAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(
-                                maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
+                            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
                             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
                             equalTo(
                                 stringKey("elasticsearch.request"), experimental("IndexRequest")),

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchNodeClientTest.java
@@ -71,12 +71,14 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("ClusterHealthAction")
+                    span.hasName(operationName("ClusterHealthAction", "cluster.health"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "ClusterHealthAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                operationName("ClusterHealthAction", "cluster.health")),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental("ClusterHealthAction")),
@@ -114,7 +116,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         new ArrayList<>(
             asList(
                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                equalTo(maybeStable(DB_OPERATION), "GetAction"),
+                equalTo(maybeStable(DB_OPERATION), operationName("GetAction", "get")),
                 equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
                 equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
                 equalTo(
@@ -134,7 +136,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
                         .hasStatus(StatusData.error())
                         .hasException(expectedException),
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
@@ -161,7 +163,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
     return new ArrayList<>(
         asList(
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "GetAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("GetAction", "get")),
             equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental(indexName)),
@@ -205,12 +207,14 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("CreateIndexAction")
+                    span.hasName(operationName("CreateIndexAction", "indices.create"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "CreateIndexAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                operationName("CreateIndexAction", "indices.create")),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental("CreateIndexAction")),
@@ -223,12 +227,14 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("ClusterHealthAction")
+                    span.hasName(operationName("ClusterHealthAction", "cluster.health"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "ClusterHealthAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                operationName("ClusterHealthAction", "cluster.health")),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental("ClusterHealthAction")),
@@ -238,7 +244,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -246,12 +252,13 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("IndexAction")
+                    span.hasName(operationName("IndexAction", "index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), "IndexAction"),
+                            equalTo(
+                                maybeStable(DB_OPERATION), operationName("IndexAction", "index")),
                             equalTo(stringKey("elasticsearch.action"), experimental("IndexAction")),
                             equalTo(
                                 stringKey("elasticsearch.request"), experimental("IndexRequest")),
@@ -275,7 +282,7 @@ public abstract class AbstractElasticsearchNodeClientTest extends AbstractElasti
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
@@ -306,7 +306,7 @@ public abstract class AbstractElasticsearchTransportClientTest
                                     experimental(0)),
                                 equalTo(
                                     longKey("elasticsearch.request.write.version"),
-                                    hasWriteVersion() ? experimental(-3) : null)))),
+                                    hasWriteVersion() ? experimental(-4) : null)))),
         // moved here by sorting, chronologically happens before PutMappingAction
         trace ->
             trace.hasSpansSatisfyingExactly(

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractElasticsearchTransportClientTest
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("ClusterHealthAction")
+                    span.hasName(operationName("ClusterHealthAction", "cluster.health"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -90,7 +90,9 @@ public abstract class AbstractElasticsearchTransportClientTest
                                 equalTo(NETWORK_PEER_ADDRESS, getAddress()),
                                 equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "ClusterHealthAction"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    operationName("ClusterHealthAction", "cluster.health")),
                                 equalTo(
                                     stringKey("elasticsearch.action"),
                                     experimental("ClusterHealthAction")),
@@ -136,7 +138,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         new ArrayList<>(
             asList(
                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                equalTo(maybeStable(DB_OPERATION), "GetAction"),
+                equalTo(maybeStable(DB_OPERATION), operationName("GetAction", "get")),
                 equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
                 equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
                 equalTo(
@@ -156,7 +158,7 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasStatus(StatusData.error())
                         .hasException(expectedException),
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
@@ -183,6 +185,10 @@ public abstract class AbstractElasticsearchTransportClientTest
 
   protected String getPutMappingActionName() {
     return "PutMappingAction";
+  }
+
+  private String putMappingOperationName() {
+    return operationName(getPutMappingActionName(), "indices.put_mapping");
   }
 
   @Test
@@ -218,11 +224,14 @@ public abstract class AbstractElasticsearchTransportClientTest
     // PutMappingAction and IndexAction run in separate threads so their order can vary
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName(
-            "CreateIndexAction", getPutMappingActionName(), "IndexAction", "GetAction"),
+            operationName("CreateIndexAction", "indices.create"),
+            putMappingOperationName(),
+            operationName("IndexAction", "index"),
+            operationName("GetAction", "get")),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("CreateIndexAction")
+                    span.hasName(operationName("CreateIndexAction", "indices.create"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -230,7 +239,9 @@ public abstract class AbstractElasticsearchTransportClientTest
                                 equalTo(NETWORK_PEER_ADDRESS, getAddress()),
                                 equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "CreateIndexAction"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    operationName("CreateIndexAction", "indices.create")),
                                 equalTo(
                                     stringKey("elasticsearch.action"),
                                     experimental("CreateIndexAction")),
@@ -243,12 +254,12 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(getPutMappingActionName())
+                    span.hasName(putMappingOperationName())
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                            equalTo(maybeStable(DB_OPERATION), getPutMappingActionName()),
+                            equalTo(maybeStable(DB_OPERATION), putMappingOperationName()),
                             equalTo(
                                 stringKey("elasticsearch.action"),
                                 experimental(getPutMappingActionName())),
@@ -258,7 +269,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("IndexAction")
+                    span.hasName(operationName("IndexAction", "index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -266,7 +277,9 @@ public abstract class AbstractElasticsearchTransportClientTest
                                 equalTo(NETWORK_PEER_ADDRESS, getAddress()),
                                 equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "IndexAction"),
+                                equalTo(
+                                    maybeStable(DB_OPERATION),
+                                    operationName("IndexAction", "index")),
                                 equalTo(
                                     stringKey("elasticsearch.action"), experimental("IndexAction")),
                                 equalTo(
@@ -296,7 +309,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -304,7 +317,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GetAction")
+                    span.hasName(operationName("GetAction", "get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -318,7 +331,7 @@ public abstract class AbstractElasticsearchTransportClientTest
             equalTo(NETWORK_PEER_ADDRESS, getAddress()),
             equalTo(NETWORK_PEER_PORT, getPort()),
             equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-            equalTo(maybeStable(DB_OPERATION), "GetAction"),
+            equalTo(maybeStable(DB_OPERATION), operationName("GetAction", "get")),
             equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
             equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
             equalTo(stringKey("elasticsearch.request.indices"), experimental(indexName)),

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
@@ -212,7 +212,7 @@ public abstract class AbstractElasticsearchTransportClientTest
     assertThat(emptyResult.getIndex()).isEqualTo(indexName);
 
     IndexResponse createResult =
-        client.prepareIndex(indexName, indexType, id).setSource(emptyMap()).get();
+        client.prepareIndex(indexName, indexType, id).setSource(emptyMap()).setCreate(true).get();
     assertThat(createResult.getId()).isEqualTo(id);
     assertThat(createResult.getType()).isEqualTo(indexType);
     assertThat(createResult.getIndex()).isEqualTo(indexName);
@@ -230,7 +230,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         orderByRootSpanName(
             operationName("CreateIndexAction", "indices.create"),
             putMappingOperationName(),
-            operationName("IndexAction", "index"),
+            "IndexAction",
             operationName("GetAction", "get")),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -273,7 +273,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(operationName("IndexAction", "index"))
+                    span.hasName("IndexAction")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -281,9 +281,7 @@ public abstract class AbstractElasticsearchTransportClientTest
                                 equalTo(NETWORK_PEER_ADDRESS, getAddress()),
                                 equalTo(NETWORK_PEER_PORT, getPort()),
                                 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    operationName("IndexAction", "index")),
+                                equalTo(maybeStable(DB_OPERATION), "IndexAction"),
                                 equalTo(
                                     stringKey("elasticsearch.action"), experimental("IndexAction")),
                                 equalTo(

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
@@ -188,7 +188,11 @@ public abstract class AbstractElasticsearchTransportClientTest
   }
 
   private String putMappingOperationName() {
-    return operationName(getPutMappingActionName(), "indices.put_mapping");
+    String actionName = getPutMappingActionName();
+    // AutoPutMappingAction has no REST API equivalent, so it keeps its action class name
+    return "AutoPutMappingAction".equals(actionName)
+        ? actionName
+        : operationName(actionName, "indices.put_mapping");
   }
 
   @Test


### PR DESCRIPTION
Elasticsearch transport client spans now report `db.operation.name` as the REST API name, the same value the REST and api-client instrumentations report. They used to report the action class simple name, so one logical operation landed in two time series on `db.client.operation.duration` depending on which client the application used.

```
ClusterHealthAction  ->  cluster.health
CreateIndexAction    ->  indices.create
SearchAction         ->  search
```

Span names follow, because `db.operation.name` feeds span naming.

Old semantic conventions are untouched. `db.operation` and old-semconv span names still report the action class name.

### Unmapped actions

An action keeps its class name when no single REST API name fits:

- `IndexAction` covers both the `index` and `create` op types.
- `ResizeAction` covers `indices.shrink`, `indices.split`, and `indices.clone`.
- Internal actions such as persistent task actions and shard-level actions have no REST API.

The table maps 112 of the 128 action classes that declare a transport action name across Elasticsearch 5.0, 6.0, and 7.17.
