### PR TITLE
Capture Ratpack HTTP client protocol version

### DIFF
--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
@@ -30,8 +30,10 @@ public final class HttpProtocolUtil {
   }
 
   public static String normalizeHttpVersion(String version) {
-    if ("2.0".equals(version) || "3.0".equals(version)) {
-      return version.substring(0, version.length() - 2);
+    if ("2.0".equals(version)) {
+      return "2";
+    } else if ("3.0".equals(version)) {
+      return "3";
     }
 
     return version;

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/HttpProtocolUtil.java
@@ -30,8 +30,8 @@ public final class HttpProtocolUtil {
   }
 
   public static String normalizeHttpVersion(String version) {
-    if ("2.0".equals(version)) {
-      return "2";
+    if ("2.0".equals(version) || "3.0".equals(version)) {
+      return version.substring(0, version.length() - 2);
     }
 
     return version;

--- a/instrumentation/ratpack/ratpack-1.4/testing/src/main/java/io/opentelemetry/instrumentation/ratpack/client/AbstractRatpackHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.4/testing/src/main/java/io/opentelemetry/instrumentation/ratpack/client/AbstractRatpackHttpClientTest.java
@@ -156,8 +156,7 @@ public abstract class AbstractRatpackHttpClientTest extends AbstractHttpClientTe
           // underlying netty instrumentation does not provide these
           attributes.remove(SERVER_ADDRESS);
           attributes.remove(SERVER_PORT);
-        } else {
-          // ratpack client instrumentation does not provide this
+        } else if (!capturesProtocolVersion() || uri.getPath().equals("/read-timeout")) {
           attributes.remove(NETWORK_PROTOCOL_VERSION);
         }
         return attributes;
@@ -166,6 +165,10 @@ public abstract class AbstractRatpackHttpClientTest extends AbstractHttpClientTe
 
   protected boolean useNettyClientAttributes() {
     return true;
+  }
+
+  protected boolean capturesProtocolVersion() {
+    return false;
   }
 
   private static Throwable nettyClientSpanErrorMapper(URI uri, Throwable exception) {

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersion.java
@@ -17,7 +17,7 @@ import java.lang.ref.WeakReference;
 import javax.annotation.Nullable;
 import ratpack.http.client.RequestSpec;
 
-final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
+class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
 
   private static final String HANDLER_NAME = RatpackHttpProtocolVersion.class.getName();
   private static final String REDIRECT_HANDLER_NAME = "redirect";

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersion.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.ratpack.v1_7;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpVersion;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.lang.ref.WeakReference;
+import javax.annotation.Nullable;
+import ratpack.http.client.RequestSpec;
+
+final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
+
+  private static final String HANDLER_NAME = RatpackHttpProtocolVersion.class.getName();
+  private static final String REDIRECT_HANDLER_NAME = "redirect";
+  private static final VirtualField<RequestSpec, RatpackHttpProtocolVersion>
+      REQUEST_PROTOCOL_VERSION =
+          VirtualField.find(RequestSpec.class, RatpackHttpProtocolVersion.class);
+
+  private final WeakReference<RequestSpec> request;
+  private final Channel channel;
+  @Nullable private volatile String protocolVersion;
+
+  static void attach(RequestSpec request, Channel channel) {
+    RatpackHttpProtocolVersion previous = REQUEST_PROTOCOL_VERSION.get(request);
+    if (previous != null) {
+      previous.clear();
+    }
+
+    ChannelPipeline pipeline = channel.pipeline();
+    ChannelHandler existingHandler = pipeline.get(HANDLER_NAME);
+    if (existingHandler instanceof RatpackHttpProtocolVersion) {
+      ((RatpackHttpProtocolVersion) existingHandler).clear();
+    } else if (existingHandler != null) {
+      pipeline.remove(existingHandler);
+    }
+
+    RatpackHttpProtocolVersion handler = new RatpackHttpProtocolVersion(request, channel);
+    REQUEST_PROTOCOL_VERSION.set(request, handler);
+    pipeline.addBefore(REDIRECT_HANDLER_NAME, HANDLER_NAME, handler);
+  }
+
+  @Nullable
+  static String get(RequestSpec request) {
+    RatpackHttpProtocolVersion handler = REQUEST_PROTOCOL_VERSION.get(request);
+    return handler != null ? handler.protocolVersion : null;
+  }
+
+  static void clearRequest(RequestSpec request) {
+    RatpackHttpProtocolVersion handler = REQUEST_PROTOCOL_VERSION.get(request);
+    if (handler != null) {
+      handler.clear();
+    }
+  }
+
+  private RatpackHttpProtocolVersion(RequestSpec request, Channel channel) {
+    this.request = new WeakReference<>(request);
+    this.channel = channel;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext context, Object message) {
+    if (message instanceof HttpResponse) {
+      HttpResponse response = (HttpResponse) message;
+      int statusCode = response.status().code();
+      if (statusCode < 100 || statusCode >= 200) {
+        protocolVersion = normalize(response.protocolVersion());
+        removeFromPipeline();
+      }
+    }
+    context.fireChannelRead(message);
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext context) {
+    clear();
+    context.fireChannelInactive();
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+    clear();
+    context.fireExceptionCaught(cause);
+  }
+
+  private void clear() {
+    RequestSpec request = this.request.get();
+    if (request != null && REQUEST_PROTOCOL_VERSION.get(request) == this) {
+      REQUEST_PROTOCOL_VERSION.set(request, null);
+    }
+    removeFromPipeline();
+  }
+
+  private void removeFromPipeline() {
+    ChannelPipeline pipeline = channel.pipeline();
+    if (pipeline.context(this) != null) {
+      pipeline.remove(this);
+    }
+  }
+
+  private static String normalize(HttpVersion version) {
+    int major = version.majorVersion();
+    int minor = version.minorVersion();
+    return minor == 0 ? Integer.toString(major) : major + "." + minor;
+  }
+}

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSIO
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackHttpProtocolVersion;
 import javax.annotation.Nullable;
 import ratpack.http.client.HttpResponse;
 import ratpack.http.client.RequestSpec;

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.ratpack.v1_7;
+
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import javax.annotation.Nullable;
+import ratpack.http.client.HttpResponse;
+import ratpack.http.client.RequestSpec;
+
+final class RatpackProtocolVersionAttributesExtractor
+    implements AttributesExtractor<RequestSpec, HttpResponse> {
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, RequestSpec request) {}
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      RequestSpec request,
+      @Nullable HttpResponse response,
+      @Nullable Throwable error) {
+    attributes.put(NETWORK_PROTOCOL_VERSION, RatpackHttpProtocolVersion.get(request));
+    RatpackHttpProtocolVersion.clearRequest(request);
+  }
+}

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackProtocolVersionAttributesExtractor.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 import ratpack.http.client.HttpResponse;
 import ratpack.http.client.RequestSpec;
 
-final class RatpackProtocolVersionAttributesExtractor
+class RatpackProtocolVersionAttributesExtractor
     implements AttributesExtractor<RequestSpec, HttpResponse> {
 
   @Override

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackSingletons.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackSingletons.java
@@ -14,6 +14,7 @@ import io.opentelemetry.instrumentation.ratpack.v1_7.internal.OpenTelemetryHttpC
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackClientInstrumenterBuilderFactory;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import ratpack.exec.Execution;
+import ratpack.http.client.RequestSpec;
 
 public class RatpackSingletons {
 
@@ -24,6 +25,7 @@ public class RatpackSingletons {
         new OpenTelemetryHttpClient(
             RatpackClientInstrumenterBuilderFactory.create(
                     "io.opentelemetry.ratpack-1.7", GlobalOpenTelemetry.get())
+                .addAttributesExtractor(new RatpackProtocolVersionAttributesExtractor())
                 .configure(AgentCommonConfig.get())
                 .build());
   }
@@ -39,6 +41,14 @@ public class RatpackSingletons {
             .map(ContextHolder::context)
             .orElse(Context.current());
     channel.attr(AttributeKeys.CLIENT_PARENT_CONTEXT).set(parentContext);
+  }
+
+  public static void captureProtocolVersion(Execution execution, Channel channel) {
+    RequestSpec request =
+        execution.maybeGet(ContextHolder.class).map(ContextHolder::requestSpec).orElse(null);
+    if (request != null) {
+      RatpackHttpProtocolVersion.attach(request, channel);
+    }
   }
 
   private RatpackSingletons() {}

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackSingletons.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackSingletons.java
@@ -12,6 +12,7 @@ import io.opentelemetry.instrumentation.netty.v4_1.internal.AttributeKeys;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.ContextHolder;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.OpenTelemetryHttpClient;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackClientInstrumenterBuilderFactory;
+import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackHttpProtocolVersion;
 import io.opentelemetry.javaagent.bootstrap.internal.AgentCommonConfig;
 import ratpack.exec.Execution;
 import ratpack.http.client.RequestSpec;

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
@@ -57,9 +57,15 @@ class RequestActionSupportInstrumentation implements TypeInstrumentation {
   public static class SendAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static void injectChannelAttribute(
+    public static void onEnter(
         @Advice.FieldValue("execution") Execution execution, @Advice.Argument(1) Channel channel) {
       RatpackSingletons.propagateContextToChannel(execution, channel);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.FieldValue("execution") Execution execution, @Advice.Argument(1) Channel channel) {
+      RatpackSingletons.captureProtocolVersion(execution, channel);
     }
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
@@ -13,10 +13,13 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackHttpProtocolVersion;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import ratpack.http.client.RequestSpec;
 
@@ -39,6 +42,7 @@ class RatpackHttpProtocolVersionTest {
     assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNull();
 
     RatpackHttpProtocolVersion.clearRequest(request);
+    assertThat(RatpackHttpProtocolVersion.get(request)).isNull();
     channel.finishAndReleaseAll();
   }
 
@@ -56,6 +60,7 @@ class RatpackHttpProtocolVersionTest {
     assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1.1");
 
     RatpackHttpProtocolVersion.clearRequest(request);
+    assertThat(RatpackHttpProtocolVersion.get(request)).isNull();
     channel.finishAndReleaseAll();
   }
 
@@ -72,13 +77,80 @@ class RatpackHttpProtocolVersionTest {
     channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
     assertThat(RatpackHttpProtocolVersion.get(secondRequest)).isEqualTo("1.1");
 
+    RatpackHttpProtocolVersion.clearRequest(firstRequest);
     RatpackHttpProtocolVersion.clearRequest(secondRequest);
     channel.finishAndReleaseAll();
   }
 
+  @Test
+  void clearRequestRemovesPendingHandler() {
+    RequestSpec request = mock(RequestSpec.class);
+    EmbeddedChannel channel = channel();
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    RatpackHttpProtocolVersion.clearRequest(request);
+
+    assertThat(RatpackHttpProtocolVersion.get(request)).isNull();
+    assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNull();
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void channelInactiveRemovesHandlerAndForwardsEvent() {
+    RequestSpec request = mock(RequestSpec.class);
+    AtomicBoolean inactive = new AtomicBoolean();
+    EmbeddedChannel channel =
+        channel(
+            new ChannelInboundHandlerAdapter() {
+              @Override
+              public void channelInactive(ChannelHandlerContext context) {
+                inactive.set(true);
+                context.fireChannelInactive();
+              }
+            });
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.close();
+
+    assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNull();
+    assertThat(inactive).isTrue();
+
+    RatpackHttpProtocolVersion.clearRequest(request);
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void exceptionCaughtRemovesHandlerAndForwardsEvent() {
+    RequestSpec request = mock(RequestSpec.class);
+    RuntimeException error = new RuntimeException();
+    AtomicReference<Throwable> forwardedError = new AtomicReference<>();
+    EmbeddedChannel channel =
+        channel(
+            new ChannelInboundHandlerAdapter() {
+              @Override
+              public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
+                forwardedError.set(cause);
+              }
+            });
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.pipeline().fireExceptionCaught(error);
+
+    assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNull();
+    assertThat(forwardedError).hasValue(error);
+
+    RatpackHttpProtocolVersion.clearRequest(request);
+    channel.finishAndReleaseAll();
+  }
+
   private static EmbeddedChannel channel() {
+    return channel(new ChannelInboundHandlerAdapter());
+  }
+
+  private static EmbeddedChannel channel(ChannelInboundHandlerAdapter redirectHandler) {
     EmbeddedChannel channel = new EmbeddedChannel();
-    channel.pipeline().addLast("redirect", new ChannelInboundHandlerAdapter());
+    channel.pipeline().addLast("redirect", redirectHandler);
     return channel;
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
@@ -11,16 +11,22 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_0;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.mock;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackHttpProtocolVersion;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import ratpack.http.client.RequestSpec;
 
 class RatpackHttpProtocolVersionTest {
@@ -53,7 +59,7 @@ class RatpackHttpProtocolVersionTest {
 
     RatpackHttpProtocolVersion.attach(request, channel);
     channel.writeInbound(new DefaultHttpResponse(HTTP_1_0, FOUND));
-    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1");
+    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1.0");
 
     RatpackHttpProtocolVersion.attach(request, channel);
     channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
@@ -62,6 +68,29 @@ class RatpackHttpProtocolVersionTest {
     RatpackHttpProtocolVersion.clearRequest(request);
     assertThat(RatpackHttpProtocolVersion.get(request)).isNull();
     channel.finishAndReleaseAll();
+  }
+
+  @ParameterizedTest
+  @MethodSource("protocolVersions")
+  void capturesProtocolVersion(HttpVersion version, String expected) {
+    RequestSpec request = mock(RequestSpec.class);
+    EmbeddedChannel channel = channel();
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.writeInbound(new DefaultHttpResponse(version, OK));
+
+    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo(expected);
+
+    RatpackHttpProtocolVersion.clearRequest(request);
+    channel.finishAndReleaseAll();
+  }
+
+  private static Stream<Arguments> protocolVersions() {
+    return Stream.of(
+        argumentSet("HTTP/1.0", HTTP_1_0, "1.0"),
+        argumentSet("HTTP/1.1", HTTP_1_1, "1.1"),
+        argumentSet("HTTP/2.0", new HttpVersion("HTTP/2.0", true), "2"),
+        argumentSet("HTTP/3.0", new HttpVersion("HTTP/3.0", true), "3"));
   }
 
   @Test

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.ratpack.v1_7;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_0;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import org.junit.jupiter.api.Test;
+import ratpack.http.client.RequestSpec;
+
+class RatpackHttpProtocolVersionTest {
+
+  @Test
+  void ignoresInformationalResponses() {
+    RequestSpec request = mock(RequestSpec.class);
+    EmbeddedChannel channel = channel();
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.writeInbound(new DefaultHttpResponse(HTTP_1_0, CONTINUE));
+
+    assertThat(RatpackHttpProtocolVersion.get(request)).isNull();
+    assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNotNull();
+
+    channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
+
+    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1.1");
+    assertThat(channel.pipeline().context(RatpackHttpProtocolVersion.class)).isNull();
+
+    RatpackHttpProtocolVersion.clearRequest(request);
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void finalRedirectResponseWins() {
+    RequestSpec request = mock(RequestSpec.class);
+    EmbeddedChannel channel = channel();
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.writeInbound(new DefaultHttpResponse(HTTP_1_0, FOUND));
+    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1");
+
+    RatpackHttpProtocolVersion.attach(request, channel);
+    channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
+    assertThat(RatpackHttpProtocolVersion.get(request)).isEqualTo("1.1");
+
+    RatpackHttpProtocolVersion.clearRequest(request);
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void replacesStaleHandlerOnReusedChannel() {
+    RequestSpec firstRequest = mock(RequestSpec.class);
+    RequestSpec secondRequest = mock(RequestSpec.class);
+    EmbeddedChannel channel = channel();
+
+    RatpackHttpProtocolVersion.attach(firstRequest, channel);
+    RatpackHttpProtocolVersion.attach(secondRequest, channel);
+
+    assertThat(RatpackHttpProtocolVersion.get(firstRequest)).isNull();
+    channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
+    assertThat(RatpackHttpProtocolVersion.get(secondRequest)).isEqualTo("1.1");
+
+    RatpackHttpProtocolVersion.clearRequest(secondRequest);
+    channel.finishAndReleaseAll();
+  }
+
+  private static EmbeddedChannel channel() {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    channel.pipeline().addLast("redirect", new ChannelInboundHandlerAdapter());
+    return channel;
+  }
+}

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RatpackHttpProtocolVersionTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.opentelemetry.instrumentation.ratpack.v1_7.internal.RatpackHttpProtocolVersion;
 import org.junit.jupiter.api.Test;
 import ratpack.http.client.RequestSpec;
 

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackForkedHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackForkedHttpClientTest.java
@@ -22,6 +22,11 @@ class RatpackForkedHttpClientTest extends AbstractRatpackForkedHttpClientTest {
   }
 
   @Override
+  protected boolean capturesProtocolVersion() {
+    return true;
+  }
+
+  @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     super.configure(optionsBuilder);
     optionsBuilder.setClientSpanErrorMapper(RatpackTestUtils::ratpackClientSpanErrorMapper);

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackHttpClientTest.java
@@ -5,10 +5,21 @@
 
 package io.opentelemetry.javaagent.instrumentation.ratpack.v1_7.client;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.opentelemetry.instrumentation.ratpack.client.AbstractRatpackHttpClientTest;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.http.HttpClientTestOptions;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class RatpackHttpClientTest extends AbstractRatpackHttpClientTest {
@@ -22,8 +33,36 @@ class RatpackHttpClientTest extends AbstractRatpackHttpClientTest {
   }
 
   @Override
+  protected boolean capturesProtocolVersion() {
+    return true;
+  }
+
+  @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     super.configure(optionsBuilder);
     optionsBuilder.setClientSpanErrorMapper(RatpackTestUtils::ratpackClientSpanErrorMapper);
+  }
+
+  @Test
+  void durationMetricHasProtocolVersion() throws Exception {
+    URI uri = resolveAddress("/success");
+
+    assertThat(sendRequest(null, "GET", uri, emptyMap())).isEqualTo(200);
+
+    testing.waitAndAssertMetrics(
+        "io.opentelemetry.ratpack-1.7",
+        metric ->
+            metric
+                .hasName("http.client.request.duration")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point.hasAttributesSatisfyingExactly(
+                                    equalTo(HTTP_REQUEST_METHOD, "GET"),
+                                    equalTo(HTTP_RESPONSE_STATUS_CODE, 200),
+                                    equalTo(NETWORK_PROTOCOL_VERSION, "1.1"),
+                                    equalTo(SERVER_ADDRESS, uri.getHost()),
+                                    equalTo(SERVER_PORT, uri.getPort())))));
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackPooledHttpClientTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/client/RatpackPooledHttpClientTest.java
@@ -22,6 +22,11 @@ class RatpackPooledHttpClientTest extends AbstractRatpackPooledHttpClientTest {
   }
 
   @Override
+  protected boolean capturesProtocolVersion() {
+    return true;
+  }
+
+  @Override
   protected void configure(HttpClientTestOptions.Builder optionsBuilder) {
     super.configure(optionsBuilder);
     optionsBuilder.setClientSpanErrorMapper(RatpackTestUtils::ratpackClientSpanErrorMapper);

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
@@ -13,7 +13,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
-import java.lang.ref.WeakReference;
 import javax.annotation.Nullable;
 import ratpack.http.client.RequestSpec;
 
@@ -29,23 +28,22 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
       REQUEST_PROTOCOL_VERSION =
           VirtualField.find(RequestSpec.class, RatpackHttpProtocolVersion.class);
 
-  private final WeakReference<RequestSpec> request;
   private final Channel channel;
   @Nullable private volatile String protocolVersion;
 
   public static void attach(RequestSpec request, Channel channel) {
     RatpackHttpProtocolVersion previous = REQUEST_PROTOCOL_VERSION.get(request);
     if (previous != null) {
-      previous.clear();
+      previous.removeFromPipeline();
     }
 
     ChannelPipeline pipeline = channel.pipeline();
     ChannelHandler existingHandler = pipeline.get(HANDLER_NAME);
     if (existingHandler instanceof RatpackHttpProtocolVersion) {
-      ((RatpackHttpProtocolVersion) existingHandler).clear();
+      ((RatpackHttpProtocolVersion) existingHandler).removeFromPipeline();
     }
 
-    RatpackHttpProtocolVersion handler = new RatpackHttpProtocolVersion(request, channel);
+    RatpackHttpProtocolVersion handler = new RatpackHttpProtocolVersion(channel);
     REQUEST_PROTOCOL_VERSION.set(request, handler);
     pipeline.addBefore(REDIRECT_HANDLER_NAME, HANDLER_NAME, handler);
   }
@@ -58,13 +56,13 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
 
   public static void clearRequest(RequestSpec request) {
     RatpackHttpProtocolVersion handler = REQUEST_PROTOCOL_VERSION.get(request);
+    REQUEST_PROTOCOL_VERSION.set(request, null);
     if (handler != null) {
-      handler.clear();
+      handler.removeFromPipeline();
     }
   }
 
-  private RatpackHttpProtocolVersion(RequestSpec request, Channel channel) {
-    this.request = new WeakReference<>(request);
+  private RatpackHttpProtocolVersion(Channel channel) {
     this.channel = channel;
   }
 
@@ -83,22 +81,14 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
 
   @Override
   public void channelInactive(ChannelHandlerContext context) {
-    clear();
+    removeFromPipeline();
     context.fireChannelInactive();
   }
 
   @Override
   public void exceptionCaught(ChannelHandlerContext context, Throwable cause) {
-    clear();
-    context.fireExceptionCaught(cause);
-  }
-
-  private void clear() {
-    RequestSpec request = this.request.get();
-    if (request != null && REQUEST_PROTOCOL_VERSION.get(request) == this) {
-      REQUEST_PROTOCOL_VERSION.set(request, null);
-    }
     removeFromPipeline();
+    context.fireExceptionCaught(cause);
   }
 
   private void removeFromPipeline() {

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.ratpack.v1_7;
+package io.opentelemetry.instrumentation.ratpack.v1_7.internal;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -17,7 +17,11 @@ import java.lang.ref.WeakReference;
 import javax.annotation.Nullable;
 import ratpack.http.client.RequestSpec;
 
-class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
 
   private static final String HANDLER_NAME = RatpackHttpProtocolVersion.class.getName();
   private static final String REDIRECT_HANDLER_NAME = "redirect";
@@ -29,7 +33,7 @@ class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
   private final Channel channel;
   @Nullable private volatile String protocolVersion;
 
-  static void attach(RequestSpec request, Channel channel) {
+  public static void attach(RequestSpec request, Channel channel) {
     RatpackHttpProtocolVersion previous = REQUEST_PROTOCOL_VERSION.get(request);
     if (previous != null) {
       previous.clear();
@@ -49,12 +53,12 @@ class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapter {
   }
 
   @Nullable
-  static String get(RequestSpec request) {
+  public static String get(RequestSpec request) {
     RatpackHttpProtocolVersion handler = REQUEST_PROTOCOL_VERSION.get(request);
     return handler != null ? handler.protocolVersion : null;
   }
 
-  static void clearRequest(RequestSpec request) {
+  public static void clearRequest(RequestSpec request) {
     RatpackHttpProtocolVersion handler = REQUEST_PROTOCOL_VERSION.get(request);
     if (handler != null) {
       handler.clear();

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
@@ -11,7 +11,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpVersion;
+import io.opentelemetry.instrumentation.api.internal.HttpProtocolUtil;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import javax.annotation.Nullable;
 import ratpack.http.client.RequestSpec;
@@ -72,7 +72,7 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
       HttpResponse response = (HttpResponse) message;
       int statusCode = response.status().code();
       if (statusCode < 100 || statusCode >= 200) {
-        protocolVersion = normalize(response.protocolVersion());
+        protocolVersion = HttpProtocolUtil.getVersion(response.protocolVersion().text());
         removeFromPipeline();
       }
     }
@@ -96,11 +96,5 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
     if (pipeline.context(this) != null) {
       pipeline.remove(this);
     }
-  }
-
-  private static String normalize(HttpVersion version) {
-    int major = version.majorVersion();
-    int minor = version.minorVersion();
-    return minor == 0 ? Integer.toString(major) : major + "." + minor;
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/main/java/io/opentelemetry/instrumentation/ratpack/v1_7/internal/RatpackHttpProtocolVersion.java
@@ -43,8 +43,6 @@ public final class RatpackHttpProtocolVersion extends ChannelInboundHandlerAdapt
     ChannelHandler existingHandler = pipeline.get(HANDLER_NAME);
     if (existingHandler instanceof RatpackHttpProtocolVersion) {
       ((RatpackHttpProtocolVersion) existingHandler).clear();
-    } else if (existingHandler != null) {
-      pipeline.remove(existingHandler);
     }
 
     RatpackHttpProtocolVersion handler = new RatpackHttpProtocolVersion(request, channel);


### PR DESCRIPTION
Ratpack 1.7 javaagent HTTP client spans and `http.client.request.duration` metric points now include `network.protocol.version`. Standalone library instrumentation remains unchanged.
