### PR TITLE
Run the pekko-http tests against the scala 3 artifacts

### DIFF
--- a/.github/config/latest-dep-versions.json
+++ b/.github/config/latest-dep-versions.json
@@ -332,6 +332,7 @@
     "org.apache.pekko:pekko-slf4j_2.13#+": "1.7.0",
     "org.apache.pekko:pekko-stream_2.12#+": "1.4.0",
     "org.apache.pekko:pekko-stream_2.13#+": "1.7.0",
+    "org.apache.pekko:pekko-stream_3#+": "1.7.0",
     "org.apache.pulsar:pulsar-client#+": "4.2.4",
     "org.apache.pulsar:pulsar-client-admin#+": "4.2.4",
     "org.apache.rocketmq:rocketmq-client#+": "5.5.0",

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -65,6 +65,17 @@ dependencies {
 
 testing {
   suites {
+    // the agent matches methods of pekko classes by name, some of them are private and scala
+    // mangles their names, run the tests against the scala 3 artifacts to catch a name that only
+    // holds for scala 2
+    register<JvmTestSuite>("scala3Test") {
+      dependencies {
+        implementation("org.scala-lang:scala3-library_3:3.3.6")
+        implementation("org.apache.pekko:pekko-http_3:${baseVersion("1.0.0").orLatest()}")
+        implementation("org.apache.pekko:pekko-stream_3:${baseVersion("1.0.1").orLatest()}")
+      }
+    }
+
     register<JvmTestSuite>("tapirTest") {
       dependencies {
         val scalaVersion = if (otelProps.testLatestDeps) "2.13" else "2.12"
@@ -78,6 +89,19 @@ testing {
       }
     }
   }
+}
+
+// the scala 3 suite runs the same tests as the scala 2 suite, against the _3 artifacts
+sourceSets.named("scala3Test") {
+  java.srcDir("src/test/java")
+  resources.srcDir("src/test/resources")
+  extensions.getByType(org.gradle.api.tasks.ScalaSourceDirectorySet::class.java).srcDir("src/test/scala")
+}
+
+// -target:jvm-1.8 is scala 2 syntax, the scala 3 compiler rejects it
+tasks.named<ScalaCompile>("compileScala3TestScala") {
+  scalaCompileOptions.additionalParameters =
+    scalaCompileOptions.additionalParameters.orEmpty().filter { it != "-target:jvm-1.8" }
 }
 
 tasks {

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/build.gradle.kts
@@ -98,10 +98,13 @@ sourceSets.named("scala3Test") {
   extensions.getByType(org.gradle.api.tasks.ScalaSourceDirectorySet::class.java).srcDir("src/test/scala")
 }
 
-// -target:jvm-1.8 is scala 2 syntax, the scala 3 compiler rejects it
+// -target:jvm-1.8 is scala 2 syntax that the scala 3 compiler rejects, -release is how scala 3
+// targets an older jvm, without it the tests are compiled for whichever jdk runs the build and
+// can not be loaded when the tests run on java 8
 tasks.named<ScalaCompile>("compileScala3TestScala") {
   scalaCompileOptions.additionalParameters =
-    scalaCompileOptions.additionalParameters.orEmpty().filter { it != "-target:jvm-1.8" }
+    scalaCompileOptions.additionalParameters.orEmpty().filter { it != "-target:jvm-1.8" } +
+    "-release:8"
 }
 
 tasks {

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestServerSourceWebServer.scala
@@ -28,7 +28,7 @@ object PekkoHttpTestServerSourceWebServer {
   var route = get {
     concat(
       path("timeout") {
-        headerValueByType[`Timeout-Access`]() { timeout =>
+        headerValueByType[`Timeout-Access`](()) { timeout =>
           timeout.timeoutAccess.updateTimeout(Duration(1, MILLISECONDS))
           complete {
             after(Duration(1, SECONDS)) {
@@ -39,7 +39,8 @@ object PekkoHttpTestServerSourceWebServer {
       },
       path(SUCCESS.rawPath()) {
         complete(
-          AbstractHttpServerTest.controller(SUCCESS, supplier(SUCCESS.getBody))
+          AbstractHttpServerTest
+            .controller[String, Exception](SUCCESS, supplier(SUCCESS.getBody))
         )
       },
       path(INDEXED_CHILD.rawPath()) {
@@ -53,33 +54,43 @@ object PekkoHttpTestServerSourceWebServer {
               INDEXED_CHILD.getBody
             }
           }
-          complete(AbstractHttpServerTest.controller(INDEXED_CHILD, supplier))
+          complete(
+            AbstractHttpServerTest
+              .controller[String, Exception](INDEXED_CHILD, supplier)
+          )
         }
       },
       path(QUERY_PARAM.rawPath()) {
         extractUri { uri =>
           complete(
             AbstractHttpServerTest
-              .controller(QUERY_PARAM, supplier(uri.queryString().orNull))
+              .controller[String, Exception](
+                QUERY_PARAM,
+                supplier(uri.queryString().orNull)
+              )
           )
         }
       },
       path(REDIRECT.rawPath()) {
         redirect(
           AbstractHttpServerTest
-            .controller(REDIRECT, supplier(REDIRECT.getBody)),
+            .controller[String, Exception](
+              REDIRECT,
+              supplier(REDIRECT.getBody)
+            ),
           Found
         )
       },
       path(ERROR.rawPath()) {
         complete(
           500 -> AbstractHttpServerTest
-            .controller(ERROR, supplier(ERROR.getBody))
+            .controller[String, Exception](ERROR, supplier(ERROR.getBody))
         )
       },
       path("path" / LongNumber / "param") { id =>
         complete(
-          AbstractHttpServerTest.controller(PATH_PARAM, supplier(id.toString))
+          AbstractHttpServerTest
+            .controller[String, Exception](PATH_PARAM, supplier(id.toString))
         )
       },
       path(

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/PekkoHttpTestWebServer.scala
@@ -28,7 +28,7 @@ object PekkoHttpTestWebServer {
   var route = get {
     concat(
       path(TIMEOUT.rawPath()) {
-        headerValueByType[`Timeout-Access`]() { timeout =>
+        headerValueByType[`Timeout-Access`](()) { timeout =>
           timeout.timeoutAccess.updateTimeout(Duration(1, MILLISECONDS))
           complete {
             after(Duration(1, SECONDS)) {
@@ -39,7 +39,8 @@ object PekkoHttpTestWebServer {
       },
       path(SUCCESS.rawPath()) {
         complete(
-          AbstractHttpServerTest.controller(SUCCESS, supplier(SUCCESS.getBody))
+          AbstractHttpServerTest
+            .controller[String, Exception](SUCCESS, supplier(SUCCESS.getBody))
         )
       },
       path(INDEXED_CHILD.rawPath()) {
@@ -53,33 +54,43 @@ object PekkoHttpTestWebServer {
               INDEXED_CHILD.getBody
             }
           }
-          complete(AbstractHttpServerTest.controller(INDEXED_CHILD, supplier))
+          complete(
+            AbstractHttpServerTest
+              .controller[String, Exception](INDEXED_CHILD, supplier)
+          )
         }
       },
       path(QUERY_PARAM.rawPath()) {
         extractUri { uri =>
           complete(
             AbstractHttpServerTest
-              .controller(QUERY_PARAM, supplier(uri.queryString().orNull))
+              .controller[String, Exception](
+                QUERY_PARAM,
+                supplier(uri.queryString().orNull)
+              )
           )
         }
       },
       path(REDIRECT.rawPath()) {
         redirect(
           AbstractHttpServerTest
-            .controller(REDIRECT, supplier(REDIRECT.getBody)),
+            .controller[String, Exception](
+              REDIRECT,
+              supplier(REDIRECT.getBody)
+            ),
           Found
         )
       },
       path(ERROR.rawPath()) {
         complete(
           500 -> AbstractHttpServerTest
-            .controller(ERROR, supplier(ERROR.getBody))
+            .controller[String, Exception](ERROR, supplier(ERROR.getBody))
         )
       },
       path("path" / LongNumber / "param") { id =>
         complete(
-          AbstractHttpServerTest.controller(PATH_PARAM, supplier(id.toString))
+          AbstractHttpServerTest
+            .controller[String, Exception](PATH_PARAM, supplier(id.toString))
         )
       },
       path(


### PR DESCRIPTION
### Why

The pekko-http instrumentation matches methods by name, and some of those methods are private, so what it matches is the name scala mangled them to. The clearest case is in the client instrumentation:

```java
named("org$apache$pekko$http$impl$engine$client$PoolMasterActor$$startPoolInterface")
```

Muzzle verifies the classes and methods that advice code *calls*, and disables an instrumentation when they are gone. It does not verify the *matchers*. If a matched method is renamed, mangled differently, or inlined away, the advice simply never applies: no error, no failing muzzle check, just missing telemetry.

The muzzle directives in this module claim support for `pekko-http_3`, but every test ran against `_2.12` or `_2.13`, so nothing checked that the matchers hold for the scala 3 artifacts.

### What this adds

A `scala3Test` suite that runs the existing server, client, route and java route tests against `pekko-http_3` and `pekko-stream_3`, following the `tapirTest` pattern already in this build file. It shares the test sources with the scala 2 suite rather than copying them, so the two cannot drift.

122 tests run and pass.

Two build details worth a look in review:

- `otel.scala-conventions` adds `-target:jvm-1.8` to every `ScalaCompile` task, which the scala 3 compiler rejects, so the suite's compile task filters it out.
- The suite's source set adds `src/test/scala`, `src/test/java` and `src/test/resources`. The resources matter: `application.conf` sets `max-retries = 0` and a shorter connecting timeout, and without it the client tests fail in ways that look like real divergence but are not.

### Test source changes

Two files needed changes to compile with both compilers. Both are still valid scala 2:

- `headerValueByType[X]()` becomes `headerValueByType[X](())`. Scala 3 does not insert an empty argument list for a missing one, and scala 2.13 already warned about it ("Adaptation of argument list by inserting () is deprecated").
- `AbstractHttpServerTest.controller(endpoint, supplier)` becomes `controller[String, Exception](endpoint, supplier)`. Scala 3 does not infer `T` and `E` from a `ThrowingSupplier[String, Exception]` argument.

### What it found

For the record, the answer to the question that motivated this: the matchers do hold for scala 3. I checked the bytecode of `pekko-http-core_3` 1.0.0 and 1.4.0 and the mangled `PoolMasterActor$$startPoolInterface` name is identical to `_2.13`, as are `HttpServerBluePrint$.requestPreparation`, `Http2Ext.bindAndHandleAsync`, `Directive.tapply`, `PathMatcher$.apply` and `GraphInterpreter.processPush`. The differences between the two compilers are confined to lambda names and to private accessors that scala 3 emits as fields, none of which this instrumentation matches.

So this suite is not fixing a known break, it is closing the gap that would have hidden one.