### PR TITLE
Add NullAway to first instrumentation batch

### DIFF
--- a/instrumentation/avaje-jex-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/avaje-jex-3.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/c3p0-0.9/javaagent/build.gradle.kts
+++ b/instrumentation/c3p0-0.9/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/couchbase/couchbase-common-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-common-2.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/external-annotations/javaagent/build.gradle.kts
+++ b/instrumentation/external-annotations/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/build.gradle.kts
+++ b/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 // this instrumentation applies to the class 'org.eclipse.osgi.internal.loader.BundleLoader'

--- a/instrumentation/internal/internal-url-class-loader/javaagent/build.gradle.kts
+++ b/instrumentation/internal/internal-url-class-loader/javaagent/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }

--- a/instrumentation/java-util-logging/javaagent/build.gradle.kts
+++ b/instrumentation/java-util-logging/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/javalin/javalin-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/javalin/javalin-5.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/javalin/javalin-7.0/javaagent/build.gradle.kts
+++ b/instrumentation/javalin/javalin-7.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-common/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-common/javaagent/build.gradle.kts
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-common/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jaxws/jaxws-common-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/jaxws/jaxws-common-2.0/javaagent/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }

--- a/instrumentation/jedis/jedis-common-1.4/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-common-1.4/javaagent/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }

--- a/instrumentation/jedis/jedis-common-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/common/v1_4/JedisRequestContext.java
+++ b/instrumentation/jedis/jedis-common-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/common/v1_4/JedisRequestContext.java
@@ -33,7 +33,7 @@ public class JedisRequestContext<T> {
 
   public void detachAndEnd() {
     contextThreadLocal.remove();
-    if (request != null) {
+    if (request != null && instrumenter != null && context != null) {
       endSpan(instrumenter, context, request, throwable);
     }
   }

--- a/instrumentation/jetty/jetty-common-8.0/javaagent/build.gradle.kts
+++ b/instrumentation/jetty/jetty-common-8.0/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jmx-metrics/javaagent/build.gradle.kts
+++ b/instrumentation/jmx-metrics/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jsf/jsf-common-jakarta/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-common-jakarta/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfServerSpanNaming.java
+++ b/instrumentation/jsf/jsf-common-jakarta/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/jakarta/JsfServerSpanNaming.java
@@ -31,7 +31,9 @@ public class JsfServerSpanNaming {
     // view, such as a JSP page or a Facelets page.
     String viewId = uiViewRoot.getViewId();
     String name = ServletContextPath.prepend(context, viewId);
-    serverSpan.updateName(name);
+    if (name != null) {
+      serverSpan.updateName(name);
+    }
   }
 
   private JsfServerSpanNaming() {}

--- a/instrumentation/jsf/jsf-common-javax/javaagent/build.gradle.kts
+++ b/instrumentation/jsf/jsf-common-javax/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 dependencies {

--- a/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfServerSpanNaming.java
+++ b/instrumentation/jsf/jsf-common-javax/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jsf/common/javax/JsfServerSpanNaming.java
@@ -31,7 +31,9 @@ public class JsfServerSpanNaming {
     // view, such as a JSP page or a Facelets page.
     String viewId = uiViewRoot.getViewId();
     String name = ServletContextPath.prepend(context, viewId);
-    serverSpan.updateName(name);
+    if (name != null) {
+      serverSpan.updateName(name);
+    }
   }
 
   private JsfServerSpanNaming() {}

--- a/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/build.gradle.kts
+++ b/instrumentation/kotlinx-coroutines/kotlinx-coroutines-flow-1.3/javaagent/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
+++ b/instrumentation/log4j/log4j-appender-2.17/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
+++ b/instrumentation/mongo/mongo-3.1/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 muzzle {

--- a/instrumentation/payara-5.2020/javaagent/build.gradle.kts
+++ b/instrumentation/payara-5.2020/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 // No muzzle check because this instrumentation is written in ASM and muzzle won't work with it.

--- a/instrumentation/spark-2.3/javaagent/build.gradle.kts
+++ b/instrumentation/spark-2.3/javaagent/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("otel.javaagent-instrumentation")
+  id("otel.nullaway-conventions")
 }
 
 // building against 2.3 and testing against 2.4 because JettyHandler is available since 2.4 only


### PR DESCRIPTION
## Summary

Enable `otel.nullaway-conventions` for 24 small instrumentation modules as part of the NullAway migration tracked by #15991.

### Covered modules

- Elasticsearch REST common 5.0
- Jedis common 1.4
- Internal Eclipse OSGi 3.6
- Internal URL class loader
- Jetty common 8.0
- JMX metrics
- Payara 5.2020
- Avaje Jex 3.0
- c3p0 0.9
- Couchbase common 2.0
- External annotations
- Java Util Logging
- Javalin 5.0 and 7.0
- JAX-RS 2.0 common and 3.0 common
- JAX-WS common 2.0
- JSF common javax and Jakarta
- kotlinx-coroutines-flow 1.3
- Log4j appender 2.17
- Mongo 3.1
- OpenTelemetry extension Kotlin 1.0
- Spark 2.3

The changes are limited to enabling NullAway plus localized handling for nullable values: a Jedis deferred span guard and guards in both JSF common modules before updating the server span name.

### Deferred follow-up modules

These were intentionally left for follow-up because they need more than a straightforward convention-plugin addition:
- Reactor 3.4: a nullable default context is intentionally passed to a shared API and needs a nullable-contract decision.
- JAX-WS 2.0 and JAX-WS JWS API 1.1: advice code passes nullable `context` and `request` values to `instrumenter().end(...)` and needs proper handling.

## Tests

Ran the targeted Gradle `check` task for all 24 modules after rebasing onto the current `origin/main`; all passed.

Part of #15991