### PR TITLE
Test InfluxDB server attributes from URLs with credentials

### DIFF
--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -454,7 +454,17 @@ class InfluxDbClientTest {
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfying(
-                            equalTo(SERVER_ADDRESS, host), equalTo(SERVER_PORT, port))));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), INFLUXDB),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(maybeStable(DB_STATEMENT), "SELECT * FROM cpu"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "SELECT cpu" : null))));
   }
 }

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -441,8 +441,8 @@ class InfluxDbClientTest {
   }
 
   @Test
-  void testConfiguredUrlIsSanitized() {
-    // the credentials and the path of the configured url must not reach server.address
+  void testServerAttributesFromConfiguredUrlWithUserInfo() {
+    // the credentials in the configured url must not reach server.address
     String serverUrl = "http://influxuser:influxsecret@" + host + ":" + port + "/";
     InfluxDB influxDbWithCredentialsInUrl = InfluxDBFactory.connect(serverUrl);
     cleanup.deferCleanup(influxDbWithCredentialsInUrl);

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -439,4 +439,22 @@ class InfluxDbClientTest {
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? "write" : "WRITE"))));
   }
+
+  @Test
+  void testConfiguredUrlIsSanitized() {
+    // the credentials and the path of the configured url must not reach server.address
+    String serverUrl = "http://influxuser:influxsecret@" + host + ":" + port + "/";
+    InfluxDB influxDbWithCredentialsInUrl = InfluxDBFactory.connect(serverUrl);
+    cleanup.deferCleanup(influxDbWithCredentialsInUrl);
+
+    influxDbWithCredentialsInUrl.query(new Query("SELECT * FROM cpu", DATABASE_NAME));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfying(
+                            equalTo(SERVER_ADDRESS, host), equalTo(SERVER_PORT, port))));
+  }
 }

--- a/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
+++ b/instrumentation/influxdb-2.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/influxdb/v2_4/InfluxDbClientTest.java
@@ -442,7 +442,6 @@ class InfluxDbClientTest {
 
   @Test
   void testServerAttributesFromConfiguredUrlWithUserInfo() {
-    // the credentials in the configured url must not reach server.address
     String serverUrl = "http://influxuser:influxsecret@" + host + ":" + port + "/";
     InfluxDB influxDbWithCredentialsInUrl = InfluxDBFactory.connect(serverUrl);
     cleanup.deferCleanup(influxDbWithCredentialsInUrl);


### PR DESCRIPTION
Adds a test that verifies InfluxDB spans derive `server.address` and `server.port` from a configured URL without exposing URL credentials in `server.address`.

This test-only change does not alter instrumentation behavior.