### PR TITLE
[jmx] add recommendation for naming percentile metrics

### DIFF
--- a/instrumentation/jmx-metrics/README.md
+++ b/instrumentation/jmx-metrics/README.md
@@ -517,3 +517,6 @@ To contribute to pre-defined metrics definitions or extend them through custom c
 - when metrics represent an upper and lower bounds or a resource, use the `.limit.upper` and `.limit.lower`suffixes, for example:
   - `pool.limit.upper` to represent the upper limit of the pool size (maximum capacity)
   - `pool.limit.lower` to represent the minimum number of threads that should be kept in the pool, even if there is no load.
+- when a metric represents a percentile, use the `.pXX` suffix where `XX` is the percentile value, for example:
+  - `request.duration.p50` for the 50th percentile (median)
+  - `request.duration.p99` for the 99th percentile


### PR DESCRIPTION
Adds recommendation for percentile jmx metrics to use `.p50` or `.p99` as suffixes when capturing percentiles.

For example `cassandra.client.request.latency.p99` already fits, whereas `kafka.request.time.99p` does not.

This particular inconsistency will be covered as part of https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14279