### PR TITLE
Use semeru instead of adopt-openj9

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -314,7 +314,7 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           # using zulu because new releases get published quickly
-          distribution: ${{ matrix.vm == 'hotspot' && 'zulu' || 'adopt-openj9'}}
+          distribution: ${{ matrix.vm == 'hotspot' && 'zulu' || 'semeru'}}
           java-version: ${{ matrix.test-java-version != '25-deny-unsafe' && matrix.test-java-version || '25' }}
 
       - name: Set up JDK for running Gradle


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19794
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19802
setup-java v6 removed adopt-openj9, semeru should be used instead
