### PR TITLE
Test Commons Pool metric registration idempotency

### DIFF
--- a/instrumentation/apache-commons-pool-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolMetrics.java
+++ b/instrumentation/apache-commons-pool-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolMetrics.java
@@ -20,8 +20,9 @@ final class CommonsPoolMetrics {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.apache-commons-pool-2.0";
 
   // a weak map does not make sense here because each Meter holds a reference to the pool
-  // use identity comparison because pools are mutable lifecycle objects
-  private static final Map<IdentityPoolKey, BatchCallback> poolMetrics = new ConcurrentHashMap<>();
+  // GenericObjectPool and GenericKeyedObjectPool do not implement equals()/hashCode(), so it's
+  // safe to keep them in a plain ConcurrentHashMap
+  private static final Map<Object, BatchCallback> poolMetrics = new ConcurrentHashMap<>();
 
   static void registerMetrics(
       OpenTelemetry openTelemetry, GenericObjectPoolMXBean pool, String poolName) {
@@ -62,7 +63,7 @@ final class CommonsPoolMetrics {
       IntSupplier maxTotal,
       IntSupplier waiters) {
     poolMetrics.computeIfAbsent(
-        new IdentityPoolKey(pool),
+        pool,
         unused ->
             createCallback(
                 openTelemetry, poolName, active, idle, minIdle, maxIdle, maxTotal, waiters));
@@ -117,28 +118,9 @@ final class CommonsPoolMetrics {
   }
 
   static void unregisterMetrics(Object pool) {
-    BatchCallback callback = poolMetrics.remove(new IdentityPoolKey(pool));
+    BatchCallback callback = poolMetrics.remove(pool);
     if (callback != null) {
       callback.close();
-    }
-  }
-
-  private static final class IdentityPoolKey {
-    private final Object pool;
-
-    private IdentityPoolKey(Object pool) {
-      this.pool = pool;
-    }
-
-    @Override
-    @SuppressWarnings("ReferenceEquality")
-    public boolean equals(@Nullable Object other) {
-      return other instanceof IdentityPoolKey && pool == ((IdentityPoolKey) other).pool;
-    }
-
-    @Override
-    public int hashCode() {
-      return System.identityHashCode(pool);
     }
   }
 

--- a/instrumentation/apache-commons-pool-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolMetrics.java
+++ b/instrumentation/apache-commons-pool-2.0/library/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolMetrics.java
@@ -20,9 +20,8 @@ final class CommonsPoolMetrics {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.apache-commons-pool-2.0";
 
   // a weak map does not make sense here because each Meter holds a reference to the pool
-  // GenericObjectPool and GenericKeyedObjectPool do not implement equals()/hashCode(), so it's
-  // safe to keep them in a plain ConcurrentHashMap
-  private static final Map<Object, BatchCallback> poolMetrics = new ConcurrentHashMap<>();
+  // use identity comparison because pools are mutable lifecycle objects
+  private static final Map<IdentityPoolKey, BatchCallback> poolMetrics = new ConcurrentHashMap<>();
 
   static void registerMetrics(
       OpenTelemetry openTelemetry, GenericObjectPoolMXBean pool, String poolName) {
@@ -63,7 +62,7 @@ final class CommonsPoolMetrics {
       IntSupplier maxTotal,
       IntSupplier waiters) {
     poolMetrics.computeIfAbsent(
-        pool,
+        new IdentityPoolKey(pool),
         unused ->
             createCallback(
                 openTelemetry, poolName, active, idle, minIdle, maxIdle, maxTotal, waiters));
@@ -118,9 +117,28 @@ final class CommonsPoolMetrics {
   }
 
   static void unregisterMetrics(Object pool) {
-    BatchCallback callback = poolMetrics.remove(pool);
+    BatchCallback callback = poolMetrics.remove(new IdentityPoolKey(pool));
     if (callback != null) {
       callback.close();
+    }
+  }
+
+  private static final class IdentityPoolKey {
+    private final Object pool;
+
+    private IdentityPoolKey(Object pool) {
+      this.pool = pool;
+    }
+
+    @Override
+    @SuppressWarnings("ReferenceEquality")
+    public boolean equals(@Nullable Object other) {
+      return other instanceof IdentityPoolKey && pool == ((IdentityPoolKey) other).pool;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(pool);
     }
   }
 

--- a/instrumentation/apache-commons-pool-2.0/library/src/test/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolInstrumentationTest.java
+++ b/instrumentation/apache-commons-pool-2.0/library/src/test/java/io/opentelemetry/instrumentation/apachecommonspool/v2_0/CommonsPoolInstrumentationTest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.instrumentation.testing.junit.LibraryInstrumentationExte
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class CommonsPoolInstrumentationTest extends AbstractCommonsPoolInstrumentationTest {
@@ -48,5 +49,30 @@ class CommonsPoolInstrumentationTest extends AbstractCommonsPoolInstrumentationT
   @Override
   protected void shutdown(GenericKeyedObjectPool<?, ?> pool) {
     telemetry.unregisterMetrics(pool);
+  }
+
+  @Test
+  void shouldRegisterSamePoolInstanceIdempotently() throws Exception {
+    String poolName = "duplicateRegistrationPool";
+    String ignoredPoolName = "ignoredDuplicateRegistrationPool";
+    GenericObjectPool<Object> pool = createGenericObjectPool(poolName, false);
+    Object borrowed = null;
+    try {
+      configure(pool, poolName);
+      configure(pool, ignoredPoolName);
+
+      borrowed = pool.borrowObject();
+
+      assertGenericObjectPoolMetrics(poolName);
+      verifyPoolNameNotReported(ignoredPoolName);
+    } finally {
+      if (borrowed != null) {
+        pool.returnObject(borrowed);
+      }
+      shutdown(pool);
+      pool.close();
+    }
+
+    assertNoMetrics();
   }
 }

--- a/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
+++ b/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
@@ -129,17 +129,17 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
   @Test
   void shouldRegisterSamePoolInstanceIdempotently() throws Exception {
     String poolName = "duplicateRegistrationPool";
+    String ignoredPoolName = "ignoredDuplicateRegistrationPool";
     GenericObjectPool<Object> pool = createGenericObjectPool(poolName, false);
     Object borrowed = null;
     try {
-      // registering the same pool instance twice must not create a second callback: otherwise
-      // the metrics below would be reported twice (once per callback) and fail the assertion
       configure(pool, poolName);
-      configure(pool, poolName);
+      configure(pool, ignoredPoolName);
 
       borrowed = pool.borrowObject();
 
       assertGenericObjectPoolMetrics(poolName);
+      verifyPoolNameNotReported(ignoredPoolName);
     } finally {
       if (borrowed != null) {
         pool.returnObject(borrowed);
@@ -285,6 +285,17 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
             metricData ->
                 metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME))
         .noneMatch(metricData -> metricData.getName().equals(metricName));
+  }
+
+  private void verifyPoolNameNotReported(String poolName) {
+    assertThat(testing().metrics())
+        .filteredOn(
+            metricData ->
+                metricData.getInstrumentationScopeInfo().getName().equals(INSTRUMENTATION_NAME))
+        .noneMatch(
+            metricData ->
+                metricData.getLongSumData().getPoints().stream()
+                    .anyMatch(point -> poolName.equals(point.getAttributes().get(POOL_NAME))));
   }
 
   private void verifyObjectCount(String poolName) {

--- a/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
+++ b/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
@@ -126,31 +126,6 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
     assertNoMetrics();
   }
 
-  @Test
-  void shouldRegisterSamePoolInstanceIdempotently() throws Exception {
-    String poolName = "duplicateRegistrationPool";
-    String ignoredPoolName = "ignoredDuplicateRegistrationPool";
-    GenericObjectPool<Object> pool = createGenericObjectPool(poolName, false);
-    Object borrowed = null;
-    try {
-      configure(pool, poolName);
-      configure(pool, ignoredPoolName);
-
-      borrowed = pool.borrowObject();
-
-      assertGenericObjectPoolMetrics(poolName);
-      verifyPoolNameNotReported(ignoredPoolName);
-    } finally {
-      if (borrowed != null) {
-        pool.returnObject(borrowed);
-      }
-      shutdown(pool);
-      pool.close();
-    }
-
-    assertNoMetrics();
-  }
-
   private void testGenericObjectPoolMetrics(boolean jmxEnabled) throws Exception {
     String poolName = jmxEnabled ? "objectPool" : "pool";
     GenericObjectPool<Object> pool = createGenericObjectPool(poolName, jmxEnabled);
@@ -257,7 +232,7 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
     return new GenericKeyedObjectPool<>(new TestKeyedObjectFactory(), config);
   }
 
-  private void assertGenericObjectPoolMetrics(String poolName) {
+  protected void assertGenericObjectPoolMetrics(String poolName) {
     verifyCommonPoolMetrics(poolName);
     verifyMinIdleObjects(poolName);
     verifyMaxIdleObjects(poolName);
@@ -287,7 +262,7 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
         .noneMatch(metricData -> metricData.getName().equals(metricName));
   }
 
-  private void verifyPoolNameNotReported(String poolName) {
+  protected void verifyPoolNameNotReported(String poolName) {
     assertThat(testing().metrics())
         .filteredOn(
             metricData ->

--- a/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
+++ b/instrumentation/apache-commons-pool-2.0/testing/src/main/java/io/opentelemetry/instrumentation/apachecommonspool/AbstractCommonsPoolInstrumentationTest.java
@@ -126,6 +126,31 @@ public abstract class AbstractCommonsPoolInstrumentationTest {
     assertNoMetrics();
   }
 
+  @Test
+  void shouldRegisterSamePoolInstanceIdempotently() throws Exception {
+    String poolName = "duplicateRegistrationPool";
+    GenericObjectPool<Object> pool = createGenericObjectPool(poolName, false);
+    Object borrowed = null;
+    try {
+      // registering the same pool instance twice must not create a second callback: otherwise
+      // the metrics below would be reported twice (once per callback) and fail the assertion
+      configure(pool, poolName);
+      configure(pool, poolName);
+
+      borrowed = pool.borrowObject();
+
+      assertGenericObjectPoolMetrics(poolName);
+    } finally {
+      if (borrowed != null) {
+        pool.returnObject(borrowed);
+      }
+      shutdown(pool);
+      pool.close();
+    }
+
+    assertNoMetrics();
+  }
+
   private void testGenericObjectPoolMetrics(boolean jmxEnabled) throws Exception {
     String poolName = jmxEnabled ? "objectPool" : "pool";
     GenericObjectPool<Object> pool = createGenericObjectPool(poolName, jmxEnabled);


### PR DESCRIPTION
Adds coverage that registering metrics twice for the same pool keeps the original callback. The second registration uses a different pool name and asserts that name is absent, so metric coalescing cannot hide a duplicate callback.