### PR TITLE
Add missing messaging semantic convention test variants

### DIFF
--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -105,12 +105,20 @@ tasks {
   }
 
   val testJms2BothSemconv = register<Test>("testJms2BothSemconv") {
+    val sourceTask = named<Test>("jms2Test").get()
+    setJvmArgs(sourceTask.jvmArgs)
+    setSystemProperties(sourceTask.systemProperties)
+
     testClassesDirs = sourceSets["jms2Test"].output.classesDirs
     classpath = sourceSets["jms2Test"].runtimeClasspath
-    isEnabled = project.tasks.named("jms2Test").get().enabled
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+
+    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
+    jvmArgs("-D$semconvConfig")
+    systemProperty(
+      "metadataConfig",
+      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+    )
+    isEnabled = sourceTask.enabled
   }
 
   val testBothSemconv = register<Test>("testBothSemconv") {

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -107,6 +107,7 @@ tasks {
   val testJms2BothSemconv = register<Test>("testJms2BothSemconv") {
     testClassesDirs = sourceSets["jms2Test"].output.classesDirs
     classpath = sourceSets["jms2Test"].runtimeClasspath
+    isEnabled = project.tasks.named("jms2Test").get().enabled
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -105,20 +105,12 @@ tasks {
   }
 
   val testJms2BothSemconv = register<Test>("testJms2BothSemconv") {
-    val sourceTask = named<Test>("jms2Test").get()
-    setJvmArgs(sourceTask.jvmArgs)
-    setSystemProperties(sourceTask.systemProperties)
-
     testClassesDirs = sourceSets["jms2Test"].output.classesDirs
     classpath = sourceSets["jms2Test"].runtimeClasspath
-
-    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
-    jvmArgs("-D$semconvConfig")
-    systemProperty(
-      "metadataConfig",
-      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
-    )
-    isEnabled = sourceTask.enabled
+    isEnabled = project.tasks.named("jms2Test").get().enabled
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   val testBothSemconv = register<Test>("testBothSemconv") {

--- a/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
+++ b/instrumentation/jms/jms-1.1/javaagent/build.gradle.kts
@@ -104,6 +104,14 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testJms2BothSemconv = register<Test>("testJms2BothSemconv") {
+    testClassesDirs = sourceSets["jms2Test"].output.classesDirs
+    classpath = sourceSets["jms2Test"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   val testBothSemconv = register<Test>("testBothSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
@@ -136,6 +144,7 @@ tasks {
       testMessagingPreview,
       testMessagingPreviewReceiveSpansDisabled,
       testJms2MessagingPreview,
+      testJms2BothSemconv,
       testBothSemconv,
     )
   }

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -137,14 +137,6 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
-  val testV1_3_3ReceiveSpansDisabled = register<Test>("testV1_3_3ReceiveSpansDisabled") {
-    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
-    classpath = sourceSets["testV1_3_3"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_3").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-  }
-
   val testV1_3_3MessagingPreview = register<Test>("testV1_3_3MessagingPreview") {
     testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
     classpath = sourceSets["testV1_3_3"].runtimeClasspath
@@ -175,14 +167,6 @@ tasks {
       jvmArgs("-Dotel.semconv-stability.preview=messaging")
       systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
     }
-
-  val testV1_3_21ReceiveSpansDisabled = register<Test>("testV1_3_21ReceiveSpansDisabled") {
-    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
-    classpath = sourceSets["testV1_3_21"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_21").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-  }
 
   val testV1_3_21MessagingPreview = register<Test>("testV1_3_21MessagingPreview") {
     testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
@@ -232,11 +216,9 @@ tasks {
       testMessagingPreview,
       testBothSemconv,
       testMessagingPreviewReceiveSpansDisabled,
-      testV1_3_3ReceiveSpansDisabled,
       testV1_3_3MessagingPreview,
       testV1_3_3BothSemconv,
       testV1_3_3MessagingPreviewReceiveSpansDisabled,
-      testV1_3_21ReceiveSpansDisabled,
       testV1_3_21MessagingPreview,
       testV1_3_21BothSemconv,
       testV1_3_21MessagingPreviewReceiveSpansDisabled,

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -137,6 +137,76 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testV1_3_3ReceiveSpansDisabled = register<Test>("testV1_3_3ReceiveSpansDisabled") {
+    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
+    classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+  }
+
+  val testV1_3_3MessagingPreview = register<Test>("testV1_3_3MessagingPreview") {
+    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
+    classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testV1_3_3BothSemconv = register<Test>("testV1_3_3BothSemconv") {
+    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
+    classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
+  val testV1_3_3MessagingPreviewReceiveSpansDisabled =
+    register<Test>("testV1_3_3MessagingPreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
+      classpath = sourceSets["testV1_3_3"].runtimeClasspath
+      systemProperty("hasConsumerGroup", true)
+      jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
+  val testV1_3_21ReceiveSpansDisabled = register<Test>("testV1_3_21ReceiveSpansDisabled") {
+    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
+    classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+  }
+
+  val testV1_3_21MessagingPreview = register<Test>("testV1_3_21MessagingPreview") {
+    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
+    classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+  }
+
+  val testV1_3_21BothSemconv = register<Test>("testV1_3_21BothSemconv") {
+    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
+    classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    systemProperty("hasConsumerGroup", true)
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
+  val testV1_3_21MessagingPreviewReceiveSpansDisabled =
+    register<Test>("testV1_3_21MessagingPreviewReceiveSpansDisabled") {
+      testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
+      classpath = sourceSets["testV1_3_21"].runtimeClasspath
+      systemProperty("hasConsumerGroup", true)
+      jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+      jvmArgs("-Dotel.semconv-stability.preview=messaging")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    }
+
   test {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
@@ -154,6 +224,14 @@ tasks {
       testMessagingPreview,
       testBothSemconv,
       testMessagingPreviewReceiveSpansDisabled,
+      testV1_3_3ReceiveSpansDisabled,
+      testV1_3_3MessagingPreview,
+      testV1_3_3BothSemconv,
+      testV1_3_3MessagingPreviewReceiveSpansDisabled,
+      testV1_3_21ReceiveSpansDisabled,
+      testV1_3_21MessagingPreview,
+      testV1_3_21BothSemconv,
+      testV1_3_21MessagingPreviewReceiveSpansDisabled,
     )
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -110,94 +110,66 @@ tasks {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
   }
 
-  val testMessagingPreview = register<Test>("testMessagingPreview") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
-  }
+  val messagingPreviewSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}MessagingPreview") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
 
-  val testBothSemconv = register<Test>("testBothSemconv") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
-  }
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-  val testMessagingPreviewReceiveSpansDisabled = register<Test>("testMessagingPreviewReceiveSpansDisabled") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-    systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
-  }
-
-  val testV1_3_3MessagingPreview = register<Test>("testV1_3_3MessagingPreview") {
-    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
-    classpath = sourceSets["testV1_3_3"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_3").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
-  }
-
-  val testV1_3_3BothSemconv = register<Test>("testV1_3_3BothSemconv") {
-    testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
-    classpath = sourceSets["testV1_3_3"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_3").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
-  }
-
-  val testV1_3_3MessagingPreviewReceiveSpansDisabled =
-    register<Test>("testV1_3_3MessagingPreviewReceiveSpansDisabled") {
-      testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
-      classpath = sourceSets["testV1_3_3"].runtimeClasspath
-      isEnabled = project.tasks.named("testV1_3_3").get().enabled
-      systemProperty("hasConsumerGroup", true)
-      jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-      jvmArgs("-Dotel.semconv-stability.preview=messaging")
-      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+        val semconvConfig = "otel.semconv-stability.preview=messaging"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+        jvmArgs("-D$semconvConfig")
+        systemProperty(
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+        )
+        isEnabled = sourceTask.enabled
+      }
     }
 
-  val testV1_3_21MessagingPreview = register<Test>("testV1_3_21MessagingPreview") {
-    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
-    classpath = sourceSets["testV1_3_21"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_21").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
-  }
+  val bothSemconvSuites = testing.suites.withType(JvmTestSuite::class)
+    .map { suite ->
+      register<Test>("${suite.name}BothSemconv") {
+        val sourceTask = named<Test>(suite.name).get()
+        setJvmArgs(sourceTask.jvmArgs)
+        setSystemProperties(sourceTask.systemProperties)
 
-  val testV1_3_21BothSemconv = register<Test>("testV1_3_21BothSemconv") {
-    testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
-    classpath = sourceSets["testV1_3_21"].runtimeClasspath
-    isEnabled = project.tasks.named("testV1_3_21").get().enabled
-    systemProperty("hasConsumerGroup", true)
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
-  }
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
 
-  val testV1_3_21MessagingPreviewReceiveSpansDisabled =
-    register<Test>("testV1_3_21MessagingPreviewReceiveSpansDisabled") {
-      testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
-      classpath = sourceSets["testV1_3_21"].runtimeClasspath
-      isEnabled = project.tasks.named("testV1_3_21").get().enabled
-      systemProperty("hasConsumerGroup", true)
-      jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-      jvmArgs("-Dotel.semconv-stability.preview=messaging")
-      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+        val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
+        jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
+        jvmArgs("-D$semconvConfig")
+        systemProperty(
+          "metadataConfig",
+          listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+        )
+        isEnabled = sourceTask.enabled
+      }
     }
+
+  val messagingPreviewReceiveSpansDisabledSuites =
+    testing.suites.withType(JvmTestSuite::class)
+      .map { suite ->
+        register<Test>("${suite.name}MessagingPreviewReceiveSpansDisabled") {
+          val sourceTask = named<Test>(suite.name).get()
+          setJvmArgs(sourceTask.jvmArgs)
+          setSystemProperties(sourceTask.systemProperties)
+
+          testClassesDirs = suite.sources.output.classesDirs
+          classpath = suite.sources.runtimeClasspath
+
+          val semconvConfig = "otel.semconv-stability.preview=messaging"
+          jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+          jvmArgs("-D$semconvConfig")
+          systemProperty("metadataConfig", semconvConfig)
+          isEnabled = sourceTask.enabled
+        }
+      }
 
   test {
     systemProperty("hasConsumerGroup", otelProps.testLatestDeps)
@@ -213,15 +185,9 @@ tasks {
       testing.suites,
       experimentalSuites,
       testReceiveSpansDisabled,
-      testMessagingPreview,
-      testBothSemconv,
-      testMessagingPreviewReceiveSpansDisabled,
-      testV1_3_3MessagingPreview,
-      testV1_3_3BothSemconv,
-      testV1_3_3MessagingPreviewReceiveSpansDisabled,
-      testV1_3_21MessagingPreview,
-      testV1_3_21BothSemconv,
-      testV1_3_21MessagingPreviewReceiveSpansDisabled,
+      messagingPreviewSuites,
+      bothSemconvSuites,
+      messagingPreviewReceiveSpansDisabledSuites,
     )
   }
 }

--- a/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/reactor/reactor-kafka-1.0/javaagent/build.gradle.kts
@@ -140,6 +140,7 @@ tasks {
   val testV1_3_3ReceiveSpansDisabled = register<Test>("testV1_3_3ReceiveSpansDisabled") {
     testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
     classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_3").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
   }
@@ -147,6 +148,7 @@ tasks {
   val testV1_3_3MessagingPreview = register<Test>("testV1_3_3MessagingPreview") {
     testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
     classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_3").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
@@ -156,6 +158,7 @@ tasks {
   val testV1_3_3BothSemconv = register<Test>("testV1_3_3BothSemconv") {
     testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
     classpath = sourceSets["testV1_3_3"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_3").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
@@ -166,6 +169,7 @@ tasks {
     register<Test>("testV1_3_3MessagingPreviewReceiveSpansDisabled") {
       testClassesDirs = sourceSets["testV1_3_3"].output.classesDirs
       classpath = sourceSets["testV1_3_3"].runtimeClasspath
+      isEnabled = project.tasks.named("testV1_3_3").get().enabled
       systemProperty("hasConsumerGroup", true)
       jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
       jvmArgs("-Dotel.semconv-stability.preview=messaging")
@@ -175,6 +179,7 @@ tasks {
   val testV1_3_21ReceiveSpansDisabled = register<Test>("testV1_3_21ReceiveSpansDisabled") {
     testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
     classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_21").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
   }
@@ -182,6 +187,7 @@ tasks {
   val testV1_3_21MessagingPreview = register<Test>("testV1_3_21MessagingPreview") {
     testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
     classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_21").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
@@ -191,6 +197,7 @@ tasks {
   val testV1_3_21BothSemconv = register<Test>("testV1_3_21BothSemconv") {
     testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
     classpath = sourceSets["testV1_3_21"].runtimeClasspath
+    isEnabled = project.tasks.named("testV1_3_21").get().enabled
     systemProperty("hasConsumerGroup", true)
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
@@ -201,6 +208,7 @@ tasks {
     register<Test>("testV1_3_21MessagingPreviewReceiveSpansDisabled") {
       testClassesDirs = sourceSets["testV1_3_21"].output.classesDirs
       classpath = sourceSets["testV1_3_21"].runtimeClasspath
+      isEnabled = project.tasks.named("testV1_3_21").get().enabled
       systemProperty("hasConsumerGroup", true)
       jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
       jvmArgs("-Dotel.semconv-stability.preview=messaging")

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -73,6 +73,14 @@ tasks {
       systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
     }
 
+  val testBothSemconvReceiveSpansDisabled =
+    register<Test>("testBothSemconvReceiveSpansDisabled") {
+      testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
+      classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+      jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+    }
+
   // this does not apply to testReceiveSpansDisabled
   test {
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=true")
@@ -119,6 +127,7 @@ tasks {
       testing.suites,
       testMessagingPreview,
       testMessagingPreviewReceiveSpansDisabled,
+      testBothSemconvReceiveSpansDisabled,
       testJmsDisabled,
       testBothSemconv,
     )

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -75,20 +75,11 @@ tasks {
 
   val testBothSemconvReceiveSpansDisabled =
     register<Test>("testBothSemconvReceiveSpansDisabled") {
-      val sourceTask = named<Test>("testReceiveSpansDisabled").get()
-      setJvmArgs(sourceTask.jvmArgs)
-      setSystemProperties(sourceTask.systemProperties)
-
       testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
       classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
-
-      val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
-      jvmArgs("-D$semconvConfig")
-      systemProperty(
-        "metadataConfig",
-        listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
-      )
-      isEnabled = sourceTask.enabled
+      isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
+      jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
     }
 
   // this does not apply to testReceiveSpansDisabled

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -75,11 +75,20 @@ tasks {
 
   val testBothSemconvReceiveSpansDisabled =
     register<Test>("testBothSemconvReceiveSpansDisabled") {
+      val sourceTask = named<Test>("testReceiveSpansDisabled").get()
+      setJvmArgs(sourceTask.jvmArgs)
+      setSystemProperties(sourceTask.systemProperties)
+
       testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
       classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
-      isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
-      jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-      systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+
+      val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
+      jvmArgs("-D$semconvConfig")
+      systemProperty(
+        "metadataConfig",
+        listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+      )
+      isEnabled = sourceTask.enabled
     }
 
   // this does not apply to testReceiveSpansDisabled

--- a/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-jms/spring-jms-2.0/javaagent/build.gradle.kts
@@ -77,6 +77,7 @@ tasks {
     register<Test>("testBothSemconvReceiveSpansDisabled") {
       testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
       classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+      isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
       jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
       systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
     }

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -105,13 +105,20 @@ tasks {
   }
 
   val testBothSemconvReceiveSpansDisabled = register<Test>("testBothSemconvReceiveSpansDisabled") {
+    val sourceTask = named<Test>("testReceiveSpansDisabled").get()
+    setJvmArgs(sourceTask.jvmArgs)
+    setSystemProperties(sourceTask.systemProperties)
+
     testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
     classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
-    isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
-    jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+
+    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
+    jvmArgs("-D$semconvConfig")
+    systemProperty(
+      "metadataConfig",
+      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+    )
+    isEnabled = sourceTask.enabled
   }
 
   check {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -104,8 +104,23 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconvReceiveSpansDisabled = register<Test>("testBothSemconvReceiveSpansDisabled") {
+    testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
+    classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testing.suites, testMessagingPreview, testBothSemconv, testMessagingPreviewReceiveSpansDisabled)
+    dependsOn(
+      testing.suites,
+      testMessagingPreview,
+      testBothSemconv,
+      testMessagingPreviewReceiveSpansDisabled,
+      testBothSemconvReceiveSpansDisabled,
+    )
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -105,20 +105,13 @@ tasks {
   }
 
   val testBothSemconvReceiveSpansDisabled = register<Test>("testBothSemconvReceiveSpansDisabled") {
-    val sourceTask = named<Test>("testReceiveSpansDisabled").get()
-    setJvmArgs(sourceTask.jvmArgs)
-    setSystemProperties(sourceTask.systemProperties)
-
     testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
     classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
-
-    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
-    jvmArgs("-D$semconvConfig")
-    systemProperty(
-      "metadataConfig",
-      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
-    )
-    isEnabled = sourceTask.enabled
+    isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
+    jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -101,7 +101,13 @@ tasks {
     jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
+    systemProperty(
+      "metadataConfig",
+      listOf(
+        "otel.instrumentation.pulsar.experimental-span-attributes=true",
+        "otel.semconv-stability.preview=messaging",
+      ).joinToString(","),
+    )
   }
 
   val testBothSemconvReceiveSpansDisabled = register<Test>("testBothSemconvReceiveSpansDisabled") {
@@ -111,7 +117,13 @@ tasks {
     jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+    systemProperty(
+      "metadataConfig",
+      listOf(
+        "otel.instrumentation.pulsar.experimental-span-attributes=true",
+        "otel.semconv-stability.preview=messaging/dup",
+      ).joinToString(","),
+    )
   }
 
   check {

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -103,10 +103,7 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
     systemProperty(
       "metadataConfig",
-      listOf(
-        "otel.instrumentation.pulsar.experimental-span-attributes=true",
-        "otel.semconv-stability.preview=messaging",
-      ).joinToString(","),
+      "otel.instrumentation.pulsar.experimental-span-attributes=true,otel.semconv-stability.preview=messaging",
     )
   }
 
@@ -119,10 +116,7 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     systemProperty(
       "metadataConfig",
-      listOf(
-        "otel.instrumentation.pulsar.experimental-span-attributes=true",
-        "otel.semconv-stability.preview=messaging/dup",
-      ).joinToString(","),
+      "otel.instrumentation.pulsar.experimental-span-attributes=true,otel.semconv-stability.preview=messaging/dup",
     )
   }
 

--- a/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/spring/spring-pulsar-1.0/javaagent/build.gradle.kts
@@ -107,6 +107,7 @@ tasks {
   val testBothSemconvReceiveSpansDisabled = register<Test>("testBothSemconvReceiveSpansDisabled") {
     testClassesDirs = sourceSets["testReceiveSpansDisabled"].output.classesDirs
     classpath = sourceSets["testReceiveSpansDisabled"].runtimeClasspath
+    isEnabled = project.tasks.named("testReceiveSpansDisabled").get().enabled
     jvmArgs("-Dotel.instrumentation.pulsar.experimental-span-attributes=true")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -89,7 +89,22 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(
+      testing.suites,
+      experimentalSuites,
+      testMessagingPreview,
+      testBothSemconv,
+      testMessagingPreviewNoReceiveTelemetry,
+      testBothSemconvNoReceiveTelemetry,
+    )
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -90,21 +90,12 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
-    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
-    setJvmArgs(sourceTask.jvmArgs)
-    setSystemProperties(sourceTask.systemProperties)
-
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-
-    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-    jvmArgs("-D$semconvConfig")
-    systemProperty(
-      "metadataConfig",
-      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
-    )
-    isEnabled = sourceTask.enabled
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
   }
 
   check {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-3.6-testing/build.gradle.kts
@@ -90,12 +90,21 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
+    setJvmArgs(sourceTask.jvmArgs)
+    setSystemProperties(sourceTask.systemProperties)
+
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
+
+    val semconvConfig = "otel.semconv-stability.preview=messaging/dup"
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
-    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    systemProperty("metadataConfig", "otel.semconv-stability.preview=messaging/dup")
+    jvmArgs("-D$semconvConfig")
+    systemProperty(
+      "metadataConfig",
+      listOfNotNull(sourceTask.systemProperties["metadataConfig"], semconvConfig).joinToString(","),
+    )
+    isEnabled = sourceTask.enabled
   }
 
   check {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -89,6 +89,7 @@ tasks {
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -86,7 +86,22 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(
+      testing.suites,
+      experimentalSuites,
+      testMessagingPreview,
+      testBothSemconv,
+      testMessagingPreviewNoReceiveTelemetry,
+      testBothSemconvNoReceiveTelemetry,
+    )
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -87,15 +87,12 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
-    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
-    setJvmArgs(sourceTask.jvmArgs)
-    setSystemProperties(sourceTask.systemProperties)
-
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    isEnabled = sourceTask.enabled
   }
 
   check {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-4-testing/build.gradle.kts
@@ -87,12 +87,15 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
+    setJvmArgs(sourceTask.jvmArgs)
+    setSystemProperties(sourceTask.systemProperties)
+
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    isEnabled = sourceTask.enabled
   }
 
   check {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -89,6 +89,7 @@ tasks {
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
     jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
     jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -86,7 +86,22 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.preview=messaging")
   }
 
+  val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
+    classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+    jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+  }
+
   check {
-    dependsOn(testing.suites, experimentalSuites, testMessagingPreview, testBothSemconv, testMessagingPreviewNoReceiveTelemetry)
+    dependsOn(
+      testing.suites,
+      experimentalSuites,
+      testMessagingPreview,
+      testBothSemconv,
+      testMessagingPreviewNoReceiveTelemetry,
+      testBothSemconvNoReceiveTelemetry,
+    )
   }
 }

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -87,15 +87,12 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
-    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
-    setJvmArgs(sourceTask.jvmArgs)
-    setSystemProperties(sourceTask.systemProperties)
-
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-
+    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
+    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
+    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
-    isEnabled = sourceTask.enabled
   }
 
   check {

--- a/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
+++ b/instrumentation/vertx/vertx-kafka-client-3.6/vertx-kafka-client-5-testing/build.gradle.kts
@@ -87,12 +87,15 @@ tasks {
   }
 
   val testBothSemconvNoReceiveTelemetry = register<Test>("testBothSemconvNoReceiveTelemetry") {
+    val sourceTask = named<Test>("testNoReceiveTelemetry").get()
+    setJvmArgs(sourceTask.jvmArgs)
+    setSystemProperties(sourceTask.systemProperties)
+
     testClassesDirs = sourceSets["testNoReceiveTelemetry"].output.classesDirs
     classpath = sourceSets["testNoReceiveTelemetry"].runtimeClasspath
-    isEnabled = project.tasks.named("testNoReceiveTelemetry").get().enabled
-    jvmArgs("-Dotel.instrumentation.kafka.experimental-span-attributes=false")
-    jvmArgs("-Dotel.instrumentation.messaging.experimental.receive-telemetry.enabled=false")
+
     jvmArgs("-Dotel.semconv-stability.preview=messaging/dup")
+    isEnabled = sourceTask.enabled
   }
 
   check {


### PR DESCRIPTION
Adds missing messaging semantic convention coverage to custom JVM test source sets.

Reactor Kafka 1.3.3 and 1.3.21 now run messaging preview, both semantic conventions, and messaging preview with receive spans disabled. JMS 2, Spring JMS, Spring Pulsar, and Vert.x Kafka 3.6, 4, and 5 now run both semantic conventions in the custom source sets that lacked that variant.

Hoping some of this will simplify with https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19792
