### PR TITLE
Separate documentation drift from audit failures

### DIFF
--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -40,10 +40,10 @@ jobs:
             exit $gradle_exit
           fi
           audit_exit=$(cat instrumentation-docs/build/audit-exit-code)
-          if [[ "$audit_exit" -eq 0 ]]; then
-            echo "success=true" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "$audit_exit" -eq 42 ]]; then
             echo "success=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Open or close documentation sync issue

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -9,9 +9,8 @@ permissions:
 
 jobs:
   crawl:
-    permissions:
-      contents: read
-      issues: write
+    outputs:
+      success: ${{ steps.doc-site-audit.outputs.success }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,31 +47,13 @@ jobs:
               ;;
           esac
 
-      - name: Open or close documentation sync issue
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUDIT_SUCCESS: ${{ steps.doc-site-audit.outputs.success }}
-        run: |
-          set -euo pipefail
-
-          issue_title="Documentation sync needed: opentelemetry.io site out of sync"
-          number=$(
-            gh issue list \
-              --state open \
-              --search "in:title $issue_title" \
-              --limit 100 \
-              --json number,title \
-              --jq "map(select(.title | startswith(\"$issue_title (#\")))[0].number // empty"
-          )
-          issue_body="See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
-
-          if [[ -n "$number" ]]; then
-            if [[ "$AUDIT_SUCCESS" == "true" ]]; then
-              gh issue close "$number"
-            else
-              gh issue comment "$number" --body "$issue_body"
-            fi
-          elif [[ "$AUDIT_SUCCESS" == "false" ]]; then
-            gh issue create --title "$issue_title (#$GITHUB_RUN_NUMBER)" --body "$issue_body"
-          fi
+  workflow-notification:
+    permissions:
+      contents: read
+      issues: write
+    needs:
+      - crawl
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.crawl.outputs.success == 'true' }}
+      title: "Documentation sync needed: opentelemetry.io site out of sync"

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -47,7 +47,7 @@ jobs:
               ;;
           esac
 
-  workflow-notification:
+  documentation-notification:
     permissions:
       contents: read
       issues: write
@@ -57,3 +57,14 @@ jobs:
     with:
       success: ${{ needs.crawl.outputs.success == 'true' }}
       title: "Documentation sync needed: opentelemetry.io site out of sync"
+
+  workflow-notification:
+    permissions:
+      contents: read
+      issues: write
+    needs:
+      - crawl
+    if: always()
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.crawl.result == 'success' }}

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -32,7 +32,15 @@ jobs:
       - name: Run doc site audit
         id: doc-site-audit
         run: |
-          if ./gradlew :instrumentation-docs:docSiteAudit; then
+          set +e
+          ./gradlew :instrumentation-docs:docSiteAudit
+          gradle_exit=$?
+          set -e
+          if [[ $gradle_exit -ne 0 ]]; then
+            exit $gradle_exit
+          fi
+          audit_exit=$(cat instrumentation-docs/build/audit-exit-code)
+          if [[ "$audit_exit" -eq 0 ]]; then
             echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "success=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -9,6 +9,9 @@ permissions:
 
 jobs:
   crawl:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,16 +30,39 @@ jobs:
         run: ./gradlew :instrumentation-docs:runAnalysis
 
       - name: Run doc site audit
-        run: ./gradlew :instrumentation-docs:docSiteAudit
+        id: doc-site-audit
+        run: |
+          if ./gradlew :instrumentation-docs:docSiteAudit; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+          fi
 
-  workflow-notification:
-    permissions:
-      contents: read
-      issues: write
-    needs:
-      - crawl
-    if: always()
-    uses: ./.github/workflows/reusable-workflow-notification.yml
-    with:
-      success: ${{ needs.crawl.result == 'success' }}
-      title: "Documentation sync needed: opentelemetry.io site out of sync"
+      - name: Open or close documentation sync issue
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUDIT_SUCCESS: ${{ steps.doc-site-audit.outputs.success }}
+        run: |
+          set -euo pipefail
+
+          issue_title="Documentation sync needed: opentelemetry.io site out of sync"
+          number=$(
+            gh issue list \
+              --state open \
+              --search "in:title $issue_title" \
+              --limit 100 \
+              --json number,title \
+              --jq "map(select(.title | startswith(\"$issue_title (#\")))[0].number // empty"
+          )
+          issue_body="See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+
+          if [[ -n "$number" ]]; then
+            if [[ "$AUDIT_SUCCESS" == "true" ]]; then
+              gh issue close "$number"
+            else
+              gh issue comment "$number" --body "$issue_body"
+            fi
+          elif [[ "$AUDIT_SUCCESS" == "false" ]]; then
+            gh issue create --title "$issue_title (#$GITHUB_RUN_NUMBER)" --body "$issue_body"
+          fi

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -32,19 +32,21 @@ jobs:
       - name: Run doc site audit
         id: doc-site-audit
         run: |
-          set +e
+          set -euo pipefail
           ./gradlew :instrumentation-docs:docSiteAudit
-          gradle_exit=$?
-          set -e
-          if [[ $gradle_exit -ne 0 ]]; then
-            exit $gradle_exit
-          fi
-          audit_exit=$(cat instrumentation-docs/build/audit-exit-code)
-          if [[ "$audit_exit" -eq 42 ]]; then
-            echo "success=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "success=true" >> "$GITHUB_OUTPUT"
-          fi
+          audit_result=$(cat instrumentation-docs/build/audit-result)
+          case "$audit_result" in
+            clean)
+              echo "success=true" >> "$GITHUB_OUTPUT"
+              ;;
+            drift)
+              echo "success=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected documentation audit result: $audit_result" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Open or close documentation sync issue
         env:

--- a/.github/workflows/documentation-synchronization-audit.yml
+++ b/.github/workflows/documentation-synchronization-audit.yml
@@ -47,12 +47,13 @@ jobs:
               ;;
           esac
 
-  documentation-notification:
+  documentation-drift-notification:
     permissions:
       contents: read
       issues: write
     needs:
       - crawl
+    if: ${{ needs.crawl.result == 'success' }}
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.crawl.outputs.success == 'true' }}

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -8,6 +8,10 @@ on:
       success:
         type: boolean
         required: true
+      title:
+        type: string
+        required: false
+        description: "Custom title for the issue (defaults to 'Workflow failed: $GITHUB_WORKFLOW')"
       failure-notification-after-attempts:
         type: number
         required: false
@@ -33,8 +37,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_SUCCESS: ${{ inputs.success }}
+          INPUT_TITLE: ${{ inputs.title }}
         run: |
-          issue_title="Workflow failed: $GITHUB_WORKFLOW"
+          # Use custom title if provided, otherwise use default
+          if [[ -n "$INPUT_TITLE" ]]; then
+            issue_title="$INPUT_TITLE"
+          else
+            issue_title="Workflow failed: $GITHUB_WORKFLOW"
+          fi
 
           # TODO (trask) search doesn't support exact phrases, so it's possible that this could grab the wrong issue
           number=$(gh issue list --search "in:title $issue_title" --limit 1 --json number -q .[].number)

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -8,10 +8,6 @@ on:
       success:
         type: boolean
         required: true
-      title:
-        type: string
-        required: false
-        description: "Custom title for the issue (defaults to 'Workflow failed: $GITHUB_WORKFLOW')"
       failure-notification-after-attempts:
         type: number
         required: false
@@ -37,14 +33,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_SUCCESS: ${{ inputs.success }}
-          INPUT_TITLE: ${{ inputs.title }}
         run: |
-          # Use custom title if provided, otherwise use default
-          if [[ -n "$INPUT_TITLE" ]]; then
-            issue_title="$INPUT_TITLE"
-          else
-            issue_title="Workflow failed: $GITHUB_WORKFLOW"
-          fi
+          issue_title="Workflow failed: $GITHUB_WORKFLOW"
 
           # TODO (trask) search doesn't support exact phrases, so it's possible that this could grab the wrong issue
           number=$(gh issue list --search "in:title $issue_title" --limit 1 --json number -q .[].number)

--- a/instrumentation-docs/build.gradle.kts
+++ b/instrumentation-docs/build.gradle.kts
@@ -49,11 +49,15 @@ tasks {
     mainClass.set("io.opentelemetry.instrumentation.docs.DocSynchronization")
     classpath(sourceSets["main"].runtimeClasspath)
 
+    // Resolved during configuration so that the task action below captures only this value,
+    // and not the build script object, which the configuration cache cannot serialize.
+    val exitCodeFile = layout.buildDirectory.file("audit-exit-code")
+
     doLast {
       val exitValue = executionResult.get().exitValue
       // Write the Java process exit code so the CI workflow can distinguish
       // drift (exit 42) from execution errors (any other nonzero exit).
-      layout.buildDirectory.file("audit-exit-code").get().asFile.also {
+      exitCodeFile.get().asFile.also {
         it.parentFile.mkdirs()
         it.writeText(exitValue.toString())
       }

--- a/instrumentation-docs/build.gradle.kts
+++ b/instrumentation-docs/build.gradle.kts
@@ -43,9 +43,24 @@ tasks {
 
   register<JavaExec>("docSiteAudit") {
     dependsOn(classes)
+    isIgnoreExitValue = true
 
     systemProperty("basePath", project.rootDir)
     mainClass.set("io.opentelemetry.instrumentation.docs.DocSynchronization")
     classpath(sourceSets["main"].runtimeClasspath)
+
+    doLast {
+      val exitValue = executionResult.get().exitValue
+      // Write the Java process exit code so the CI workflow can distinguish
+      // drift (exit 1) from execution errors (exit 2+).
+      layout.buildDirectory.file("audit-exit-code").get().asFile.also {
+        it.parentFile.mkdirs()
+        it.writeText(exitValue.toString())
+      }
+      // Execution errors should still fail the Gradle task.
+      if (exitValue > 1) {
+        error("Audit execution failed with exit code $exitValue")
+      }
+    }
   }
 }

--- a/instrumentation-docs/build.gradle.kts
+++ b/instrumentation-docs/build.gradle.kts
@@ -52,13 +52,13 @@ tasks {
     doLast {
       val exitValue = executionResult.get().exitValue
       // Write the Java process exit code so the CI workflow can distinguish
-      // drift (exit 1) from execution errors (exit 2+).
+      // drift (exit 42) from execution errors (any other nonzero exit).
       layout.buildDirectory.file("audit-exit-code").get().asFile.also {
         it.parentFile.mkdirs()
         it.writeText(exitValue.toString())
       }
       // Execution errors should still fail the Gradle task.
-      if (exitValue > 1) {
+      if (exitValue != 0 && exitValue != 42) {
         error("Audit execution failed with exit code $exitValue")
       }
     }

--- a/instrumentation-docs/build.gradle.kts
+++ b/instrumentation-docs/build.gradle.kts
@@ -43,28 +43,10 @@ tasks {
 
   register<JavaExec>("docSiteAudit") {
     dependsOn(classes)
-    isIgnoreExitValue = true
 
     systemProperty("basePath", project.rootDir)
     mainClass.set("io.opentelemetry.instrumentation.docs.DocSynchronization")
     classpath(sourceSets["main"].runtimeClasspath)
-
-    // Resolved during configuration so that the task action below captures only this value,
-    // and not the build script object, which the configuration cache cannot serialize.
-    val exitCodeFile = layout.buildDirectory.file("audit-exit-code")
-
-    doLast {
-      val exitValue = executionResult.get().exitValue
-      // Write the Java process exit code so the CI workflow can distinguish
-      // drift (exit 42) from execution errors (any other nonzero exit).
-      exitCodeFile.get().asFile.also {
-        it.parentFile.mkdirs()
-        it.writeText(exitValue.toString())
-      }
-      // Execution errors should still fail the Gradle task.
-      if (exitValue != 0 && exitValue != 42) {
-        error("Audit execution failed with exit code $exitValue")
-      }
-    }
+    args(layout.buildDirectory.file("audit-result").get().asFile.absolutePath)
   }
 }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
@@ -66,6 +66,9 @@ public class DocSynchronization {
       }
 
       if (hasErrors) {
+        if (hasDrift) {
+          logger.warning("Partial drift detected (audit did not complete):\n" + driftMessage);
+        }
         logger.severe("Audit execution errors:\n" + errorMessage);
         exit(1);
       } else if (hasDrift) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
@@ -27,10 +27,13 @@ public class DocSynchronization {
   private static final List<DocumentationAuditor> AUDITORS =
       List.of(new SuppressionListAuditor(), new SupportedLibrariesAuditor());
 
-  public static void main(String[] args) {
-    HttpClient client = HttpClient.newHttpClient();
+  // Reserved exit code that means "audit ran to completion and found drift".
+  // Any other nonzero exit is treated as an execution error.
+  private static final int DRIFT_EXIT_CODE = 42;
 
+  public static void main(String[] args) {
     try {
+      HttpClient client = HttpClient.newHttpClient();
       boolean hasDrift = false;
       boolean hasErrors = false;
       StringBuilder driftMessage = new StringBuilder();
@@ -64,7 +67,7 @@ public class DocSynchronization {
 
       if (hasErrors) {
         logger.severe("Audit execution errors:\n" + errorMessage);
-        exit(2);
+        exit(1);
       } else if (hasDrift) {
         // Add custom markers and "How to Fix" section for GitHub workflow extraction
         StringBuilder finalMessage = new StringBuilder();
@@ -76,7 +79,7 @@ public class DocSynchronization {
         finalMessage.append("\n=== AUDIT_FAILURE_END ===");
 
         logger.severe(finalMessage.toString());
-        exit(1);
+        exit(DRIFT_EXIT_CODE);
       } else {
         logger.info("All documentation audits passed successfully.");
       }
@@ -84,7 +87,7 @@ public class DocSynchronization {
     } catch (RuntimeException e) {
       logger.severe("Error running documentation audits: " + e.getMessage());
       logger.severe(Arrays.toString(e.getStackTrace()));
-      exit(2);
+      exit(1);
     }
   }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
@@ -31,8 +31,10 @@ public class DocSynchronization {
     HttpClient client = HttpClient.newHttpClient();
 
     try {
-      boolean hasFailures = false;
-      StringBuilder combinedMessage = new StringBuilder();
+      boolean hasDrift = false;
+      boolean hasErrors = false;
+      StringBuilder driftMessage = new StringBuilder();
+      StringBuilder errorMessage = new StringBuilder();
 
       for (DocumentationAuditor auditor : AUDITORS) {
         try {
@@ -40,19 +42,19 @@ public class DocSynchronization {
           Optional<String> result = auditor.performAudit(client);
 
           if (result.isPresent()) {
-            hasFailures = true;
-            if (!combinedMessage.isEmpty()) {
-              combinedMessage.append("\n\n");
+            hasDrift = true;
+            if (!driftMessage.isEmpty()) {
+              driftMessage.append("\n\n");
             }
-            combinedMessage.append(result.get());
+            driftMessage.append(result.get());
           }
         } catch (IOException | InterruptedException | RuntimeException e) {
           logger.severe("Error running " + auditor.getAuditorName() + ": " + e.getMessage());
-          hasFailures = true;
-          if (!combinedMessage.isEmpty()) {
-            combinedMessage.append("\n\n");
+          hasErrors = true;
+          if (!errorMessage.isEmpty()) {
+            errorMessage.append("\n\n");
           }
-          combinedMessage
+          errorMessage
               .append("Error in ")
               .append(auditor.getAuditorName())
               .append(": ")
@@ -60,11 +62,14 @@ public class DocSynchronization {
         }
       }
 
-      if (hasFailures) {
+      if (hasErrors) {
+        logger.severe("Audit execution errors:\n" + errorMessage);
+        exit(2);
+      } else if (hasDrift) {
         // Add custom markers and "How to Fix" section for GitHub workflow extraction
         StringBuilder finalMessage = new StringBuilder();
         finalMessage.append("=== AUDIT_FAILURE_START ===\n");
-        finalMessage.append(combinedMessage.toString());
+        finalMessage.append(driftMessage.toString());
         finalMessage.append("\n\n## How to Fix\n\n");
         finalMessage.append(
             "For guidance on updating the OpenTelemetry.io documentation, see: [Documenting Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/documenting-instrumentation.md#opentelemetryio)");
@@ -79,7 +84,7 @@ public class DocSynchronization {
     } catch (RuntimeException e) {
       logger.severe("Error running documentation audits: " + e.getMessage());
       logger.severe(Arrays.toString(e.getStackTrace()));
-      exit(1);
+      exit(2);
     }
   }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocSynchronization.java
@@ -6,12 +6,15 @@
 package io.opentelemetry.instrumentation.docs;
 
 import static java.lang.System.exit;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.opentelemetry.instrumentation.docs.auditors.DocumentationAuditor;
 import io.opentelemetry.instrumentation.docs.auditors.SupportedLibrariesAuditor;
 import io.opentelemetry.instrumentation.docs.auditors.SuppressionListAuditor;
 import java.io.IOException;
 import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -27,12 +30,12 @@ public class DocSynchronization {
   private static final List<DocumentationAuditor> AUDITORS =
       List.of(new SuppressionListAuditor(), new SupportedLibrariesAuditor());
 
-  // Reserved exit code that means "audit ran to completion and found drift".
-  // Any other nonzero exit is treated as an execution error.
-  private static final int DRIFT_EXIT_CODE = 42;
+  private static final String CLEAN_RESULT = "clean";
+  private static final String DRIFT_RESULT = "drift";
 
   public static void main(String[] args) {
     try {
+      Path auditResultPath = Path.of(args[0]);
       HttpClient client = HttpClient.newHttpClient();
       boolean hasDrift = false;
       boolean hasErrors = false;
@@ -82,16 +85,25 @@ public class DocSynchronization {
         finalMessage.append("\n=== AUDIT_FAILURE_END ===");
 
         logger.severe(finalMessage.toString());
-        exit(DRIFT_EXIT_CODE);
+        writeAuditResult(auditResultPath, DRIFT_RESULT);
       } else {
         logger.info("All documentation audits passed successfully.");
+        writeAuditResult(auditResultPath, CLEAN_RESULT);
       }
 
-    } catch (RuntimeException e) {
+    } catch (IOException | RuntimeException e) {
       logger.severe("Error running documentation audits: " + e.getMessage());
       logger.severe(Arrays.toString(e.getStackTrace()));
       exit(1);
     }
+  }
+
+  private static void writeAuditResult(Path auditResultPath, String result) throws IOException {
+    Path parent = auditResultPath.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(auditResultPath, result, UTF_8);
   }
 
   private DocSynchronization() {}


### PR DESCRIPTION
Documentation drift no longer fails the audit workflow. A separate notification job manages the opentelemetry.io sync issue, while audit errors still fail the workflow and use the standard workflow-failure issue.