### PR TITLE
Use SQLSTATE for JDBC error.type fallback

### DIFF
--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -78,8 +78,16 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   public String getErrorType(
       DbRequest request, @Nullable Void response, @Nullable Throwable error) {
     if (error instanceof SQLException) {
-      int errorCode = ((SQLException) error).getErrorCode();
-      return errorCode == 0 ? null : Integer.toString(errorCode);
+      SQLException sqlException = (SQLException) error;
+      int errorCode = sqlException.getErrorCode();
+      if (errorCode != 0) {
+        return Integer.toString(errorCode);
+      }
+      String sqlState = sqlException.getSQLState();
+      if (sqlState == null || sqlState.isEmpty() || sqlState.equals("00000")) {
+        return null;
+      }
+      return sqlState;
     }
     return null;
   }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -82,7 +82,7 @@ class JdbcTelemetryTest {
 
   @ParameterizedTest
   @MethodSource("errorCodes")
-  void error(int errorCode, String expectedErrorType) throws SQLException {
+  void error(int errorCode, String sqlState, String expectedErrorType) throws SQLException {
     assumeTrue(emitStableDatabaseSemconv());
 
     JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
@@ -91,7 +91,7 @@ class JdbcTelemetryTest {
     Statement statement = spy(connection.createStatement());
     when(source.getConnection()).thenReturn(connection);
     when(connection.createStatement()).thenReturn(statement);
-    doThrow(new SQLException("BOOM", "state", errorCode))
+    doThrow(new SQLException("BOOM", sqlState, errorCode))
         .when(statement)
         .execute(Mockito.anyString());
     DataSource dataSource = telemetry.wrap(source);
@@ -141,9 +141,18 @@ class JdbcTelemetryTest {
 
   private static Stream<Arguments> errorCodes() {
     return Stream.of(
-        argumentSet("positive vendor code", 42, "42"),
-        argumentSet("negative vendor code", -42, "-42"),
-        argumentSet("zero falls back to exception class", 0, SQLException.class.getName()));
+        argumentSet("positive vendor code takes precedence", 42, "42601", "42"),
+        argumentSet("negative vendor code", -42, null, "-42"),
+        argumentSet("SQLSTATE with zero vendor code", 0, "42601", "42601"),
+        argumentSet(
+            "null SQLSTATE falls back to exception class", 0, null, SQLException.class.getName()),
+        argumentSet(
+            "empty SQLSTATE falls back to exception class", 0, "", SQLException.class.getName()),
+        argumentSet(
+            "successful completion SQLSTATE falls back to exception class",
+            0,
+            "00000",
+            SQLException.class.getName()));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -68,20 +68,23 @@ class JdbcAttributesGetterTest {
 
   @ParameterizedTest
   @MethodSource("errorCodes")
-  void getErrorTypeNormalizesVendorCode(int errorCode, String expectedErrorType) {
+  void getErrorTypeNormalizesVendorCode(int errorCode, String sqlState, String expectedErrorType) {
     DbRequest request =
         DbRequest.create(DbInfo.builder().dbSystemName(POSTGRESQL).build(), "SELECT 1", false);
 
     assertThat(
             attributesGetter.getErrorType(
-                request, null, new SQLException("test", "state", errorCode)))
+                request, null, new SQLException("test", sqlState, errorCode)))
         .isEqualTo(expectedErrorType);
   }
 
   private static Stream<Arguments> errorCodes() {
     return Stream.of(
-        argumentSet("positive", 42, "42"),
-        argumentSet("negative", -42, "-42"),
-        argumentSet("zero is unavailable", 0, null));
+        argumentSet("positive vendor code takes precedence", 42, "42601", "42"),
+        argumentSet("negative vendor code", -42, null, "-42"),
+        argumentSet("SQLSTATE with zero vendor code", 0, "42601", "42601"),
+        argumentSet("null SQLSTATE is unavailable", 0, null, null),
+        argumentSet("empty SQLSTATE is unavailable", 0, "", null),
+        argumentSet("successful completion SQLSTATE is unavailable", 0, "00000", null));
   }
 }


### PR DESCRIPTION
JDBC `error.type` now follows the SQL database semantic conventions by using the most specific database error identifier available:

- A non-zero vendor error code
- SQLSTATE when the vendor error code is zero
- The exception class when SQLSTATE is null, empty, or `"00000"`

For example, a PostgreSQL syntax error now reports `error.type = "42601"` instead of `error.type = "org.postgresql.util.PSQLException"`.

`"00000"` means successful completion and does not provide a useful error classification.