### PR TITLE
Use OQL operation names for stable Geode spans

### DIFF
--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -16,14 +16,14 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQueryAnalyze
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import javax.annotation.Nullable;
 
-// the old database semconv hooks are deprecated, as is SqlQuery.getOperationName()
+// the old database semconv hooks are deprecated
 @SuppressWarnings("deprecation")
 final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeRequest, Void> {
 
   // Region.query(String), Region.existsValue(String) and Region.selectValue(String) all run a
   // select: either the OQL query they are given, or "SELECT * FROM <region> this WHERE <predicate>"
   // when they are given a bare query predicate
-  private static final String FALLBACK_OPERATION_NAME = "SELECT";
+  private static final String QUERY_OPERATION_NAME = "SELECT";
 
   private static final SqlQueryAnalyzer analyzer =
       SqlQueryAnalyzer.create(
@@ -75,8 +75,7 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
     if (sqlQuery == null) {
       return request.getOperationName();
     }
-    String operationName = sqlQuery.getOperationName();
-    return FALLBACK_OPERATION_NAME.equals(operationName) ? operationName : FALLBACK_OPERATION_NAME;
+    return QUERY_OPERATION_NAME;
   }
 
   @Override

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -56,17 +56,8 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   @Override
   @Nullable
   public String getDbQueryText(GeodeRequest request) {
-    // Geode query language (OQL) is very different from SQL
-    // but SQL sanitization is still useful to mask literals
-    if (emitStableDatabaseSemconv()) {
-      // even though not using the summary, this will use the same
-      // sanitization logic that will be the default under 3.0
-      return analyzeWithSummary(request).getQueryText();
-    } else {
-      // "String literals are delimited by single quotation marks."
-      // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html
-      return analyzer.analyze(request.getQueryText(), DOUBLE_QUOTES_ARE_IDENTIFIERS).getQueryText();
-    }
+    SqlQuery sqlQuery = request.getSqlQuery();
+    return sqlQuery != null ? sqlQuery.getQueryText() : null;
   }
 
   @Override
@@ -80,10 +71,11 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   @Override
   @Nullable
   public String getDbOperationName(GeodeRequest request) {
-    if (request.getQueryText() == null) {
+    SqlQuery sqlQuery = request.getSqlQuery();
+    if (sqlQuery == null) {
       return request.getOperationName();
     }
-    String operationName = analyzeWithSummary(request).getOperationName();
+    String operationName = sqlQuery.getOperationName();
     return operationName != null ? operationName : FALLBACK_OPERATION_NAME;
   }
 
@@ -94,11 +86,13 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
     return request.getOperationName();
   }
 
-  // the analyzer caches its results for queries below its large-query threshold, so callers can
-  // analyze the same query more than once
-  private static SqlQuery analyzeWithSummary(GeodeRequest request) {
+  static SqlQuery analyzeQuery(String queryText) {
     // "String literals are delimited by single quotation marks."
     // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html
-    return analyzer.analyzeWithSummary(request.getQueryText(), DOUBLE_QUOTES_ARE_IDENTIFIERS);
+    if (emitStableDatabaseSemconv()) {
+      // Use the sanitization logic that will be the default under 3.0.
+      return analyzer.analyzeWithSummary(queryText, DOUBLE_QUOTES_ARE_IDENTIFIERS);
+    }
+    return analyzer.analyze(queryText, DOUBLE_QUOTES_ARE_IDENTIFIERS);
   }
 }

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -94,7 +94,8 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
     return request.getOperationName();
   }
 
-  // the analyzer caches its results, so callers can analyze the same query more than once
+  // the analyzer caches its results for queries below its large-query threshold, so callers can
+  // analyze the same query more than once
   private static SqlQuery analyzeWithSummary(GeodeRequest request) {
     // "String literals are delimited by single quotation marks."
     // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -76,7 +76,7 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
       return request.getOperationName();
     }
     String operationName = sqlQuery.getOperationName();
-    return operationName != null ? operationName : FALLBACK_OPERATION_NAME;
+    return FALLBACK_OPERATION_NAME.equals(operationName) ? operationName : FALLBACK_OPERATION_NAME;
   }
 
   @Override

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeDbAttributesGetter.java
@@ -11,11 +11,19 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuery;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQueryAnalyzer;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import javax.annotation.Nullable;
 
+// the old database semconv hooks are deprecated, as is SqlQuery.getOperationName()
+@SuppressWarnings("deprecation")
 final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeRequest, Void> {
+
+  // Region.query(String), Region.existsValue(String) and Region.selectValue(String) all run a
+  // select: either the OQL query they are given, or "SELECT * FROM <region> this WHERE <predicate>"
+  // when they are given a bare query predicate
+  private static final String FALLBACK_OPERATION_NAME = "SELECT";
 
   private static final SqlQueryAnalyzer analyzer =
       SqlQueryAnalyzer.create(
@@ -41,7 +49,6 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   @Override
   @Nullable
   // Old database semconv still uses db.name, so we must implement the deprecated hook.
-  @SuppressWarnings("deprecation")
   public String getDbName(GeodeRequest request) {
     return request.getRegion().getName();
   }
@@ -54,12 +61,7 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
     if (emitStableDatabaseSemconv()) {
       // even though not using the summary, this will use the same
       // sanitization logic that will be the default under 3.0
-      //
-      // "String literals are delimited by single quotation marks."
-      // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html
-      return analyzer
-          .analyzeWithSummary(request.getQueryText(), DOUBLE_QUOTES_ARE_IDENTIFIERS)
-          .getQueryText();
+      return analyzeWithSummary(request).getQueryText();
     } else {
       // "String literals are delimited by single quotation marks."
       // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html
@@ -78,6 +80,24 @@ final class GeodeDbAttributesGetter implements DbClientAttributesGetter<GeodeReq
   @Override
   @Nullable
   public String getDbOperationName(GeodeRequest request) {
+    if (request.getQueryText() == null) {
+      return request.getOperationName();
+    }
+    String operationName = analyzeWithSummary(request).getOperationName();
+    return operationName != null ? operationName : FALLBACK_OPERATION_NAME;
+  }
+
+  @Override
+  @Nullable
+  // Old database semconv still uses db.operation, so we must implement the deprecated hook.
+  public String getDbOperation(GeodeRequest request) {
     return request.getOperationName();
+  }
+
+  // the analyzer caches its results, so callers can analyze the same query more than once
+  private static SqlQuery analyzeWithSummary(GeodeRequest request) {
+    // "String literals are delimited by single quotation marks."
+    // https://geode.apache.org/docs/guide/114/developing/query_additional/literals.html
+    return analyzer.analyzeWithSummary(request.getQueryText(), DOUBLE_QUOTES_ARE_IDENTIFIERS);
   }
 }

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeRequest.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeRequest.java
@@ -6,11 +6,14 @@
 package io.opentelemetry.javaagent.instrumentation.geode.v1_4;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuery;
 import javax.annotation.Nullable;
 import org.apache.geode.cache.Region;
 
 @AutoValue
 abstract class GeodeRequest {
+
+  @Nullable private SqlQuery sqlQuery;
 
   static GeodeRequest create(
       Region<?, ?> region, String operationName, @Nullable String queryText) {
@@ -23,4 +26,13 @@ abstract class GeodeRequest {
 
   @Nullable
   abstract String getQueryText();
+
+  @Nullable
+  SqlQuery getSqlQuery() {
+    String queryText = getQueryText();
+    if (sqlQuery == null && queryText != null) {
+      sqlQuery = GeodeDbAttributesGetter.analyzeQuery(queryText);
+    }
+    return sqlQuery;
+  }
 }

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -333,6 +333,59 @@ class PutGetTest {
   }
 
   @Test
+  void testSelectValueWithQueryPredicate() throws QueryException {
+    Object cacheValue =
+        testing.runWithSpan(
+            "someTrace",
+            () -> {
+              region.clear();
+              region.put("Hello", "World");
+              return region.selectValue("this = 'World'");
+            });
+    assertThat(cacheValue).isEqualTo("World");
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL),
+                span ->
+                    span.hasName("clear test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                span ->
+                    span.hasName("put test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put")),
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT test-region"
+                                : "selectValue test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "SELECT" : "selectValue"),
+                            equalTo(maybeStable(DB_STATEMENT), "this = ?"))));
+  }
+
+  @Test
   void shouldSanitizeGeodeQuery() throws QueryException {
     Card value = new Card("1234432156788765", "10/2020");
     SelectResults<Object> results =

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -208,7 +208,10 @@ class PutGetTest {
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
                             equalTo(maybeStable(DB_OPERATION), "put")),
                 span ->
-                    span.hasName("query test-region")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT test-region"
+                                : "query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), GEODE),
@@ -216,7 +219,9 @@ class PutGetTest {
                                 DB_COLLECTION_NAME,
                                 emitStableDatabaseSemconv() ? "test-region" : null),
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "query"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "SELECT" : "query"),
                             equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"))));
   }
 
@@ -257,7 +262,10 @@ class PutGetTest {
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
                             equalTo(maybeStable(DB_OPERATION), "put")),
                 span ->
-                    span.hasName("existsValue test-region")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT test-region"
+                                : "existsValue test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), GEODE),
@@ -265,8 +273,63 @@ class PutGetTest {
                                 DB_COLLECTION_NAME,
                                 emitStableDatabaseSemconv() ? "test-region" : null),
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "existsValue"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "SELECT" : "existsValue"),
                             equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM /test-region"))));
+  }
+
+  @Test
+  void testExistsValueWithQueryPredicate() throws QueryException {
+    boolean cacheValue =
+        testing.runWithSpan(
+            "someTrace",
+            () -> {
+              region.clear();
+              region.put("Hello", "World");
+              return region.existsValue("this = 'World'");
+            });
+    assertThat(cacheValue).isTrue();
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL),
+                span ->
+                    span.hasName("clear test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "clear")),
+                span ->
+                    span.hasName("put test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(maybeStable(DB_OPERATION), "put")),
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT test-region"
+                                : "existsValue test-region")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), GEODE),
+                            equalTo(
+                                DB_COLLECTION_NAME,
+                                emitStableDatabaseSemconv() ? "test-region" : null),
+                            equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "SELECT" : "existsValue"),
+                            equalTo(maybeStable(DB_STATEMENT), "this = ?"))));
   }
 
   @Test
@@ -307,7 +370,10 @@ class PutGetTest {
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
                             equalTo(maybeStable(DB_OPERATION), "put")),
                 span ->
-                    span.hasName("query test-region")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "SELECT test-region"
+                                : "query test-region")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), GEODE),
@@ -315,7 +381,9 @@ class PutGetTest {
                                 DB_COLLECTION_NAME,
                                 emitStableDatabaseSemconv() ? "test-region" : null),
                             equalTo(DB_NAME, emitStableDatabaseSemconv() ? null : "test-region"),
-                            equalTo(maybeStable(DB_OPERATION), "query"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "SELECT" : "query"),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "SELECT * FROM /test-region p WHERE p.expDate = ?"))));

--- a/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
+++ b/instrumentation/geode-1.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/PutGetTest.java
@@ -281,13 +281,14 @@ class PutGetTest {
 
   @Test
   void testExistsValueWithQueryPredicate() throws QueryException {
+    QueryValue value = new QueryValue(true);
     boolean cacheValue =
         testing.runWithSpan(
             "someTrace",
             () -> {
               region.clear();
-              region.put("Hello", "World");
-              return region.existsValue("this = 'World'");
+              region.put("Hello", value);
+              return region.existsValue("create = true");
             });
     assertThat(cacheValue).isTrue();
     testing.waitAndAssertTraces(
@@ -329,7 +330,7 @@ class PutGetTest {
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? "SELECT" : "existsValue"),
-                            equalTo(maybeStable(DB_STATEMENT), "this = ?"))));
+                            equalTo(maybeStable(DB_STATEMENT), "create = true"))));
   }
 
   @Test
@@ -440,6 +441,18 @@ class PutGetTest {
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "SELECT * FROM /test-region p WHERE p.expDate = ?"))));
+  }
+
+  static class QueryValue {
+    private final boolean create;
+
+    QueryValue(boolean create) {
+      this.create = create;
+    }
+
+    public boolean getCreate() {
+      return create;
+    }
   }
 
   static class Card implements DataSerializable {

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -1,8 +1,8 @@
 display_name: Apache Geode
 description: >
   This instrumentation enables database client spans and database client metrics for Apache Geode
-  cache operations. Under stable database semantic conventions, OQL query spans derive
-  `db.operation.name` from the query text, for example `SELECT`.
+  cache operations. Under stable database semantic conventions, OQL query spans set
+  `db.operation.name` to `SELECT`.
 library_link: https://geode.apache.org/
 semantic_conventions:
   - DATABASE_CLIENT_SPANS

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -1,5 +1,9 @@
 display_name: Apache Geode
-description: This instrumentation enables database client spans and database client metrics for Apache Geode cache operations.
+description: >
+  This instrumentation enables database client spans and database client metrics for Apache Geode
+  cache operations. Under stable database semantic conventions, spans for `Region.query`,
+  `Region.existsValue` and `Region.selectValue` set `db.operation.name` to the operation parsed from
+  the OQL query, for example `SELECT`.
 library_link: https://geode.apache.org/
 semantic_conventions:
   - DATABASE_CLIENT_SPANS

--- a/instrumentation/geode-1.4/metadata.yaml
+++ b/instrumentation/geode-1.4/metadata.yaml
@@ -1,9 +1,8 @@
 display_name: Apache Geode
 description: >
   This instrumentation enables database client spans and database client metrics for Apache Geode
-  cache operations. Under stable database semantic conventions, spans for `Region.query`,
-  `Region.existsValue` and `Region.selectValue` set `db.operation.name` to the operation parsed from
-  the OQL query, for example `SELECT`.
+  cache operations. Under stable database semantic conventions, OQL query spans derive
+  `db.operation.name` from the query text, for example `SELECT`.
 library_link: https://geode.apache.org/
 semantic_conventions:
   - DATABASE_CLIENT_SPANS


### PR DESCRIPTION
Under stable database semantic conventions, Apache Geode OQL query spans now use the query operation for `db.operation.name` and the span name. `Region.query`, `Region.existsValue`, and `Region.selectValue` report `SELECT` for full SELECT queries and bare predicates, so equivalent queries share one operation name.

For example, `region.existsValue("SELECT * FROM /test-region")` changes `db.operation.name` from `existsValue` to `SELECT` and the span name from `existsValue test-region` to `SELECT test-region`.

The old database semantic conventions still use the Java method name.