### PR TITLE
Fix Pekko HTTP/2 server context propagation

### DIFF
--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/HttpExtServerInstrumentation.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/HttpExtServerInstrumentation.java
@@ -16,7 +16,11 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 import org.apache.pekko.http.scaladsl.model.HttpResponse;
+import org.apache.pekko.http.scaladsl.settings.ServerSettings;
+import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.scaladsl.Flow;
+import scala.Function1;
+import scala.concurrent.Future;
 
 class HttpExtServerInstrumentation implements TypeInstrumentation {
   @Override
@@ -30,6 +34,13 @@ class HttpExtServerInstrumentation implements TypeInstrumentation {
         named("bindAndHandle")
             .and(takesArgument(0, named("org.apache.pekko.stream.scaladsl.Flow"))),
         getClass().getName() + "$PekkoBindAndHandleAdvice");
+
+    transformer.applyAdviceToMethod(
+        named("bindAndHandleAsync")
+            .and(takesArgument(0, named("scala.Function1")))
+            .and(takesArgument(4, named("org.apache.pekko.http.scaladsl.settings.ServerSettings")))
+            .and(takesArgument(7, named("org.apache.pekko.stream.Materializer"))),
+        getClass().getName() + "$PekkoBindAndHandleAsyncAdvice");
   }
 
   @SuppressWarnings("unused")
@@ -40,6 +51,24 @@ class HttpExtServerInstrumentation implements TypeInstrumentation {
     public static Flow<HttpRequest, HttpResponse, ?> wrapHandler(
         @Advice.Argument(value = 0) Flow<HttpRequest, HttpResponse, ?> handler) {
       return PekkoFlowWrapper.wrap(handler);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class PekkoBindAndHandleAsyncAdvice {
+
+    @Advice.AssignReturned.ToArguments(@ToArgument(0))
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static Function1<HttpRequest, Future<HttpResponse>> wrapHandler(
+        @Advice.Argument(0) Function1<HttpRequest, Future<HttpResponse>> handler,
+        @Advice.Argument(4) ServerSettings settings,
+        @Advice.Argument(7) Materializer materializer) {
+
+      if (!settings.previewServerSettings().enableHttp2()) {
+        return handler;
+      }
+
+      return PekkoAsyncHandlerWrapper.wrap(handler, materializer.executionContext());
     }
   }
 }

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoAsyncHandlerWrapper.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/server/PekkoAsyncHandlerWrapper.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server;
+
+import static io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server.PekkoHttpServerSingletons.errorResponse;
+import static io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server.PekkoHttpServerSingletons.instrumenter;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;
+import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRouteSource;
+import io.opentelemetry.javaagent.bootstrap.http.HttpServerResponseCustomizerHolder;
+import io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0.server.route.PekkoRouteHolder;
+import java.util.List;
+import org.apache.pekko.http.javadsl.model.HttpHeader;
+import org.apache.pekko.http.scaladsl.model.HttpRequest;
+import org.apache.pekko.http.scaladsl.model.HttpResponse;
+import scala.Function1;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+import scala.concurrent.impl.Promise;
+import scala.runtime.AbstractFunction1;
+import scala.util.Try;
+
+public final class PekkoAsyncHandlerWrapper
+    implements Function1<HttpRequest, Future<HttpResponse>> {
+
+  private final Function1<HttpRequest, Future<HttpResponse>> handler;
+  private final ExecutionContext executionContext;
+
+  private PekkoAsyncHandlerWrapper(
+      Function1<HttpRequest, Future<HttpResponse>> handler, ExecutionContext executionContext) {
+    this.handler = handler;
+    this.executionContext = executionContext;
+  }
+
+  public static Function1<HttpRequest, Future<HttpResponse>> wrap(
+      Function1<HttpRequest, Future<HttpResponse>> handler, ExecutionContext executionContext) {
+    if (handler instanceof PekkoAsyncHandlerWrapper) {
+      return handler;
+    }
+    return new PekkoAsyncHandlerWrapper(handler, executionContext);
+  }
+
+  @Override
+  public Future<HttpResponse> apply(HttpRequest request) {
+    PekkoTracingRequest tracingRequest =
+        request.getAttribute(PekkoTracingRequest.ATTR_KEY).orElse(PekkoTracingRequest.EMPTY);
+
+    // HTTP/1.1 branch used while HTTP/2 preview is enabled.
+    // PekkoHttpServerTracer has already created the server span.
+    if (tracingRequest != PekkoTracingRequest.EMPTY) {
+      HttpRequest applicationRequest =
+          (HttpRequest) request.removeAttribute(PekkoTracingRequest.ATTR_KEY);
+
+      try (Scope ignored = tracingRequest.context.makeCurrent()) {
+        return handler.apply(applicationRequest);
+      }
+    }
+
+    // A missing tracing request can also mean that the HTTP/1.1 tracer
+    // decided not to start a span. Only own the server span lifecycle
+    // here for an actual HTTP/2 request.
+    if (!request.protocol().value().startsWith("HTTP/2")) {
+      return handler.apply(request);
+    }
+
+    // True HTTP/2 bypasses PekkoHttpServerTracer, so create and own
+    // the server span lifecycle here.
+    Context parentContext = Context.current();
+    if (!instrumenter().shouldStart(parentContext, request)) {
+      return handler.apply(request);
+    }
+
+    PekkoRouteHolder routeHolder = PekkoRouteHolder.create();
+    Context context = instrumenter().start(parentContext, request).with(routeHolder);
+
+    HttpRequest applicationRequest =
+        (HttpRequest) request.addAttribute(PekkoRouteHolder.ATTRIBUTE_KEY, routeHolder);
+
+    Future<HttpResponse> future;
+    try (Scope ignored = context.makeCurrent()) {
+      future = handler.apply(applicationRequest);
+    } catch (RuntimeException | Error exception) {
+      instrumenter().end(context, request, errorResponse(), exception);
+      throw exception;
+    }
+
+    Promise.DefaultPromise<HttpResponse> promise = new Promise.DefaultPromise<>();
+
+    future.onComplete(
+        new AbstractFunction1<Try<HttpResponse>, Object>() {
+          @Override
+          public Object apply(Try<HttpResponse> result) {
+            try (Scope ignored = context.makeCurrent()) {
+              if (result.isFailure()) {
+                Throwable exception = result.failed().get();
+                instrumenter().end(context, request, errorResponse(), exception);
+                return promise.complete(result);
+              }
+
+              HttpResponse response = result.get();
+
+              PekkoHttpResponseMutator responseMutator = new PekkoHttpResponseMutator();
+              HttpServerResponseCustomizerHolder.getCustomizer()
+                  .customize(context, response, responseMutator);
+
+              List<HttpHeader> headers = responseMutator.getHeaders();
+              if (!headers.isEmpty()) {
+                response = (HttpResponse) response.addHeaders(headers);
+              }
+
+              PekkoRouteHolder responseRouteHolder =
+                  response.getAttribute(PekkoRouteHolder.ATTRIBUTE_KEY).orElse(routeHolder);
+
+              HttpServerRoute.update(
+                  context, HttpServerRouteSource.CONTROLLER, responseRouteHolder.route());
+
+              instrumenter().end(context, request, response, null);
+
+              return promise.success(response);
+            }
+          }
+        },
+        executionContext);
+
+    return promise;
+  }
+}

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpServerJavaRouteTest.java
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpServerJavaRouteTest.java
@@ -8,6 +8,8 @@ package io.opentelemetry.javaagent.instrumentation.pekkohttp.v1_0;
 import static org.apache.pekko.http.javadsl.server.PathMatchers.integerSegment;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.typesafe.config.ConfigFactory;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
@@ -16,6 +18,7 @@ import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpRequest;
 import io.opentelemetry.testing.internal.armeria.common.AggregatedHttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpMethod;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.ServerBinding;
@@ -29,6 +32,84 @@ class PekkoHttpServerJavaRouteTest extends AllDirectives {
   private static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
 
   private final WebClient client = WebClient.of();
+
+  @Test
+  void testContextPropagationWithHttp2Preview() {
+    ActorSystem system =
+        ActorSystem.create(
+            "my-http2-preview-system",
+            ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = true")
+                .withFallback(ConfigFactory.load()));
+
+    int port = PortUtils.findOpenPort();
+    Http http = Http.get(system);
+
+    AtomicBoolean contextValid = new AtomicBoolean();
+
+    Route route =
+        path(
+            "test",
+            () -> {
+              contextValid.set(Span.current().getSpanContext().isValid());
+              return complete("ok");
+            });
+
+    CompletionStage<ServerBinding> binding = http.newServerAt("localhost", port).bind(route);
+
+    try {
+      AggregatedHttpRequest request =
+          AggregatedHttpRequest.of(HttpMethod.GET, "h1c://localhost:" + port + "/test");
+
+      AggregatedHttpResponse response = client.execute(request).aggregate().join();
+
+      assertThat(response.status().code()).isEqualTo(200);
+      assertThat(response.contentUtf8()).isEqualTo("ok");
+      assertThat(contextValid)
+          .as("server context should be current inside route when HTTP/2 preview is enabled")
+          .isTrue();
+    } finally {
+      binding.thenCompose(ServerBinding::unbind).thenAccept(unbound -> system.terminate());
+    }
+  }
+
+  @Test
+  void testTrueHttp2ServerSpan() {
+    ActorSystem system =
+        ActorSystem.create(
+            "my-http2-system",
+            ConfigFactory.parseString("pekko.http.server.preview.enable-http2 = true")
+                .withFallback(ConfigFactory.load()));
+
+    int port = PortUtils.findOpenPort();
+    Http http = Http.get(system);
+
+    AtomicBoolean contextValid = new AtomicBoolean();
+
+    Route route =
+        path(
+            "test",
+            () -> {
+              contextValid.set(Span.current().getSpanContext().isValid());
+              return complete("ok");
+            });
+
+    CompletionStage<ServerBinding> binding = http.newServerAt("localhost", port).bind(route);
+
+    try {
+      AggregatedHttpRequest request =
+          AggregatedHttpRequest.of(HttpMethod.GET, "h2c://localhost:" + port + "/test");
+
+      AggregatedHttpResponse response = client.execute(request).aggregate().join();
+
+      assertThat(response.status().code()).isEqualTo(200);
+      assertThat(response.contentUtf8()).isEqualTo("ok");
+      assertThat(contextValid)
+          .as("server context should be current for a true HTTP/2 request")
+          .isTrue();
+    } finally {
+      binding.thenCompose(ServerBinding::unbind).thenAccept(unbound -> system.terminate());
+    }
+  }
 
   @Test
   void testRoute() {


### PR DESCRIPTION
Fixes #19816

## What changed

Fix Pekko HTTP server context propagation when the HTTP/2 preview setting is enabled.

Pekko uses a different async server binding path when
`pekko.http.server.preview.enable-http2 = true`.

This exposes two problems:

1. HTTP/1.1 requests handled through the HTTP/2-enabled server path bypass the existing `PekkoFlowWrapper`, so the SERVER span context is not made current while the application handler runs. Downstream client spans can therefore start in a separate trace.

2. True HTTP/2 requests bypass the existing `HttpServerBluePrint` instrumentation path, so no SERVER span is created.

The fix instruments `HttpExt.bindAndHandleAsync(...)` when HTTP/2 preview is enabled.

For HTTP/1.1 requests, the wrapper restores the existing SERVER span context before invoking the application handler.

For true HTTP/2 requests, the wrapper creates and owns the SERVER span lifecycle, including route updates, response customization, error handling, and span completion.

## Tests

Added regression coverage for:

- HTTP/1.1 requests with HTTP/2 preview enabled
- true cleartext HTTP/2 (`h2c`) requests

Validated with:

- focused HTTP/1.1 preview regression test
- focused true HTTP/2 regression test
- full Pekko HTTP javaagent test suite
- module muzzle compatibility checks
- Spotless formatting
- standalone Pekko 1.1.0 repro confirming downstream CLIENT and SERVER spans remain in the same trace with HTTP/2 preview enabled

Muzzle passes across supported Pekko HTTP versions and Scala 2.12, 2.13, and 3.