### PR TITLE
Populate Redis command name for Lettuce 6.0.0-6.0.2

### DIFF
--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -35,7 +35,7 @@ testing {
         implementation(project(":instrumentation:lettuce:lettuce-5.1:testing"))
       }
     }
-    register<JvmTestSuite>("testLettuce600") {
+    register<JvmTestSuite>("testLettuce60") {
       dependencies {
         implementation("io.lettuce:lettuce-core:6.0.2.RELEASE")
         implementation("org.testcontainers:testcontainers")

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/build.gradle.kts
@@ -35,6 +35,13 @@ testing {
         implementation(project(":instrumentation:lettuce:lettuce-5.1:testing"))
       }
     }
+    register<JvmTestSuite>("testLettuce600") {
+      dependencies {
+        implementation("io.lettuce:lettuce-core:6.0.2.RELEASE")
+        implementation("org.testcontainers:testcontainers")
+        implementation(project(":instrumentation:lettuce:lettuce-5.1:testing"))
+      }
+    }
   }
 }
 

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
@@ -19,8 +19,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.lettuce.v5_1.AbstractLettuceClientTest;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,11 +41,10 @@ class Lettuce60CommandNameTest extends AbstractLettuceClientTest {
   private RedisCommands<String, String> syncCommands;
 
   @BeforeAll
-  void setUp() throws UnknownHostException {
+  void setUp() {
     redisServer.start();
 
     host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
 

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-class Lettuce600CommandNameTest extends AbstractLettuceClientTest {
+class Lettuce60CommandNameTest extends AbstractLettuceClientTest {
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce60/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce60CommandNameTest.java
@@ -80,7 +80,7 @@ class Lettuce60CommandNameTest extends AbstractLettuceClientTest {
                 // server.address / network.* are absent on 6.0.0-6.0.2 (#3952)
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(spanName("SET"))
+                        span.hasName("SET")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), REDIS),

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
@@ -80,7 +80,8 @@ class Lettuce600CommandNameTest extends AbstractLettuceClientTest {
                 // server.address / network.* are absent on 6.0.0-6.0.2 (#3952)
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasKind(SpanKind.CLIENT)
+                        span.hasName(spanName("SET"))
+                            .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
                                 equalTo(maybeStable(DB_SYSTEM), REDIS),
                                 equalTo(maybeStable(DB_OPERATION), "SET"),

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v5_1;
+
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.lettuce.v5_1.AbstractLettuceClientTest;
+import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
+import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@SuppressWarnings("deprecation") // using deprecated semconv
+class Lettuce600CommandNameTest extends AbstractLettuceClientTest {
+  @RegisterExtension
+  static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @Override
+  public InstrumentationExtension testing() {
+    return testing;
+  }
+
+  @Override
+  protected RedisClient createClient(String uri) {
+    return RedisClient.create(uri);
+  }
+
+  private RedisCommands<String, String> syncCommands;
+
+  @BeforeAll
+  void setUp() throws UnknownHostException {
+    redisServer.start();
+
+    host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
+    port = redisServer.getMappedPort(6379);
+    embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
+
+    redisClient = createClient(embeddedDbUri);
+
+    connection = redisClient.connect();
+    syncCommands = connection.sync();
+
+    syncCommands.set("TESTKEY", "TESTVAL");
+    testing.waitForTraces(2);
+    testing.clearData();
+  }
+
+  @AfterAll
+  void cleanUp() {
+    connection.close();
+    redisClient.shutdown();
+    redisServer.stop();
+  }
+
+  @Test
+  void commandNameIsPopulated() {
+    String res = syncCommands.set("TESTSETKEY", "TESTSETVAL");
+    assertThat(res).isEqualTo("OK");
+
+    testing()
+        .waitAndAssertTraces(
+            trace ->
+                // server.address / network.* are absent on 6.0.0-6.0.2 (#3952)
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasKind(SpanKind.CLIENT)
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), REDIS),
+                                equalTo(maybeStable(DB_OPERATION), "SET"),
+                                equalTo(maybeStable(DB_STATEMENT), "SET TESTSETKEY ?"))));
+  }
+}

--- a/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
+++ b/instrumentation/lettuce/lettuce-5.1/javaagent/src/testLettuce600/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_1/Lettuce600CommandNameTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@SuppressWarnings("deprecation") // using deprecated semconv
 class Lettuce600CommandNameTest extends AbstractLettuceClientTest {
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -70,6 +69,7 @@ class Lettuce600CommandNameTest extends AbstractLettuceClientTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
   void commandNameIsPopulated() {
     String res = syncCommands.set("TESTSETKEY", "TESTSETVAL");
     assertThat(res).isEqualTo("OK");

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -199,6 +199,14 @@ final class OpenTelemetryTracing implements Tracing {
     @CanIgnoreReturnValue
     @SuppressWarnings({"UnusedMethod", "EffectivelyPrivate"})
     public synchronized Tracer.Span start(RedisCommand<?, ?, ?> command) {
+      // In Lettuce 6.0.0-6.0.2 the command name is missing when start() runs,
+      // so take name from the command. Later versions already sets the name correctly,
+      // so only fill it in when it is still null.
+      // getType.name() removed in  6.5.0+.
+      if (request.getCommand() == null && command.getType() != null) {
+        request.setCommand(String.valueOf(command.getType()));
+      }
+
       // Extract args BEFORE calling start() so db.query.text can include them
       if (command.getArgs() != null) {
         request.setArgsList(OtelCommandArgsUtil.getCommandArgs(command.getArgs()));

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -6,11 +6,13 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.lettuce.core.output.CommandOutput;
 import io.lettuce.core.protocol.CompleteableCommand;
 import io.lettuce.core.protocol.OtelCommandArgsUtil;
+import io.lettuce.core.protocol.ProtocolKeyword;
 import io.lettuce.core.protocol.RedisCommand;
 import io.lettuce.core.tracing.TraceContext;
 import io.lettuce.core.tracing.TraceContextProvider;
@@ -200,11 +202,13 @@ final class OpenTelemetryTracing implements Tracing {
     @SuppressWarnings({"UnusedMethod", "EffectivelyPrivate"})
     public synchronized Tracer.Span start(RedisCommand<?, ?, ?> command) {
       // In Lettuce 6.0.0-6.0.2 the command name is missing when start() runs,
-      // so take name from the command. Later versions already sets the name correctly,
+      // so take name from the command. Later versions already set the name correctly,
       // so only fill it in when it is still null.
-      // getType.name() removed in  6.5.0+.
-      if (request.getCommand() == null && command.getType() != null) {
-        request.setCommand(String.valueOf(command.getType()));
+      // getBytes() is the only method available across the muzzle range.
+      // getType().name() was removed in 6.5.0+.
+      ProtocolKeyword type = command.getType();
+      if (request.getCommand() == null && type != null) {
+        request.setCommand(new String(type.getBytes(), US_ASCII));
       }
 
       // Extract args BEFORE calling start() so db.query.text can include them

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.lettuce.core.output.CommandOutput;
@@ -203,10 +204,10 @@ final class OpenTelemetryTracing implements Tracing {
       // In Lettuce 6.0.0-6.0.2 the command name is missing when start() runs,
       // so take name from the command. Later versions already set the name correctly,
       // so only fill it in when it is still null.
-      // Use toString(): name() was removed from ProtocolKeyword in 6.5.0+.
+      // getBytes() is available across the muzzle range, unlike name().
       ProtocolKeyword type = command.getType();
       if (request.getCommand() == null && type != null) {
-        request.setCommand(type.toString());
+        request.setCommand(new String(type.getBytes(), US_ASCII));
       }
 
       // Extract args BEFORE calling start() so db.query.text can include them

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
-import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.lettuce.core.output.CommandOutput;
@@ -204,10 +203,10 @@ final class OpenTelemetryTracing implements Tracing {
       // In Lettuce 6.0.0-6.0.2 the command name is missing when start() runs,
       // so take name from the command. Later versions already set the name correctly,
       // so only fill it in when it is still null.
-      // getBytes() is available across the muzzle range, unlike name().
+      // Use toString(): name() was removed from ProtocolKeyword in 6.5.0+.
       ProtocolKeyword type = command.getType();
       if (request.getCommand() == null && type != null) {
-        request.setCommand(new String(type.getBytes(), US_ASCII));
+        request.setCommand(type.toString());
       }
 
       // Extract args BEFORE calling start() so db.query.text can include them

--- a/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
+++ b/instrumentation/lettuce/lettuce-5.1/library/src/main/java/io/opentelemetry/instrumentation/lettuce/v5_1/OpenTelemetryTracing.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.lettuce.v5_1;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
-import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.lettuce.core.output.CommandOutput;
@@ -204,11 +203,10 @@ final class OpenTelemetryTracing implements Tracing {
       // In Lettuce 6.0.0-6.0.2 the command name is missing when start() runs,
       // so take name from the command. Later versions already set the name correctly,
       // so only fill it in when it is still null.
-      // getBytes() is the only method available across the muzzle range.
-      // getType().name() was removed in 6.5.0+.
+      // Use toString(): name() was removed from ProtocolKeyword in 6.5.0+.
       ProtocolKeyword type = command.getType();
       if (request.getCommand() == null && type != null) {
-        request.setCommand(new String(type.getBytes(), US_ASCII));
+        request.setCommand(type.toString());
       }
 
       // Extract args BEFORE calling start() so db.query.text can include them


### PR DESCRIPTION
Fixes #19718

Populate the request command in `OpenTelemetrySpan.start()` when Lettuce does not invoke the name callback. Lettuce 6.0.0-6.0.2 calls `start(command)` without first calling `name()`, leaving the span name, `db.operation.name`, and `db.query.text` empty.

Use `command.getType().toString()` to match the existing Lettuce 5.0 instrumentation and remain compatible with Lettuce 6.5 and later, where `ProtocolKeyword.name()` was removed and `toString()` became required.

The null guard leaves behavior unchanged on Lettuce 6.0.3 and later, where `name(...)` runs, and on Lettuce 5.x, where this overload does not exist.