### PR TITLE
Add Geode server endpoint attributes

### DIFF
--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -80,4 +80,16 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   public String getDbOperationName(GeodeRequest request) {
     return request.getOperationName();
   }
+
+  @Override
+  @Nullable
+  public String getServerAddress(GeodeRequest request) {
+    return request.serverAddress().address();
+  }
+
+  @Override
+  @Nullable
+  public Integer getServerPort(GeodeRequest request) {
+    return request.serverAddress().port();
+  }
 }

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeRequest.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeRequest.java
@@ -14,8 +14,11 @@ abstract class GeodeRequest {
 
   static GeodeRequest create(
       Region<?, ?> region, String operationName, @Nullable String queryText) {
-    return new AutoValue_GeodeRequest(region, operationName, queryText);
+    return new AutoValue_GeodeRequest(
+        GeodeServerAddress.get(region), region, operationName, queryText);
   }
+
+  abstract GeodeServerAddress serverAddress();
 
   abstract Region<?, ?> getRegion();
 

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.geode.v1_4;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolManager;
+
+class GeodeServerAddress {
+
+  private static final GeodeServerAddress NONE = new GeodeServerAddress(null, null);
+
+  @Nullable private final String address;
+  @Nullable private final Integer port;
+
+  static GeodeServerAddress get(Region<?, ?> region) {
+    Pool pool = PoolManager.find(region);
+    if (pool == null) {
+      return NONE;
+    }
+    List<InetSocketAddress> servers = pool.getServers();
+    if (servers.size() != 1) {
+      return NONE;
+    }
+    InetSocketAddress server = servers.get(0);
+    return new GeodeServerAddress(server.getHostString(), server.getPort());
+  }
+
+  private GeodeServerAddress(@Nullable String address, @Nullable Integer port) {
+    this.address = address;
+    this.port = port;
+  }
+
+  @Nullable
+  String address() {
+    return address;
+  }
+
+  @Nullable
+  Integer port() {
+    return port;
+  }
+}

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
@@ -40,8 +40,8 @@ class GeodeServerAddress {
     // for the lifetime of the pool, and servers that the pool discovers through locators are not
     // part of it, so the result is stable for a given region.
     //
-    // On Geode 2.x this call re-creates each InetSocketAddress from its host name, which resolves
-    // the name, so it must not run on every operation.
+    // Geode 2.x Pool.getServers() re-creates each InetSocketAddress from its host name, which
+    // resolves the name. The per-region cache in get() avoids doing this on every operation.
     List<InetSocketAddress> servers = pool.getServers();
     if (servers.size() != 1) {
       return NONE;

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerAddress.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.geode.v1_4;
 
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.net.InetSocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -15,15 +16,32 @@ import org.apache.geode.cache.client.PoolManager;
 class GeodeServerAddress {
 
   private static final GeodeServerAddress NONE = new GeodeServerAddress(null, null);
+  private static final VirtualField<Region<?, ?>, GeodeServerAddress> SERVER_ADDRESSES =
+      VirtualField.find(Region.class, GeodeServerAddress.class);
 
   @Nullable private final String address;
   @Nullable private final Integer port;
 
   static GeodeServerAddress get(Region<?, ?> region) {
+    GeodeServerAddress serverAddress = SERVER_ADDRESSES.get(region);
+    if (serverAddress == null) {
+      serverAddress = resolve(region);
+      SERVER_ADDRESSES.set(region, serverAddress);
+    }
+    return serverAddress;
+  }
+
+  private static GeodeServerAddress resolve(Region<?, ?> region) {
     Pool pool = PoolManager.find(region);
     if (pool == null) {
       return NONE;
     }
+    // Pool.getServers() reports the servers that the pool was configured with. That list is fixed
+    // for the lifetime of the pool, and servers that the pool discovers through locators are not
+    // part of it, so the result is stable for a given region.
+    //
+    // On Geode 2.x this call re-creates each InetSocketAddress from its host name, which resolves
+    // the name, so it must not run on every operation.
     List<InetSocketAddress> servers = pool.getServers();
     if (servers.size() != 1) {
       return NONE;

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -26,7 +26,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.stream.Stream;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
@@ -139,15 +138,39 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("get test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("get"))));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "get"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT)))));
   }
 
   @ParameterizedTest
@@ -168,15 +191,39 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("remove test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("remove"))));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "remove"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT)))));
   }
 
   @ParameterizedTest
@@ -198,16 +245,40 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            spanAttributes("query", "SELECT * FROM /test-region"))));
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "query"),
+                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT)))));
   }
 
   @ParameterizedTest
@@ -229,16 +300,40 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("existsValue test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            spanAttributes("existsValue", "SELECT * FROM /test-region"))));
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "existsValue"),
+                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT)))));
   }
 
   @Test
@@ -261,33 +356,42 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))),
                 span ->
                     span.hasName("query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            spanAttributes(
-                                "query", "SELECT * FROM /test-region p WHERE p.expDate = ?"))));
-  }
-
-  private static AttributeAssertion[] spanAttributes(String operation) {
-    return spanAttributes(operation, null);
-  }
-
-  private static AttributeAssertion[] spanAttributes(String operation, String queryText) {
-    return new AttributeAssertion[] {
-      equalTo(maybeStable(DB_SYSTEM), GEODE),
-      equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "test-region" : null),
-      equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-      equalTo(maybeStable(DB_OPERATION), operation),
-      equalTo(maybeStable(DB_STATEMENT), queryText),
-      equalTo(SERVER_ADDRESS, geodeServer.getHost()),
-      equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))
-    };
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "query"),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                "SELECT * FROM /test-region p WHERE p.expDate = ?"),
+                            equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+                            equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT)))));
   }
 
   public static class Card implements PdxSerializable {

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.GEODE;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -32,6 +33,8 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.query.QueryException;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.pdx.PdxReader;
@@ -43,6 +46,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
@@ -117,6 +121,52 @@ class PutGetTest {
         DB_OPERATION_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 2})
+  void testEndpointAttributesRequireExactlyOneConfiguredServer(int serverCount) {
+    PoolFactory poolFactory = PoolManager.createFactory();
+    if (serverCount == 0) {
+      poolFactory.addLocator(geodeServer.getHost(), 1);
+    }
+    for (int i = 0; i < serverCount; i++) {
+      poolFactory.addServer(geodeServer.getHost(), geodeServer.getMappedPort(GEODE_PORT) + i);
+    }
+    String suffix = Integer.toString(serverCount);
+    poolFactory.create("test-pool-" + suffix);
+
+    ClientRegionFactory<Object, Object> regionFactory =
+        cache.createClientRegionFactory(ClientRegionShortcut.PROXY);
+    regionFactory.setPoolName("test-pool-" + suffix);
+    Region<Object, Object> testRegion = regionFactory.create("test-region-" + suffix);
+
+    testRegion.putAll(emptyMap());
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("putAll test-region-" + suffix)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region-" + suffix : null),
+                            equalTo(
+                                DB_NAME,
+                                emitStableDatabaseSemconv() ? null : "test-region-" + suffix),
+                            equalTo(maybeStable(DB_OPERATION), "putAll"),
+                            equalTo(SERVER_ADDRESS, null),
+                            equalTo(SERVER_PORT, null))));
+
+    assertDurationMetric(
+        testing,
+        "io.opentelemetry.geode-1.4",
+        DB_SYSTEM_NAME,
+        DB_COLLECTION_NAME,
+        DB_OPERATION_NAME);
   }
 
   @ParameterizedTest

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStability
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION_NAME;
@@ -24,6 +26,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.util.stream.Stream;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
@@ -112,7 +115,9 @@ class PutGetTest {
         "io.opentelemetry.geode-1.4",
         DB_SYSTEM_NAME,
         DB_COLLECTION_NAME,
-        DB_OPERATION_NAME);
+        DB_OPERATION_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
   }
 
   @ParameterizedTest
@@ -134,33 +139,15 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "put")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
                 span ->
                     span.hasName("get test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "get"))));
+                        .hasAttributesSatisfyingExactly(spanAttributes("get"))));
   }
 
   @ParameterizedTest
@@ -181,33 +168,15 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "put")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
                 span ->
                     span.hasName("remove test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "remove"))));
+                        .hasAttributesSatisfyingExactly(spanAttributes("remove"))));
   }
 
   @ParameterizedTest
@@ -229,34 +198,16 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "put")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
                 span ->
                     span.hasName("query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "query"),
-                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"))));
+                            spanAttributes("query", "SELECT * FROM /test-region"))));
   }
 
   @ParameterizedTest
@@ -278,34 +229,16 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "put")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
                 span ->
                     span.hasName("existsValue test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "existsValue"),
-                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"))));
+                            spanAttributes("existsValue", "SELECT * FROM /test-region"))));
   }
 
   @Test
@@ -328,36 +261,33 @@ class PutGetTest {
                 span ->
                     span.hasName("clear test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("clear")),
                 span ->
                     span.hasName("put test-region")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "put")),
+                        .hasAttributesSatisfyingExactly(spanAttributes("put")),
                 span ->
                     span.hasName("query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), GEODE),
-                            equalTo(
-                                DB_COLLECTION_NAME,
-                                emitStableDatabaseSemconv() ? "test-region" : null),
-                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "query"),
-                            equalTo(
-                                maybeStable(DB_STATEMENT),
-                                "SELECT * FROM /test-region p WHERE p.expDate = ?"))));
+                            spanAttributes(
+                                "query", "SELECT * FROM /test-region p WHERE p.expDate = ?"))));
+  }
+
+  private static AttributeAssertion[] spanAttributes(String operation) {
+    return spanAttributes(operation, null);
+  }
+
+  private static AttributeAssertion[] spanAttributes(String operation, String queryText) {
+    return new AttributeAssertion[] {
+      equalTo(maybeStable(DB_SYSTEM), GEODE),
+      equalTo(DB_COLLECTION_NAME, emitStableDatabaseSemconv() ? "test-region" : null),
+      equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+      equalTo(maybeStable(DB_OPERATION), operation),
+      equalTo(maybeStable(DB_STATEMENT), queryText),
+      equalTo(SERVER_ADDRESS, geodeServer.getHost()),
+      equalTo(SERVER_PORT, geodeServer.getMappedPort(GEODE_PORT))
+    };
   }
 
   public static class Card implements PdxSerializable {


### PR DESCRIPTION
Adds `server.address` and `server.port` to Geode 1.4 database client spans and `db.client.operation.duration` metrics.

The instrumentation sets both when `Pool.getServers()` reports exactly one server. It leaves both unset for zero or multiple servers to avoid an ambiguous endpoint.

A pool's configured server list is fixed, so the endpoint is resolved once per region rather than on every operation.