### PR TITLE
Instrument Apache HttpAsyncClient pipelined requests

### DIFF
--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpAsyncClientInstrumentationModule.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpAsyncClientInstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient.v4_1;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -20,6 +20,8 @@ public class ApacheHttpAsyncClientInstrumentationModule extends InstrumentationM
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ApacheHttpAsyncClientInstrumentation());
+    return asList(
+        new ApacheHttpAsyncClientInstrumentation(),
+        new ApacheHttpPipeliningClientInstrumentation());
   }
 }

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient.v4_1;
+
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
+import static io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient.v4_1.ApacheHttpAsyncClientSingletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned;
+import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.protocol.HttpContext;
+
+class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<ClassLoader> classLoaderOptimization() {
+    // added in 4.1
+    return hasClassesNamed("org.apache.http.nio.client.HttpPipeliningClient");
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return implementsInterface(named("org.apache.http.nio.client.HttpPipeliningClient"));
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("execute")
+            .and(takesArguments(5))
+            .and(takesArgument(0, named("org.apache.http.HttpHost")))
+            .and(takesArgument(1, named("java.util.List")))
+            .and(takesArgument(2, named("java.util.List")))
+            .and(takesArgument(3, named("org.apache.http.protocol.HttpContext")))
+            .and(takesArgument(4, named("org.apache.http.concurrent.FutureCallback"))),
+        getClass().getName() + "$PipeliningClientAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class PipeliningClientAdvice {
+
+    @AssignReturned.ToArguments({
+      @ToArgument(value = 1, index = 0),
+      @ToArgument(value = 2, index = 1),
+      @ToArgument(value = 4, index = 2)
+    })
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static Object[] onEnter(
+        @Advice.Argument(0) @Nullable HttpHost target,
+        @Advice.Argument(1) @Nullable List<? extends HttpAsyncRequestProducer> requestProducers,
+        @Advice.Argument(2) @Nullable
+            List<? extends HttpAsyncResponseConsumer<?>> responseConsumers,
+        @Advice.Argument(4) @Nullable FutureCallback<?> futureCallback) {
+      Context parentContext = currentContext();
+
+      if (requestProducers == null
+          || responseConsumers == null
+          || requestProducers.size() != responseConsumers.size()) {
+        return new Object[] {requestProducers, responseConsumers, futureCallback};
+      }
+
+      int size = requestProducers.size();
+      List<HttpAsyncRequestProducer> modifiedRequestProducers = new ArrayList<>(size);
+      List<HttpAsyncResponseConsumer<?>> modifiedResponseConsumers = new ArrayList<>(size);
+      List<PipeliningRequestState> requestStates = new ArrayList<>(size);
+
+      for (int i = 0; i < size; i++) {
+        HttpAsyncRequestProducer requestProducer = requestProducers.get(i);
+        HttpAsyncResponseConsumer<?> responseConsumer = responseConsumers.get(i);
+        if (requestProducer == null || responseConsumer == null) {
+          return new Object[] {requestProducers, responseConsumers, futureCallback};
+        }
+
+        PipeliningRequestState state = new PipeliningRequestState(parentContext, target);
+        requestStates.add(state);
+        modifiedRequestProducers.add(new DelegatingRequestProducer(requestProducer, state));
+        modifiedResponseConsumers.add(new DelegatingResponseConsumer<>(responseConsumer, state));
+      }
+
+      return new Object[] {
+        modifiedRequestProducers,
+        modifiedResponseConsumers,
+        new ContextPropagatingFutureCallback<>(parentContext, futureCallback, requestStates)
+      };
+    }
+  }
+
+  public static class PipeliningRequestState {
+    private final Context parentContext;
+    @Nullable private final HttpHost target;
+
+    private boolean started;
+    private boolean ended;
+
+    @Nullable private Context context;
+    @Nullable private ApacheHttpClientRequest request;
+    @Nullable private HttpResponse response;
+
+    public PipeliningRequestState(Context parentContext, @Nullable HttpHost target) {
+      this.parentContext = parentContext;
+      this.target = target;
+    }
+
+    public synchronized void start(HttpRequest httpRequest) {
+      if (started || ended) {
+        return;
+      }
+      started = true;
+
+      ApacheHttpClientRequest request = new ApacheHttpClientRequest(target, httpRequest);
+      if (instrumenter().shouldStart(parentContext, request)) {
+        this.request = request;
+        context = instrumenter().start(parentContext, request);
+      }
+    }
+
+    public synchronized void setResponse(HttpResponse response) {
+      if (!ended) {
+        this.response = response;
+      }
+    }
+
+    public synchronized boolean hasResponse() {
+      return response != null;
+    }
+
+    public void end(@Nullable Throwable error) {
+      Context context;
+      ApacheHttpClientRequest request;
+      HttpResponse response;
+
+      synchronized (this) {
+        if (ended) {
+          return;
+        }
+        ended = true;
+        context = this.context;
+        request = this.request;
+        response = this.response;
+      }
+
+      if (context != null && request != null) {
+        instrumenter().end(context, request, response, error);
+      }
+    }
+  }
+
+  public static class DelegatingRequestProducer implements HttpAsyncRequestProducer {
+    private final HttpAsyncRequestProducer delegate;
+    private final PipeliningRequestState state;
+
+    public DelegatingRequestProducer(
+        HttpAsyncRequestProducer delegate, PipeliningRequestState state) {
+      this.delegate = delegate;
+      this.state = state;
+    }
+
+    @Override
+    public HttpHost getTarget() {
+      return delegate.getTarget();
+    }
+
+    @Override
+    public HttpRequest generateRequest() throws IOException, HttpException {
+      HttpRequest request = delegate.generateRequest();
+      if (request != null) {
+        state.start(request);
+      }
+      return request;
+    }
+
+    @Override
+    public void produceContent(ContentEncoder encoder, IOControl ioctrl) throws IOException {
+      delegate.produceContent(encoder, ioctrl);
+    }
+
+    @Override
+    public void requestCompleted(HttpContext context) {
+      delegate.requestCompleted(context);
+    }
+
+    @Override
+    public void failed(Exception ex) {
+      delegate.failed(ex);
+    }
+
+    @Override
+    public boolean isRepeatable() {
+      return delegate.isRepeatable();
+    }
+
+    @Override
+    public void resetRequest() throws IOException {
+      delegate.resetRequest();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+
+  public static class DelegatingResponseConsumer<T> implements HttpAsyncResponseConsumer<T> {
+    private final HttpAsyncResponseConsumer<T> delegate;
+    private final PipeliningRequestState state;
+
+    @Nullable private Exception exception;
+
+    public DelegatingResponseConsumer(
+        HttpAsyncResponseConsumer<T> delegate, PipeliningRequestState state) {
+      this.delegate = delegate;
+      this.state = state;
+    }
+
+    @Override
+    public void responseReceived(HttpResponse response) throws IOException, HttpException {
+      state.setResponse(response);
+      delegate.responseReceived(response);
+    }
+
+    @Override
+    public void consumeContent(ContentDecoder decoder, IOControl ioctrl) throws IOException {
+      delegate.consumeContent(decoder, ioctrl);
+    }
+
+    @Override
+    public void responseCompleted(HttpContext context) {
+      delegate.responseCompleted(context);
+    }
+
+    @Override
+    public void failed(Exception ex) {
+      try {
+        delegate.failed(ex);
+      } finally {
+        state.end(ex);
+      }
+    }
+
+    @Override
+    @Nullable
+    public Exception getException() {
+      exception = delegate.getException();
+      return exception;
+    }
+
+    @Override
+    @Nullable
+    public T getResult() {
+      return delegate.getResult();
+    }
+
+    @Override
+    public boolean isDone() {
+      return delegate.isDone();
+    }
+
+    @Override
+    public boolean cancel() {
+      return delegate.cancel();
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        delegate.close();
+      } catch (RuntimeException e) {
+        state.end(e);
+        throw e;
+      } finally {
+        if (exception != null || state.hasResponse()) {
+          state.end(exception);
+        }
+      }
+    }
+  }
+
+  public static class ContextPropagatingFutureCallback<T> implements FutureCallback<T> {
+    private final Context parentContext;
+    @Nullable private final FutureCallback<T> delegate;
+    private final List<PipeliningRequestState> requestStates;
+
+    public ContextPropagatingFutureCallback(
+        Context parentContext,
+        @Nullable FutureCallback<T> delegate,
+        List<PipeliningRequestState> requestStates) {
+      this.parentContext = parentContext;
+      this.delegate = delegate;
+      this.requestStates = requestStates;
+    }
+
+    @Override
+    public void completed(T result) {
+      endRequestStates(null);
+      if (delegate == null) {
+        return;
+      }
+      try (Scope ignored = parentContext.makeCurrent()) {
+        delegate.completed(result);
+      }
+    }
+
+    @Override
+    public void failed(Exception ex) {
+      endRequestStates(ex);
+      if (delegate == null) {
+        return;
+      }
+      try (Scope ignored = parentContext.makeCurrent()) {
+        delegate.failed(ex);
+      }
+    }
+
+    @Override
+    public void cancelled() {
+      endRequestStates(null);
+      if (delegate == null) {
+        return;
+      }
+      try (Scope ignored = parentContext.makeCurrent()) {
+        delegate.cancelled();
+      }
+    }
+
+    private void endRequestStates(@Nullable Throwable error) {
+      try {
+        for (PipeliningRequestState state : requestStates) {
+          state.end(error);
+        }
+      } finally {
+        requestStates.clear();
+      }
+    }
+  }
+}

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
@@ -15,11 +15,9 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -101,8 +99,7 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
           return new Object[] {requestProducers, responseConsumers, futureCallback};
         }
 
-        PipeliningRequestState state =
-            new PipeliningRequestState(parentContext, target, requestProducer);
+        PipeliningRequestState state = new PipeliningRequestState(parentContext, target);
         requestStates.add(state);
         modifiedRequestProducers.add(new DelegatingRequestProducer(requestProducer, state));
         modifiedResponseConsumers.add(new DelegatingResponseConsumer<>(responseConsumer, state));
@@ -114,28 +111,12 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
         new ContextPropagatingFutureCallback<>(parentContext, futureCallback, requestStates)
       };
     }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
-    public static void onExit(
-        @Advice.Enter @Nullable Object[] enterResult, @Advice.Thrown @Nullable Throwable error) {
-      if (error == null || enterResult == null) {
-        return;
-      }
-
-      Object callback = enterResult[2];
-      if (callback instanceof ContextPropagatingFutureCallback) {
-        ((ContextPropagatingFutureCallback<?>) callback).endRequestStates(error);
-      }
-    }
   }
 
   public static class PipeliningRequestState {
     private final Context parentContext;
     @Nullable private final HttpHost target;
-    private final HttpAsyncRequestProducer requestProducer;
-    private final Instant startTime;
 
-    // True after Apache invokes the wrapped producer, even if it returns null or throws.
     private boolean started;
     private boolean ended;
 
@@ -143,25 +124,16 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
     @Nullable private ApacheHttpClientRequest request;
     @Nullable private HttpResponse response;
 
-    public PipeliningRequestState(
-        Context parentContext,
-        @Nullable HttpHost target,
-        HttpAsyncRequestProducer requestProducer) {
+    public PipeliningRequestState(Context parentContext, @Nullable HttpHost target) {
       this.parentContext = parentContext;
       this.target = target;
-      this.requestProducer = requestProducer;
-      startTime = Instant.now();
     }
 
-    public synchronized void start(@Nullable HttpRequest httpRequest) {
+    public synchronized void start(HttpRequest httpRequest) {
       if (started || ended) {
         return;
       }
       started = true;
-
-      if (httpRequest == null) {
-        return;
-      }
 
       ApacheHttpClientRequest request = new ApacheHttpClientRequest(target, httpRequest);
       if (instrumenter().shouldStart(parentContext, request)) {
@@ -184,7 +156,6 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
       Context context;
       ApacheHttpClientRequest request;
       HttpResponse response;
-      boolean started;
 
       synchronized (this) {
         if (ended) {
@@ -194,30 +165,10 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
         context = this.context;
         request = this.request;
         response = this.response;
-        started = this.started;
       }
 
       if (context != null && request != null) {
         instrumenter().end(context, request, response, error);
-      } else if (!started && error != null) {
-        startAndEnd(error);
-      }
-    }
-
-    private void startAndEnd(Throwable error) {
-      try {
-        HttpRequest httpRequest = requestProducer.generateRequest();
-        if (httpRequest == null) {
-          return;
-        }
-
-        ApacheHttpClientRequest request = new ApacheHttpClientRequest(target, httpRequest);
-        if (instrumenter().shouldStart(parentContext, request)) {
-          InstrumenterUtil.startAndEnd(
-              instrumenter(), parentContext, request, null, error, startTime, Instant.now());
-        }
-      } catch (Throwable ignored) {
-        // Instrumentation must not replace the original pipeline failure.
       }
     }
   }
@@ -239,13 +190,11 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
 
     @Override
     public HttpRequest generateRequest() throws IOException, HttpException {
-      HttpRequest request = null;
-      try {
-        request = delegate.generateRequest();
-        return request;
-      } finally {
+      HttpRequest request = delegate.generateRequest();
+      if (request != null) {
         state.start(request);
       }
+      return request;
     }
 
     @Override
@@ -401,7 +350,7 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
       }
     }
 
-    public void endRequestStates(@Nullable Throwable error) {
+    private void endRequestStates(@Nullable Throwable error) {
       try {
         for (PipeliningRequestState state : requestStates) {
           state.end(error);

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
@@ -15,9 +15,11 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -99,7 +101,8 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
           return new Object[] {requestProducers, responseConsumers, futureCallback};
         }
 
-        PipeliningRequestState state = new PipeliningRequestState(parentContext, target);
+        PipeliningRequestState state =
+            new PipeliningRequestState(parentContext, target, requestProducer);
         requestStates.add(state);
         modifiedRequestProducers.add(new DelegatingRequestProducer(requestProducer, state));
         modifiedResponseConsumers.add(new DelegatingResponseConsumer<>(responseConsumer, state));
@@ -111,12 +114,28 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
         new ContextPropagatingFutureCallback<>(parentContext, futureCallback, requestStates)
       };
     }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Enter @Nullable Object[] enterResult, @Advice.Thrown @Nullable Throwable error) {
+      if (error == null || enterResult == null) {
+        return;
+      }
+
+      Object callback = enterResult[2];
+      if (callback instanceof ContextPropagatingFutureCallback) {
+        ((ContextPropagatingFutureCallback<?>) callback).endRequestStates(error);
+      }
+    }
   }
 
   public static class PipeliningRequestState {
     private final Context parentContext;
     @Nullable private final HttpHost target;
+    private final HttpAsyncRequestProducer requestProducer;
+    private final Instant startTime;
 
+    // True after Apache invokes the wrapped producer, even if it returns null or throws.
     private boolean started;
     private boolean ended;
 
@@ -124,16 +143,25 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
     @Nullable private ApacheHttpClientRequest request;
     @Nullable private HttpResponse response;
 
-    public PipeliningRequestState(Context parentContext, @Nullable HttpHost target) {
+    public PipeliningRequestState(
+        Context parentContext,
+        @Nullable HttpHost target,
+        HttpAsyncRequestProducer requestProducer) {
       this.parentContext = parentContext;
       this.target = target;
+      this.requestProducer = requestProducer;
+      startTime = Instant.now();
     }
 
-    public synchronized void start(HttpRequest httpRequest) {
+    public synchronized void start(@Nullable HttpRequest httpRequest) {
       if (started || ended) {
         return;
       }
       started = true;
+
+      if (httpRequest == null) {
+        return;
+      }
 
       ApacheHttpClientRequest request = new ApacheHttpClientRequest(target, httpRequest);
       if (instrumenter().shouldStart(parentContext, request)) {
@@ -156,6 +184,7 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
       Context context;
       ApacheHttpClientRequest request;
       HttpResponse response;
+      boolean started;
 
       synchronized (this) {
         if (ended) {
@@ -165,10 +194,30 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
         context = this.context;
         request = this.request;
         response = this.response;
+        started = this.started;
       }
 
       if (context != null && request != null) {
         instrumenter().end(context, request, response, error);
+      } else if (!started && error != null) {
+        startAndEnd(error);
+      }
+    }
+
+    private void startAndEnd(Throwable error) {
+      try {
+        HttpRequest httpRequest = requestProducer.generateRequest();
+        if (httpRequest == null) {
+          return;
+        }
+
+        ApacheHttpClientRequest request = new ApacheHttpClientRequest(target, httpRequest);
+        if (instrumenter().shouldStart(parentContext, request)) {
+          InstrumenterUtil.startAndEnd(
+              instrumenter(), parentContext, request, null, error, startTime, Instant.now());
+        }
+      } catch (Throwable ignored) {
+        // Instrumentation must not replace the original pipeline failure.
       }
     }
   }
@@ -190,11 +239,13 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
 
     @Override
     public HttpRequest generateRequest() throws IOException, HttpException {
-      HttpRequest request = delegate.generateRequest();
-      if (request != null) {
+      HttpRequest request = null;
+      try {
+        request = delegate.generateRequest();
+        return request;
+      } finally {
         state.start(request);
       }
-      return request;
     }
 
     @Override
@@ -350,7 +401,7 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
       }
     }
 
-    private void endRequestStates(@Nullable Throwable error) {
+    public void endRequestStates(@Nullable Throwable error) {
       try {
         for (PipeliningRequestState state : requestStates) {
           state.end(error);

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientInstrumentation.java
@@ -258,11 +258,8 @@ class ApacheHttpPipeliningClientInstrumentation implements TypeInstrumentation {
 
     @Override
     public void failed(Exception ex) {
-      try {
-        delegate.failed(ex);
-      } finally {
-        state.end(ex);
-      }
+      state.end(ex);
+      delegate.failed(ex);
     }
 
     @Override

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.apachehttpasyncclient.v4_1;
+
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientResult;
+import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpPipeliningClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.BasicAsyncRequestProducer;
+import org.apache.http.nio.protocol.BasicAsyncResponseConsumer;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.protocol.HttpContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriRequest> {
+
+  @RegisterExtension
+  static final InstrumentationExtension testing = HttpClientInstrumentationExtension.forAgent();
+
+  private static final RequestConfig REQUEST_CONFIG =
+      RequestConfig.custom().setConnectTimeout((int) CONNECTION_TIMEOUT.toMillis()).build();
+
+  private static final RequestConfig READ_TIMEOUT_REQUEST_CONFIG =
+      RequestConfig.copy(REQUEST_CONFIG).setSocketTimeout((int) READ_TIMEOUT.toMillis()).build();
+
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  private CloseableHttpPipeliningClient client;
+
+  @BeforeEach
+  void setUp() {
+    client = HttpAsyncClients.createPipelining();
+    cleanup.deferCleanup(client);
+    client.start();
+  }
+
+  @Override
+  protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
+    super.configure(optionsBuilder);
+    optionsBuilder
+        .disableTestRedirects()
+        .disableTestConnectionFailure()
+        .disableTestRemoteConnection()
+        .spanEndsAfterBody();
+  }
+
+  @Override
+  public HttpUriRequest buildRequest(String method, URI uri, Map<String, String> headers) {
+    HttpUriRequest request = new HttpUriRequest(method, URI.create(fullPathFromUri(uri)));
+    request.addHeader("user-agent", "httpasyncclient");
+    headers.forEach((key, value) -> request.setHeader(new BasicHeader(key, value)));
+    return request;
+  }
+
+  @Override
+  public int sendRequest(
+      HttpUriRequest request, String method, URI uri, Map<String, String> headers)
+      throws Exception {
+    List<HttpRequest> requests = singletonList(request);
+    List<HttpResponse> responses = client.execute(target(uri), requests, context(uri), null).get();
+    return getResponseCode(responses.get(0));
+  }
+
+  @Override
+  public void sendRequestWithCallback(
+      HttpUriRequest request,
+      String method,
+      URI uri,
+      Map<String, String> headers,
+      HttpClientResult result) {
+    List<HttpRequest> requests = singletonList(request);
+    client.execute(target(uri), requests, context(uri), new ResponseCallback(result));
+  }
+
+  @Test
+  void pipelinedRequestsCreateIndependentSpansAndPropagateCallbackContext() throws Exception {
+    URI successUri = resolveAddress("/success");
+    URI errorUri = resolveAddress("/error");
+    HttpHost target = target(successUri);
+
+    HttpGet successRequest = new HttpGet(successUri.getRawPath());
+    successRequest.setHeader("test-request-id", "1");
+    HttpGet errorRequest = new HttpGet(errorUri.getRawPath());
+    errorRequest.setHeader("test-request-id", "2");
+    List<HttpRequest> requests = asList(successRequest, errorRequest);
+
+    CountDownLatch callbackDone = new CountDownLatch(1);
+    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+
+    FutureCallback<List<HttpResponse>> callback =
+        new FutureCallback<List<HttpResponse>>() {
+          @Override
+          public void completed(List<HttpResponse> ignored) {
+            try {
+              testing.runWithSpan("callback", () -> {});
+            } catch (Throwable t) {
+              callbackFailure.set(t);
+            } finally {
+              callbackDone.countDown();
+            }
+          }
+
+          @Override
+          public void failed(Exception e) {
+            callbackFailure.set(e);
+            callbackDone.countDown();
+          }
+
+          @Override
+          public void cancelled() {
+            callbackFailure.set(new CancellationException());
+            callbackDone.countDown();
+          }
+        };
+
+    List<HttpResponse> responses =
+        testing.runWithSpan("parent", () -> client.execute(target, requests, null, callback).get());
+
+    assertThat(callbackDone.await(10, SECONDS)).isTrue();
+    assertThat(callbackFailure.get()).isNull();
+    assertThat(responses)
+        .extracting(response -> getResponseCode(response))
+        .containsExactly(200, 500);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
+                span ->
+                    assertClientSpan(span, successUri, "GET", 200, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.unset()),
+                span ->
+                    assertClientSpan(span, errorUri, "GET", 500, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 1)),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 2)),
+                span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void pipelinedFailureEndsAllStartedRequestSpansWithError() throws Exception {
+    URI firstUri = resolveAddress("/long-request");
+    URI secondUri = resolveAddress("/success");
+    HttpHost target = target(firstUri);
+
+    HttpGet firstRequest = new HttpGet(firstUri.getRawPath());
+    firstRequest.setHeader("delay", "500");
+    firstRequest.setHeader("test-request-id", "3");
+    HttpGet secondRequest = new HttpGet(secondUri.getRawPath());
+    secondRequest.setHeader("test-request-id", "4");
+
+    List<? extends HttpAsyncRequestProducer> requestProducers =
+        asList(
+            new BasicAsyncRequestProducer(target, firstRequest),
+            new BasicAsyncRequestProducer(target, secondRequest));
+
+    IllegalStateException consumerFailure =
+        new IllegalStateException("pipelined response consumer failed");
+    List<? extends HttpAsyncResponseConsumer<HttpResponse>> responseConsumers =
+        asList(
+            new BasicAsyncResponseConsumer() {
+              @Override
+              protected HttpResponse buildResult(HttpContext context) {
+                throw consumerFailure;
+              }
+            },
+            new BasicAsyncResponseConsumer());
+
+    CountDownLatch callbackDone = new CountDownLatch(1);
+    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+    FutureCallback<List<HttpResponse>> callback =
+        new FutureCallback<List<HttpResponse>>() {
+          @Override
+          public void completed(List<HttpResponse> ignored) {
+            callbackDone.countDown();
+          }
+
+          @Override
+          public void failed(Exception e) {
+            try {
+              testing.runWithSpan("failure-callback", () -> {});
+              callbackFailure.set(e);
+            } catch (Throwable t) {
+              callbackFailure.set(t);
+            } finally {
+              callbackDone.countDown();
+            }
+          }
+
+          @Override
+          public void cancelled() {
+            callbackDone.countDown();
+          }
+        };
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client
+                            .execute(target, requestProducers, responseConsumers, null, callback)
+                            .get()));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class).hasCause(consumerFailure);
+    assertThat(callbackDone.await(10, SECONDS)).isTrue();
+    assertThat(callbackFailure.get()).isSameAs(consumerFailure);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, firstUri, "GET", 200, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, secondUri, "GET", null, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 3)),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 4)),
+                span ->
+                    span.hasName("failure-callback")
+                        .hasKind(INTERNAL)
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void pipelinedContentFailureEndsCurrentSpanWithError() throws Exception {
+    URI uri = resolveAddress("/success");
+    HttpHost target = target(uri);
+    HttpGet request = new HttpGet(uri.getRawPath());
+    request.setHeader("test-request-id", "6");
+
+    IOException consumerFailure = new IOException("pipelined response content failed");
+    BasicAsyncResponseConsumer responseConsumer =
+        new BasicAsyncResponseConsumer() {
+          @Override
+          protected void onContentReceived(ContentDecoder decoder, IOControl ioctrl)
+              throws IOException {
+            throw consumerFailure;
+          }
+        };
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client
+                            .execute(
+                                target,
+                                singletonList(new BasicAsyncRequestProducer(target, request)),
+                                singletonList(responseConsumer),
+                                null,
+                                null)
+                            .get()));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class).hasCause(consumerFailure);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, uri, "GET", 200, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error())
+                        .hasException(consumerFailure),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 6))));
+  }
+
+  @Test
+  void pipelinedFutureCancellationEndsSpanAndPropagatesCallbackContext() throws Exception {
+    URI uri = resolveAddress("/long-request");
+    HttpHost target = target(uri);
+    HttpGet request = new HttpGet(uri.getRawPath());
+    request.setHeader("delay", "500");
+    request.setHeader("test-request-id", "7");
+
+    CountDownLatch contentReceived = new CountDownLatch(1);
+    BasicAsyncResponseConsumer responseConsumer =
+        new BasicAsyncResponseConsumer() {
+          @Override
+          protected void onContentReceived(ContentDecoder decoder, IOControl ioctrl)
+              throws IOException {
+            super.onContentReceived(decoder, ioctrl);
+            ioctrl.suspendInput();
+            contentReceived.countDown();
+          }
+        };
+
+    CountDownLatch callbackDone = new CountDownLatch(1);
+    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+    FutureCallback<List<HttpResponse>> callback =
+        new FutureCallback<List<HttpResponse>>() {
+          @Override
+          public void completed(List<HttpResponse> ignored) {
+            callbackFailure.set(new AssertionError("cancelled pipeline completed"));
+            callbackDone.countDown();
+          }
+
+          @Override
+          public void failed(Exception ex) {
+            callbackFailure.set(ex);
+            callbackDone.countDown();
+          }
+
+          @Override
+          public void cancelled() {
+            try {
+              testing.runWithSpan("cancel-callback", () -> {});
+            } catch (Throwable t) {
+              callbackFailure.set(t);
+            } finally {
+              callbackDone.countDown();
+            }
+          }
+        };
+
+    Future<List<HttpResponse>> future =
+        testing.runWithSpan(
+            "parent",
+            () ->
+                client.execute(
+                    target,
+                    singletonList(new BasicAsyncRequestProducer(target, request)),
+                    singletonList(responseConsumer),
+                    null,
+                    callback));
+
+    assertThat(contentReceived.await(10, SECONDS)).isTrue();
+    future.cancel(true);
+
+    assertThat(callbackDone.await(10, SECONDS)).isTrue();
+    assertThat(callbackFailure.get()).isNull();
+    assertThat(future.isCancelled()).isTrue();
+    assertThat(future.isDone()).isTrue();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span -> span.hasName("parent").hasKind(INTERNAL).hasNoParent(),
+                span ->
+                    assertClientSpan(span, uri, "GET", 200, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.unset()),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 7)),
+                span ->
+                    span.hasName("cancel-callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void pipelinedConsumerCloseFailureEndsSpanWithError() throws Exception {
+    URI uri = resolveAddress("/success");
+    HttpHost target = target(uri);
+    HttpGet request = new HttpGet(uri.getRawPath());
+    request.setHeader("test-request-id", "5");
+
+    List<? extends HttpAsyncRequestProducer> requestProducers =
+        singletonList(new BasicAsyncRequestProducer(target, request));
+
+    IllegalStateException closeFailure =
+        new IllegalStateException("pipelined response consumer close failed");
+    BasicAsyncResponseConsumer delegate = new BasicAsyncResponseConsumer();
+    HttpAsyncResponseConsumer<HttpResponse> closeFailingConsumer =
+        new HttpAsyncResponseConsumer<HttpResponse>() {
+          @Override
+          public void responseReceived(HttpResponse response) throws IOException, HttpException {
+            delegate.responseReceived(response);
+          }
+
+          @Override
+          public void consumeContent(ContentDecoder decoder, IOControl ioctrl) throws IOException {
+            delegate.consumeContent(decoder, ioctrl);
+          }
+
+          @Override
+          public void responseCompleted(HttpContext context) {
+            delegate.responseCompleted(context);
+          }
+
+          @Override
+          public void failed(Exception ex) {
+            delegate.failed(ex);
+          }
+
+          @Override
+          public Exception getException() {
+            return delegate.getException();
+          }
+
+          @Override
+          public HttpResponse getResult() {
+            return delegate.getResult();
+          }
+
+          @Override
+          public boolean isDone() {
+            return delegate.isDone();
+          }
+
+          @Override
+          public boolean cancel() {
+            return delegate.cancel();
+          }
+
+          @Override
+          public void close() throws IOException {
+            delegate.close();
+            throw closeFailure;
+          }
+        };
+    List<? extends HttpAsyncResponseConsumer<HttpResponse>> responseConsumers =
+        singletonList(closeFailingConsumer);
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client
+                            .execute(target, requestProducers, responseConsumers, null, null)
+                            .get()));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class).hasCause(closeFailure);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, uri, "GET", 200, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertServerSpan(span)
+                        .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 5))));
+  }
+
+  @Test
+  void nullGeneratedRequestUsesApacheValidation() throws Exception {
+    URI uri = resolveAddress("/success");
+    HttpHost target = target(uri);
+    HttpAsyncRequestProducer nullRequestProducer =
+        new BasicAsyncRequestProducer(target, new HttpGet(uri.getRawPath())) {
+          @Override
+          public HttpRequest generateRequest() {
+            return null;
+          }
+        };
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client
+                            .execute(
+                                target,
+                                singletonList(nullRequestProducer),
+                                singletonList(new BasicAsyncResponseConsumer()),
+                                null,
+                                null)
+                            .get()));
+
+    assertThat(thrown)
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error())));
+  }
+
+  private static HttpHost target(URI uri) {
+    return new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+  }
+
+  private static HttpClientContext context(URI uri) {
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequestConfig(
+        uri.getPath().endsWith("/read-timeout") ? READ_TIMEOUT_REQUEST_CONFIG : REQUEST_CONFIG);
+    return context;
+  }
+
+  private static int getResponseCode(HttpResponse response) {
+    try {
+      if (response.getEntity() != null && response.getEntity().getContent() != null) {
+        response.getEntity().getContent().close();
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return response.getStatusLine().getStatusCode();
+  }
+
+  private static String fullPathFromUri(URI uri) {
+    StringBuilder builder = new StringBuilder();
+    if (uri.getPath() != null) {
+      builder.append(uri.getPath());
+    }
+
+    if (uri.getQuery() != null) {
+      builder.append('?').append(uri.getQuery());
+    }
+
+    if (uri.getFragment() != null) {
+      builder.append('#').append(uri.getFragment());
+    }
+    return builder.toString();
+  }
+
+  private static class ResponseCallback implements FutureCallback<List<HttpResponse>> {
+    private final HttpClientResult result;
+
+    private ResponseCallback(HttpClientResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public void completed(List<HttpResponse> responses) {
+      result.complete(getResponseCode(responses.get(0)));
+    }
+
+    @Override
+    public void failed(Exception e) {
+      result.complete(e);
+    }
+
+    @Override
+    public void cancelled() {
+      result.complete(new CancellationException());
+    }
+  }
+}

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
@@ -178,9 +178,11 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
                         .hasStatus(StatusData.error()),
                 span ->
                     assertServerSpan(span)
+                        .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 1)),
                 span ->
                     assertServerSpan(span)
+                        .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 2)),
                 span -> span.hasName("callback").hasKind(INTERNAL).hasParent(trace.getSpan(0))));
   }
@@ -273,9 +275,11 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
                         .hasStatus(StatusData.error()),
                 span ->
                     assertServerSpan(span)
+                        .hasParent(trace.getSpan(1))
                         .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 3)),
                 span ->
                     assertServerSpan(span)
+                        .hasParent(trace.getSpan(3))
                         .hasAttributesSatisfyingExactly(equalTo(longKey("test.request.id"), 4)),
                 span ->
                     span.hasName("failure-callback")

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
@@ -284,7 +284,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   }
 
   @Test
-  void pipelinedContentFailureEndsCurrentSpanWithError() throws Exception {
+  void pipelinedContentFailureEndsCurrentSpanWithError() {
     URI uri = resolveAddress("/success");
     HttpHost target = target(uri);
     HttpGet request = new HttpGet(uri.getRawPath());
@@ -418,7 +418,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   }
 
   @Test
-  void pipelinedConsumerCloseFailureEndsSpanWithError() throws Exception {
+  void pipelinedConsumerCloseFailureEndsSpanWithError() {
     URI uri = resolveAddress("/success");
     HttpHost target = target(uri);
     HttpGet request = new HttpGet(uri.getRawPath());
@@ -550,7 +550,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   }
 
   @Test
-  void nullGeneratedRequestUsesApacheValidation() throws Exception {
+  void nullGeneratedRequestUsesApacheValidation() {
     URI uri = resolveAddress("/success");
     HttpHost target = target(uri);
     AtomicInteger generateCalls = new AtomicInteger();

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
@@ -14,6 +14,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
@@ -30,6 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
@@ -78,11 +80,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     super.configure(optionsBuilder);
-    optionsBuilder
-        .disableTestRedirects()
-        .disableTestConnectionFailure()
-        .disableTestRemoteConnection()
-        .spanEndsAfterBody();
+    optionsBuilder.disableTestRedirects().disableTestRemoteConnection().spanEndsAfterBody();
   }
 
   @Override
@@ -510,13 +508,143 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   }
 
   @Test
+  void directProducerSynchronousFailureCreatesSpan() {
+    URI uri = resolveAddress("/success");
+    AtomicInteger generateCalls = new AtomicInteger();
+    HttpAsyncRequestProducer requestProducer =
+        new BasicAsyncRequestProducer(target(uri), new HttpGet(uri.toString())) {
+          @Override
+          public HttpRequest generateRequest() {
+            generateCalls.incrementAndGet();
+            return super.generateRequest();
+          }
+        };
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client.execute(
+                            null,
+                            singletonList(requestProducer),
+                            singletonList(new BasicAsyncResponseConsumer()),
+                            context(uri),
+                            null)));
+
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+    assertThat(generateCalls).hasValue(1);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, uri, "GET", null, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error())
+                        .hasException(thrown)));
+  }
+
+  @Test
+  void directProducerConnectionFailureCreatesSpanAndPropagatesCallbackContext() throws Exception {
+    URI uri = URI.create("http://localhost:" + PortUtils.UNUSABLE_PORT + '/');
+    HttpHost target = target(uri);
+    AtomicInteger generateCalls = new AtomicInteger();
+
+    HttpAsyncRequestProducer requestProducer =
+        new BasicAsyncRequestProducer(target, new HttpGet(uri.getRawPath())) {
+          @Override
+          public HttpRequest generateRequest() {
+            generateCalls.incrementAndGet();
+            return super.generateRequest();
+          }
+        };
+
+    CountDownLatch callbackDone = new CountDownLatch(1);
+    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+    FutureCallback<List<HttpResponse>> callback =
+        new FutureCallback<List<HttpResponse>>() {
+          @Override
+          public void completed(List<HttpResponse> ignored) {
+            callbackFailure.set(new AssertionError("failed pipeline completed"));
+            callbackDone.countDown();
+          }
+
+          @Override
+          public void failed(Exception e) {
+            try {
+              testing.runWithSpan("connection-failure-callback", () -> {});
+              callbackFailure.set(e);
+            } catch (Throwable t) {
+              callbackFailure.set(t);
+            } finally {
+              callbackDone.countDown();
+            }
+          }
+
+          @Override
+          public void cancelled() {
+            callbackFailure.set(new AssertionError("failed pipeline was cancelled"));
+            callbackDone.countDown();
+          }
+        };
+
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                testing.runWithSpan(
+                    "parent",
+                    () ->
+                        client
+                            .execute(
+                                target,
+                                singletonList(requestProducer),
+                                singletonList(new BasicAsyncResponseConsumer()),
+                                context(uri),
+                                callback)
+                            .get()));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class);
+    Throwable connectionFailure = thrown.getCause();
+    assertThat(callbackDone.await(10, SECONDS)).isTrue();
+    assertThat(callbackFailure.get()).isSameAs(connectionFailure);
+    assertThat(generateCalls).hasValue(1);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactlyInAnyOrder(
+                span ->
+                    span.hasName("parent")
+                        .hasKind(INTERNAL)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error()),
+                span ->
+                    assertClientSpan(span, uri, "GET", null, null)
+                        .hasParent(trace.getSpan(0))
+                        .hasStatus(StatusData.error())
+                        .hasException(connectionFailure),
+                span ->
+                    span.hasName("connection-failure-callback")
+                        .hasKind(INTERNAL)
+                        .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
   void nullGeneratedRequestUsesApacheValidation() throws Exception {
     URI uri = resolveAddress("/success");
     HttpHost target = target(uri);
+    AtomicInteger generateCalls = new AtomicInteger();
     HttpAsyncRequestProducer nullRequestProducer =
         new BasicAsyncRequestProducer(target, new HttpGet(uri.getRawPath())) {
           @Override
           public HttpRequest generateRequest() {
+            generateCalls.incrementAndGet();
             return null;
           }
         };
@@ -539,6 +667,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
     assertThat(thrown)
         .isInstanceOf(ExecutionException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class);
+    assertThat(generateCalls).hasValue(1);
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
+++ b/instrumentation/apache-httpasyncclient-4.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/apachehttpasyncclient/v4_1/ApacheHttpPipeliningClientTest.java
@@ -14,7 +14,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.AbstractHttpClientTest;
@@ -80,7 +79,11 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     super.configure(optionsBuilder);
-    optionsBuilder.disableTestRedirects().disableTestRemoteConnection().spanEndsAfterBody();
+    optionsBuilder
+        .disableTestRedirects()
+        .disableTestConnectionFailure()
+        .disableTestRemoteConnection()
+        .spanEndsAfterBody();
   }
 
   @Override
@@ -508,7 +511,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
   }
 
   @Test
-  void directProducerSynchronousFailureCreatesSpan() {
+  void directProducerSynchronousFailureDoesNotCallProducerOrCreateClientSpan() {
     URI uri = resolveAddress("/success");
     AtomicInteger generateCalls = new AtomicInteger();
     HttpAsyncRequestProducer requestProducer =
@@ -534,7 +537,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
                             null)));
 
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
-    assertThat(generateCalls).hasValue(1);
+    assertThat(generateCalls).hasValue(0);
 
     testing.waitAndAssertTraces(
         trace ->
@@ -543,96 +546,7 @@ class ApacheHttpPipeliningClientTest extends AbstractHttpClientTest<HttpUriReque
                     span.hasName("parent")
                         .hasKind(INTERNAL)
                         .hasNoParent()
-                        .hasStatus(StatusData.error()),
-                span ->
-                    assertClientSpan(span, uri, "GET", null, null)
-                        .hasParent(trace.getSpan(0))
-                        .hasStatus(StatusData.error())
-                        .hasException(thrown)));
-  }
-
-  @Test
-  void directProducerConnectionFailureCreatesSpanAndPropagatesCallbackContext() throws Exception {
-    URI uri = URI.create("http://localhost:" + PortUtils.UNUSABLE_PORT + '/');
-    HttpHost target = target(uri);
-    AtomicInteger generateCalls = new AtomicInteger();
-
-    HttpAsyncRequestProducer requestProducer =
-        new BasicAsyncRequestProducer(target, new HttpGet(uri.getRawPath())) {
-          @Override
-          public HttpRequest generateRequest() {
-            generateCalls.incrementAndGet();
-            return super.generateRequest();
-          }
-        };
-
-    CountDownLatch callbackDone = new CountDownLatch(1);
-    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
-    FutureCallback<List<HttpResponse>> callback =
-        new FutureCallback<List<HttpResponse>>() {
-          @Override
-          public void completed(List<HttpResponse> ignored) {
-            callbackFailure.set(new AssertionError("failed pipeline completed"));
-            callbackDone.countDown();
-          }
-
-          @Override
-          public void failed(Exception e) {
-            try {
-              testing.runWithSpan("connection-failure-callback", () -> {});
-              callbackFailure.set(e);
-            } catch (Throwable t) {
-              callbackFailure.set(t);
-            } finally {
-              callbackDone.countDown();
-            }
-          }
-
-          @Override
-          public void cancelled() {
-            callbackFailure.set(new AssertionError("failed pipeline was cancelled"));
-            callbackDone.countDown();
-          }
-        };
-
-    Throwable thrown =
-        catchThrowable(
-            () ->
-                testing.runWithSpan(
-                    "parent",
-                    () ->
-                        client
-                            .execute(
-                                target,
-                                singletonList(requestProducer),
-                                singletonList(new BasicAsyncResponseConsumer()),
-                                context(uri),
-                                callback)
-                            .get()));
-
-    assertThat(thrown).isInstanceOf(ExecutionException.class);
-    Throwable connectionFailure = thrown.getCause();
-    assertThat(callbackDone.await(10, SECONDS)).isTrue();
-    assertThat(callbackFailure.get()).isSameAs(connectionFailure);
-    assertThat(generateCalls).hasValue(1);
-
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactlyInAnyOrder(
-                span ->
-                    span.hasName("parent")
-                        .hasKind(INTERNAL)
-                        .hasNoParent()
-                        .hasStatus(StatusData.error()),
-                span ->
-                    assertClientSpan(span, uri, "GET", null, null)
-                        .hasParent(trace.getSpan(0))
-                        .hasStatus(StatusData.error())
-                        .hasException(connectionFailure),
-                span ->
-                    span.hasName("connection-failure-callback")
-                        .hasKind(INTERNAL)
-                        .hasParent(trace.getSpan(0))));
+                        .hasStatus(StatusData.error())));
   }
 
   @Test


### PR DESCRIPTION
Adds tracing for Apache HttpAsyncClient pipelined requests. Each request gets its own client span and propagated context.

The instrumentation records each response, ends spans on success, failure, or cancellation, and runs callbacks under the original parent context.