### PR TITLE
Report db.namespace for rediscala

### DIFF
--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaAttributesGetter.java
@@ -9,7 +9,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttribu
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import javax.annotation.Nullable;
 
-final class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
+class RediscalaAttributesGetter implements DbClientAttributesGetter<RediscalaRequest, Void> {
 
   @Override
   public String getDbSystemName(RediscalaRequest request) {
@@ -19,6 +19,17 @@ final class RediscalaAttributesGetter implements DbClientAttributesGetter<Redisc
   @Override
   @Nullable
   public String getDbNamespace(RediscalaRequest request) {
+    // Rediscala only selects the database when the connection is established, so a SELECT sent
+    // later by application code is not reflected here.
+    Integer databaseIndex = request.getDatabaseIndex();
+    return databaseIndex != null ? String.valueOf(databaseIndex) : null;
+  }
+
+  @Deprecated // to be removed in 3.0
+  @Override
+  @Nullable
+  public String getDbName(RediscalaRequest request) {
+    // old semconv reports the redis database index as db.redis.database_index, not db.name
     return null;
   }
 

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaRequest.java
@@ -35,40 +35,34 @@ class RediscalaRequest {
   private final String operationName;
   private final String stableOperationName;
   @Nullable private final Long batchSize;
-  @Nullable private final String host;
-  @Nullable private final Integer port;
+  @Nullable private final ServerEndpoint endpoint;
 
-  static RediscalaRequest create(
-      RedisCommand<?, ?> command, @Nullable String host, @Nullable Integer port) {
+  static RediscalaRequest create(RedisCommand<?, ?> command, @Nullable ServerEndpoint endpoint) {
     return new RediscalaRequest(
         operationName(command, /* stable= */ false),
         operationName(command, /* stable= */ true),
         null,
-        host,
-        port);
+        endpoint);
   }
 
   static RediscalaRequest createTransaction(
-      Queue<Operation<?, ?>> operations, @Nullable String host, @Nullable Integer port) {
+      Queue<Operation<?, ?>> operations, @Nullable ServerEndpoint endpoint) {
     return new RediscalaRequest(
         transactionOperationName(operations, /* stable= */ false),
         transactionOperationName(operations, /* stable= */ true),
         batchSize(operations),
-        host,
-        port);
+        endpoint);
   }
 
   private RediscalaRequest(
       String operationName,
       String stableOperationName,
       @Nullable Long batchSize,
-      @Nullable String host,
-      @Nullable Integer port) {
+      @Nullable ServerEndpoint endpoint) {
     this.operationName = operationName;
     this.stableOperationName = stableOperationName;
     this.batchSize = batchSize;
-    this.host = host;
-    this.port = port;
+    this.endpoint = endpoint;
   }
 
   String getOperationName() {
@@ -86,12 +80,17 @@ class RediscalaRequest {
 
   @Nullable
   String getHost() {
-    return host;
+    return endpoint != null ? endpoint.getHost() : null;
   }
 
   @Nullable
   Integer getPort() {
-    return port;
+    return endpoint != null ? endpoint.getPort() : null;
+  }
+
+  @Nullable
+  Integer getDatabaseIndex() {
+    return endpoint != null ? endpoint.getDatabaseIndex() : null;
   }
 
   private static String transactionOperationName(

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaSingletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
+import javax.annotation.Nullable;
 import redis.commands.TransactionBuilder;
 
 public class RediscalaSingletons {
@@ -28,12 +29,22 @@ public class RediscalaSingletons {
 
   static {
     RediscalaAttributesGetter dbAttributesGetter = new RediscalaAttributesGetter();
+    // Redis semantic conventions don't follow the regular pattern of adding db.namespace to the
+    // span name.
+    RediscalaAttributesGetter spanNameAttributesGetter =
+        new RediscalaAttributesGetter() {
+          @Override
+          @Nullable
+          public String getDbNamespace(RediscalaRequest request) {
+            return null;
+          }
+        };
 
     InstrumenterBuilder<RediscalaRequest, Void> builder =
         Instrumenter.<RediscalaRequest, Void>builder(
                 GlobalOpenTelemetry.get(),
                 INSTRUMENTATION_NAME,
-                DbClientSpanNameExtractor.create(dbAttributesGetter))
+                DbClientSpanNameExtractor.create(spanNameAttributesGetter))
             .addAttributesExtractor(DbClientAttributesExtractor.create(dbAttributesGetter))
             .addOperationMetrics(DbClientMetrics.get());
     setDbClientExceptionEventExtractor(builder);

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RequestInstrumentation.java
@@ -78,14 +78,11 @@ class RequestInstrumentation implements TypeInstrumentation {
           return null;
         }
 
-        String host = null;
-        Integer port = null;
+        ServerEndpoint endpoint = null;
         if (action instanceof RedisClientActorLike) {
-          RedisClientActorLike client = (RedisClientActorLike) action;
-          host = client.host();
-          port = client.port();
+          endpoint = ServerEndpoint.create((RedisClientActorLike) action);
         }
-        RediscalaRequest request = RediscalaRequest.create(cmd, host, port);
+        RediscalaRequest request = RediscalaRequest.create(cmd, endpoint);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
@@ -5,20 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
-import javax.annotation.Nullable;
 import redis.RedisClientActorLike;
 import scala.Option;
 
 public class ServerEndpoint {
   private final String host;
   private final int port;
-  @Nullable private final Integer databaseIndex;
+  private final int databaseIndex;
 
   public static ServerEndpoint create(RedisClientActorLike client) {
     return new ServerEndpoint(client.host(), client.port(), databaseIndex(client));
   }
 
-  private ServerEndpoint(String host, int port, @Nullable Integer databaseIndex) {
+  private ServerEndpoint(String host, int port, int databaseIndex) {
     this.host = host;
     this.port = port;
     this.databaseIndex = databaseIndex;
@@ -32,17 +31,15 @@ public class ServerEndpoint {
     return port;
   }
 
-  @Nullable
-  Integer getDatabaseIndex() {
+  int getDatabaseIndex() {
     return databaseIndex;
   }
 
-  @Nullable
-  private static Integer databaseIndex(RedisClientActorLike client) {
-    // db is a scala Option[Int], which erases to an Option holding a boxed Integer. It is empty
-    // when the client was not configured with an index, in which case the server default database
-    // is used.
+  private static int databaseIndex(RedisClientActorLike client) {
+    // db is a scala Option[Int], which erases to an Option holding a boxed Integer. When it is
+    // empty rediscala sends no SELECT and the connection stays on the server default database, so
+    // the index is 0.
     Option<Object> db = client.db();
-    return db.isDefined() ? (Integer) db.get() : null;
+    return db.isDefined() ? (Integer) db.get() : 0;
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
@@ -5,13 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.rediscala.v1_8;
 
+import javax.annotation.Nullable;
+import redis.RedisClientActorLike;
+import scala.Option;
+
 public class ServerEndpoint {
   private final String host;
   private final int port;
+  @Nullable private final Integer databaseIndex;
 
-  public ServerEndpoint(String host, int port) {
+  private ServerEndpoint(String host, int port, @Nullable Integer databaseIndex) {
     this.host = host;
     this.port = port;
+    this.databaseIndex = databaseIndex;
+  }
+
+  public static ServerEndpoint create(RedisClientActorLike client) {
+    return new ServerEndpoint(client.host(), client.port(), databaseIndex(client));
   }
 
   String getHost() {
@@ -20,5 +30,19 @@ public class ServerEndpoint {
 
   int getPort() {
     return port;
+  }
+
+  @Nullable
+  Integer getDatabaseIndex() {
+    return databaseIndex;
+  }
+
+  @Nullable
+  private static Integer databaseIndex(RedisClientActorLike client) {
+    // db is a scala Option[Int], which erases to an Option holding a boxed Integer. It is empty
+    // when the client was not configured with an index, in which case the server default database
+    // is used.
+    Option<Object> db = client.db();
+    return db.isDefined() ? (Integer) db.get() : null;
   }
 }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/ServerEndpoint.java
@@ -14,14 +14,14 @@ public class ServerEndpoint {
   private final int port;
   @Nullable private final Integer databaseIndex;
 
+  public static ServerEndpoint create(RedisClientActorLike client) {
+    return new ServerEndpoint(client.host(), client.port(), databaseIndex(client));
+  }
+
   private ServerEndpoint(String host, int port, @Nullable Integer databaseIndex) {
     this.host = host;
     this.port = port;
     this.databaseIndex = databaseIndex;
-  }
-
-  public static ServerEndpoint create(RedisClientActorLike client) {
-    return new ServerEndpoint(client.host(), client.port(), databaseIndex(client));
   }
 
   String getHost() {

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionBuilderInstrumentation.java
@@ -41,8 +41,7 @@ class TransactionBuilderInstrumentation implements TypeInstrumentation {
         @Advice.This RedisClientActorLike client,
         @Advice.Return TransactionBuilder transactionBuilder) {
       if (transactionBuilder != null) {
-        TRANSACTION_ENDPOINT.set(
-            transactionBuilder, new ServerEndpoint(client.host(), client.port()));
+        TRANSACTION_ENDPOINT.set(transactionBuilder, ServerEndpoint.create(client));
       }
     }
   }

--- a/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
+++ b/instrumentation/rediscala-1.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/TransactionInstrumentation.java
@@ -53,11 +53,7 @@ class TransactionInstrumentation implements TypeInstrumentation {
       public static AdviceScope start(TransactionBuilder transactionBuilder) {
         Queue<Operation<?, ?>> operations = transactionBuilder.operations().result();
         ServerEndpoint endpoint = TRANSACTION_ENDPOINT.get(transactionBuilder);
-        RediscalaRequest request =
-            RediscalaRequest.createTransaction(
-                operations,
-                endpoint != null ? endpoint.getHost() : null,
-                endpoint != null ? endpoint.getPort() : null);
+        RediscalaRequest request = RediscalaRequest.createTransaction(operations, endpoint);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -17,7 +17,11 @@ import io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS
-import io.opentelemetry.semconv.DbAttributes.{DB_OPERATION_NAME, DB_SYSTEM_NAME}
+import io.opentelemetry.semconv.DbAttributes.{
+  DB_NAMESPACE,
+  DB_OPERATION_NAME,
+  DB_SYSTEM_NAME
+}
 import io.opentelemetry.semconv.ServerAttributes.{SERVER_ADDRESS, SERVER_PORT}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterAll, BeforeAll, Test, TestInstance}
@@ -39,9 +43,12 @@ class RediscalaClientTest {
 
   @RegisterExtension val testing = AgentInstrumentationExtension.create
 
+  private val nonDefaultDbIndex = 1
+
   var system: Object = null
   var redisServer: GenericContainer[_] = null
   var redisClient: RedisClient = null
+  var nonDefaultDbClient: RedisClient = null
   var host: String = null
   var port: JLong = null
 
@@ -63,17 +70,22 @@ class RediscalaClientTest {
         system = clazz.getMethod("create").invoke(null)
     }
 
+    redisClient = createClient(None)
+    nonDefaultDbClient = createClient(Some(nonDefaultDbIndex))
+  }
+
+  private def createClient(db: Option[Int]): RedisClient =
     try {
       // latest RedisClient constructor takes username as argument
       classOf[RedisClient].getMethod("username")
-      redisClient = classOf[RedisClient]
+      classOf[RedisClient]
         .getConstructors()(0)
         .newInstance(
           host,
           Integer.valueOf(port.intValue()),
           Option.apply(null),
           Option.apply(null),
-          Option.apply(null),
+          db,
           "RedisClient",
           Option.apply(null),
           system,
@@ -82,13 +94,13 @@ class RediscalaClientTest {
         .asInstanceOf[RedisClient]
     } catch {
       case _: Exception =>
-        redisClient = classOf[RedisClient]
+        classOf[RedisClient]
           .getConstructors()(0)
           .newInstance(
             host,
             Integer.valueOf(port.intValue()),
             Option.apply(null),
-            Option.apply(null),
+            db,
             "RedisClient",
             Option.apply(null),
             system,
@@ -96,7 +108,6 @@ class RediscalaClientTest {
           )
           .asInstanceOf[RedisClient]
     }
-  }
 
   @AfterAll
   def tearDown(): Unit = {
@@ -351,6 +362,93 @@ class RediscalaClientTest {
 
   private def spanName(operation: String): String =
     if (emitStableDatabaseSemconv()) s"$operation $host:$port" else operation
+
+  @Test def testNonDefaultDatabaseIndex(): Unit = {
+    val value = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[Boolean], Exception] {
+        override def get(): Future[Boolean] =
+          nonDefaultDbClient.set("non-default-db", "value")
+      }
+    )
+
+    assertThat(Await.result(value, Duration.apply("3 second"))).isTrue
+    testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+      override def accept(trace: TraceAssert): Unit =
+        trace.hasSpansSatisfyingExactly(
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span.hasName("parent").hasNoParent
+            }
+          },
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span
+                // the database index is deliberately not part of the span name
+                .hasName(spanName("SET"))
+                .hasKind(CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                  equalTo(maybeStable(DB_OPERATION), "SET"),
+                  equalTo(DB_NAMESPACE, nonDefaultNamespace),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port)
+                )
+            }
+          }
+        )
+    })
+  }
+
+  @Test def testNonDefaultDatabaseIndexTransaction(): Unit = {
+    val result = testing.runWithSpan(
+      "parent",
+      new ThrowingSupplier[Future[_], Exception] {
+        override def get(): Future[_] = {
+          val transaction = nonDefaultDbClient.multi()
+          transaction.set("non-default-db-transaction-1", "value")
+          transaction.set("non-default-db-transaction-2", "value")
+          transaction.exec()
+        }
+      }
+    )
+
+    Await.result(result, Duration("3 second"))
+    testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+      override def accept(trace: TraceAssert): Unit =
+        trace.hasSpansSatisfyingExactly(
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span.hasName("parent").hasNoParent
+            }
+          },
+          new Consumer[SpanDataAssert] {
+            override def accept(span: SpanDataAssert): Unit = {
+              span
+                // the database index is deliberately not part of the span name
+                .hasName(spanName("MULTI SET"))
+                .hasKind(CLIENT)
+                .hasParent(trace.getSpan(0))
+                .hasAttributesSatisfyingExactly(
+                  equalTo(maybeStable(DB_SYSTEM), REDIS),
+                  equalTo(maybeStable(DB_OPERATION), "MULTI SET"),
+                  equalTo(DB_NAMESPACE, nonDefaultNamespace),
+                  equalTo(SERVER_ADDRESS, host),
+                  equalTo(SERVER_PORT, port),
+                  equalTo(
+                    DB_OPERATION_BATCH_SIZE,
+                    if (emitStableDatabaseSemconv()) JLong.valueOf(2) else null
+                  )
+                )
+            }
+          }
+        )
+    })
+  }
+
+  private def nonDefaultNamespace: String =
+    if (emitStableDatabaseSemconv()) nonDefaultDbIndex.toString else null
 
   private def transactionScenarios(): Stream[Arguments] =
     Stream.of(

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -43,6 +43,7 @@ class RediscalaClientTest {
 
   @RegisterExtension val testing = AgentInstrumentationExtension.create
 
+  private val defaultDbIndex = 0
   private val nonDefaultDbIndex = 1
 
   var system: Object = null
@@ -145,6 +146,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), "SET"),
+                  equalTo(DB_NAMESPACE, namespace(defaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port)
                 )
@@ -158,6 +160,7 @@ class RediscalaClientTest {
       "io.opentelemetry.rediscala-1.8",
       DB_SYSTEM_NAME,
       DB_OPERATION_NAME,
+      DB_NAMESPACE,
       SERVER_ADDRESS,
       SERVER_PORT
     )
@@ -202,6 +205,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), "SET"),
+                  equalTo(DB_NAMESPACE, namespace(defaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port)
                 )
@@ -216,6 +220,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), "GET"),
+                  equalTo(DB_NAMESPACE, namespace(defaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port)
                 )
@@ -305,6 +310,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), operationName),
+                  equalTo(DB_NAMESPACE, namespace(defaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port)
                 )
@@ -346,6 +352,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), scenario.operationName),
+                  equalTo(DB_NAMESPACE, namespace(defaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port),
                   equalTo(
@@ -391,7 +398,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), "SET"),
-                  equalTo(DB_NAMESPACE, nonDefaultNamespace),
+                  equalTo(DB_NAMESPACE, namespace(nonDefaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port)
                 )
@@ -443,7 +450,7 @@ class RediscalaClientTest {
                 .hasAttributesSatisfyingExactly(
                   equalTo(maybeStable(DB_SYSTEM), REDIS),
                   equalTo(maybeStable(DB_OPERATION), "MULTI SET"),
-                  equalTo(DB_NAMESPACE, nonDefaultNamespace),
+                  equalTo(DB_NAMESPACE, namespace(nonDefaultDbIndex)),
                   equalTo(SERVER_ADDRESS, host),
                   equalTo(SERVER_PORT, port),
                   equalTo(
@@ -467,8 +474,8 @@ class RediscalaClientTest {
     )
   }
 
-  private def nonDefaultNamespace: String =
-    if (emitStableDatabaseSemconv()) nonDefaultDbIndex.toString else null
+  private def namespace(databaseIndex: Int): String =
+    if (emitStableDatabaseSemconv()) databaseIndex.toString else null
 
   private def transactionScenarios(): Stream[Arguments] =
     Stream.of(

--- a/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
+++ b/instrumentation/rediscala-1.8/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/rediscala/v1_8/RediscalaClientTest.scala
@@ -399,6 +399,16 @@ class RediscalaClientTest {
           }
         )
     })
+
+    assertDurationMetric(
+      testing,
+      "io.opentelemetry.rediscala-1.8",
+      DB_SYSTEM_NAME,
+      DB_OPERATION_NAME,
+      DB_NAMESPACE,
+      SERVER_ADDRESS,
+      SERVER_PORT
+    )
   }
 
   @Test def testNonDefaultDatabaseIndexTransaction(): Unit = {
@@ -445,6 +455,16 @@ class RediscalaClientTest {
           }
         )
     })
+
+    assertDurationMetric(
+      testing,
+      "io.opentelemetry.rediscala-1.8",
+      DB_SYSTEM_NAME,
+      DB_OPERATION_NAME,
+      DB_NAMESPACE,
+      SERVER_ADDRESS,
+      SERVER_PORT
+    )
   }
 
   private def nonDefaultNamespace: String =


### PR DESCRIPTION
Rediscala spans and `db.client.operation.duration` metrics now carry `db.namespace`, letting users filter telemetry by Redis database index as jedis and lettuce already do.

The index comes from the `db` the client was constructed with:

```scala
val client = RedisClient(host, port, db = Some(1))
client.set("key", "value")   // db.namespace = "1"
```

Both single commands and transactions report it.

### Span names are unchanged

`db.namespace` is added as an attribute but omitted from span names, as Redis semantic conventions recommend. This matches jedis and lettuce.

### Caveats

- When `db` is not set, the connection uses database 0, reported as `"0"`. This matches jedis, lettuce, redisson, and the Vert.x Redis client.
- Rediscala selects the database only at connect time. A `SELECT` sent later by application code does not update `db.namespace`. Lettuce has the same limitation.

Old semantic conventions are unaffected. `db.name` is suppressed because old semconv reports the Redis database index as `db.redis.database_index`.