### PR TITLE
Handle malformed OpenAI streaming choice indices

### DIFF
--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
@@ -14,9 +14,8 @@ import com.openai.models.completions.CompletionUsage;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -24,7 +23,7 @@ final class StreamListener {
 
   private final Context context;
   private final ChatCompletionCreateParams request;
-  private final List<StreamedMessageBuffer> choiceBuffers;
+  private final Map<Long, StreamedMessageBuffer> choiceBuffers;
 
   private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
   private final Logger eventLogger;
@@ -49,7 +48,7 @@ final class StreamListener {
     this.eventLogger = eventLogger;
     this.captureMessageContent = captureMessageContent;
     this.newSpan = newSpan;
-    choiceBuffers = new ArrayList<>();
+    choiceBuffers = new TreeMap<>();
     hasEnded = new AtomicBoolean();
   }
 
@@ -59,14 +58,9 @@ final class StreamListener {
     chunk.usage().ifPresent(u -> usage = u);
 
     for (ChatCompletionChunk.Choice choice : chunk.choices()) {
-      while (choiceBuffers.size() <= choice.index()) {
-        choiceBuffers.add(null);
-      }
-      StreamedMessageBuffer buffer = choiceBuffers.get((int) choice.index());
-      if (buffer == null) {
-        buffer = new StreamedMessageBuffer(choice.index(), captureMessageContent);
-        choiceBuffers.set((int) choice.index(), buffer);
-      }
+      StreamedMessageBuffer buffer =
+          choiceBuffers.computeIfAbsent(
+              choice.index(), index -> new StreamedMessageBuffer(index, captureMessageContent));
       buffer.append(choice.delta());
       if (choice.finishReason().isPresent()) {
         buffer.finishReason = choice.finishReason().get().toString();
@@ -99,8 +93,7 @@ final class StreamListener {
             .model(model)
             .id(responseId)
             .choices(
-                choiceBuffers.stream()
-                    .filter(Objects::nonNull)
+                choiceBuffers.values().stream()
                     .map(StreamedMessageBuffer::toChoice)
                     .collect(toList()));
 

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -1018,6 +1018,39 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
   }
 
   @Test
+  void streamMalformedChoiceIndex() {
+    ChatCompletionCreateParams params =
+        ChatCompletionCreateParams.builder()
+            .messages(singletonList(createUserMessage(TEST_CHAT_INPUT)))
+            .model(TEST_CHAT_MODEL)
+            .seed(19746)
+            .build();
+
+    List<ChatCompletionChunk> chunks = doCompletionsStreaming(params);
+
+    assertThat(chunks).hasSize(2);
+    assertThat(chunks.get(0).choices().get(0).index()).isEqualTo(-1);
+    assertThat(chunks.get(0).choices().get(0).delta().content()).hasValue("Atlantic Ocean.");
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    maybeWithTransportSpan(
+                        span ->
+                            span.hasAttributesSatisfyingExactly(
+                                equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
+                                equalTo(GEN_AI_OPERATION_NAME, CHAT),
+                                equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                equalTo(GEN_AI_REQUEST_SEED, 19746),
+                                satisfies(GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
+                                equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
+                                satisfies(
+                                    GEN_AI_RESPONSE_FINISH_REASONS,
+                                    val -> val.containsExactly("stop"))))));
+  }
+
+  @Test
   void streamIncludeUsage() {
     ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.openai.v1_1.abstractchattest.streammalformedchoiceindex.yaml
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.openai.v1_1.abstractchattest.streammalformedchoiceindex.yaml
@@ -1,0 +1,33 @@
+---
+id: 19746000-0000-4000-8000-000000000001
+name: chat_completions
+request:
+  url: /chat/completions
+  method: POST
+  bodyPatterns:
+  - equalToJson: |-
+      {
+        "messages" : [ {
+          "content" : "Answer in up to 3 words: Which ocean contains Bouvet Island?",
+          "role" : "user"
+        } ],
+        "model" : "gpt-4o-mini",
+        "seed" : 19746,
+        "stream" : true
+      }
+    ignoreArrayOrder: false
+    ignoreExtraElements: false
+response:
+  status: 200
+  body: |+
+    data: {"id":"chatcmpl-malformed-choice-index","object":"chat.completion.chunk","created":1752819045,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":null,"choices":[{"index":-1,"delta":{"role":"assistant","content":"Atlantic Ocean.","refusal":null},"logprobs":null,"finish_reason":null}]}
+
+    data: {"id":"chatcmpl-malformed-choice-index","object":"chat.completion.chunk","created":1752819045,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":null,"choices":[{"index":-1,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+    data: [DONE]
+
+  headers:
+    Content-Type: text/event-stream; charset=utf-8
+uuid: 19746000-0000-4000-8000-000000000001
+persistent: true
+insertionIndex: 19


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19746.

OpenAI streaming instrumentation currently treats the response controlled `choice.index()` as an `ArrayList` position. A negative index throws before the application receives the chunk, while a large sparse index can cause excessive allocation. Instrumentation of observability should not fail close for the application that depends on it.

## What
Replace the positional `ArrayList` with a `TreeMap<Long, StreamedMessageBuffer>` keyed by `choice.index()`. 

## Why the approach
`TreeMap` preserves ascending `choice.index()` order, matching the deterministic ordering previously provided by the list, while ensuring that there is no vertical scaling limit of the responses that are coming from the SDK.

## Validation
Added regression test at both library module level and Java-agent level. Together they verify end to end that:
* Both malformed streaming chunks reach the application.
* The original index and message content are preserved.
* The span contains the expected provider, operation, request, response, and finish-reason attributes.
* The behavior works across direct library and Java agent instrumentation, including synchronous and asynchronous clients.
```
./gradlew :instrumentation:openai:openai-java-1.1:library:check  :instrumentation:openai:openai-java-1.1:javaagent:check  --no-build-cache
 ```