### PR TITLE
Add Couchbase server endpoint attributes

### DIFF
--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
@@ -13,8 +13,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.couchbase.common.v2_0.CouchbaseRequestInfo;
+import io.opentelemetry.javaagent.instrumentation.couchbase.common.v2_0.CouchbaseRequestInfo.Endpoint;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
@@ -65,7 +65,11 @@ final class CouchbaseAttributesGetter
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       CouchbaseRequestInfo request, @Nullable Void unused) {
-    SocketAddress address = request.getPeerAddress();
+    Endpoint endpoint = request.getEndpoint();
+    if (endpoint == null) {
+      return null;
+    }
+    SocketAddress address = endpoint.getPeerAddress();
     if (address instanceof InetSocketAddress) {
       return (InetSocketAddress) address;
     }
@@ -83,16 +87,13 @@ final class CouchbaseAttributesGetter
       CouchbaseRequestInfo request,
       @Nullable Void unused,
       @Nullable Throwable error) {
-    SocketAddress peerAddress = request.getPeerAddress();
-    if (!(peerAddress instanceof InetSocketAddress)) {
+    Endpoint endpoint = request.getEndpoint();
+    if (endpoint == null) {
       return;
     }
 
-    InetSocketAddress serverAddress = (InetSocketAddress) peerAddress;
-    InetAddress address = serverAddress.getAddress();
-    attributes.put(
-        SERVER_ADDRESS, address != null ? address.getHostAddress() : serverAddress.getHostString());
-    int serverPort = serverAddress.getPort();
+    attributes.put(SERVER_ADDRESS, endpoint.getServerAddress());
+    int serverPort = endpoint.getServerPort();
     if (serverPort > 0) {
       attributes.put(SERVER_PORT, serverPort);
     }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetter.java
@@ -5,15 +5,23 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
 
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.javaagent.instrumentation.couchbase.common.v2_0.CouchbaseRequestInfo;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
 final class CouchbaseAttributesGetter
-    implements DbClientAttributesGetter<CouchbaseRequestInfo, Void> {
+    implements DbClientAttributesGetter<CouchbaseRequestInfo, Void>,
+        AttributesExtractor<CouchbaseRequestInfo, Void> {
 
   @Override
   public String getDbSystemName(CouchbaseRequestInfo couchbaseRequest) {
@@ -62,5 +70,31 @@ final class CouchbaseAttributesGetter
       return (InetSocketAddress) address;
     }
     return null;
+  }
+
+  @Override
+  public void onStart(
+      AttributesBuilder attributes, Context parentContext, CouchbaseRequestInfo request) {}
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      CouchbaseRequestInfo request,
+      @Nullable Void unused,
+      @Nullable Throwable error) {
+    SocketAddress peerAddress = request.getPeerAddress();
+    if (!(peerAddress instanceof InetSocketAddress)) {
+      return;
+    }
+
+    InetSocketAddress serverAddress = (InetSocketAddress) peerAddress;
+    InetAddress address = serverAddress.getAddress();
+    attributes.put(
+        SERVER_ADDRESS, address != null ? address.getHostAddress() : serverAddress.getHostString());
+    int serverPort = serverAddress.getPort();
+    if (serverPort > 0) {
+      attributes.put(SERVER_PORT, serverPort);
+    }
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
@@ -66,7 +66,8 @@ class CouchbaseBucketInstrumentation implements TypeInstrumentation {
       }
       CouchbaseRequestInfo request =
           CouchbaseRequestInfo.create(bucket, declaringClass, methodName);
-      return Observable.create(new TracedOnSubscribe<>(result, instrumenter(), request));
+      return Observable.create(
+          TracedOnSubscribe.perSubscription(result, instrumenter(), request.copySupplier()));
     }
   }
 
@@ -97,7 +98,8 @@ class CouchbaseBucketInstrumentation implements TypeInstrumentation {
           query == null
               ? CouchbaseRequestInfo.create(bucket, declaringClass, methodName)
               : CouchbaseRequestInfo.create(bucket, query);
-      return Observable.create(new TracedOnSubscribe<>(result, instrumenter(), request));
+      return Observable.create(
+          TracedOnSubscribe.perSubscription(result, instrumenter(), request.copySupplier()));
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
@@ -62,7 +62,8 @@ class CouchbaseClusterInstrumentation implements TypeInstrumentation {
       }
 
       CouchbaseRequestInfo request = CouchbaseRequestInfo.create(null, declaringClass, methodName);
-      return Observable.create(new TracedOnSubscribe<>(result, instrumenter(), request));
+      return Observable.create(
+          TracedOnSubscribe.perSubscription(result, instrumenter(), request.copySupplier()));
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseSingletons.java
@@ -33,6 +33,7 @@ public class CouchbaseSingletons {
         Instrumenter.<CouchbaseRequestInfo, Void>builder(
                 GlobalOpenTelemetry.get(), INSTRUMENTATION_NAME, spanNameExtractor)
             .addAttributesExtractor(DbClientAttributesExtractor.create(couchbaseAttributesGetter))
+            .addAttributesExtractor(couchbaseAttributesGetter)
             .addContextCustomizer(
                 (context, couchbaseRequest, startAttributes) ->
                     CouchbaseRequestInfo.init(context, couchbaseRequest))

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
+import com.couchbase.client.core.endpoint.AbstractEndpoint;
 import com.couchbase.client.core.message.CouchbaseRequest;
 import com.couchbase.client.deps.io.netty.channel.ChannelHandlerContext;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -45,13 +46,15 @@ class CouchbaseNetworkInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void addNetworkTagsToSpan(
+        @Advice.FieldValue("endpoint") AbstractEndpoint endpoint,
         @Advice.FieldValue("localSocket") String localSocket,
         @Advice.Argument(0) ChannelHandlerContext channelHandlerContext,
         @Advice.Argument(1) CouchbaseRequest request) {
 
       CouchbaseRequestInfo requestInfo = COUCHBASE_REQUEST_INFO.get(request);
       if (requestInfo != null) {
-        requestInfo.setPeerAddress(channelHandlerContext.channel().remoteAddress());
+        requestInfo.setEndpoint(
+            channelHandlerContext.channel().remoteAddress(), endpoint.remoteAddress());
         requestInfo.setLocalAddress(localSocket);
       }
     }

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/Couchbase26Util.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/Couchbase26Util.java
@@ -11,8 +11,6 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -76,9 +74,7 @@ public class Couchbase26Util {
     return new AttributeAssertionBuilder()
         .add(equalTo(NETWORK_TYPE, "ipv4"))
         .add(equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"))
-        .add(satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()))
-        .add(equalTo(SERVER_ADDRESS, "127.0.0.1"))
-        .add(satisfies(SERVER_PORT, val -> val.isNotNull()));
+        .add(satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()));
   }
 
   private static class AttributeAssertionBuilder {

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/Couchbase26Util.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/Couchbase26Util.java
@@ -11,6 +11,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -74,7 +76,9 @@ public class Couchbase26Util {
     return new AttributeAssertionBuilder()
         .add(equalTo(NETWORK_TYPE, "ipv4"))
         .add(equalTo(NETWORK_PEER_ADDRESS, "127.0.0.1"))
-        .add(satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()));
+        .add(satisfies(NETWORK_PEER_PORT, val -> val.isNotNull()))
+        .add(equalTo(SERVER_ADDRESS, "127.0.0.1"))
+        .add(satisfies(SERVER_PORT, val -> val.isNotNull()));
   }
 
   private static class AttributeAssertionBuilder {

--- a/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java
+++ b/instrumentation/couchbase/couchbase-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_6/CouchbaseClient26Test.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.couchbase.client.java.CouchbaseCluster;
@@ -50,6 +52,8 @@ class CouchbaseClient26Test extends AbstractCouchbaseClientTest {
         DB_SYSTEM_NAME,
         DB_OPERATION_NAME,
         NETWORK_PEER_ADDRESS,
-        NETWORK_PEER_PORT);
+        NETWORK_PEER_PORT,
+        SERVER_ADDRESS,
+        SERVER_PORT);
   }
 }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   testImplementation(project(":instrumentation-api-incubator"))
   testImplementation(project(":javaagent-extension-api"))
+  testImplementation(project(":instrumentation:couchbase:couchbase-2.0:javaagent"))
   testImplementation(project(":instrumentation:couchbase:couchbase-common-2.0:javaagent"))
   testImplementation("com.couchbase.client:java-client:2.5.0")
 }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetterTest.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetterTest.java
@@ -19,45 +19,57 @@ import org.junit.jupiter.api.Test;
 class CouchbaseAttributesGetterTest {
 
   @Test
-  void omitsServerWhenOperationTargetsMultipleServers() {
+  void usesCanonicalServerAddressAndActualPeerAddress() {
     CouchbaseRequestInfo request = CouchbaseRequestInfo.create("bucket", getClass(), "operation");
-    InetSocketAddress first = InetSocketAddress.createUnresolved("first.example", 11210);
-    InetSocketAddress second = InetSocketAddress.createUnresolved("second.example", 11210);
-
-    request.setPeerAddress(first);
-    request.setPeerAddress(first);
-    assertThat(request.getPeerAddress()).isEqualTo(first);
-
-    request.setPeerAddress(second);
-    request.setPeerAddress(first);
-    assertThat(request.getPeerAddress()).isNull();
+    InetSocketAddress peerAddress = new InetSocketAddress("192.0.2.1", 32768);
+    request.setEndpoint(peerAddress, "node.example:11210");
 
     CouchbaseAttributesGetter getter = new CouchbaseAttributesGetter();
-    assertThat(getter.getNetworkPeerInetSocketAddress(request, null)).isNull();
+    assertThat(getter.getNetworkPeerInetSocketAddress(request, null)).isEqualTo(peerAddress);
+    assertThat(extractServerAttributes(request))
+        .isEqualTo(Attributes.of(SERVER_ADDRESS, "node.example", SERVER_PORT, 11210L));
+  }
 
-    AttributesBuilder attributes = Attributes.builder();
-    getter.onEnd(attributes, Context.root(), request, null, null);
+  @Test
+  void retainsLastContactedEndpointAsAPair() {
+    CouchbaseRequestInfo request = CouchbaseRequestInfo.create("bucket", getClass(), "operation");
+    InetSocketAddress firstPeer = new InetSocketAddress("192.0.2.1", 32768);
+    InetSocketAddress secondPeer = new InetSocketAddress("192.0.2.2", 32769);
 
-    assertThat(attributes.build().asMap()).doesNotContainKeys(SERVER_ADDRESS, SERVER_PORT);
+    request.setEndpoint(firstPeer, "2001:db8::1:11210");
+    assertThat(extractServerAttributes(request))
+        .isEqualTo(Attributes.of(SERVER_ADDRESS, "2001:db8::1", SERVER_PORT, 11210L));
+
+    request.setEndpoint(secondPeer, "[2001:db8::2]:11211");
+
+    CouchbaseAttributesGetter getter = new CouchbaseAttributesGetter();
+    assertThat(getter.getNetworkPeerInetSocketAddress(request, null)).isEqualTo(secondPeer);
+    assertThat(extractServerAttributes(request))
+        .isEqualTo(Attributes.of(SERVER_ADDRESS, "2001:db8::2", SERVER_PORT, 11211L));
   }
 
   @Test
   void copyResetsPerSubscriptionState() {
     CouchbaseRequestInfo request = CouchbaseRequestInfo.create("bucket", getClass(), "operation");
-    InetSocketAddress first = InetSocketAddress.createUnresolved("first.example", 11210);
-    InetSocketAddress second = InetSocketAddress.createUnresolved("second.example", 11210);
+    InetSocketAddress firstPeer = new InetSocketAddress("192.0.2.1", 32768);
+    InetSocketAddress secondPeer = new InetSocketAddress("192.0.2.2", 32769);
+    request.setEndpoint(secondPeer, "second.example:11211");
 
-    // Drive the original into an ambiguous state
-    request.setPeerAddress(first);
-    request.setPeerAddress(second);
-    assertThat(request.getPeerAddress()).isNull();
-
-    // A copy should start with clean mutable state
     CouchbaseRequestInfo copy = request.copySupplier().get();
-    copy.setPeerAddress(first);
-    assertThat(copy.getPeerAddress()).isEqualTo(first);
+    copy.setEndpoint(firstPeer, "first.example:11210");
 
-    // Original remains ambiguous and is unaffected by the copy
-    assertThat(request.getPeerAddress()).isNull();
+    CouchbaseAttributesGetter getter = new CouchbaseAttributesGetter();
+    assertThat(getter.getNetworkPeerInetSocketAddress(request, null)).isEqualTo(secondPeer);
+    assertThat(extractServerAttributes(request))
+        .isEqualTo(Attributes.of(SERVER_ADDRESS, "second.example", SERVER_PORT, 11211L));
+    assertThat(getter.getNetworkPeerInetSocketAddress(copy, null)).isEqualTo(firstPeer);
+    assertThat(extractServerAttributes(copy))
+        .isEqualTo(Attributes.of(SERVER_ADDRESS, "first.example", SERVER_PORT, 11210L));
+  }
+
+  private static Attributes extractServerAttributes(CouchbaseRequestInfo request) {
+    AttributesBuilder attributes = Attributes.builder();
+    new CouchbaseAttributesGetter().onEnd(attributes, Context.root(), request, null, null);
+    return attributes.build();
   }
 }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetterTest.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/couchbase/v2_0/CouchbaseAttributesGetterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.couchbase.v2_0;
+
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.javaagent.instrumentation.couchbase.common.v2_0.CouchbaseRequestInfo;
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.Test;
+
+class CouchbaseAttributesGetterTest {
+
+  @Test
+  void omitsServerWhenOperationTargetsMultipleServers() {
+    CouchbaseRequestInfo request = CouchbaseRequestInfo.create("bucket", getClass(), "operation");
+    InetSocketAddress first = InetSocketAddress.createUnresolved("first.example", 11210);
+    InetSocketAddress second = InetSocketAddress.createUnresolved("second.example", 11210);
+
+    request.setPeerAddress(first);
+    request.setPeerAddress(first);
+    assertThat(request.getPeerAddress()).isEqualTo(first);
+
+    request.setPeerAddress(second);
+    request.setPeerAddress(first);
+    assertThat(request.getPeerAddress()).isNull();
+
+    CouchbaseAttributesGetter getter = new CouchbaseAttributesGetter();
+    assertThat(getter.getNetworkPeerInetSocketAddress(request, null)).isNull();
+
+    AttributesBuilder attributes = Attributes.builder();
+    getter.onEnd(attributes, Context.root(), request, null, null);
+
+    assertThat(attributes.build().asMap()).doesNotContainKeys(SERVER_ADDRESS, SERVER_PORT);
+  }
+
+  @Test
+  void copyResetsPerSubscriptionState() {
+    CouchbaseRequestInfo request = CouchbaseRequestInfo.create("bucket", getClass(), "operation");
+    InetSocketAddress first = InetSocketAddress.createUnresolved("first.example", 11210);
+    InetSocketAddress second = InetSocketAddress.createUnresolved("second.example", 11210);
+
+    // Drive the original into an ambiguous state
+    request.setPeerAddress(first);
+    request.setPeerAddress(second);
+    assertThat(request.getPeerAddress()).isNull();
+
+    // A copy should start with clean mutable state
+    CouchbaseRequestInfo copy = request.copySupplier().get();
+    copy.setPeerAddress(first);
+    assertThat(copy.getPeerAddress()).isEqualTo(first);
+
+    // Original remains ambiguous and is unaffected by the copy
+    assertThat(request.getPeerAddress()).isNull();
+  }
+}

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -16,6 +16,7 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlQuery;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -35,6 +36,7 @@ public abstract class CouchbaseRequestInfo {
   @Nullable private String localAddress;
   @Nullable private String operationId;
   @Nullable private SocketAddress peerAddress;
+  private boolean peerAddressAmbiguous;
 
   public static CouchbaseRequestInfo create(
       @Nullable String bucket, Class<?> declaringClass, String methodName) {
@@ -87,6 +89,20 @@ public abstract class CouchbaseRequestInfo {
 
   public abstract boolean isMethodCall();
 
+  public CouchbaseRequestInfo copy() {
+    return new AutoValue_CouchbaseRequestInfo(
+        getBucket(), getSqlQuery(), getSqlQueryWithSummary(), getOperation(), isMethodCall());
+  }
+
+  public Supplier<CouchbaseRequestInfo> copySupplier() {
+    return new Supplier<CouchbaseRequestInfo>() {
+      @Override
+      public CouchbaseRequestInfo get() {
+        return copy();
+      }
+    };
+  }
+
   @Nullable
   public String getLocalAddress() {
     return localAddress;
@@ -106,11 +122,19 @@ public abstract class CouchbaseRequestInfo {
   }
 
   @Nullable
-  public SocketAddress getPeerAddress() {
-    return peerAddress;
+  public synchronized SocketAddress getPeerAddress() {
+    return peerAddressAmbiguous ? null : peerAddress;
   }
 
-  public void setPeerAddress(@Nullable SocketAddress peerAddress) {
-    this.peerAddress = peerAddress;
+  public synchronized void setPeerAddress(@Nullable SocketAddress peerAddress) {
+    if (peerAddress == null || peerAddressAmbiguous) {
+      return;
+    }
+    if (this.peerAddress == null) {
+      this.peerAddress = peerAddress;
+    } else if (!this.peerAddress.equals(peerAddress)) {
+      this.peerAddress = null;
+      peerAddressAmbiguous = true;
+    }
   }
 }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -35,8 +35,7 @@ public abstract class CouchbaseRequestInfo {
 
   @Nullable private String localAddress;
   @Nullable private String operationId;
-  @Nullable private SocketAddress peerAddress;
-  private boolean peerAddressAmbiguous;
+  @Nullable private volatile Endpoint endpoint;
 
   public static CouchbaseRequestInfo create(
       @Nullable String bucket, Class<?> declaringClass, String methodName) {
@@ -122,19 +121,45 @@ public abstract class CouchbaseRequestInfo {
   }
 
   @Nullable
-  public synchronized SocketAddress getPeerAddress() {
-    return peerAddressAmbiguous ? null : peerAddress;
+  public Endpoint getEndpoint() {
+    return endpoint;
   }
 
-  public synchronized void setPeerAddress(@Nullable SocketAddress peerAddress) {
-    if (peerAddress == null || peerAddressAmbiguous) {
+  public void setEndpoint(@Nullable SocketAddress peerAddress, String remoteAddress) {
+    if (peerAddress == null) {
       return;
     }
-    if (this.peerAddress == null) {
+
+    int portSeparator = remoteAddress.lastIndexOf(':');
+    String serverAddress = remoteAddress.substring(0, portSeparator);
+    if (serverAddress.startsWith("[") && serverAddress.endsWith("]")) {
+      serverAddress = serverAddress.substring(1, serverAddress.length() - 1);
+    }
+    int serverPort = Integer.parseInt(remoteAddress.substring(portSeparator + 1));
+    endpoint = new Endpoint(peerAddress, serverAddress, serverPort);
+  }
+
+  public static final class Endpoint {
+    private final SocketAddress peerAddress;
+    private final String serverAddress;
+    private final int serverPort;
+
+    private Endpoint(SocketAddress peerAddress, String serverAddress, int serverPort) {
       this.peerAddress = peerAddress;
-    } else if (!this.peerAddress.equals(peerAddress)) {
-      this.peerAddress = null;
-      peerAddressAmbiguous = true;
+      this.serverAddress = serverAddress;
+      this.serverPort = serverPort;
+    }
+
+    public SocketAddress getPeerAddress() {
+      return peerAddress;
+    }
+
+    public String getServerAddress() {
+      return serverAddress;
+    }
+
+    public int getServerPort() {
+      return serverPort;
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -88,7 +88,7 @@ public abstract class CouchbaseRequestInfo {
 
   public abstract boolean isMethodCall();
 
-  public CouchbaseRequestInfo copy() {
+  private CouchbaseRequestInfo copy() {
     return new AutoValue_CouchbaseRequestInfo(
         getBucket(), getSqlQuery(), getSqlQueryWithSummary(), getOperation(), isMethodCall());
   }

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/common/v2_0/CouchbaseRequestInfo.java
@@ -88,11 +88,6 @@ public abstract class CouchbaseRequestInfo {
 
   public abstract boolean isMethodCall();
 
-  private CouchbaseRequestInfo copy() {
-    return new AutoValue_CouchbaseRequestInfo(
-        getBucket(), getSqlQuery(), getSqlQueryWithSummary(), getOperation(), isMethodCall());
-  }
-
   public Supplier<CouchbaseRequestInfo> copySupplier() {
     return new Supplier<CouchbaseRequestInfo>() {
       @Override
@@ -100,6 +95,11 @@ public abstract class CouchbaseRequestInfo {
         return copy();
       }
     };
+  }
+
+  private CouchbaseRequestInfo copy() {
+    return new AutoValue_CouchbaseRequestInfo(
+        getBucket(), getSqlQuery(), getSqlQueryWithSummary(), getOperation(), isMethodCall());
   }
 
   @Nullable

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -14,6 +14,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import rx.Observable;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbaseTest {
@@ -131,6 +134,8 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
   }
@@ -184,6 +189,8 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -246,6 +253,8 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -264,6 +273,8 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -326,6 +337,85 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
+                            satisfies(
+                                stringKey("couchbase.local.address"), experimentalAttribute()),
+                            satisfies(
+                                stringKey("couchbase.operation_id"), experimentalAttribute()))));
+  }
+
+  @ParameterizedTest
+  @MethodSource("bucketSettings")
+  void repeatedSubscription(BucketSettings bucketSettings) {
+    CouchbaseAsyncCluster cluster = getCluster(bucketSettings);
+
+    JsonObject content = JsonObject.create().put("hello", "world");
+    CompletableFuture<JsonDocument> first = new CompletableFuture<>();
+    CompletableFuture<JsonDocument> second = new CompletableFuture<>();
+    testing.runWithSpan(
+        "someTrace",
+        () ->
+            cluster
+                .openBucket(bucketSettings.name(), bucketSettings.password())
+                .subscribe(
+                    bucket -> {
+                      Observable<JsonDocument> observable =
+                          bucket.upsert(JsonDocument.create("helloworld", content));
+                      observable.subscribe(first::complete);
+                      observable.subscribe(second::complete);
+                    }));
+
+    assertThat(first).succeedsWithin(TIMEOUT);
+    assertThat(second).succeedsWithin(TIMEOUT);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("someTrace").hasKind(SpanKind.INTERNAL).hasNoParent(),
+                span ->
+                    span.hasName("Cluster.openBucket")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
+                            equalTo(maybeStable(DB_OPERATION), "Cluster.openBucket")),
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketSettings.name()
+                                : "Bucket.upsert")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
+                            equalTo(maybeStable(DB_NAME), bucketSettings.name()),
+                            equalTo(maybeStable(DB_OPERATION), "Bucket.upsert"),
+                            equalTo(NETWORK_TYPE, networkType()),
+                            equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
+                            satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
+                            satisfies(
+                                stringKey("couchbase.local.address"), experimentalAttribute()),
+                            satisfies(
+                                stringKey("couchbase.operation_id"), experimentalAttribute())),
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "Bucket.upsert " + bucketSettings.name()
+                                : "Bucket.upsert")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(1))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), COUCHBASE),
+                            equalTo(maybeStable(DB_NAME), bucketSettings.name()),
+                            equalTo(maybeStable(DB_OPERATION), "Bucket.upsert"),
+                            equalTo(NETWORK_TYPE, networkType()),
+                            equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
+                            satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseAsyncClientTest.java
@@ -134,7 +134,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
@@ -189,7 +189,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -253,7 +253,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -273,7 +273,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -337,7 +337,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -394,7 +394,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -414,7 +414,7 @@ public abstract class AbstractCouchbaseAsyncClientTest extends AbstractCouchbase
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
@@ -169,7 +169,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -189,7 +189,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -241,7 +241,7 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseClientTest.java
@@ -14,6 +14,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
@@ -109,6 +111,8 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
   }
@@ -165,6 +169,8 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -183,6 +189,8 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -233,6 +241,8 @@ public abstract class AbstractCouchbaseClientTest extends AbstractCouchbaseTest 
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
@@ -126,6 +126,14 @@ public abstract class AbstractCouchbaseTest {
     return includesNetworkAttributes() ? val -> val.isNotNull() : val -> val.isNull();
   }
 
+  protected String serverAddress() {
+    return includesNetworkAttributes() ? "127.0.0.1" : null;
+  }
+
+  protected LongAssertConsumer serverPort() {
+    return includesNetworkAttributes() ? val -> val.isNotNull() : val -> val.isNull();
+  }
+
   protected StringAssertConsumer experimentalAttribute() {
     return includesExperimentalAttributes() ? val -> val.isNotNull() : val -> val.isNull();
   }

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/AbstractCouchbaseTest.java
@@ -126,8 +126,8 @@ public abstract class AbstractCouchbaseTest {
     return includesNetworkAttributes() ? val -> val.isNotNull() : val -> val.isNull();
   }
 
-  protected String serverAddress() {
-    return includesNetworkAttributes() ? "127.0.0.1" : null;
+  protected StringAssertConsumer serverAddress() {
+    return includesNetworkAttributes() ? val -> val.isNotNull() : val -> val.isNull();
   }
 
   protected LongAssertConsumer serverPort() {

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
@@ -143,7 +143,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -183,7 +183,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -203,7 +203,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -241,7 +241,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -261,7 +261,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -301,7 +301,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -321,7 +321,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -340,7 +340,7 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringRepositoryTest.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
@@ -110,6 +112,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
   }
@@ -139,6 +143,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -177,6 +183,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -195,6 +203,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -231,6 +241,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -249,6 +261,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -287,6 +301,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -305,6 +321,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -322,6 +340,8 @@ public abstract class AbstractCouchbaseSpringRepositoryTest extends AbstractCouc
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()))));
   }

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -120,6 +122,8 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -138,6 +142,8 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -173,6 +179,8 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -191,6 +199,8 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(
@@ -218,6 +228,8 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
+                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
                             satisfies(

--- a/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
+++ b/instrumentation/couchbase/couchbase-common/testing/src/main/java/io/opentelemetry/instrumentation/couchbase/springdata/AbstractCouchbaseSpringTemplateTest.java
@@ -122,7 +122,7 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -142,7 +142,7 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -179,7 +179,7 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -199,7 +199,7 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),
@@ -228,7 +228,7 @@ public abstract class AbstractCouchbaseSpringTemplateTest extends AbstractCouchb
                             equalTo(NETWORK_TYPE, networkType()),
                             equalTo(NETWORK_PEER_ADDRESS, networkPeerAddress()),
                             satisfies(NETWORK_PEER_PORT, networkPeerPort()),
-                            equalTo(SERVER_ADDRESS, serverAddress()),
+                            satisfies(SERVER_ADDRESS, serverAddress()),
                             satisfies(SERVER_PORT, serverPort()),
                             satisfies(
                                 stringKey("couchbase.local.address"), experimentalAttribute()),

--- a/instrumentation/rxjava/rxjava-1.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava/v1_0/TracedOnSubscribe.java
+++ b/instrumentation/rxjava/rxjava-1.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava/v1_0/TracedOnSubscribe.java
@@ -20,6 +20,13 @@ public final class TracedOnSubscribe<T, REQUEST> implements Observable.OnSubscri
   private final Supplier<REQUEST> requestFactory;
   private final Context parentContext;
 
+  public static <T, REQUEST> TracedOnSubscribe<T, REQUEST> perSubscription(
+      Observable<T> originalObservable,
+      Instrumenter<REQUEST, ?> instrumenter,
+      Supplier<REQUEST> requestFactory) {
+    return new TracedOnSubscribe<>(originalObservable, instrumenter, requestFactory);
+  }
+
   public TracedOnSubscribe(
       Observable<T> originalObservable, Instrumenter<REQUEST, ?> instrumenter, REQUEST request) {
     delegate = OpenTelemetryTracingUtil.extractOnSubscribe(originalObservable);
@@ -36,13 +43,6 @@ public final class TracedOnSubscribe<T, REQUEST> implements Observable.OnSubscri
     this.instrumenter = instrumenter;
     this.requestFactory = requestFactory;
     parentContext = Context.current();
-  }
-
-  public static <T, REQUEST> TracedOnSubscribe<T, REQUEST> perSubscription(
-      Observable<T> originalObservable,
-      Instrumenter<REQUEST, ?> instrumenter,
-      Supplier<REQUEST> requestFactory) {
-    return new TracedOnSubscribe<>(originalObservable, instrumenter, requestFactory);
   }
 
   @Override

--- a/instrumentation/rxjava/rxjava-1.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava/v1_0/TracedOnSubscribe.java
+++ b/instrumentation/rxjava/rxjava-1.0/library/src/main/java/io/opentelemetry/instrumentation/rxjava/v1_0/TracedOnSubscribe.java
@@ -9,6 +9,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import rx.Observable;
 import rx.OpenTelemetryTracingUtil;
 import rx.Subscriber;
@@ -16,16 +17,32 @@ import rx.Subscriber;
 public final class TracedOnSubscribe<T, REQUEST> implements Observable.OnSubscribe<T> {
   private final Observable.OnSubscribe<T> delegate;
   private final Instrumenter<REQUEST, ?> instrumenter;
-  private final REQUEST request;
+  private final Supplier<REQUEST> requestFactory;
   private final Context parentContext;
 
   public TracedOnSubscribe(
       Observable<T> originalObservable, Instrumenter<REQUEST, ?> instrumenter, REQUEST request) {
     delegate = OpenTelemetryTracingUtil.extractOnSubscribe(originalObservable);
     this.instrumenter = instrumenter;
-    this.request = request;
-
+    this.requestFactory = () -> request;
     parentContext = Context.current();
+  }
+
+  private TracedOnSubscribe(
+      Observable<T> originalObservable,
+      Instrumenter<REQUEST, ?> instrumenter,
+      Supplier<REQUEST> requestFactory) {
+    delegate = OpenTelemetryTracingUtil.extractOnSubscribe(originalObservable);
+    this.instrumenter = instrumenter;
+    this.requestFactory = requestFactory;
+    parentContext = Context.current();
+  }
+
+  public static <T, REQUEST> TracedOnSubscribe<T, REQUEST> perSubscription(
+      Observable<T> originalObservable,
+      Instrumenter<REQUEST, ?> instrumenter,
+      Supplier<REQUEST> requestFactory) {
+    return new TracedOnSubscribe<>(originalObservable, instrumenter, requestFactory);
   }
 
   @Override
@@ -41,6 +58,7 @@ public final class TracedOnSubscribe<T, REQUEST> implements Observable.OnSubscri
     }
      */
 
+    REQUEST request = requestFactory.get();
     Context context = instrumenter.start(parentContext, request);
     AtomicReference<Context> contextRef = new AtomicReference<>(context);
     try (Scope ignored = context.makeCurrent()) {


### PR DESCRIPTION
Records `network.peer.*` from the actual connected Couchbase node and stable `server.address`/`server.port` from the canonical endpoint on Couchbase 2.6+ client spans.

When an operation makes multiple network calls, the endpoint attributes describe the last contacted node. Each RxJava subscription gets its own request state so repeated subscriptions do not share routing information.