### PR TITLE
Add NullAway to agent exporter

### DIFF
--- a/testing/agent-exporter/build.gradle.kts
+++ b/testing/agent-exporter/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("com.gradleup.shadow")
   id("otel.java-conventions")
+  id("otel.nullaway-conventions")
 }
 
 tasks.jar {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestExporterCustomizerProvider.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestExporterCustomizerProvider.java
@@ -13,6 +13,7 @@ import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigura
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ConsoleExporterModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordExporterModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordExporterPropertyModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LogRecordProcessorModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.LoggerProviderModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.MeterProviderModel;
@@ -20,9 +21,11 @@ import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.MetricReaderMo
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.PeriodicMetricReaderModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.PushMetricExporterModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.PushMetricExporterPropertyModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SimpleLogRecordProcessorModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SimpleSpanProcessorModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanExporterModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanExporterPropertyModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SpanProcessorModel;
 import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.TracerProviderModel;
 import java.util.ArrayList;
@@ -62,13 +65,15 @@ public class AgentTestExporterCustomizerProvider
     //      processors:
     //        - simple:
     //            exporter:
-    //              agent_test:
+    //              agent_test: {}
     //        - simple:
     //            exporter:
     //              console:
     List<SpanProcessorModel> processors = new ArrayList<>();
     processors.add(
-        getProcessorModel(new SpanExporterModel().withAdditionalProperty("agent_test", null)));
+        getProcessorModel(
+            new SpanExporterModel()
+                .withAdditionalProperty("agent_test", new SpanExporterPropertyModel())));
     processors.add(
         getProcessorModel(new SpanExporterModel().withConsole(new ConsoleExporterModel())));
     model.withTracerProvider(new TracerProviderModel().withProcessors(processors));
@@ -85,7 +90,7 @@ public class AgentTestExporterCustomizerProvider
     //      processors:
     //        - simple:
     //            exporter:
-    //              agent_test:
+    //              agent_test: {}
     model.withLoggerProvider(
         new LoggerProviderModel()
             .withProcessors(
@@ -95,7 +100,9 @@ public class AgentTestExporterCustomizerProvider
                             new SimpleLogRecordProcessorModel()
                                 .withExporter(
                                     new LogRecordExporterModel()
-                                        .withAdditionalProperty("agent_test", null))))));
+                                        .withAdditionalProperty(
+                                            "agent_test",
+                                            new LogRecordExporterPropertyModel()))))));
   }
 
   private static void addMeterProvider(OpenTelemetryConfigurationModel model) {
@@ -105,7 +112,7 @@ public class AgentTestExporterCustomizerProvider
     //        - periodic:
     //            interval: 1000000
     //            exporter:
-    //              agent_test:
+    //              agent_test: {}
     model.withMeterProvider(
         new MeterProviderModel()
             .withReaders(
@@ -118,6 +125,8 @@ public class AgentTestExporterCustomizerProvider
                                 .withInterval(1000000)
                                 .withExporter(
                                     new PushMetricExporterModel()
-                                        .withAdditionalProperty("agent_test", null))))));
+                                        .withAdditionalProperty(
+                                            "agent_test",
+                                            new PushMetricExporterPropertyModel()))))));
   }
 }

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestLogRecordExporterComponentProvider.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestLogRecordExporterComponentProvider.java
@@ -11,11 +11,12 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import javax.annotation.Nullable;
 
 @AutoService(ComponentProvider.class)
 public class AgentTestLogRecordExporterComponentProvider implements ComponentProvider {
 
-  private static LogRecordExporter logRecordExporter;
+  @Nullable private static LogRecordExporter logRecordExporter;
 
   @Override
   public Class<LogRecordExporter> getType() {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestMetricExporterComponentProvider.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestMetricExporterComponentProvider.java
@@ -11,11 +11,12 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import javax.annotation.Nullable;
 
 @AutoService(ComponentProvider.class)
 public class AgentTestMetricExporterComponentProvider implements ComponentProvider {
 
-  private static MetricExporter metricExporter;
+  @Nullable private static MetricExporter metricExporter;
 
   @Override
   public Class<MetricExporter> getType() {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestSpanExporterComponentProvider.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/provider/AgentTestSpanExporterComponentProvider.java
@@ -11,11 +11,12 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import javax.annotation.Nullable;
 
 @AutoService(ComponentProvider.class)
 public class AgentTestSpanExporterComponentProvider implements ComponentProvider {
 
-  private static SpanExporter spanExporter;
+  @Nullable private static SpanExporter spanExporter;
 
   @Override
   public Class<SpanExporter> getType() {

--- a/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/util/KeysVerifyingPropagator.java
+++ b/testing/agent-exporter/src/main/java/io/opentelemetry/javaagent/testing/util/KeysVerifyingPropagator.java
@@ -38,7 +38,7 @@ public class KeysVerifyingPropagator implements TextMapPropagator {
   }
 
   @Override
-  public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
     // This propagator doesn't inject anything
   }
 
@@ -46,7 +46,9 @@ public class KeysVerifyingPropagator implements TextMapPropagator {
   @SuppressWarnings("OtelCanIgnoreReturnValueSuggester")
   public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
     // Exercise methods to verify no errors
-    getter.keys(carrier).forEach(key -> getter.get(carrier, key));
+    if (carrier != null) {
+      getter.keys(carrier).forEach(key -> getter.get(carrier, key));
+    }
 
     return context;
   }


### PR DESCRIPTION
## Summary

Enable `otel.nullaway-conventions` for the core `testing/agent-exporter` module as part of the NullAway migration tracked by #15991.

- Annotate lazily initialized exporter statics as `@Nullable`.
- Handle nullable propagator carriers safely.
- Represent the intentionally empty `agent_test` exporter configuration with the appropriate empty property models, avoiding NullAway suppressions.

## Tests

- `./gradlew :testing:agent-exporter:check`

Part of #15991