### PR TITLE
Report memcached commands in stable db.operation.name

### DIFF
--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedAttributesGetter.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedAttributesGetter.java
@@ -31,6 +31,12 @@ class SpymemcachedAttributesGetter
 
   @Override
   public String getDbOperationName(SpymemcachedRequest spymemcachedRequest) {
+    return spymemcachedRequest.getStableOperationName();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation") // old database semconv still use db.operation
+  public String getDbOperation(SpymemcachedRequest spymemcachedRequest) {
     return spymemcachedRequest.getOperationName();
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -73,7 +73,7 @@ public abstract class SpymemcachedRequest {
     String operationName = getOperationName();
     switch (operationName) {
       case "getBulk":
-        // a multi-key get is sent as a single get carrying all of the keys
+        // a multi-key get is sent as one or more memcached get commands
         return "get";
       case "getAndTouch":
         return "gat";

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -69,7 +69,7 @@ public abstract class SpymemcachedRequest {
   }
 
   /** Returns the memcached command that corresponds to the client method. */
-  public String getStableOperationName() {
+  String getStableOperationName() {
     String operationName = getOperationName();
     switch (operationName) {
       case "getBulk":

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -67,4 +67,18 @@ public abstract class SpymemcachedRequest {
     chars[0] = Character.toLowerCase(chars[0]);
     return new String(chars);
   }
+
+  /** Returns the memcached command that corresponds to the client method. */
+  public String getStableOperationName() {
+    String operationName = getOperationName();
+    switch (operationName) {
+      case "getBulk":
+        // a multi-key get is sent as a single get carrying all of the keys
+        return "get";
+      case "getAndTouch":
+        return "gat";
+      default:
+        return operationName;
+    }
+  }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -57,7 +57,7 @@ public abstract class SpymemcachedRequest {
     String operationName = getOperationName();
     switch (operationName) {
       case "getBulk":
-        // Multi-key retrieval is the same logical memcached get operation.
+        // getBulk is get with multiple keys.
         return "get";
       case "getAndTouch":
         return "gat";

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -52,6 +52,20 @@ public abstract class SpymemcachedRequest {
     return handlingNodeAddress;
   }
 
+  /** Returns the memcached command that corresponds to the client method. */
+  String getStableOperationName() {
+    String operationName = getOperationName();
+    switch (operationName) {
+      case "getBulk":
+        // a multi-key get is sent as one or more memcached get commands
+        return "get";
+      case "getAndTouch":
+        return "gat";
+      default:
+        return operationName;
+    }
+  }
+
   public String getOperationName() {
     String queryText = getQueryText();
     if (queryText.startsWith("async")) {
@@ -66,19 +80,5 @@ public abstract class SpymemcachedRequest {
     // Lowercase first letter
     chars[0] = Character.toLowerCase(chars[0]);
     return new String(chars);
-  }
-
-  /** Returns the memcached command that corresponds to the client method. */
-  String getStableOperationName() {
-    String operationName = getOperationName();
-    switch (operationName) {
-      case "getBulk":
-        // a multi-key get is sent as one or more memcached get commands
-        return "get";
-      case "getAndTouch":
-        return "gat";
-      default:
-        return operationName;
-    }
   }
 }

--- a/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedRequest.java
@@ -57,7 +57,7 @@ public abstract class SpymemcachedRequest {
     String operationName = getOperationName();
     switch (operationName) {
       case "getBulk":
-        // a multi-key get is sent as one or more memcached get commands
+        // Multi-key retrieval is the same logical memcached get operation.
         return "get";
       case "getAndTouch":
         return "gat";

--- a/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedTest.java
+++ b/instrumentation/spymemcached-2.12/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spymemcached/v2_12/SpymemcachedTest.java
@@ -307,12 +307,14 @@ class SpymemcachedTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasTotalAttributeCount(0),
                 span ->
-                    span.hasName("getBulk")
+                    span.hasName(emitStableDatabaseSemconv() ? "get" : "getBulk")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), MEMCACHED),
-                            equalTo(maybeStable(DB_OPERATION), "getBulk"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "get" : "getBulk"),
                             equalTo(SERVER_ADDRESS, memcachedContainer.getHost()),
                             equalTo(SERVER_PORT, memcachedContainer.getMappedPort(11211)))));
   }
@@ -791,12 +793,14 @@ class SpymemcachedTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasTotalAttributeCount(0),
                 span ->
-                    span.hasName("getAndTouch")
+                    span.hasName(emitStableDatabaseSemconv() ? "gat" : "getAndTouch")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), MEMCACHED),
-                            equalTo(maybeStable(DB_OPERATION), "getAndTouch"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "gat" : "getAndTouch"),
                             equalTo(SERVER_ADDRESS, memcachedContainer.getHost()),
                             equalTo(SERVER_PORT, memcachedContainer.getMappedPort(11211)))));
   }
@@ -816,12 +820,14 @@ class SpymemcachedTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasNoParent().hasTotalAttributeCount(0),
                 span ->
-                    span.hasName("getAndTouch")
+                    span.hasName(emitStableDatabaseSemconv() ? "gat" : "getAndTouch")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), MEMCACHED),
-                            equalTo(maybeStable(DB_OPERATION), "getAndTouch"),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? "gat" : "getAndTouch"),
                             equalTo(SERVER_ADDRESS, memcachedContainer.getHost()),
                             equalTo(SERVER_PORT, memcachedContainer.getMappedPort(11211)))));
   }

--- a/instrumentation/spymemcached-2.12/metadata.yaml
+++ b/instrumentation/spymemcached-2.12/metadata.yaml
@@ -1,6 +1,8 @@
 description: >
   This instrumentation enables database client spans and database client metrics for Memcached
-  operations using the Spymemcached client.
+  operations using the Spymemcached client. Under stable database semantic conventions,
+  `db.operation.name` is the memcached command the client sends, so `getBulk` is reported as `get`
+  and `getAndTouch` as `gat`.
 display_name: Spymemcached
 semantic_conventions:
   - DATABASE_CLIENT_SPANS

--- a/instrumentation/spymemcached-2.12/metadata.yaml
+++ b/instrumentation/spymemcached-2.12/metadata.yaml
@@ -1,8 +1,6 @@
 description: >
   This instrumentation enables database client spans and database client metrics for Memcached
-  operations using the Spymemcached client. Under stable database semantic conventions,
-  `db.operation.name` is the memcached command the client sends, so `getBulk` is reported as `get`
-  and `getAndTouch` as `gat`.
+  operations using the Spymemcached client.
 display_name: Spymemcached
 semantic_conventions:
   - DATABASE_CLIENT_SPANS


### PR DESCRIPTION
Spymemcached now reports the memcached protocol command in `db.operation.name` and the span name when stable database semantic conventions are enabled.

```
getBulk     -> get
getAndTouch -> gat
```

Legacy database semantic conventions keep the Java-derived `db.operation` and span names.