### PR TITLE
Test experimental attributes in all JVM suite variants

### DIFF
--- a/.github/agents/knowledge/gradle-conventions.md
+++ b/.github/agents/knowledge/gradle-conventions.md
@@ -222,6 +222,42 @@ The map produces `testStableSemconv` for the built-in suite, so the conventional
 preserved. Declare a separate map per variant when a module has more than one, for example
 `${suite.name}StableSemconv` and `${suite.name}BothSemconv` for RPC modules.
 
+#### Preserving source suite JVM settings
+
+When source suite tasks have different JVM arguments or system properties, copy those values into
+the variant before adding its own configuration. This avoids rebuilding source settings with
+suite-name checks. When metadata collection is already active, append the variant setting to the
+inherited `metadataConfig`:
+
+```kotlin
+val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+  .map { suite ->
+    register<Test>("${suite.name}Experimental") {
+      val sourceTask = named<Test>(suite.name).get()
+      setJvmArgs(sourceTask.jvmArgs)
+      setSystemProperties(sourceTask.systemProperties)
+
+      testClassesDirs = suite.sources.output.classesDirs
+      classpath = suite.sources.runtimeClasspath
+
+      val experimentalConfig = "otel.instrumentation.example.experimental-span-attributes=true"
+      jvmArgs("-D$experimentalConfig")
+      systemProperty(
+        "metadataConfig",
+        listOfNotNull(sourceTask.systemProperties["metadataConfig"], experimentalConfig)
+          .joinToString(","),
+      )
+      isEnabled = sourceTask.enabled
+    }
+  }
+```
+
+Use `setJvmArgs` and `setSystemProperties`, not `sourceTask.copyTo(this)`. Gradle's
+`JavaForkOptions.copyTo` evaluates the source task's `jvmArgumentProviders` and turns their output
+into ordinary JVM arguments. Repository conventions later attach providers to the variant itself.
+This can add the javaagent twice and drop the copied providers' input tracking. The variant gets its
+own argument providers from the repository conventions.
+
 Points to watch:
 
 - Do not fan a variant out merely because custom suites exist. Keep it bound to
@@ -231,9 +267,9 @@ Points to watch:
   the extra coverage is worth the additional build-script complexity.
 - The `testing { suites { … } }` block must appear **before** the `tasks { }` block that maps
   over it. `.map` realizes the container, so suites registered afterwards are silently missed.
-- When a source suite task is conditionally disabled, inherit its state in the derived task
-  with `isEnabled = project.tasks.named(suite.name).get().enabled` instead of repeating the
-  condition in a separate `named(...)` block.
+- When a source suite task is conditionally disabled, inherit its state in the derived task with
+  `isEnabled = sourceTask.enabled` instead of repeating the condition in a separate `named(...)`
+  block.
 - Keep a variant task bound to a single source set when it is deliberately narrow — one bound
   to a specific suite, or narrowed with `includeTestsMatching(...)`. Fanning such a task across
   every suite fails the build, because Gradle fails a `Test` task whose filter matches nothing.

--- a/.github/agents/knowledge/testing-experimental-flags.md
+++ b/.github/agents/knowledge/testing-experimental-flags.md
@@ -38,6 +38,12 @@ The `testExperimental` task follows the standard custom test task pattern — se
 [gradle-conventions.md](gradle-conventions.md) for `testClassesDirs`, `classpath`,
 `collectMetadata`, `metadataConfig`, and `check` wiring requirements.
 
+When the module creates an experimental variant for every `JvmTestSuite` and source suites have
+task-specific JVM arguments or system properties, follow the
+[source suite JVM settings](gradle-conventions.md#preserving-source-suite-jvm-settings)
+pattern. Inherit the source values, then add the experimental flag. Do not reconstruct source
+settings with checks against `suite.name`.
+
 The domain-specific parts are the `jvmArgs` and `metadataConfig` values:
 
 ```kotlin

--- a/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
@@ -68,6 +68,7 @@ tasks {
 
         jvmArgs("-Dotel.instrumentation.kubernetes-client.experimental-span-attributes=true")
         systemProperty("metadataConfig", "otel.instrumentation.kubernetes-client.experimental-span-attributes=true")
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 
@@ -82,13 +83,6 @@ tasks {
         isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
-
-  // client-java-api 22.0.0+ requires Java 11+
-  if (testJavaVersion.isJava8) {
-    named<Test>("version22TestExperimental") {
-      enabled = false
-    }
-  }
 
   check {
     dependsOn(experimentalSuites, stableSemconvSuites)

--- a/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
@@ -60,13 +60,16 @@ tasks {
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.kubernetes-client.experimental-span-attributes=true")
-    systemProperty("metadataConfig", "otel.instrumentation.kubernetes-client.experimental-span-attributes=true")
-  }
+        jvmArgs("-Dotel.instrumentation.kubernetes-client.experimental-span-attributes=true")
+        systemProperty("metadataConfig", "otel.instrumentation.kubernetes-client.experimental-span-attributes=true")
+      }
+    }
 
   val stableSemconvSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
@@ -80,7 +83,14 @@ tasks {
       }
     }
 
+  // client-java-api 22.0.0+ requires Java 11+
+  if (testJavaVersion.isJava8) {
+    named<Test>("version22TestExperimental") {
+      enabled = false
+    }
+  }
+
   check {
-    dependsOn(testExperimental, stableSemconvSuites)
+    dependsOn(experimentalSuites, stableSemconvSuites)
   }
 }

--- a/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/kubernetes-client-7.0/javaagent/build.gradle.kts
@@ -63,12 +63,20 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        jvmArgs("-Dotel.instrumentation.kubernetes-client.experimental-span-attributes=true")
-        systemProperty("metadataConfig", "otel.instrumentation.kubernetes-client.experimental-span-attributes=true")
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        val experimentalConfig = "otel.instrumentation.kubernetes-client.experimental-span-attributes=true"
+        jvmArgs("-D$experimentalConfig")
+        systemProperty(
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], experimentalConfig).joinToString(","),
+        )
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -95,6 +95,7 @@ tasks {
           "hasConsumerGroup",
           if (suite.name == "test") otelProps.testLatestDeps else true,
         )
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -89,8 +89,16 @@ tasks {
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
+        val receiveTelemetryEnabled = suite.name == "test"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
         jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-        systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
+        val metadataConfig =
+          if (receiveTelemetryEnabled) {
+            "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true"
+          } else {
+            "otel.instrumentation.kafka.experimental-span-attributes=true"
+          }
+        systemProperty("metadataConfig", metadataConfig)
         systemProperty(
           "hasConsumerGroup",
           if (suite.name == "test") otelProps.testLatestDeps else true,

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -83,14 +83,20 @@ tasks {
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-    systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
-    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
-  }
+        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+        systemProperty("metadataConfig", "otel.instrumentation.kafka.experimental-span-attributes=true")
+        systemProperty(
+          "hasConsumerGroup",
+          if (suite.name == "test") otelProps.testLatestDeps else true,
+        )
+      }
+    }
 
   val testReceiveSpansDisabled = register<Test>("testReceiveSpansDisabled") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -138,7 +144,7 @@ tasks {
   check {
     dependsOn(
       testing.suites,
-      testExperimental,
+      experimentalSuites,
       testReceiveSpansDisabled,
       testMessagingPreview,
       testBothSemconv,

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -86,24 +86,20 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        val receiveTelemetryEnabled = suite.name == "test"
-        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
-        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-        val metadataConfig =
-          if (receiveTelemetryEnabled) {
-            "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true"
-          } else {
-            "otel.instrumentation.kafka.experimental-span-attributes=true"
-          }
-        systemProperty("metadataConfig", metadataConfig)
+        val experimentalConfig = "otel.instrumentation.kafka.experimental-span-attributes=true"
+        jvmArgs("-D$experimentalConfig")
         systemProperty(
-          "hasConsumerGroup",
-          if (suite.name == "test") otelProps.testLatestDeps else true,
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], experimentalConfig).joinToString(","),
         )
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -45,17 +45,24 @@ tasks {
     )
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-    systemProperty(
-      "metadataConfig",
-      "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true",
-    )
-  }
+        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
+        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+        val metadataConfig =
+          if (receiveTelemetryEnabled) {
+            "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true"
+          } else {
+            "otel.instrumentation.kafka.experimental-span-attributes=true"
+          }
+        systemProperty("metadataConfig", metadataConfig)
+      }
+    }
 
   val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -82,6 +89,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -61,6 +61,7 @@ tasks {
             "otel.instrumentation.kafka.experimental-span-attributes=true"
           }
         systemProperty("metadataConfig", metadataConfig)
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -48,20 +48,20 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
-        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
-        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-        val metadataConfig =
-          if (receiveTelemetryEnabled) {
-            "otel.instrumentation.messaging.experimental.receive-telemetry.enabled=true,otel.instrumentation.kafka.experimental-span-attributes=true"
-          } else {
-            "otel.instrumentation.kafka.experimental-span-attributes=true"
-          }
-        systemProperty("metadataConfig", metadataConfig)
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        val experimentalConfig = "otel.instrumentation.kafka.experimental-span-attributes=true"
+        jvmArgs("-D$experimentalConfig")
+        systemProperty(
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], experimentalConfig).joinToString(","),
+        )
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -49,13 +49,17 @@ tasks {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-  }
+        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
+        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+      }
+    }
 
   val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -80,6 +84,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -58,6 +58,7 @@ tasks {
         val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
         jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
         jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -52,13 +52,15 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
-        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
         jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -49,13 +49,17 @@ tasks {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-  }
+        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
+        jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+      }
+    }
 
   val testMessagingPreview = register<Test>("testMessagingPreview") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -80,6 +84,6 @@ tasks {
   }
 
   check {
-    dependsOn(testing.suites, testExperimental, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -58,6 +58,7 @@ tasks {
         val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
         jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
         jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -52,13 +52,15 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        val receiveTelemetryEnabled = suite.name != "testNoReceiveTelemetry"
-        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=$receiveTelemetryEnabled")
         jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=true")
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
@@ -54,12 +54,20 @@ tasks {
   val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
     .map { suite ->
       register<Test>("${suite.name}Experimental") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
+
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
 
-        jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
-        systemProperty("metadataConfig", "otel.instrumentation.xxl-job.experimental-span-attributes=true")
-        isEnabled = project.tasks.named(suite.name).get().enabled
+        val experimentalConfig = "otel.instrumentation.xxl-job.experimental-span-attributes=true"
+        jvmArgs("-D$experimentalConfig")
+        systemProperty(
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], experimentalConfig).joinToString(","),
+        )
+        isEnabled = sourceTask.enabled
       }
     }
 

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
@@ -51,13 +51,16 @@ tasks {
     systemProperty("collectMetadata", otelProps.collectMetadata)
   }
 
-  val testExperimental = register<Test>("testExperimental") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
+  val experimentalSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}Experimental") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-    jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
-    systemProperty("metadataConfig", "otel.instrumentation.xxl-job.experimental-span-attributes=true")
-  }
+        jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
+        systemProperty("metadataConfig", "otel.instrumentation.xxl-job.experimental-span-attributes=true")
+      }
+    }
 
   named("compileXxlJob33TestJava", JavaCompile::class).configure {
     options.release.set(17)
@@ -67,10 +70,12 @@ tasks {
     named("xxlJob33Test", Test::class).configure {
       enabled = false
     }
+    named("xxlJob33TestExperimental", Test::class).configure {
+      enabled = false
+    }
   }
 
   check {
-    dependsOn(testing.suites)
-    dependsOn(testExperimental)
+    dependsOn(testing.suites, experimentalSuites)
   }
 }

--- a/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
+++ b/instrumentation/xxl-job/xxl-job-2.3.0/javaagent/build.gradle.kts
@@ -59,6 +59,7 @@ tasks {
 
         jvmArgs("-Dotel.instrumentation.xxl-job.experimental-span-attributes=true")
         systemProperty("metadataConfig", "otel.instrumentation.xxl-job.experimental-span-attributes=true")
+        isEnabled = project.tasks.named(suite.name).get().enabled
       }
     }
 
@@ -68,9 +69,6 @@ tasks {
   val testJavaVersion = otelProps.testJavaVersion ?: JavaVersion.current()
   if (!testJavaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
     named("xxlJob33Test", Test::class).configure {
-      enabled = false
-    }
-    named("xxlJob33TestExperimental", Test::class).configure {
       enabled = false
     }
   }


### PR DESCRIPTION
Runs experimental-attribute tests for every registered JVM test suite in Kubernetes client, Reactor Kafka, Vert.x Kafka client, and XXL Job instrumentation.

The new test tasks preserve each source suite's Java-version and receive-telemetry settings.

Follow-up: #19792 tracks reusable Gradle helpers for derived JVM test suite variants.