### PR TITLE
fix(thrift): reset async server exception state per request

### DIFF
--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
@@ -41,6 +41,10 @@ class ThriftTBaseAsyncProcessorInstrumentation implements TypeInstrumentation {
     public static void methodEnter(
         @Advice.Argument(0) AbstractNonblockingServer.AsyncFrameBuffer fb,
         @Advice.FieldValue("iface") Object iface) {
+      ServerOutProtocolDecorator serverOutProtocolDecorator =
+          (ServerOutProtocolDecorator) fb.getOutputProtocol();
+      serverOutProtocolDecorator.resetExceptionState();
+
       String serviceName = iface.getClass().getName();
       ((ServerInProtocolDecorator) fb.getInputProtocol()).setServiceName(serviceName);
     }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerAsyncProcessorDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerAsyncProcessorDecorator.java
@@ -41,6 +41,7 @@ public final class ServerAsyncProcessorDecorator implements TAsyncProcessor, TPr
     ServerOutProtocolDecorator serverOutProtocolDecorator =
         (ServerOutProtocolDecorator) fb.getOutputProtocol();
 
+    serverOutProtocolDecorator.resetExceptionState();
     serverInProtocolDecorator.setServiceName(serviceName);
     ServerCallContext serverCallContext = ServerCallContext.start(transport);
     Throwable error = null;

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerOutProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerOutProtocolDecorator.java
@@ -25,6 +25,10 @@ public final class ServerOutProtocolDecorator extends TProtocolDecorator {
     super(protocol);
   }
 
+  public void resetExceptionState() {
+    hasException = false;
+  }
+
   @Override
   public void writeMessageBegin(TMessage message) throws TException {
     if (message.type == TMessageType.EXCEPTION) {

--- a/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/AbstractThriftTest.java
+++ b/instrumentation/thrift-0.13/testing/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/AbstractThriftTest.java
@@ -449,7 +449,7 @@ public abstract class AbstractThriftTest {
     assertMetrics(port);
   }
 
-  private static Stream<Arguments> transports() throws Exception {
+  private static TTransportFactory framedTransportFactory() throws Exception {
     Class<?> framedTransportClass;
     try {
       framedTransportClass = Class.forName("org.apache.thrift.transport.TFramedTransport$Factory");
@@ -457,6 +457,10 @@ public abstract class AbstractThriftTest {
       framedTransportClass =
           Class.forName("org.apache.thrift.transport.layered.TFramedTransport$Factory");
     }
+    return (TTransportFactory) framedTransportClass.getConstructor().newInstance();
+  }
+
+  private static Stream<Arguments> transports() throws Exception {
     Class<?> fastFramedTransportClass;
     try {
       fastFramedTransportClass =
@@ -465,12 +469,10 @@ public abstract class AbstractThriftTest {
       fastFramedTransportClass =
           Class.forName("org.apache.thrift.transport.layered.TFastFramedTransport$Factory");
     }
-    TTransportFactory framedTransportFactory =
-        (TTransportFactory) framedTransportClass.getConstructor().newInstance();
     TTransportFactory fastFramedTransportFactory =
         (TTransportFactory) fastFramedTransportClass.getConstructor().newInstance();
     return Stream.of(
-        Arguments.of(named("framed", framedTransportFactory)),
+        Arguments.of(named("framed", framedTransportFactory())),
         Arguments.of(named("fast framed", fastFramedTransportFactory)));
   }
 
@@ -1070,5 +1072,43 @@ public abstract class AbstractThriftTest {
                         span.hasName("callback")
                             .hasKind(SpanKind.INTERNAL)
                             .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void asyncServerErrorDoesNotAffectFollowingRequestOnSameConnection() throws Exception {
+    int port = startAsyncServer();
+    CustomService.Iface client = createClient(port, framedTransportFactory());
+
+    assertThatThrownBy(client::withError).isInstanceOf(TApplicationException.class);
+    assertThat(client.say("After", "Error")).isEqualTo("Say After Error");
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertClientSpan(span, "withError", port, true)
+                            .hasNoParent()
+                            .hasStatus(StatusData.error()),
+                    span ->
+                        assertServerSpan(
+                                span,
+                                CustomAsyncHandler.class.getName(),
+                                "withError",
+                                port,
+                                IllegalStateException.class.getName())
+                            .hasParent(trace.getSpan(0))
+                            .hasStatus(StatusData.error())),
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        assertClientSpan(span, "say", port)
+                            .hasNoParent()
+                            .hasStatus(StatusData.unset()),
+                    span ->
+                        assertServerSpan(
+                                span, CustomAsyncHandler.class.getName(), "say", port, null)
+                            .hasParent(trace.getSpan(0))
+                            .hasStatus(StatusData.unset())));
   }
 }


### PR DESCRIPTION
## Summary

- Reset the server output protocol exception state at the start of each async request.
- Apply the fix to both javaagent and library instrumentation.
- Add regression coverage for a successful request following an error on the same connection.