### PR TITLE
Require SCREAMING_SNAKE_CASE for static final VirtualField fields

### DIFF
--- a/.github/agents/knowledge/javaagent-singletons-patterns.md
+++ b/.github/agents/knowledge/javaagent-singletons-patterns.md
@@ -34,13 +34,15 @@ same accessor and call-site rules when these classes expose stored singleton fie
   - `CONTEXT` stays `CONTEXT`
   - `REQUEST_INFO` stays `REQUEST_INFO`
   - `RESPONSE_STATUS` stays `RESPONSE_STATUS`
-- `VirtualField` fields must be `SCREAMING_SNAKE_CASE` whether the field is `private` or `public`.
-  Visibility only decides whether the field is exposed directly (per the previous bullet) or kept
-  private and used only inside the holder class — it never justifies a lower camel case name. This
-  also applies when the value is created by a runtime factory method such as
-  `VirtualField.find(...)`; the runtime-created origin does not make it a collaborator object.
-  Other semantic key/handle types (`ContextKey`, `AttributeKey`, `MethodHandle`, `Pattern`) are good
-  candidates for the same treatment, but this repository does not yet require it for them.
+- A `static final VirtualField` field must be `SCREAMING_SNAKE_CASE` whether the field is `private`
+  or `public`. Visibility only decides whether the field is exposed directly (per the previous
+  bullet) or kept private and used only inside the holder class — it never justifies a lower camel
+  case name. This also applies when the value is created by a runtime factory method such as
+  `VirtualField.find(...)`; the runtime-created origin does not make it a collaborator object. This
+  does not apply to non-static `VirtualField` fields, such as one passed into a constructor and
+  stored as an instance field. Other semantic key/handle types (`ContextKey`, `AttributeKey`,
+  `MethodHandle`, `Pattern`) are good candidates for the same treatment, but this repository does not
+  yet require it for them.
 - Callers should static import only exported singleton accessors and uppercase constant-like
   fields, and use those members unqualified: accessors for lower camel collaborators, fields for
   uppercase constant-like members. This includes route/span naming accessors such as
@@ -117,9 +119,11 @@ class MyInstrumentation implements TypeInstrumentation {
 ## What to Flag in Review
 
 - Exposed lower camel collaborator fields such as `public static final Instrumenter ...`.
-- Private or public `VirtualField` fields named in lower camel case, including ones created via a
-  runtime factory such as `VirtualField.find(...)`. This rule is mandatory for `VirtualField` only —
-  do not flag existing camelCase `MethodHandle` or `Pattern` fields on this basis.
+- Private or public `static final VirtualField` fields named in lower camel case, including ones
+  created via a runtime factory such as `VirtualField.find(...)`. This rule is mandatory for
+  `VirtualField` only — do not flag existing camelCase `MethodHandle` or `Pattern` fields on this
+  basis, and do not flag a non-static `VirtualField` field, such as one passed into a constructor and
+  stored as an instance field.
 - Private + accessor wrappers around uppercase constant-like fields when a direct
   `public static final` field would be clearer and matches the naming guidance, including semantic
   keys/handles and immutable value constants.

--- a/.github/agents/knowledge/javaagent-singletons-patterns.md
+++ b/.github/agents/knowledge/javaagent-singletons-patterns.md
@@ -34,12 +34,13 @@ same accessor and call-site rules when these classes expose stored singleton fie
   - `CONTEXT` stays `CONTEXT`
   - `REQUEST_INFO` stays `REQUEST_INFO`
   - `RESPONSE_STATUS` stays `RESPONSE_STATUS`
-- Semantic key/handle fields (`VirtualField`, `ContextKey`, `AttributeKey`, `MethodHandle`,
-  `Pattern`) must be `SCREAMING_SNAKE_CASE` whether the field is `private` or `public`. Visibility
-  only decides whether the field is exposed directly (per the previous bullet) or kept private and
-  used only inside the holder class — it never justifies a lower camel case name. This also applies
-  when the value is created by a runtime factory method such as `VirtualField.find(...)`; the
-  runtime-created origin does not make it a collaborator object.
+- `VirtualField` fields must be `SCREAMING_SNAKE_CASE` whether the field is `private` or `public`.
+  Visibility only decides whether the field is exposed directly (per the previous bullet) or kept
+  private and used only inside the holder class — it never justifies a lower camel case name. This
+  also applies when the value is created by a runtime factory method such as
+  `VirtualField.find(...)`; the runtime-created origin does not make it a collaborator object.
+  Other semantic key/handle types (`ContextKey`, `AttributeKey`, `MethodHandle`, `Pattern`) are good
+  candidates for the same treatment, but this repository does not yet require it for them.
 - Callers should static import only exported singleton accessors and uppercase constant-like
   fields, and use those members unqualified: accessors for lower camel collaborators, fields for
   uppercase constant-like members. This includes route/span naming accessors such as
@@ -116,9 +117,9 @@ class MyInstrumentation implements TypeInstrumentation {
 ## What to Flag in Review
 
 - Exposed lower camel collaborator fields such as `public static final Instrumenter ...`.
-- Private or public semantic key/handle fields (`VirtualField`, `ContextKey`, `AttributeKey`,
-  `MethodHandle`, `Pattern`) named in lower camel case, including ones created via a runtime
-  factory such as `VirtualField.find(...)`.
+- Private or public `VirtualField` fields named in lower camel case, including ones created via a
+  runtime factory such as `VirtualField.find(...)`. This rule is mandatory for `VirtualField` only —
+  do not flag existing camelCase `MethodHandle` or `Pattern` fields on this basis.
 - Private + accessor wrappers around uppercase constant-like fields when a direct
   `public static final` field would be clearer and matches the naming guidance, including semantic
   keys/handles and immutable value constants.

--- a/.github/agents/knowledge/javaagent-singletons-patterns.md
+++ b/.github/agents/knowledge/javaagent-singletons-patterns.md
@@ -34,6 +34,12 @@ same accessor and call-site rules when these classes expose stored singleton fie
   - `CONTEXT` stays `CONTEXT`
   - `REQUEST_INFO` stays `REQUEST_INFO`
   - `RESPONSE_STATUS` stays `RESPONSE_STATUS`
+- Semantic key/handle fields (`VirtualField`, `ContextKey`, `AttributeKey`, `MethodHandle`,
+  `Pattern`) must be `SCREAMING_SNAKE_CASE` whether the field is `private` or `public`. Visibility
+  only decides whether the field is exposed directly (per the previous bullet) or kept private and
+  used only inside the holder class — it never justifies a lower camel case name. This also applies
+  when the value is created by a runtime factory method such as `VirtualField.find(...)`; the
+  runtime-created origin does not make it a collaborator object.
 - Callers should static import only exported singleton accessors and uppercase constant-like
   fields, and use those members unqualified: accessors for lower camel collaborators, fields for
   uppercase constant-like members. This includes route/span naming accessors such as
@@ -110,6 +116,9 @@ class MyInstrumentation implements TypeInstrumentation {
 ## What to Flag in Review
 
 - Exposed lower camel collaborator fields such as `public static final Instrumenter ...`.
+- Private or public semantic key/handle fields (`VirtualField`, `ContextKey`, `AttributeKey`,
+  `MethodHandle`, `Pattern`) named in lower camel case, including ones created via a runtime
+  factory such as `VirtualField.find(...)`.
 - Private + accessor wrappers around uppercase constant-like fields when a direct
   `public static final` field would be clearer and matches the naming guidance, including semantic
   keys/handles and immutable value constants.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,17 @@ In **catch clauses only** (not method/lambda parameters or fields):
 
 Public API getters use `get*` (or `is*` for booleans).
 
+## [Naming] Semantic Key/Handle Field Names
+
+Semantic key/handle types — `AttributeKey`, `ContextKey`, `VirtualField`,
+`MethodHandle`, and `Pattern` — must use `SCREAMING_SNAKE_CASE` for `static
+final` fields, regardless of visibility (`private` or `public`) and regardless
+of whether the value is created by a runtime factory method (e.g.
+`VirtualField.find(...)`). Flag a camelCase `static final` field of one of
+these types. Runtime collaborator objects (loggers, instrumenters, helpers,
+caches, and similar service objects) keep lower camel case even when `static
+final` — do not flag those.
+
 ## [Style] No Redundant Null Guards on Attribute Puts
 
 `AttributesBuilder.put`, `Span.setAttribute`, `SpanBuilder.setAttribute`, and

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,16 +39,21 @@ In **catch clauses only** (not method/lambda parameters or fields):
 
 Public API getters use `get*` (or `is*` for booleans).
 
-## [Naming] Semantic Key/Handle Field Names
+## [Naming] VirtualField Handle Field Names
 
-Semantic key/handle types — `AttributeKey`, `ContextKey`, `VirtualField`,
-`MethodHandle`, and `Pattern` — must use `SCREAMING_SNAKE_CASE` for `static
-final` fields, regardless of visibility (`private` or `public`) and regardless
-of whether the value is created by a runtime factory method (e.g.
-`VirtualField.find(...)`). Flag a camelCase `static final` field of one of
-these types. Runtime collaborator objects (loggers, instrumenters, helpers,
-caches, and similar service objects) keep lower camel case even when `static
-final` — do not flag those.
+A `static final VirtualField` field must use `SCREAMING_SNAKE_CASE`, regardless
+of visibility (`private` or `public`) and regardless of the fact that
+`VirtualField.find(...)` creates the handle at runtime rather than at compile
+time. Flag a camelCase `static final VirtualField` field.
+
+Other semantic key/handle types (`AttributeKey`, `ContextKey`, `MethodHandle`,
+`Pattern`) are good candidates for uppercase names too, but this repository
+does not yet treat that as mandatory — do not flag existing camelCase
+`MethodHandle` or `Pattern` fields on this basis alone.
+
+Runtime collaborator objects (loggers, instrumenters, helpers, caches, and
+similar service objects) keep lower camel case even when `static final` — do
+not flag those.
 
 ## [Style] No Redundant Null Guards on Attribute Puts
 

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -28,11 +28,13 @@ Follow `docs/contributing/style-guide.md`.
 - **Static utility classes**: place the private no-arg constructor after all
   methods.
 - **Uppercase field names**: use `SCREAMING_SNAKE_CASE` only for constant-like
-  values — literals, immutable value constants (e.g. `Duration` timeouts),
-  semantic keys/handles (`AttributeKey`, `ContextKey`, `VirtualField`,
-  `MethodHandle`, `Pattern`), and canonical singletons (`INSTANCE`, `EMPTY`,
-  `NOOP`). Use lower camel case for runtime collaborators (loggers,
-  instrumenters, helpers, caches), even when `static final`.
+  values — literals, immutable value constants (e.g. `Duration` timeouts), and
+  canonical singletons (`INSTANCE`, `EMPTY`, `NOOP`). Semantic key/handle types
+  (`AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`, `Pattern`)
+  **must** be `SCREAMING_SNAKE_CASE`, regardless of visibility and regardless
+  of whether the value is created by a runtime factory (e.g.
+  `VirtualField.find(...)`). Use lower camel case for runtime collaborators
+  (loggers, instrumenters, helpers, caches), even when `static final`.
 - **Collection constants**: public, protected, and package-private collection
   constants must be unmodifiable. Private collection constants must also be
   unmodifiable when their collection reference escapes the declaring class.

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -28,13 +28,14 @@ Follow `docs/contributing/style-guide.md`.
 - **Static utility classes**: place the private no-arg constructor after all
   methods.
 - **Uppercase field names**: use `SCREAMING_SNAKE_CASE` only for constant-like
-  values — literals, immutable value constants (e.g. `Duration` timeouts), and
-  canonical singletons (`INSTANCE`, `EMPTY`, `NOOP`). Semantic key/handle types
-  (`AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`, `Pattern`)
-  **must** be `SCREAMING_SNAKE_CASE`, regardless of visibility and regardless
-  of whether the value is created by a runtime factory (e.g.
-  `VirtualField.find(...)`). Use lower camel case for runtime collaborators
-  (loggers, instrumenters, helpers, caches), even when `static final`.
+  values — literals, immutable value constants (e.g. `Duration` timeouts),
+  canonical singletons (`INSTANCE`, `EMPTY`, `NOOP`), and semantic key/handle
+  types (`AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`,
+  `Pattern`). A `static final VirtualField` field **must** be
+  `SCREAMING_SNAKE_CASE` regardless of visibility and regardless of the fact
+  that `VirtualField.find(...)` creates the handle at runtime rather than at
+  compile time. Use lower camel case for runtime collaborators (loggers,
+  instrumenters, helpers, caches), even when `static final`.
 - **Collection constants**: public, protected, and package-private collection
   constants must be unmodifiable. Private collection constants must also be
   unmodifiable when their collection reference escapes the declaring class.

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -132,12 +132,15 @@ Examples that may remain uppercase include:
   `Duration` timeouts, intervals, or deadlines
 - canonical singleton or sentinel fields named `INSTANCE`, `EMPTY`, or `NOOP`
 
-Semantic key and handle types — `AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`, and
-`Pattern` — **must** use uppercase names for `static final` fields, regardless of visibility
-(`private` or `public`) and regardless of whether the value is created by a runtime factory method
-(for example `VirtualField.find(...)`). These types identify a fixed, well-known slot or pattern
-rather than a mutable collaborator, so the field name should read the same way no matter where the
-value comes from.
+Semantic key and handle types such as `AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`,
+and `Pattern` identify a fixed, well-known slot or pattern rather than a mutable collaborator, so
+`static final` fields of these types are good candidates for uppercase names.
+
+`VirtualField` handles are a specific case where this is required: a `static final VirtualField`
+field **must** use an uppercase name, regardless of visibility (`private` or `public`) and
+regardless of the fact that `VirtualField.find(...)` creates the handle at runtime rather than at
+compile time. The runtime-created origin does not make it a mutable collaborator — it still
+identifies one fixed, well-known storage slot for the lifetime of the class.
 
 Private `static final` arrays of constant or immutable values should also use uppercase names when
 the array is not exposed outside the class and is not mutated after initialization. Even though Java

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -130,9 +130,14 @@ Examples that may remain uppercase include:
 - literal strings, numbers, and booleans that behave like module constants
 - immutable value objects that are treated as fixed constants after initialization, such as
   `Duration` timeouts, intervals, or deadlines
-- semantic keys and handles such as `AttributeKey`, `ContextKey`, `VirtualField`,
-  `MethodHandle`, and `Pattern`
 - canonical singleton or sentinel fields named `INSTANCE`, `EMPTY`, or `NOOP`
+
+Semantic key and handle types — `AttributeKey`, `ContextKey`, `VirtualField`, `MethodHandle`, and
+`Pattern` — **must** use uppercase names for `static final` fields, regardless of visibility
+(`private` or `public`) and regardless of whether the value is created by a runtime factory method
+(for example `VirtualField.find(...)`). These types identify a fixed, well-known slot or pattern
+rather than a mutable collaborator, so the field name should read the same way no matter where the
+value comes from.
 
 Private `static final` arrays of constant or immutable values should also use uppercase names when
 the array is not exposed outside the class and is not mutated after initialization. Even though Java

--- a/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/org/apache/hadoop/hbase/ipc/OpenTelemetryCallUtil.java
+++ b/instrumentation/hbase/hbase-client-common-1.0/javaagent/src/main/java/org/apache/hadoop/hbase/ipc/OpenTelemetryCallUtil.java
@@ -11,18 +11,18 @@ import javax.annotation.Nullable;
 
 // Helper for accessing the virtual field on package-private Call.
 public final class OpenTelemetryCallUtil {
-  private static final VirtualField<Call, RequestAndContext> requestAndContextField =
+  private static final VirtualField<Call, RequestAndContext> REQUEST_AND_CONTEXT =
       VirtualField.find(Call.class, RequestAndContext.class);
 
   public static void setRequestAndContext(
       Object call, @Nullable RequestAndContext requestAndContext) {
-    requestAndContextField.set((Call) call, requestAndContext);
+    REQUEST_AND_CONTEXT.set((Call) call, requestAndContext);
   }
 
   @Nullable
   public static RequestAndContext getAndClearRequestAndContext(Object call) {
-    RequestAndContext requestAndContext = requestAndContextField.get((Call) call);
-    requestAndContextField.set((Call) call, null);
+    RequestAndContext requestAndContext = REQUEST_AND_CONTEXT.get((Call) call);
+    REQUEST_AND_CONTEXT.set((Call) call, null);
     return requestAndContext;
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcData.java
@@ -33,12 +33,12 @@ public final class JdbcData {
       VirtualField.find(Connection.class, DbInfo.class);
   public static final VirtualField<PreparedStatement, String> PREPARED_STATEMENT =
       VirtualField.find(PreparedStatement.class, String.class);
-  private static final VirtualField<Statement, StatementBatchInfo> statementBatch =
+  private static final VirtualField<Statement, StatementBatchInfo> STATEMENT_BATCH =
       VirtualField.find(Statement.class, StatementBatchInfo.class);
   private static final VirtualField<PreparedStatement, PreparedStatementBatchInfo>
-      preparedStatementBatch =
+      PREPARED_STATEMENT_BATCH =
           VirtualField.find(PreparedStatement.class, PreparedStatementBatchInfo.class);
-  private static final VirtualField<PreparedStatement, Map<String, String>> parameters =
+  private static final VirtualField<PreparedStatement, Map<String, String>> STATEMENT_PARAMETERS =
       VirtualField.find(PreparedStatement.class, Map.class);
 
   private JdbcData() {}
@@ -66,54 +66,54 @@ public final class JdbcData {
   }
 
   public static void addStatementBatch(Statement statement, String sql) {
-    StatementBatchInfo batchInfo = statementBatch.get(statement);
+    StatementBatchInfo batchInfo = STATEMENT_BATCH.get(statement);
     if (batchInfo == null) {
       batchInfo = new StatementBatchInfo();
-      statementBatch.set(statement, batchInfo);
+      STATEMENT_BATCH.set(statement, batchInfo);
     }
     batchInfo.add(sql);
   }
 
   public static void addPreparedStatementBatch(PreparedStatement statement) {
-    PreparedStatementBatchInfo batchInfo = preparedStatementBatch.get(statement);
+    PreparedStatementBatchInfo batchInfo = PREPARED_STATEMENT_BATCH.get(statement);
     if (batchInfo == null) {
       batchInfo = new PreparedStatementBatchInfo();
-      preparedStatementBatch.set(statement, batchInfo);
+      PREPARED_STATEMENT_BATCH.set(statement, batchInfo);
     }
     batchInfo.add();
   }
 
   public static void clearBatch(Statement statement) {
     if (statement instanceof PreparedStatement) {
-      preparedStatementBatch.set((PreparedStatement) statement, null);
+      PREPARED_STATEMENT_BATCH.set((PreparedStatement) statement, null);
     } else {
-      statementBatch.set(statement, null);
+      STATEMENT_BATCH.set(statement, null);
     }
   }
 
   public static StatementBatchInfo getStatementBatchInfo(Statement statement) {
-    return statementBatch.get(statement);
+    return STATEMENT_BATCH.get(statement);
   }
 
   public static Long getPreparedStatementBatchSize(PreparedStatement statement) {
-    PreparedStatementBatchInfo batchInfo = preparedStatementBatch.get(statement);
+    PreparedStatementBatchInfo batchInfo = PREPARED_STATEMENT_BATCH.get(statement);
     return batchInfo != null ? batchInfo.getBatchSize() : null;
   }
 
   public static void close(Statement statement) {
     // when statement is closed remove all of our virtual fields in case the JDBC driver reuses the
     // same statement instance for a subsequent query
-    statementBatch.set(statement, null);
+    STATEMENT_BATCH.set(statement, null);
     if (statement instanceof PreparedStatement) {
       PreparedStatement prepared = (PreparedStatement) statement;
       PREPARED_STATEMENT.set(prepared, null);
-      preparedStatementBatch.set(prepared, null);
-      parameters.set(prepared, null);
+      PREPARED_STATEMENT_BATCH.set(prepared, null);
+      STATEMENT_PARAMETERS.set(prepared, null);
     }
   }
 
   public static Map<String, String> getParameters(PreparedStatement statement) {
-    Map<String, String> parametersMap = parameters.get(statement);
+    Map<String, String> parametersMap = STATEMENT_PARAMETERS.get(statement);
     return parametersMap != null ? parametersMap : emptyMap();
   }
 
@@ -122,16 +122,16 @@ public final class JdbcData {
       return;
     }
 
-    Map<String, String> parametersMap = parameters.get(statement);
+    Map<String, String> parametersMap = STATEMENT_PARAMETERS.get(statement);
     if (parametersMap == null) {
       parametersMap = new HashMap<>();
-      parameters.set(statement, parametersMap);
+      STATEMENT_PARAMETERS.set(statement, parametersMap);
     }
     parametersMap.put(key, value);
   }
 
   public static void clearParameters(PreparedStatement statement) {
-    parameters.set(statement, null);
+    STATEMENT_PARAMETERS.set(statement, null);
   }
 
   /**

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaConsumerContextUtil.java
@@ -29,15 +29,15 @@ public final class KafkaConsumerContextUtil {
       ContextKey.named("opentelemetry-kafka-receive-operation");
   // these fields can be used for multiple instrumentations because of that we don't use a helper
   // class as field type
-  private static final VirtualField<ConsumerRecord<?, ?>, Context> recordContextField =
+  private static final VirtualField<ConsumerRecord<?, ?>, Context> RECORD_CONTEXT =
       VirtualField.find(ConsumerRecord.class, Context.class);
-  private static final VirtualField<ConsumerRecord<?, ?>, String[]> recordConsumerInfoField =
+  private static final VirtualField<ConsumerRecord<?, ?>, String[]> RECORD_CONSUMER_INFO =
       VirtualField.find(ConsumerRecord.class, String[].class);
-  private static final VirtualField<ConsumerRecords<?, ?>, Context> recordsContextField =
+  private static final VirtualField<ConsumerRecords<?, ?>, Context> RECORDS_CONTEXT =
       VirtualField.find(ConsumerRecords.class, Context.class);
-  private static final VirtualField<ConsumerRecords<?, ?>, String[]> recordsConsumerInfoField =
+  private static final VirtualField<ConsumerRecords<?, ?>, String[]> RECORDS_CONSUMER_INFO =
       VirtualField.find(ConsumerRecords.class, String[].class);
-  private static final VirtualField<ConsumerRecord<?, ?>, Boolean> recordCountedField =
+  private static final VirtualField<ConsumerRecord<?, ?>, Boolean> RECORD_COUNTED =
       VirtualField.find(ConsumerRecord.class, Boolean.class);
 
   public static Context withoutLeakedProcessSpan(Context context) {
@@ -79,18 +79,18 @@ public final class KafkaConsumerContextUtil {
    * that operations that observe the same record do not count it twice.
    */
   public static boolean markConsumedMessageCounted(ConsumerRecord<?, ?> record) {
-    if (Boolean.TRUE.equals(recordCountedField.get(record))) {
+    if (Boolean.TRUE.equals(RECORD_COUNTED.get(record))) {
       return false;
     }
-    recordCountedField.set(record, true);
+    RECORD_COUNTED.set(record, true);
     return true;
   }
 
   public static KafkaConsumerContext get(ConsumerRecord<?, ?> records) {
-    Context receiveContext = recordContextField.get(records);
+    Context receiveContext = RECORD_CONTEXT.get(records);
     String consumerGroup = null;
     String clientId = null;
-    String[] consumerInfo = recordConsumerInfoField.get(records);
+    String[] consumerInfo = RECORD_CONSUMER_INFO.get(records);
     if (consumerInfo != null) {
       consumerGroup = consumerInfo[0];
       clientId = consumerInfo[1];
@@ -99,10 +99,10 @@ public final class KafkaConsumerContextUtil {
   }
 
   public static KafkaConsumerContext get(ConsumerRecords<?, ?> records) {
-    Context receiveContext = recordsContextField.get(records);
+    Context receiveContext = RECORDS_CONTEXT.get(records);
     String consumerGroup = null;
     String clientId = null;
-    String[] consumerInfo = recordsConsumerInfoField.get(records);
+    String[] consumerInfo = RECORDS_CONSUMER_INFO.get(records);
     if (consumerInfo != null) {
       consumerGroup = consumerInfo[0];
       clientId = consumerInfo[1];
@@ -132,8 +132,8 @@ public final class KafkaConsumerContextUtil {
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId) {
-    recordContextField.set(record, context);
-    recordConsumerInfoField.set(record, new String[] {consumerGroup, clientId});
+    RECORD_CONTEXT.set(record, context);
+    RECORD_CONSUMER_INFO.set(record, new String[] {consumerGroup, clientId});
   }
 
   public static void set(ConsumerRecords<?, ?> records, KafkaConsumerContext consumerContext) {
@@ -149,13 +149,13 @@ public final class KafkaConsumerContextUtil {
       @Nullable Context context,
       @Nullable String consumerGroup,
       @Nullable String clientId) {
-    recordsContextField.set(records, context);
-    recordsConsumerInfoField.set(records, new String[] {consumerGroup, clientId});
+    RECORDS_CONTEXT.set(records, context);
+    RECORDS_CONSUMER_INFO.set(records, new String[] {consumerGroup, clientId});
   }
 
   public static void copy(ConsumerRecord<?, ?> from, ConsumerRecord<?, ?> to) {
-    recordContextField.set(to, recordContextField.get(from));
-    recordConsumerInfoField.set(to, recordConsumerInfoField.get(from));
+    RECORD_CONTEXT.set(to, RECORD_CONTEXT.get(from));
+    RECORD_CONSUMER_INFO.set(to, RECORD_CONSUMER_INFO.get(from));
   }
 
   private KafkaConsumerContextUtil() {}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common-0.11/library/src/main/java/io/opentelemetry/instrumentation/kafkaclients/common/v0_11/internal/KafkaUtil.java
@@ -35,7 +35,7 @@ public final class KafkaUtil {
   private static final String CONSUMER_GROUP = "consumer_group";
   private static final String CLIENT_ID = "client_id";
 
-  private static final VirtualField<Consumer<?, ?>, Map<String, String>> consumerInfoField =
+  private static final VirtualField<Consumer<?, ?>, Map<String, String>> CONSUMER_INFO =
       VirtualField.find(Consumer.class, Map.class);
 
   private static final MethodHandle GET_GROUP_METADATA;
@@ -88,12 +88,12 @@ public final class KafkaUtil {
     if (consumer == null) {
       return emptyMap();
     }
-    Map<String, String> map = consumerInfoField.get(consumer);
+    Map<String, String> map = CONSUMER_INFO.get(consumer);
     if (map == null) {
       map = new HashMap<>();
       map.put(CONSUMER_GROUP, extractConsumerGroup(consumer));
       map.put(CLIENT_ID, extractClientId(consumer));
-      consumerInfoField.set(consumer, map);
+      CONSUMER_INFO.set(consumer, map);
     }
     return map;
   }

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/HttpClientRequestTracingHandler.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.netty.v3_8.client;
 
+import static io.opentelemetry.javaagent.instrumentation.netty.v3_8.VirtualFieldHelper.CONNECTION_CONTEXT;
 import static io.opentelemetry.javaagent.instrumentation.netty.v3_8.client.NettyClientSingletons.instrumenter;
 
 import io.opentelemetry.context.Context;
@@ -20,9 +21,7 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 
 public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHandler {
 
-  private static final VirtualField<Channel, NettyConnectionContext> connectionContextField =
-      VirtualField.find(Channel.class, NettyConnectionContext.class);
-  private static final VirtualField<Channel, NettyClientRequestAndContexts> requestContextsField =
+  private static final VirtualField<Channel, NettyClientRequestAndContexts> REQUEST_AND_CONTEXTS =
       VirtualField.find(Channel.class, NettyClientRequestAndContexts.class);
 
   @Override
@@ -34,7 +33,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     }
 
     Context parentContext = null;
-    NettyConnectionContext connectionContext = connectionContextField.get(ctx.getChannel());
+    NettyConnectionContext connectionContext = CONNECTION_CONTEXT.get(ctx.getChannel());
     if (connectionContext != null) {
       parentContext = connectionContext.remove();
     }
@@ -49,7 +48,7 @@ public class HttpClientRequestTracingHandler extends SimpleChannelDownstreamHand
     }
 
     Context context = instrumenter().start(parentContext, request);
-    requestContextsField.set(
+    REQUEST_AND_CONTEXTS.set(
         ctx.getChannel(), NettyClientRequestAndContexts.create(parentContext, context, request));
 
     try (Scope ignored = context.makeCurrent()) {

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/client/HttpClientResponseTracingHandler.java
@@ -18,12 +18,12 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 
 public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandler {
 
-  private static final VirtualField<Channel, NettyClientRequestAndContexts> requestContextsField =
+  private static final VirtualField<Channel, NettyClientRequestAndContexts> REQUEST_AND_CONTEXTS =
       VirtualField.find(Channel.class, NettyClientRequestAndContexts.class);
 
   @Override
   public void messageReceived(ChannelHandlerContext ctx, MessageEvent msg) throws Exception {
-    NettyClientRequestAndContexts requestAndContexts = requestContextsField.get(ctx.getChannel());
+    NettyClientRequestAndContexts requestAndContexts = REQUEST_AND_CONTEXTS.get(ctx.getChannel());
 
     if (requestAndContexts == null) {
       super.messageReceived(ctx, msg);
@@ -37,7 +37,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
               requestAndContexts.request(),
               (HttpResponse) msg.getMessage(),
               NettyErrorHolder.getOrDefault(requestAndContexts.context(), null));
-      requestContextsField.set(ctx.getChannel(), null);
+      REQUEST_AND_CONTEXTS.set(ctx.getChannel(), null);
     }
 
     // We want the callback in the scope of the parent, not the client span

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -19,14 +19,14 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 
 public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandler {
 
-  private static final VirtualField<Channel, NettyServerRequestAndContext> requestAndContextField =
+  private static final VirtualField<Channel, NettyServerRequestAndContext> REQUEST_AND_CONTEXT =
       VirtualField.find(Channel.class, NettyServerRequestAndContext.class);
 
   @Override
   public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) throws Exception {
     Object message = event.getMessage();
     if (!(message instanceof HttpRequest)) {
-      NettyServerRequestAndContext requestAndContext = requestAndContextField.get(ctx.getChannel());
+      NettyServerRequestAndContext requestAndContext = REQUEST_AND_CONTEXT.get(ctx.getChannel());
       if (requestAndContext == null) {
         super.messageReceived(ctx, event);
       } else {
@@ -45,7 +45,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     }
 
     Context context = instrumenter().start(parentContext, request);
-    requestAndContextField.set(
+    REQUEST_AND_CONTEXT.set(
         ctx.getChannel(), NettyServerRequestAndContext.create(request, context));
 
     try (Scope ignored = context.makeCurrent()) {

--- a/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
@@ -22,12 +22,12 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 
 public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHandler {
 
-  private static final VirtualField<Channel, NettyServerRequestAndContext> requestAndContextField =
+  private static final VirtualField<Channel, NettyServerRequestAndContext> REQUEST_AND_CONTEXT =
       VirtualField.find(Channel.class, NettyServerRequestAndContext.class);
 
   @Override
   public void writeRequested(ChannelHandlerContext ctx, MessageEvent msg) throws Exception {
-    NettyServerRequestAndContext requestAndContext = requestAndContextField.get(ctx.getChannel());
+    NettyServerRequestAndContext requestAndContext = REQUEST_AND_CONTEXT.get(ctx.getChannel());
 
     if (requestAndContext == null || !(msg.getMessage() instanceof HttpResponse)) {
       super.writeRequested(ctx, msg);
@@ -39,7 +39,7 @@ public class HttpServerResponseTracingHandler extends SimpleChannelDownstreamHan
     HttpResponse response = (HttpResponse) msg.getMessage();
     customizeResponse(context, response);
 
-    requestAndContextField.set(ctx.getChannel(), null);
+    REQUEST_AND_CONTEXT.set(ctx.getChannel(), null);
     try (Scope ignored = context.makeCurrent()) {
       super.writeRequested(ctx, msg);
     } catch (Throwable t) {

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/TracingCallFactory.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/okhttp/v3_0/TracingCallFactory.java
@@ -22,7 +22,7 @@ import okio.Timeout;
 
 class TracingCallFactory implements Call.Factory {
 
-  private static final VirtualField<Request, Context> contextsByRequest =
+  private static final VirtualField<Request, Context> REQUEST_CONTEXT =
       VirtualField.find(Request.class, Context.class);
   private static final boolean supportsTags = supportsTags();
 
@@ -60,7 +60,7 @@ class TracingCallFactory implements Call.Factory {
     if (supportsTags) {
       return getContextFromRequestTag(request);
     }
-    return contextsByRequest.get(request);
+    return REQUEST_CONTEXT.get(request);
   }
 
   @Nullable
@@ -83,7 +83,7 @@ class TracingCallFactory implements Call.Factory {
     }
     Request newRequest = builder.build();
     if (!supportsTags) {
-      contextsByRequest.set(newRequest, context);
+      REQUEST_CONTEXT.set(newRequest, context);
     }
     return newRequest;
   }

--- a/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
+++ b/instrumentation/reactor/reactor-netty/reactor-netty-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/reactornetty/v1_0/InstrumentationContexts.java
@@ -20,7 +20,7 @@ import reactor.netty.http.client.HttpClientRequest;
 import reactor.netty.http.client.HttpClientResponse;
 
 final class InstrumentationContexts {
-  private static final VirtualField<HttpClientRequest, Context> requestContextVirtualField =
+  private static final VirtualField<HttpClientRequest, Context> REQUEST_CONTEXT =
       VirtualField.find(HttpClientRequest.class, Context.class);
 
   private static final AtomicReferenceFieldUpdater<InstrumentationContexts, Context>
@@ -59,7 +59,7 @@ final class InstrumentationContexts {
     Context context = null;
     if (instrumenter().shouldStart(parentContext, request)) {
       context = instrumenter().start(parentContext, request);
-      requestContextVirtualField.set(request, context);
+      REQUEST_CONTEXT.set(request, context);
       clientContexts.offer(new RequestAndContext(request, context));
     }
     return context;
@@ -71,7 +71,7 @@ final class InstrumentationContexts {
     RequestAndContext requestAndContext = clientContexts.poll();
     if (response instanceof HttpClientRequest) {
       request = (HttpClientRequest) response;
-      context = requestContextVirtualField.get(request);
+      context = REQUEST_CONTEXT.get(request);
     } else if (requestAndContext != null) {
       // this branch is taken when there was an error (e.g. timeout) and response was null
       request = requestAndContext.request;

--- a/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/ServletOutputStreamInjectionState.java
+++ b/instrumentation/servlet/servlet-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v3_0/snippet/ServletOutputStreamInjectionState.java
@@ -11,25 +11,25 @@ import javax.annotation.Nullable;
 import javax.servlet.ServletOutputStream;
 
 public class ServletOutputStreamInjectionState {
-  private static final VirtualField<ServletOutputStream, InjectionState> virtualField =
+  private static final VirtualField<ServletOutputStream, InjectionState> INJECTION_STATE =
       VirtualField.find(ServletOutputStream.class, InjectionState.class);
 
   public static void initializeInjectionStateIfNeeded(
       ServletOutputStream servletOutputStream, Servlet3SnippetInjectingResponseWrapper wrapper) {
-    InjectionState state = virtualField.get(servletOutputStream);
+    InjectionState state = INJECTION_STATE.get(servletOutputStream);
     if (!wrapper.isContentTypeTextHtml()) {
-      virtualField.set(servletOutputStream, null);
+      INJECTION_STATE.set(servletOutputStream, null);
       return;
     }
     if (state == null || state.getWrapper() != wrapper) {
       state = new InjectionState(wrapper);
-      virtualField.set(servletOutputStream, state);
+      INJECTION_STATE.set(servletOutputStream, state);
     }
   }
 
   @Nullable
   public static InjectionState getInjectionState(ServletOutputStream servletOutputStream) {
-    return virtualField.get(servletOutputStream);
+    return INJECTION_STATE.get(servletOutputStream);
   }
 
   private ServletOutputStreamInjectionState() {}

--- a/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/SpringAwsUtil.java
+++ b/instrumentation/spring/spring-cloud-aws-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/cloud/aws/v3_0/SpringAwsUtil.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 
 public class SpringAwsUtil {
   private static final ThreadLocal<TracingList> context = new ThreadLocal<>();
-  private static final VirtualField<Message<?>, TracingContext> tracingContextField =
+  private static final VirtualField<Message<?>, TracingContext> TRACING_CONTEXT =
       VirtualField.find(Message.class, TracingContext.class);
 
   // put the TracingList into thread local, so we can use it in attachTracingState method
@@ -52,7 +52,7 @@ public class SpringAwsUtil {
       return;
     }
 
-    tracingContextField.set(convertedMessage, new TracingContext(tracingList, message));
+    TRACING_CONTEXT.set(convertedMessage, new TracingContext(tracingList, message));
   }
 
   public static void copyTracingState(Message<?> original, Message<?> transformed) {
@@ -60,12 +60,12 @@ public class SpringAwsUtil {
       return;
     }
 
-    tracingContextField.set(transformed, tracingContextField.get(original));
+    TRACING_CONTEXT.set(transformed, TRACING_CONTEXT.get(original));
   }
 
   @Nullable
   public static MessageScope handleMessage(Message<?> message) {
-    TracingContext tracingContext = tracingContextField.get(message);
+    TracingContext tracingContext = TRACING_CONTEXT.get(message);
     if (tracingContext == null) {
       return null;
     }
@@ -80,7 +80,7 @@ public class SpringAwsUtil {
       return null;
     }
     Message<?> message = messages.iterator().next();
-    TracingContext tracingContext = tracingContextField.get(message);
+    TracingContext tracingContext = TRACING_CONTEXT.get(message);
     if (tracingContext == null) {
       return null;
     }

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedBatchInterceptor.java
@@ -21,7 +21,7 @@ import org.springframework.kafka.listener.BatchInterceptor;
 
 final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V> {
 
-  private static final VirtualField<ConsumerRecords<?, ?>, State<KafkaReceiveRequest>> stateField =
+  private static final VirtualField<ConsumerRecords<?, ?>, State<KafkaReceiveRequest>> BATCH_STATE =
       VirtualField.find(ConsumerRecords.class, State.class);
   private static final ThreadLocal<WeakReference<ConsumerRecords<?, ?>>> lastProcessed =
       new ThreadLocal<>();
@@ -44,7 +44,7 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
     if (batchProcessInstrumenter.shouldStart(parentContext, request) && !skipProcessing(records)) {
       Context context = batchProcessInstrumenter.start(parentContext, request);
       Scope scope = context.makeCurrent();
-      stateField.set(records, State.create(request, context, scope));
+      BATCH_STATE.set(records, State.create(request, context, scope));
     }
 
     return decorated == null ? records : decorated.intercept(records, consumer);
@@ -92,8 +92,8 @@ final class InstrumentedBatchInterceptor<K, V> implements BatchInterceptor<K, V>
   }
 
   private void end(ConsumerRecords<K, V> records, @Nullable Throwable error) {
-    State<KafkaReceiveRequest> state = stateField.get(records);
-    stateField.set(records, null);
+    State<KafkaReceiveRequest> state = BATCH_STATE.get(records);
+    BATCH_STATE.set(records, null);
     if (state != null) {
       KafkaReceiveRequest request = state.request();
       state.scope().close();

--- a/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
+++ b/instrumentation/spring/spring-kafka-2.7/library/src/main/java/io/opentelemetry/instrumentation/spring/kafka/v2_7/InstrumentedRecordInterceptor.java
@@ -20,7 +20,7 @@ import org.springframework.kafka.listener.RecordInterceptor;
 
 final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, V> {
 
-  private static final VirtualField<ConsumerRecord<?, ?>, State<KafkaProcessRequest>> stateField =
+  private static final VirtualField<ConsumerRecord<?, ?>, State<KafkaProcessRequest>> RECORD_STATE =
       VirtualField.find(ConsumerRecord.class, State.class);
   private static final ThreadLocal<ThreadState> threadLocalState = new ThreadLocal<>();
 
@@ -56,7 +56,7 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
     if (processInstrumenter.shouldStart(parentContext, request)) {
       Context context = processInstrumenter.start(parentContext, request);
       Scope scope = context.makeCurrent();
-      stateField.set(record, State.create(request, context, scope));
+      RECORD_STATE.set(record, State.create(request, context, scope));
     }
   }
 
@@ -100,8 +100,8 @@ final class InstrumentedRecordInterceptor<K, V> implements RecordInterceptor<K, 
   }
 
   private void end(ConsumerRecord<K, V> record, @Nullable Throwable error) {
-    State<KafkaProcessRequest> state = stateField.get(record);
-    stateField.set(record, null);
+    State<KafkaProcessRequest> state = RECORD_STATE.get(record);
+    RECORD_STATE.set(record, null);
     if (state != null) {
       KafkaProcessRequest request = state.request();
       state.scope().close();

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftSingletons.java
@@ -21,7 +21,7 @@ import org.apache.thrift.protocol.TProtocol;
 
 public final class ThriftSingletons {
 
-  private static final VirtualField<TProtocol, TProtocol> protocolVirtualField =
+  private static final VirtualField<TProtocol, TProtocol> PROTOCOL_DECORATOR =
       VirtualField.find(TProtocol.class, TProtocol.class);
   private static final Instrumenter<ThriftRequest, ThriftResponse> clientInstrumenter =
       ThriftInstrumenterFactory.createClientInstrumenter(
@@ -44,7 +44,7 @@ public final class ThriftSingletons {
   }
 
   public static TProtocol getProtocolDecorator(TProtocol protocol, boolean isOutput) {
-    TProtocol protocolDecorator = protocolVirtualField.get(protocol);
+    TProtocol protocolDecorator = PROTOCOL_DECORATOR.get(protocol);
     if (protocolDecorator != null) {
       return protocolDecorator;
     }
@@ -53,7 +53,7 @@ public final class ThriftSingletons {
         isOutput
             ? new ServerOutProtocolDecorator(protocol)
             : new ServerInProtocolDecorator(protocol, null, serverInstrumenter());
-    protocolVirtualField.set(protocol, protocolDecorator);
+    PROTOCOL_DECORATOR.set(protocol, protocolDecorator);
     return protocolDecorator;
   }
 

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcSingletons.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcSingletons.java
@@ -10,18 +10,18 @@ import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 
 public class TomcatJdbcSingletons {
-  private static final VirtualField<PoolProperties, Boolean> CONFIGURED_POOL_NAME =
+  private static final VirtualField<PoolProperties, Boolean> POOL_NAME_CONFIGURED =
       VirtualField.find(PoolProperties.class, Boolean.class);
 
   public static void setPoolNameConfigured(PoolProperties poolProperties, boolean configured) {
-    CONFIGURED_POOL_NAME.set(poolProperties, configured);
+    POOL_NAME_CONFIGURED.set(poolProperties, configured);
   }
 
   public static boolean isPoolNameConfigured(PoolConfiguration poolProperties) {
     if (!(poolProperties instanceof PoolProperties)) {
       return true;
     }
-    return Boolean.TRUE.equals(CONFIGURED_POOL_NAME.get((PoolProperties) poolProperties));
+    return Boolean.TRUE.equals(POOL_NAME_CONFIGURED.get((PoolProperties) poolProperties));
   }
 
   private TomcatJdbcSingletons() {}

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcSingletons.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatJdbcSingletons.java
@@ -10,18 +10,18 @@ import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 
 public class TomcatJdbcSingletons {
-  private static final VirtualField<PoolProperties, Boolean> configuredPoolNameField =
+  private static final VirtualField<PoolProperties, Boolean> CONFIGURED_POOL_NAME =
       VirtualField.find(PoolProperties.class, Boolean.class);
 
   public static void setPoolNameConfigured(PoolProperties poolProperties, boolean configured) {
-    configuredPoolNameField.set(poolProperties, configured);
+    CONFIGURED_POOL_NAME.set(poolProperties, configured);
   }
 
   public static boolean isPoolNameConfigured(PoolConfiguration poolProperties) {
     if (!(poolProperties instanceof PoolProperties)) {
       return true;
     }
-    return Boolean.TRUE.equals(configuredPoolNameField.get((PoolProperties) poolProperties));
+    return Boolean.TRUE.equals(CONFIGURED_POOL_NAME.get((PoolProperties) poolProperties));
   }
 
   private TomcatJdbcSingletons() {}

--- a/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientSingletons.java
+++ b/instrumentation/vertx/vertx-redis-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/redisclient/v4_0/VertxRedisClientSingletons.java
@@ -30,9 +30,9 @@ public class VertxRedisClientSingletons {
   private static final Instrumenter<VertxRedisClientRequest, Void> instrumenter;
 
   private static final ThreadLocal<RedisURI> redisUriThreadLocal = new ThreadLocal<>();
-  private static final VirtualField<Command, String> commandNameField =
+  private static final VirtualField<Command, String> COMMAND_NAME =
       VirtualField.find(Command.class, String.class);
-  private static final VirtualField<RedisStandaloneConnection, RedisURI> redisUriField =
+  private static final VirtualField<RedisStandaloneConnection, RedisURI> REDIS_URI =
       VirtualField.find(RedisStandaloneConnection.class, RedisURI.class);
 
   static {
@@ -97,22 +97,22 @@ public class VertxRedisClientSingletons {
   }
 
   public static void setCommandName(Command command, String commandName) {
-    commandNameField.set(command, commandName);
+    COMMAND_NAME.set(command, commandName);
   }
 
   @Nullable
   public static String getCommandName(Command command) {
-    return commandNameField.get(command);
+    return COMMAND_NAME.get(command);
   }
 
   public static void setRedisUri(
       RedisStandaloneConnection connection, @Nullable RedisURI redisUri) {
-    redisUriField.set(connection, redisUri);
+    REDIS_URI.set(connection, redisUri);
   }
 
   @Nullable
   public static RedisURI getRedisUri(RedisStandaloneConnection connection) {
-    return redisUriField.get(connection);
+    return REDIS_URI.get(connection);
   }
 
   private VertxRedisClientSingletons() {}

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v4_0/VertxSqlClientSingletons.java
@@ -20,10 +20,10 @@ public class VertxSqlClientSingletons {
   private static final Instrumenter<VertxSqlClientRequest, Void> instrumenter =
       VertxSqlInstrumenterFactory.createInstrumenter(INSTRUMENTATION_NAME);
 
-  private static final VirtualField<SqlClientBase<?>, SqlConnectOptions> connectOptionsField =
+  private static final VirtualField<SqlClientBase<?>, SqlConnectOptions> CONNECT_OPTIONS =
       VirtualField.find(SqlClientBase.class, SqlConnectOptions.class);
 
-  private static final VirtualField<SqlConnectOptions, String> connectOptionsDbSystem =
+  private static final VirtualField<SqlConnectOptions, String> CONNECT_OPTIONS_DB_SYSTEM =
       VirtualField.find(SqlConnectOptions.class, String.class);
 
   public static Instrumenter<VertxSqlClientRequest, Void> instrumenter() {
@@ -32,24 +32,24 @@ public class VertxSqlClientSingletons {
 
   public static void storeConnectOptionsDbSystem(
       SqlConnectOptions connectOptions, String dbSystem) {
-    connectOptionsDbSystem.set(connectOptions, dbSystem);
+    CONNECT_OPTIONS_DB_SYSTEM.set(connectOptions, dbSystem);
   }
 
   @Nullable
   public static String getConnectOptionsDbSystem(SqlConnectOptions connectOptions) {
     // null when db system was not captured at pool creation time; callers should fall back
     // to getDbSystemNameFromClassName() on the connect options instance
-    return connectOptionsDbSystem.get(connectOptions);
+    return CONNECT_OPTIONS_DB_SYSTEM.get(connectOptions);
   }
 
   @Nullable
   public static SqlConnectOptions getSqlConnectOptions(SqlClientBase<?> sqlClientBase) {
-    return connectOptionsField.get(sqlClientBase);
+    return CONNECT_OPTIONS.get(sqlClientBase);
   }
 
   public static void attachConnectOptions(
       SqlClientBase<?> sqlClientBase, @Nullable SqlConnectOptions connectOptions) {
-    connectOptionsField.set(sqlClientBase, connectOptions);
+    CONNECT_OPTIONS.set(sqlClientBase, connectOptions);
   }
 
   public static Future<SqlConnection> attachConnectOptions(
@@ -57,7 +57,7 @@ public class VertxSqlClientSingletons {
     return future.map(
         sqlConnection -> {
           if (sqlConnection instanceof SqlClientBase) {
-            connectOptionsField.set((SqlClientBase<?>) sqlConnection, connectOptions);
+            CONNECT_OPTIONS.set((SqlClientBase<?>) sqlConnection, connectOptions);
           }
           return sqlConnection;
         });

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
@@ -23,17 +23,17 @@ public class VertxSqlClientSingletons {
   private static final Instrumenter<VertxSqlClientRequest, Void> instrumenter =
       VertxSqlInstrumenterFactory.createInstrumenter(INSTRUMENTATION_NAME);
 
-  private static final VirtualField<Pool, String> poolDbSystem =
+  private static final VirtualField<Pool, String> POOL_DB_SYSTEM =
       VirtualField.find(Pool.class, String.class);
 
-  private static final VirtualField<SqlConnectOptions, String> connectOptionsDbSystem =
+  private static final VirtualField<SqlConnectOptions, String> CONNECT_OPTIONS_DB_SYSTEM =
       VirtualField.find(SqlConnectOptions.class, String.class);
 
-  private static final VirtualField<SqlClientBase, SqlConnectOptions> connectOptionsField =
+  private static final VirtualField<SqlClientBase, SqlConnectOptions> CONNECT_OPTIONS =
       VirtualField.find(SqlClientBase.class, SqlConnectOptions.class);
 
   @Nullable
-  private static final VirtualField<Object, Context> commandContextField =
+  private static final VirtualField<Object, Context> COMMAND_CONTEXT =
       getCommandContextVirtualField();
 
   public static Instrumenter<VertxSqlClientRequest, Void> instrumenter() {
@@ -66,39 +66,39 @@ public class VertxSqlClientSingletons {
 
   @Nullable
   public static Context getCommandContext(Object command) {
-    return commandContextField != null ? commandContextField.get(command) : null;
+    return COMMAND_CONTEXT != null ? COMMAND_CONTEXT.get(command) : null;
   }
 
   public static void setCommandContext(Object command, Context context) {
-    if (commandContextField != null) {
-      commandContextField.set(command, context);
+    if (COMMAND_CONTEXT != null) {
+      COMMAND_CONTEXT.set(command, context);
     }
   }
 
   public static void storePoolDbSystem(Pool pool, String dbSystem) {
-    poolDbSystem.set(pool, dbSystem);
+    POOL_DB_SYSTEM.set(pool, dbSystem);
   }
 
   @Nullable
   public static String getConnectOptionsDbSystem(SqlConnectOptions sqlConnectOptions) {
-    return connectOptionsDbSystem.get(sqlConnectOptions);
+    return CONNECT_OPTIONS_DB_SYSTEM.get(sqlConnectOptions);
   }
 
   public static void resolveAndStoreDbSystem(Pool pool, SqlConnectOptions sqlConnectOptions) {
-    String dbSystem = poolDbSystem.get(pool);
+    String dbSystem = POOL_DB_SYSTEM.get(pool);
     if (sqlConnectOptions != null && dbSystem != null) {
-      connectOptionsDbSystem.set(sqlConnectOptions, dbSystem);
+      CONNECT_OPTIONS_DB_SYSTEM.set(sqlConnectOptions, dbSystem);
     }
   }
 
   @Nullable
   public static SqlConnectOptions getSqlConnectOptions(SqlClientBase sqlClientBase) {
-    return connectOptionsField.get(sqlClientBase);
+    return CONNECT_OPTIONS.get(sqlClientBase);
   }
 
   public static void attachConnectOptions(
       SqlClientBase sqlClientBase, @Nullable SqlConnectOptions connectOptions) {
-    connectOptionsField.set(sqlClientBase, connectOptions);
+    CONNECT_OPTIONS.set(sqlClientBase, connectOptions);
   }
 
   public static Future<SqlConnection> attachConnectOptions(
@@ -106,7 +106,7 @@ public class VertxSqlClientSingletons {
     return future.map(
         sqlConnection -> {
           if (sqlConnection instanceof SqlClientBase) {
-            connectOptionsField.set((SqlClientBase) sqlConnection, connectOptions);
+            CONNECT_OPTIONS.set((SqlClientBase) sqlConnection, connectOptions);
           }
           return sqlConnection;
         });

--- a/smoke-tests/extensions/extension/src/main/java/io/opentelemetry/smoketest/extensions/inlined/SmokeInlinedInstrumentation.java
+++ b/smoke-tests/extensions/extension/src/main/java/io/opentelemetry/smoketest/extensions/inlined/SmokeInlinedInstrumentation.java
@@ -75,7 +75,7 @@ class SmokeInlinedInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void onEnter(
         @Advice.Argument(0) Object target, @Advice.Argument(1) Integer value) {
-      VirtualFieldHelper.field.set(target, value);
+      VirtualFieldHelper.VALUE.set(target, value);
     }
   }
 
@@ -85,7 +85,7 @@ class SmokeInlinedInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @AssignReturned.ToReturned
     public static Integer onExit(@Advice.Argument(0) Object target) {
-      return VirtualFieldHelper.field.get(target);
+      return VirtualFieldHelper.VALUE.get(target);
     }
   }
 
@@ -105,7 +105,7 @@ class SmokeInlinedInstrumentation implements TypeInstrumentation {
   }
 
   public static class VirtualFieldHelper {
-    public static final VirtualField<Object, Integer> field =
+    public static final VirtualField<Object, Integer> VALUE =
         VirtualField.find(Object.class, Integer.class);
 
     private VirtualFieldHelper() {}


### PR DESCRIPTION
Requires every `static final VirtualField` field to use `SCREAMING_SNAKE_CASE` and documents the rule for contributors and code review. Renames the 32 existing camelCase fields without changing their behavior.

Netty 3.8 now reuses the shared connection-context `VirtualField` instead of defining a duplicate slot.
