### PR TITLE
Test exception signal logs in all OkHttp JVM suites

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -66,6 +66,8 @@ tasks {
       register<Test>("${suite.name}ExceptionSignalLogs") {
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
+        isEnabled = project.tasks.named(suite.name).get().enabled
+
         jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
         systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
       }

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -66,7 +66,6 @@ tasks {
       register<Test>("${suite.name}ExceptionSignalLogs") {
         testClassesDirs = suite.sources.output.classesDirs
         classpath = suite.sources.runtimeClasspath
-        isEnabled = project.tasks.named(suite.name).get().enabled
 
         jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
         systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -60,7 +60,18 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
   }
 
+  val exceptionSignalLogsSuites = testing.suites.withType(JvmTestSuite::class)
+    .matching { it.name == "http2Test" }
+    .map { suite ->
+      register<Test>("${suite.name}ExceptionSignalLogs") {
+        testClassesDirs = suite.sources.output.classesDirs
+        classpath = suite.sources.runtimeClasspath
+        jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+        systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
+      }
+    }
+
   check {
-    dependsOn(testing.suites, stableSemconvSuites, testExceptionSignalLogs)
+    dependsOn(testing.suites, stableSemconvSuites, testExceptionSignalLogs, exceptionSignalLogsSuites)
   }
 }

--- a/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/okhttp/okhttp-3.0/javaagent/build.gradle.kts
@@ -53,15 +53,7 @@ tasks {
       }
     }
 
-  val testExceptionSignalLogs = register<Test>("testExceptionSignalLogs") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
-    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
-  }
-
   val exceptionSignalLogsSuites = testing.suites.withType(JvmTestSuite::class)
-    .matching { it.name == "http2Test" }
     .map { suite ->
       register<Test>("${suite.name}ExceptionSignalLogs") {
         testClassesDirs = suite.sources.output.classesDirs
@@ -73,6 +65,6 @@ tasks {
     }
 
   check {
-    dependsOn(testing.suites, stableSemconvSuites, testExceptionSignalLogs, exceptionSignalLogsSuites)
+    dependsOn(testing.suites, stableSemconvSuites, exceptionSignalLogsSuites)
   }
 }


### PR DESCRIPTION
Runs every OkHttp 3 JVM test suite with `otel.semconv.exception.signal.preview=logs`, including the default and HTTP/2 suites.