### PR TITLE
Handle generic @SpanAttribute values

### DIFF
--- a/instrumentation-annotations-support/src/main/java/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactory.java
+++ b/instrumentation-annotations-support/src/main/java/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactory.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.api.annotation.support;
 import static java.util.Arrays.asList;
 
 import io.opentelemetry.api.common.AttributeKey;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.AbstractList;
 import java.util.List;
@@ -60,6 +62,9 @@ class AttributeBindingFactory {
   }
 
   private static boolean isArrayType(Type type) {
+    if (type instanceof GenericArrayType) {
+      return true;
+    }
     if (type instanceof Class) {
       return ((Class<?>) type).isArray();
     }
@@ -67,6 +72,9 @@ class AttributeBindingFactory {
   }
 
   private static Optional<Type> resolveListComponentType(Type type) {
+    if (!(type instanceof Class) && !(type instanceof ParameterizedType)) {
+      return Optional.empty();
+    }
     return ParameterizedClass.of(type)
         .findParameterizedSuperclass(List.class)
         .map(pc -> pc.getActualTypeArguments()[0]);

--- a/instrumentation-annotations-support/src/test/java/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactoryTest.java
+++ b/instrumentation-annotations-support/src/test/java/io/opentelemetry/instrumentation/api/annotation/support/AttributeBindingFactoryTest.java
@@ -127,9 +127,25 @@ class AttributeBindingFactoryTest {
   }
 
   @Test
+  void createDefaultAttributeBindingForTypeVariable() throws Exception {
+    Type type = GenericTestFields.class.getDeclaredField("value").getGenericType();
+    AttributeBindingFactory.createBinding("key", type).apply(setter, new TestClass("foo"));
+    verify(setter).put(stringKey("key"), "TestClass{value = foo}");
+  }
+
+  @Test
   void createDefaultAttributeBindingForArray() {
     List<String> expected = asList("TestClass{value = foo}", "TestClass{value = bar}", null);
     AttributeBindingFactory.createBinding("key", TestClass[].class)
+        .apply(setter, new TestClass[] {new TestClass("foo"), new TestClass("bar"), null});
+    verify(setter).put(stringArrayKey("key"), expected);
+  }
+
+  @Test
+  void createDefaultAttributeBindingForGenericArray() throws Exception {
+    List<String> expected = asList("TestClass{value = foo}", "TestClass{value = bar}", null);
+    Type type = GenericTestFields.class.getDeclaredField("values").getGenericType();
+    AttributeBindingFactory.createBinding("key", type)
         .apply(setter, new TestClass[] {new TestClass("foo"), new TestClass("bar"), null});
     verify(setter).put(stringArrayKey("key"), expected);
   }
@@ -224,5 +240,10 @@ class AttributeBindingFactoryTest {
     List<Float> floatList;
     List<TestClass> otherList;
     ArrayList<Long> longArrayList;
+  }
+
+  static class GenericTestFields<T> {
+    T value;
+    T[] values;
   }
 }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/TracedWithSpan.java
@@ -55,6 +55,12 @@ class TracedWithSpan {
   }
 
   @WithSpan
+  <T> String withGenericSpanAttributes(
+      @SpanAttribute("value") T value, @SpanAttribute("values") T[] values) {
+    return String.valueOf(value);
+  }
+
+  @WithSpan
   CompletionStage<String> completionStage(CompletableFuture<String> future) {
     return future;
   }

--- a/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
+++ b/instrumentation/opentelemetry-instrumentation-annotations-1.16/javaagent/src/test/java/io/opentelemetry/test/annotation/WithSpanInstrumentationTest.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.test.annotation;
 
+import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil.orderByRootSpanName;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.api.trace.SpanId;
@@ -339,6 +341,27 @@ class WithSpanInstrumentationTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName("TracedWithSpan.withSpanAttributes")
+                        .hasKind(SpanKind.INTERNAL)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(assertions)));
+  }
+
+  @Test
+  void captureGenericAttributes() {
+    String result =
+        new TracedWithSpan().withGenericSpanAttributes("foo", new String[] {"bar", "baz"});
+    assertThat(result).isEqualTo("foo");
+
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(codeAttributeAssertions("withGenericSpanAttributes"));
+    assertions.add(equalTo(stringKey("value"), "foo"));
+    assertions.add(equalTo(stringArrayKey("values"), asList("bar", "baz")));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName("TracedWithSpan.withGenericSpanAttributes")
                         .hasKind(SpanKind.INTERNAL)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(assertions)));


### PR DESCRIPTION
`@SpanAttribute` now captures generic scalar and array values without failing span creation. It stores generic scalar values as string attributes and generic arrays as string array attributes.
