### PR TITLE
Support db.client.operation.exception log events in HBase

### DIFF
--- a/instrumentation/hbase/hbase-client-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/hbase/hbase-client-2.0/javaagent/build.gradle.kts
@@ -67,8 +67,19 @@ tasks {
       }
     }
 
+  val testExceptionSignalLogs = register<Test>("testExceptionSignalLogs") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    filter {
+      includeTestsMatching("*HbaseClient20Test.testGetTimeout")
+    }
+    jvmArgs("-Dotel.semconv.exception.signal.preview=logs")
+    systemProperty("metadataConfig", "otel.semconv.exception.signal.preview=logs")
+  }
+
   check {
-    dependsOn(testing.suites, stableSemconvSuites)
+    dependsOn(testing.suites, stableSemconvSuites, testExceptionSignalLogs)
   }
 
   if (otelProps.denyUnsafe) {

--- a/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/common/HbaseInstrumenterFactory.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/client/common/HbaseInstrumenterFactory.java
@@ -5,24 +5,29 @@
 
 package io.opentelemetry.javaagent.instrumentation.hbase.client.common;
 
+import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 
 public class HbaseInstrumenterFactory {
 
   public static Instrumenter<HbaseRequest, Void> create(String instrumentationName) {
     HbaseAttributesGetter hbaseAttributesGetter = new HbaseAttributesGetter();
-    return Instrumenter.<HbaseRequest, Void>builder(
-            GlobalOpenTelemetry.get(),
-            instrumentationName,
-            DbClientSpanNameExtractor.create(hbaseAttributesGetter))
-        .addAttributesExtractor(DbClientAttributesExtractor.create(hbaseAttributesGetter))
-        .addOperationMetrics(DbClientMetrics.get())
-        .buildInstrumenter(SpanKindExtractor.alwaysClient());
+    InstrumenterBuilder<HbaseRequest, Void> builder =
+        Instrumenter.<HbaseRequest, Void>builder(
+                GlobalOpenTelemetry.get(),
+                instrumentationName,
+                DbClientSpanNameExtractor.create(hbaseAttributesGetter))
+            .addAttributesExtractor(DbClientAttributesExtractor.create(hbaseAttributesGetter))
+            .addOperationMetrics(DbClientMetrics.get());
+    setDbClientExceptionEventExtractor(builder);
+    return builder.buildInstrumenter(SpanKindExtractor.alwaysClient());
   }
 
   private HbaseInstrumenterFactory() {}

--- a/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/hbase/testing/AbstractHbaseTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.hbase.testing;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsLogs;
+import static io.opentelemetry.instrumentation.api.internal.SemconvExceptionSignal.emitExceptionAsSpanEvents;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
@@ -31,6 +33,7 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -303,50 +306,66 @@ public abstract class AbstractHbaseTest {
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
-                    span ->
-                        span.hasName(
-                                GET
-                                    + " "
-                                    + (emitStableDatabaseSemconv()
-                                        ? TABLE_NAME.getQualifierAsString()
-                                        : TABLE_NAME.getNameAsString()))
-                            .hasKind(SpanKind.CLIENT)
-                            .hasStatus(StatusData.error())
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(
-                                    maybeStable(DB_SYSTEM),
-                                    maybeStableDbSystemName(DB_SYSTEM_VALUE)),
-                                equalTo(maybeStable(DB_OPERATION), GET),
-                                equalTo(
-                                    maybeStable(DB_NAME),
-                                    emitStableDatabaseSemconv()
-                                        ? TABLE_NAME.getNamespaceAsString()
-                                        : TABLE_NAME.getNameAsString()),
-                                equalTo(
-                                    DB_COLLECTION_NAME,
-                                    emitStableDatabaseSemconv()
-                                        ? TABLE_NAME.getQualifierAsString()
-                                        : null),
-                                equalTo(SERVER_ADDRESS, hostname),
-                                equalTo(SERVER_PORT, REGION_SERVER_PORT),
-                                equalTo(
-                                    ERROR_TYPE,
-                                    emitStableDatabaseSemconv() ? timeoutSpanExceptionType : null),
-                                satisfies(
-                                    DB_USER,
-                                    emitStableDatabaseSemconv()
-                                        ? AbstractAssert::isNull
-                                        : AbstractAssert::isNotNull))
-                            .hasEventsSatisfyingExactly(
-                                event ->
-                                    event
-                                        .hasName("exception")
-                                        .hasAttributesSatisfyingExactly(
-                                            equalTo(EXCEPTION_TYPE, timeoutSpanExceptionType),
-                                            satisfies(EXCEPTION_MESSAGE, AbstractAssert::isNotNull),
-                                            satisfies(
-                                                EXCEPTION_STACKTRACE,
-                                                AbstractAssert::isNotNull)))));
+                    span -> {
+                      span.hasName(
+                              GET
+                                  + " "
+                                  + (emitStableDatabaseSemconv()
+                                      ? TABLE_NAME.getQualifierAsString()
+                                      : TABLE_NAME.getNameAsString()))
+                          .hasKind(SpanKind.CLIENT)
+                          .hasStatus(StatusData.error())
+                          .hasAttributesSatisfyingExactly(
+                              equalTo(
+                                  maybeStable(DB_SYSTEM), maybeStableDbSystemName(DB_SYSTEM_VALUE)),
+                              equalTo(maybeStable(DB_OPERATION), GET),
+                              equalTo(
+                                  maybeStable(DB_NAME),
+                                  emitStableDatabaseSemconv()
+                                      ? TABLE_NAME.getNamespaceAsString()
+                                      : TABLE_NAME.getNameAsString()),
+                              equalTo(
+                                  DB_COLLECTION_NAME,
+                                  emitStableDatabaseSemconv()
+                                      ? TABLE_NAME.getQualifierAsString()
+                                      : null),
+                              equalTo(SERVER_ADDRESS, hostname),
+                              equalTo(SERVER_PORT, REGION_SERVER_PORT),
+                              equalTo(
+                                  ERROR_TYPE,
+                                  emitStableDatabaseSemconv() ? timeoutSpanExceptionType : null),
+                              satisfies(
+                                  DB_USER,
+                                  emitStableDatabaseSemconv()
+                                      ? AbstractAssert::isNull
+                                      : AbstractAssert::isNotNull));
+                      if (emitExceptionAsSpanEvents()) {
+                        span.hasEventsSatisfyingExactly(
+                            event ->
+                                event
+                                    .hasName("exception")
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(EXCEPTION_TYPE, timeoutSpanExceptionType),
+                                        satisfies(EXCEPTION_MESSAGE, AbstractAssert::isNotNull),
+                                        satisfies(
+                                            EXCEPTION_STACKTRACE, AbstractAssert::isNotNull)));
+                      } else {
+                        span.hasEventsSatisfyingExactly();
+                      }
+                    }));
+
+    if (emitExceptionAsLogs()) {
+      testing()
+          .waitAndAssertLogRecords(
+              logRecord ->
+                  logRecord
+                      .hasSeverity(Severity.WARN)
+                      .hasEventName("db.client.operation.exception")
+                      .hasAttributesSatisfyingExactly(
+                          equalTo(EXCEPTION_TYPE, timeoutSpanExceptionType),
+                          satisfies(EXCEPTION_MESSAGE, AbstractAssert::isNotNull),
+                          satisfies(EXCEPTION_STACKTRACE, AbstractAssert::isNotNull)));
+    }
   }
 
   private Configuration getTimeoutConfig() {


### PR DESCRIPTION
﻿With `otel.semconv.exception.signal.preview=logs`, failed HBase client operations now emit `db.client.operation.exception` log events at `WARN` severity instead of generic `exception` span events.

This matches the exception event behavior of the other database client instrumentations.