### PR TITLE
Report configured JDBC targets in stable server.address

### DIFF
--- a/docs/declarative-configuration-example.yaml
+++ b/docs/declarative-configuration-example.yaml
@@ -188,9 +188,11 @@ instrumentation/development:
           # with only a span link connecting it to the producer trace.
           enabled: false
 
-      # Used to specify a mapping from host names or IP addresses to peer services.
+      # Used to specify a mapping from server addresses or configured targets to peer services.
+      # Configured targets containing commas or equals signs can only be mapped with declarative
+      # `service_peer_mapping`.
       # Each list entry is an object with the following properties:
-      #   peer (string, required): Host name or IP address to match against.
+      #   peer (string, required): Server address or configured target to match against.
       #   service_name (string, required): Peer service name to record for matching peers.
       # Example:
       #   service_peer_mapping:

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -23,9 +23,8 @@ definitions:
     common.peer-service-mapping:
       name: otel.instrumentation.common.peer-service-mapping
       declarative_name: java.common.service_peer_mapping
-      description: Used to specify a mapping from server addresses or configured targets
-        to peer services. Configured targets containing commas or equals signs can
-        only be mapped with declarative `service_peer_mapping`.
+      description: Used to specify a mapping from host names or IP addresses to peer
+        services.
       type: map
       default: ''
       declarative_type: structured_list
@@ -37,7 +36,7 @@ definitions:
         properties:
           peer:
             type: string
-            description: Server address or configured target to match against.
+            description: Host name or IP address to match against.
             example: host
           service_name:
             type: string

--- a/docs/instrumentation-list.yaml
+++ b/docs/instrumentation-list.yaml
@@ -23,8 +23,9 @@ definitions:
     common.peer-service-mapping:
       name: otel.instrumentation.common.peer-service-mapping
       declarative_name: java.common.service_peer_mapping
-      description: Used to specify a mapping from host names or IP addresses to peer
-        services.
+      description: Used to specify a mapping from server addresses or configured targets
+        to peer services. Configured targets containing commas or equals signs can
+        only be mapped with declarative `service_peer_mapping`.
       type: map
       default: ''
       declarative_type: structured_list
@@ -36,7 +37,7 @@ definitions:
         properties:
           peer:
             type: string
-            description: Host name or IP address to match against.
+            description: Server address or configured target to match against.
             example: host
           service_name:
             type: string

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -33,7 +33,8 @@ import javax.annotation.Nullable;
  */
 public class DbServerTargetBuilder {
 
-  public static final int MAX_ENDPOINTS = 5;
+  private static final int DEFAULT_MAX_ENDPOINTS = 5;
+
   private static final int MIN_PORT = 1;
   private static final int MAX_PORT = 65535;
   private static final int MAX_HOST_NAME_LENGTH = 253;
@@ -41,7 +42,7 @@ public class DbServerTargetBuilder {
 
   @Nullable private final Integer defaultPort;
   private final List<Endpoint> endpoints = new ArrayList<>();
-  private int maxEndpoints = MAX_ENDPOINTS;
+  private int maxEndpoints = DEFAULT_MAX_ENDPOINTS;
   private boolean sorted;
   private boolean portAlwaysInline;
   @Nullable private String suffix;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -41,6 +41,7 @@ public class DbServerTargetBuilder {
 
   @Nullable private final Integer defaultPort;
   private final List<Endpoint> endpoints = new ArrayList<>();
+  private int maxEndpoints = MAX_ENDPOINTS;
   private boolean sorted;
   private boolean portAlwaysInline;
   @Nullable private String suffix;
@@ -62,6 +63,16 @@ public class DbServerTargetBuilder {
   @CanIgnoreReturnValue
   public DbServerTargetBuilder setSorted(boolean sorted) {
     this.sorted = sorted;
+    return this;
+  }
+
+  /** Render at most {@code maxEndpoints} endpoints. Default is 5. */
+  @CanIgnoreReturnValue
+  public DbServerTargetBuilder setMaxEndpoints(int maxEndpoints) {
+    if (maxEndpoints < 1) {
+      throw new IllegalArgumentException("maxEndpoints must be positive");
+    }
+    this.maxEndpoints = maxEndpoints;
     return this;
   }
 
@@ -177,7 +188,7 @@ public class DbServerTargetBuilder {
     if (sorted) {
       rendered.sort(String::compareTo);
     }
-    return String.join(",", rendered.subList(0, Math.min(MAX_ENDPOINTS, rendered.size())));
+    return String.join(",", rendered.subList(0, Math.min(maxEndpoints, rendered.size())));
   }
 
   private DbServerTarget target(String address, @Nullable Integer port) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -50,6 +50,11 @@ public class DbServerTargetBuilder {
     this.defaultPort = defaultPort;
   }
 
+  /** Returns whether {@code host} can be represented safely as a database server host. */
+  public static boolean isValidHost(@Nullable String host) {
+    return sanitizeHost(host) != null;
+  }
+
   /**
    * Sort the rendered endpoints in natural string order. Default is to preserve the configured
    * order. Turn sorting on only when endpoint order carries no semantic meaning.

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  */
 public class DbServerTargetBuilder {
 
-  private static final int DEFAULT_MAX_ENDPOINTS = 5;
+  public static final int MAX_ENDPOINTS = 5;
 
   private static final int MIN_PORT = 1;
   private static final int MAX_PORT = 65535;
@@ -42,7 +42,7 @@ public class DbServerTargetBuilder {
 
   @Nullable private final Integer defaultPort;
   private final List<Endpoint> endpoints = new ArrayList<>();
-  private int maxEndpoints = DEFAULT_MAX_ENDPOINTS;
+  private int maxEndpoints = MAX_ENDPOINTS;
   private boolean sorted;
   private boolean portAlwaysInline;
   @Nullable private String suffix;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -42,7 +42,6 @@ public class DbServerTargetBuilder {
 
   @Nullable private final Integer defaultPort;
   private final List<Endpoint> endpoints = new ArrayList<>();
-  private int maxEndpoints = MAX_ENDPOINTS;
   private boolean sorted;
   private boolean portAlwaysInline;
   @Nullable private String suffix;
@@ -64,16 +63,6 @@ public class DbServerTargetBuilder {
   @CanIgnoreReturnValue
   public DbServerTargetBuilder setSorted(boolean sorted) {
     this.sorted = sorted;
-    return this;
-  }
-
-  /** Render at most {@code maxEndpoints} endpoints. Default is 5. */
-  @CanIgnoreReturnValue
-  public DbServerTargetBuilder setMaxEndpoints(int maxEndpoints) {
-    if (maxEndpoints < 1) {
-      throw new IllegalArgumentException("maxEndpoints must be positive");
-    }
-    this.maxEndpoints = maxEndpoints;
     return this;
   }
 
@@ -189,7 +178,7 @@ public class DbServerTargetBuilder {
     if (sorted) {
       rendered.sort(String::compareTo);
     }
-    return String.join(",", rendered.subList(0, Math.min(maxEndpoints, rendered.size())));
+    return String.join(",", rendered.subList(0, Math.min(MAX_ENDPOINTS, rendered.size())));
   }
 
   private DbServerTarget target(String address, @Nullable Integer port) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -149,6 +149,12 @@ public class ServicePeerResolver {
   @Nullable
   private ServicePeer resolveServicePeer(
       String host, @Nullable Integer port, Supplier<String> pathSupplier) {
+    if (port != null && hasMultipleEndpoints(host)) {
+      ServicePeer exactHostPortMatch = exactServicePeerMapping.get(host + ":" + port);
+      if (exactHostPortMatch != null) {
+        return exactHostPortMatch;
+      }
+    }
     ServicePeer exactMatch = exactServicePeerMapping.get(host);
     if (exactMatch != null) {
       return exactMatch;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -20,11 +20,12 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -42,6 +43,8 @@ public class ServicePeerResolver {
       AttributeKey.stringKey("service.peer.name");
   private static final AttributeKey<String> SERVICE_PEER_NAMESPACE =
       AttributeKey.stringKey("service.peer.namespace");
+  private static final Pattern ADDRESS_ENTRY_PATTERN =
+      Pattern.compile("\\(\\s*address\\s*=", Pattern.CASE_INSENSITIVE);
 
   private static final Comparator<ServiceMatcher> matcherComparator =
       nullsFirst(
@@ -109,9 +112,11 @@ public class ServicePeerResolver {
         return true;
       }
     }
-    String lowercasePeer = peer.toLowerCase(Locale.ROOT);
-    int firstAddress = lowercasePeer.indexOf("(address=");
-    return firstAddress >= 0 && lowercasePeer.indexOf("(address=", firstAddress + 1) >= 0;
+    Matcher addressMatcher = ADDRESS_ENTRY_PATTERN.matcher(peer);
+    if (!addressMatcher.find()) {
+      return false;
+    }
+    return addressMatcher.find();
   }
 
   public boolean isEmpty() {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -43,7 +43,7 @@ public class ServicePeerResolver {
       AttributeKey.stringKey("service.peer.name");
   private static final AttributeKey<String> SERVICE_PEER_NAMESPACE =
       AttributeKey.stringKey("service.peer.namespace");
-  private static final Pattern ADDRESS_ENTRY_PATTERN =
+  private static final Pattern PARENTHESIZED_ADDRESS_ENTRY_PATTERN =
       Pattern.compile("\\(\\s*address\\s*=", Pattern.CASE_INSENSITIVE);
 
   private static final Comparator<ServiceMatcher> matcherComparator =
@@ -112,7 +112,7 @@ public class ServicePeerResolver {
         return true;
       }
     }
-    Matcher addressMatcher = ADDRESS_ENTRY_PATTERN.matcher(peer);
+    Matcher addressMatcher = PARENTHESIZED_ADDRESS_ENTRY_PATTERN.matcher(peer);
     if (!addressMatcher.find()) {
       return false;
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -149,12 +149,6 @@ public class ServicePeerResolver {
   @Nullable
   private ServicePeer resolveServicePeer(
       String host, @Nullable Integer port, Supplier<String> pathSupplier) {
-    if (port != null && hasMultipleEndpoints(host)) {
-      ServicePeer exactHostPortMatch = exactServicePeerMapping.get(host + ":" + port);
-      if (exactHostPortMatch != null) {
-        return exactHostPortMatch;
-      }
-    }
     ServicePeer exactMatch = exactServicePeerMapping.get(host);
     if (exactMatch != null) {
       return exactMatch;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -20,6 +20,7 @@ import io.opentelemetry.instrumentation.api.incubator.config.internal.Declarativ
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -48,6 +49,7 @@ public class ServicePeerResolver {
               .thenComparing(ServiceMatcher::getPath, nullsFirst(naturalOrder())));
 
   private final Map<String, Map<ServiceMatcher, ServicePeer>> servicePeerMapping = new HashMap<>();
+  private final Map<String, ServicePeer> exactServicePeerMapping = new HashMap<>();
 
   public ServicePeerResolver(OpenTelemetry openTelemetry) {
     DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "common")
@@ -84,13 +86,36 @@ public class ServicePeerResolver {
     String host = UrlParser.getHost(url);
     Integer port = UrlParser.getPort(url);
     String path = UrlParser.getPath(url);
+    if (!peer.equals(host)) {
+      exactServicePeerMapping.putIfAbsent(peer, info);
+      if (hasMultipleEndpoints(peer)) {
+        return;
+      }
+    }
     Map<ServiceMatcher, ServicePeer> matchers =
         servicePeerMapping.computeIfAbsent(host, x -> new HashMap<>());
     matchers.putIfAbsent(ServiceMatcher.create(port, path), info);
   }
 
+  private static boolean hasMultipleEndpoints(String peer) {
+    int schemeEnd = peer.indexOf("://");
+    int authorityStart = schemeEnd < 0 ? 0 : schemeEnd + 3;
+    for (int i = authorityStart; i < peer.length(); i++) {
+      char c = peer.charAt(i);
+      if (c == '/' || c == '?' || c == '#') {
+        return false;
+      }
+      if (c == ',') {
+        return true;
+      }
+    }
+    String lowercasePeer = peer.toLowerCase(Locale.ROOT);
+    int firstAddress = lowercasePeer.indexOf("(address=");
+    return firstAddress >= 0 && lowercasePeer.indexOf("(address=", firstAddress + 1) >= 0;
+  }
+
   public boolean isEmpty() {
-    return servicePeerMapping.isEmpty();
+    return servicePeerMapping.isEmpty() && exactServicePeerMapping.isEmpty();
   }
 
   @SuppressWarnings("deprecation") // old semconv
@@ -124,6 +149,10 @@ public class ServicePeerResolver {
   @Nullable
   private ServicePeer resolveServicePeer(
       String host, @Nullable Integer port, Supplier<String> pathSupplier) {
+    ServicePeer exactMatch = exactServicePeerMapping.get(host);
+    if (exactMatch != null) {
+      return exactMatch;
+    }
     Map<ServiceMatcher, ServicePeer> matchers = servicePeerMapping.get(host);
     if (matchers == null) {
       return null;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -47,12 +47,10 @@ public class ServicePeerResolver {
           comparing(PortPathMatcher::getPort, nullsFirst(naturalOrder()))
               .thenComparing(PortPathMatcher::getPath, nullsFirst(naturalOrder())));
 
-  // Mappings indexed by parsed host. They match server.address together with a separately supplied
-  // server.port and, when available, URL path.
+  // Mappings resolved from separately supplied server.address, server.port, and optional URL path.
   private final Map<String, Map<PortPathMatcher, ServicePeer>> servicePeersByHost = new HashMap<>();
 
-  // Mappings indexed by the complete configured peer string. They allow server.address values that
-  // represent a logical target, such as a comma-separated database cluster, to match verbatim.
+  // Mappings resolved by matching the complete server.address value verbatim.
   private final Map<String, ServicePeer> servicePeersByExactAddress = new HashMap<>();
 
   public ServicePeerResolver(OpenTelemetry openTelemetry) {
@@ -90,6 +88,9 @@ public class ServicePeerResolver {
     String host = UrlParser.getHost(url);
     Integer port = UrlParser.getPort(url);
     String path = UrlParser.getPath(url);
+    // A non-host peer may be reported verbatim in server.address or as separate address, port, and
+    // path components. Index single-endpoint peers both ways. A multi-endpoint peer has no single
+    // host identity, so only exact matching is meaningful.
     if (!peer.equals(host)) {
       servicePeersByExactAddress.putIfAbsent(peer, info);
       if (hasMultipleEndpoints(peer)) {
@@ -120,6 +121,10 @@ public class ServicePeerResolver {
     return servicePeersByHost.isEmpty() && servicePeersByExactAddress.isEmpty();
   }
 
+  /**
+   * Resolves an exact server.address match first, then falls back to matching server.address as a
+   * host together with the separately supplied port and path.
+   */
   @SuppressWarnings("deprecation") // old semconv
   public void resolve(
       String serverAddress,

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -42,13 +42,18 @@ public class ServicePeerResolver {
   private static final AttributeKey<String> SERVICE_PEER_NAMESPACE =
       AttributeKey.stringKey("service.peer.namespace");
 
-  private static final Comparator<ServiceMatcher> matcherComparator =
+  private static final Comparator<PortPathMatcher> matcherComparator =
       nullsFirst(
-          comparing(ServiceMatcher::getPort, nullsFirst(naturalOrder()))
-              .thenComparing(ServiceMatcher::getPath, nullsFirst(naturalOrder())));
+          comparing(PortPathMatcher::getPort, nullsFirst(naturalOrder()))
+              .thenComparing(PortPathMatcher::getPath, nullsFirst(naturalOrder())));
 
-  private final Map<String, Map<ServiceMatcher, ServicePeer>> servicePeerMapping = new HashMap<>();
-  private final Map<String, ServicePeer> exactServicePeerMapping = new HashMap<>();
+  // Mappings indexed by parsed host. They match server.address together with a separately supplied
+  // server.port and, when available, URL path.
+  private final Map<String, Map<PortPathMatcher, ServicePeer>> servicePeersByHost = new HashMap<>();
+
+  // Mappings indexed by the complete configured peer string. They allow server.address values that
+  // represent a logical target, such as a comma-separated database cluster, to match verbatim.
+  private final Map<String, ServicePeer> servicePeersByExactAddress = new HashMap<>();
 
   public ServicePeerResolver(OpenTelemetry openTelemetry) {
     DeclarativeConfigUtil.getInstrumentationConfig(openTelemetry, "common")
@@ -86,14 +91,14 @@ public class ServicePeerResolver {
     Integer port = UrlParser.getPort(url);
     String path = UrlParser.getPath(url);
     if (!peer.equals(host)) {
-      exactServicePeerMapping.putIfAbsent(peer, info);
+      servicePeersByExactAddress.putIfAbsent(peer, info);
       if (hasMultipleEndpoints(peer)) {
         return;
       }
     }
-    Map<ServiceMatcher, ServicePeer> matchers =
-        servicePeerMapping.computeIfAbsent(host, x -> new HashMap<>());
-    matchers.putIfAbsent(ServiceMatcher.create(port, path), info);
+    Map<PortPathMatcher, ServicePeer> matchers =
+        servicePeersByHost.computeIfAbsent(host, x -> new HashMap<>());
+    matchers.putIfAbsent(PortPathMatcher.create(port, path), info);
   }
 
   private static boolean hasMultipleEndpoints(String peer) {
@@ -112,16 +117,16 @@ public class ServicePeerResolver {
   }
 
   public boolean isEmpty() {
-    return servicePeerMapping.isEmpty() && exactServicePeerMapping.isEmpty();
+    return servicePeersByHost.isEmpty() && servicePeersByExactAddress.isEmpty();
   }
 
   @SuppressWarnings("deprecation") // old semconv
   public void resolve(
-      String host,
+      String serverAddress,
       @Nullable Integer port,
       Supplier<String> pathSupplier,
       BiConsumer<AttributeKey<String>, String> attributeSetter) {
-    ServicePeer servicePeer = resolveServicePeer(host, port, pathSupplier);
+    ServicePeer servicePeer = resolveServicePeer(serverAddress, port, pathSupplier);
     if (servicePeer == null) {
       return;
     }
@@ -145,12 +150,12 @@ public class ServicePeerResolver {
 
   @Nullable
   private ServicePeer resolveServicePeer(
-      String host, @Nullable Integer port, Supplier<String> pathSupplier) {
-    ServicePeer exactMatch = exactServicePeerMapping.get(host);
+      String serverAddress, @Nullable Integer port, Supplier<String> pathSupplier) {
+    ServicePeer exactMatch = servicePeersByExactAddress.get(serverAddress);
     if (exactMatch != null) {
       return exactMatch;
     }
-    Map<ServiceMatcher, ServicePeer> matchers = servicePeerMapping.get(host);
+    Map<PortPathMatcher, ServicePeer> matchers = servicePeersByHost.get(serverAddress);
     if (matchers == null) {
       return null;
     }
@@ -162,10 +167,10 @@ public class ServicePeerResolver {
   }
 
   @AutoValue
-  abstract static class ServiceMatcher {
+  abstract static class PortPathMatcher {
 
-    static ServiceMatcher create(@Nullable Integer port, @Nullable String path) {
-      return new AutoValue_ServicePeerResolver_ServiceMatcher(port, path);
+    static PortPathMatcher create(@Nullable Integer port, @Nullable String path) {
+      return new AutoValue_ServicePeerResolver_PortPathMatcher(port, path);
     }
 
     @Nullable

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -32,6 +34,8 @@ import javax.annotation.Nullable;
  */
 public class ServicePeerResolver {
 
+  private static final Pattern ADDRESS_GROUP_PATTERN =
+      Pattern.compile("\\(\\s*address\\s*=", Pattern.CASE_INSENSITIVE);
   private static final Logger logger = Logger.getLogger(ServicePeerResolver.class.getName());
 
   // copied from PeerIncubatingAttributes
@@ -105,16 +109,23 @@ public class ServicePeerResolver {
   private static boolean hasMultipleEndpoints(String peer) {
     int schemeEnd = peer.indexOf("://");
     int authorityStart = schemeEnd < 0 ? 0 : schemeEnd + 3;
+    int authorityEnd = peer.length();
     for (int i = authorityStart; i < peer.length(); i++) {
       char c = peer.charAt(i);
       if (c == '/' || c == '?' || c == '#') {
-        return false;
+        authorityEnd = i;
+        break;
       }
       if (c == ',') {
         return true;
       }
     }
-    return false;
+    Matcher addressGroups = ADDRESS_GROUP_PATTERN.matcher(peer);
+    addressGroups.region(authorityStart, authorityEnd);
+    if (!addressGroups.find()) {
+      return false;
+    }
+    return addressGroups.find();
   }
 
   public boolean isEmpty() {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolver.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
@@ -43,8 +41,6 @@ public class ServicePeerResolver {
       AttributeKey.stringKey("service.peer.name");
   private static final AttributeKey<String> SERVICE_PEER_NAMESPACE =
       AttributeKey.stringKey("service.peer.namespace");
-  private static final Pattern PARENTHESIZED_ADDRESS_ENTRY_PATTERN =
-      Pattern.compile("\\(\\s*address\\s*=", Pattern.CASE_INSENSITIVE);
 
   private static final Comparator<ServiceMatcher> matcherComparator =
       nullsFirst(
@@ -112,11 +108,7 @@ public class ServicePeerResolver {
         return true;
       }
     }
-    Matcher addressMatcher = PARENTHESIZED_ADDRESS_ENTRY_PATTERN.matcher(peer);
-    if (!addressMatcher.find()) {
-      return false;
-    }
-    return addressMatcher.find();
+    return false;
   }
 
   public boolean isEmpty() {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientMetricsTest.java
@@ -17,7 +17,6 @@ import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -59,8 +58,7 @@ class DbClientMetricsTest {
             .put(DB_NAMESPACE, "potatoes")
             .put(DB_OPERATION_NAME, "SELECT")
             .put(DB_QUERY_SUMMARY, "SELECT table")
-            .put(SERVER_ADDRESS, "localhost")
-            .put(SERVER_PORT, 1234)
+            .put(SERVER_ADDRESS, "db1.example:5432,db2.example:5432")
             .build();
 
     Attributes responseAttributes =
@@ -105,8 +103,9 @@ class DbClientMetricsTest {
                                             equalTo(DB_OPERATION_NAME, "SELECT"),
                                             equalTo(DB_COLLECTION_NAME, "table"),
                                             equalTo(DB_QUERY_SUMMARY, "SELECT table"),
-                                            equalTo(SERVER_ADDRESS, "localhost"),
-                                            equalTo(SERVER_PORT, 1234),
+                                            equalTo(
+                                                SERVER_ADDRESS,
+                                                "db1.example:5432,db2.example:5432"),
                                             equalTo(ERROR_TYPE, "400"),
                                             equalTo(NETWORK_PEER_ADDRESS, "1.2.3.4"),
                                             equalTo(NETWORK_PEER_PORT, 8080))

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractorTest.java
@@ -189,6 +189,21 @@ class DbClientSpanNameExtractorTest {
   }
 
   @Test
+  void shouldUseConfiguredTargetWithoutAddingAPort() {
+    DbRequest dbRequest = new DbRequest();
+    if (emitStableDatabaseSemconv()) {
+      when(dbAttributesGetter.getServerAddress(dbRequest))
+          .thenReturn("db1.example:5432,db2.example:5432");
+      when(dbAttributesGetter.getServerPort(dbRequest)).thenReturn(null);
+    }
+
+    String spanName = DbClientSpanNameExtractor.create(dbAttributesGetter).extract(dbRequest);
+
+    assertThat(spanName)
+        .isEqualTo(emitStableDatabaseSemconv() ? "db1.example:5432,db2.example:5432" : "DB Query");
+  }
+
+  @Test
   void shouldFallBackToDefaultSpanName() {
     // given
     DbRequest dbRequest = new DbRequest();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.net.InetAddress;
@@ -287,6 +288,26 @@ class DbServerTargetTest {
         .isEqualTo(
             "node1.example.com,node2.example.com,node3.example.com,node4.example.com,"
                 + "node5.example.com");
+  }
+
+  @Test
+  void endpointCapIsConfigurable() {
+    DbServerTarget target =
+        builder()
+            .setMaxEndpoints(2)
+            .addEndpoint("a.example.com", -1)
+            .addEndpoint("b.example.com", -1)
+            .addEndpoint("c.example.com", -1)
+            .build();
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
+  }
+
+  @Test
+  void endpointCapMustBePositive() {
+    assertThatThrownBy(() -> builder().setMaxEndpoints(0))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
@@ -315,25 +315,20 @@ class DbServerTargetTest {
     DbServerTarget target =
         builder()
             .setSorted(true)
+            .setMaxEndpoints(2)
             .addEndpoint("c.example.com", -1)
             .addEndpoint("a.example.com", -1)
             .addEndpoint("b.example.com", -1)
-            .addEndpoint("e.example.com", -1)
-            .addEndpoint("d.example.com", -1)
-            .addEndpoint("f.example.com", -1)
             .build();
 
     assertThat(target).isNotNull();
-    assertThat(target.getAddress())
-        .isEqualTo("a.example.com,b.example.com,c.example.com,d.example.com,e.example.com");
+    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
   }
 
   @Test
   void anUnsafeEndpointBeyondTheCapStillDropsTheTarget() {
-    DbServerTargetBuilder builder = builder();
-    for (int i = 1; i <= 5; i++) {
-      builder.addEndpoint("node" + i + ".example.com", -1);
-    }
+    DbServerTargetBuilder builder = builder().setMaxEndpoints(1);
+    builder.addEndpoint("a.example.com", -1);
     builder.addEndpoint("evil host", -1);
 
     assertThat(builder.build()).isNull();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.net.InetAddress;
@@ -291,44 +290,29 @@ class DbServerTargetTest {
   }
 
   @Test
-  void endpointCapIsConfigurable() {
-    DbServerTarget target =
-        builder()
-            .setMaxEndpoints(2)
-            .addEndpoint("a.example.com", -1)
-            .addEndpoint("b.example.com", -1)
-            .addEndpoint("c.example.com", -1)
-            .build();
-
-    assertThat(target).isNotNull();
-    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
-  }
-
-  @Test
-  void endpointCapMustBePositive() {
-    assertThatThrownBy(() -> builder().setMaxEndpoints(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
   void endpointsAreSortedBeforeTheyAreCapped() {
     DbServerTarget target =
         builder()
             .setSorted(true)
-            .setMaxEndpoints(2)
             .addEndpoint("c.example.com", -1)
             .addEndpoint("a.example.com", -1)
             .addEndpoint("b.example.com", -1)
+            .addEndpoint("e.example.com", -1)
+            .addEndpoint("d.example.com", -1)
+            .addEndpoint("f.example.com", -1)
             .build();
 
     assertThat(target).isNotNull();
-    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
+    assertThat(target.getAddress())
+        .isEqualTo("a.example.com,b.example.com,c.example.com,d.example.com,e.example.com");
   }
 
   @Test
   void anUnsafeEndpointBeyondTheCapStillDropsTheTarget() {
-    DbServerTargetBuilder builder = builder().setMaxEndpoints(1);
-    builder.addEndpoint("a.example.com", -1);
+    DbServerTargetBuilder builder = builder();
+    for (int i = 1; i <= 5; i++) {
+      builder.addEndpoint("node" + i + ".example.com", -1);
+    }
     builder.addEndpoint("evil host", -1);
 
     assertThat(builder.build()).isNull();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/ServicePeerAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/ServicePeerAttributesExtractorTest.java
@@ -113,6 +113,27 @@ class ServicePeerAttributesExtractorTest {
     }
   }
 
+  @Test
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  void shouldMatchConfiguredTargetExactly() {
+    String target = "db1.example:5432,db2.example:5432";
+    ServicePeerResolver resolver = createResolver(mapping(target, "myService", null));
+    AttributesExtractor<String, String> underTest =
+        new ServicePeerAttributesExtractor<>(attributesGetter, resolver);
+    when(attributesGetter.getServerAddress(any())).thenReturn(target);
+
+    AttributesBuilder attributes = Attributes.builder();
+    underTest.onEnd(attributes, Context.root(), "request", "response", null);
+
+    Attributes attrs = attributes.build();
+    if (emitOldServicePeerSemconv() && emitStableServicePeerSemconv()) {
+      assertThat(attrs)
+          .containsOnly(entry(PEER_SERVICE, "myService"), entry(SERVICE_PEER_NAME, "myService"));
+    } else {
+      assertThat(attrs).containsOnly(entry(maybeStablePeerService(), "myService"));
+    }
+  }
+
   private static ServicePeerResolver createResolver(DeclarativeConfigProperties... entries) {
     ExtendedOpenTelemetry otel = mock(ExtendedOpenTelemetry.class);
     DeclarativeConfigProperties commonConfig = mock(DeclarativeConfigProperties.class);

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -109,20 +109,6 @@ class ServicePeerResolverTest {
   }
 
   @Test
-  void configuredTargetCanMatchACommonPort() {
-    String target = "node1,node2";
-    ServicePeerResolver r = createResolver(mapping(target + ":15432", "cluster", null));
-
-    AttributesBuilder attrs = Attributes.builder();
-    r.resolve(target, 15432, () -> null, attrs::put);
-    assertName("cluster", attrs.build());
-
-    attrs = Attributes.builder();
-    r.resolve(target, null, () -> null, attrs::put);
-    assertThat(attrs.build().isEmpty()).isTrue();
-  }
-
-  @Test
   void opaqueConfiguredTargetDoesNotAlsoMatchItsDriverName() {
     String target =
         "oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -109,6 +109,20 @@ class ServicePeerResolverTest {
   }
 
   @Test
+  void configuredTargetCanMatchACommonPort() {
+    String target = "node1,node2";
+    ServicePeerResolver r = createResolver(mapping(target + ":15432", "cluster", null));
+
+    AttributesBuilder attrs = Attributes.builder();
+    r.resolve(target, 15432, () -> null, attrs::put);
+    assertName("cluster", attrs.build());
+
+    attrs = Attributes.builder();
+    r.resolve(target, null, () -> null, attrs::put);
+    assertThat(attrs.build().isEmpty()).isTrue();
+  }
+
+  @Test
   void opaqueConfiguredTargetDoesNotAlsoMatchItsDriverName() {
     String target =
         "oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -111,8 +111,8 @@ class ServicePeerResolverTest {
   @Test
   void opaqueConfiguredTargetDoesNotAlsoMatchItsDriverName() {
     String target =
-        "oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"
-            + "(ADDRESS=(PROTOCOL=tcp)(HOST=h2)(PORT=1521)))";
+        "oracle:thin:@(DESCRIPTION=( ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"
+            + "(ADDRESS = (PROTOCOL=tcp)(HOST=h2)(PORT=1521)))";
     ServicePeerResolver r = createResolver(mapping(target, "cluster", null));
 
     AttributesBuilder attrs = Attributes.builder();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -94,6 +94,47 @@ class ServicePeerResolverTest {
   }
 
   @Test
+  void configuredTargetDoesNotAlsoMatchItsFirstHost() {
+    String target = "node1:6379,node2:6380";
+    ServicePeerResolver r = createResolver(mapping(target, "cluster", null));
+    assertThat(r.isEmpty()).isFalse();
+
+    AttributesBuilder attrs = Attributes.builder();
+    r.resolve(target, null, () -> null, attrs::put);
+    assertName("cluster", attrs.build());
+
+    attrs = Attributes.builder();
+    r.resolve("node1", 6379, () -> null, attrs::put);
+    assertThat(attrs.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void opaqueConfiguredTargetDoesNotAlsoMatchItsDriverName() {
+    String target =
+        "oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"
+            + "(ADDRESS=(PROTOCOL=tcp)(HOST=h2)(PORT=1521)))";
+    ServicePeerResolver r = createResolver(mapping(target, "cluster", null));
+
+    AttributesBuilder attrs = Attributes.builder();
+    r.resolve(target, null, () -> null, attrs::put);
+    assertName("cluster", attrs.build());
+
+    attrs = Attributes.builder();
+    r.resolve("oracle", null, () -> null, attrs::put);
+    assertThat(attrs.build().isEmpty()).isTrue();
+  }
+
+  @Test
+  void commaInPathStillUsesHostAndPathMatching() {
+    ServicePeerResolver r = createResolver(mapping("example.com/api,v2", "versionedApi", null));
+
+    AttributesBuilder attrs = Attributes.builder();
+    r.resolve("example.com", null, () -> "/api,v2", attrs::put);
+
+    assertName("versionedApi", attrs.build());
+  }
+
+  @Test
   void shouldSkipEntryWithNullPeer() {
     ServicePeerResolver r =
         createResolver(mapping(null, "svc", null), mapping("valid.com", "validSvc", null));

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -109,22 +109,6 @@ class ServicePeerResolverTest {
   }
 
   @Test
-  void opaqueConfiguredTargetDoesNotAlsoMatchItsDriverName() {
-    String target =
-        "oracle:thin:@(DESCRIPTION=( ADDRESS=(PROTOCOL=tcp)(HOST=h1)(PORT=1521))"
-            + "(ADDRESS = (PROTOCOL=tcp)(HOST=h2)(PORT=1521)))";
-    ServicePeerResolver r = createResolver(mapping(target, "cluster", null));
-
-    AttributesBuilder attrs = Attributes.builder();
-    r.resolve(target, null, () -> null, attrs::put);
-    assertName("cluster", attrs.build());
-
-    attrs = Attributes.builder();
-    r.resolve("oracle", null, () -> null, attrs::put);
-    assertThat(attrs.build().isEmpty()).isTrue();
-  }
-
-  @Test
   void commaInPathStillUsesHostAndPathMatching() {
     ServicePeerResolver r = createResolver(mapping("example.com/api,v2", "versionedApi", null));
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/service/peer/internal/ServicePeerResolverTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ServicePeerResolverTest {
   // resolver with a rich set of mappings exercising name, namespace, and specificity
@@ -105,6 +106,24 @@ class ServicePeerResolverTest {
 
     attrs = Attributes.builder();
     r.resolve("node1", 6379, () -> null, attrs::put);
+    assertThat(attrs.build().isEmpty()).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "oracle:thin:@(description=(address=(host=h1))(address=(host=h2)))",
+        "oracle:thin:@(DESCRIPTION=(ADDRESS = (HOST=h1))(ADDRESS = (HOST=h2)))"
+      })
+  void oracleDescriptorDoesNotAlsoMatchParsedHost(String target) {
+    ServicePeerResolver r = createResolver(mapping(target, "cluster", null));
+
+    AttributesBuilder attrs = Attributes.builder();
+    r.resolve(target, null, () -> null, attrs::put);
+    assertName("cluster", attrs.build());
+
+    attrs = Attributes.builder();
+    r.resolve("oracle", null, () -> null, attrs::put);
     assertThat(attrs.build().isEmpty()).isTrue();
   }
 

--- a/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
+++ b/instrumentation-docs/src/main/resources/shared-config-definitions.yaml
@@ -23,7 +23,7 @@ configurations:
   common.peer-service-mapping:
     name: otel.instrumentation.common.peer-service-mapping
     declarative_name: java.common.service_peer_mapping
-    description: "Used to specify a mapping from host names or IP addresses to peer services."
+    description: "Used to specify a mapping from server addresses or configured targets to peer services. Configured targets containing commas or equals signs can only be mapped with declarative `service_peer_mapping`."
     type: map
     default: ""
     declarative_type: structured_list
@@ -35,7 +35,7 @@ configurations:
       properties:
         peer:
           type: string
-          description: "Host name or IP address to match against."
+          description: "Server address or configured target to match against."
           example: host
         service_name:
           type: string

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -110,7 +110,7 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   public String getServerAddress(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
     String addressGroup = dbInfo.getServerAddressGroup();
-    if (emitStableDatabaseSemconv() && addressGroup != null) {
+    if (emitStableDatabaseSemconv() && (addressGroup != null || dbInfo.isMultiTarget())) {
       return addressGroup;
     }
     return dbInfo.getServerAddress();
@@ -120,7 +120,8 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   @Override
   public Integer getServerPort(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
-    if (emitStableDatabaseSemconv() && dbInfo.getServerAddressGroup() != null) {
+    if (emitStableDatabaseSemconv()
+        && (dbInfo.getServerAddressGroup() != null || dbInfo.isMultiTarget())) {
       return null;
     }
     return dbInfo.getServerPort();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -6,9 +6,11 @@
 package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.SqlDialectUtil.fromDbSystemName;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
+import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
@@ -106,12 +108,21 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   @Nullable
   @Override
   public String getServerAddress(DbRequest request) {
-    return request.getDbInfo().getServerAddress();
+    DbInfo dbInfo = request.getDbInfo();
+    String addressGroup = dbInfo.getServerAddressGroup();
+    if (emitStableDatabaseSemconv() && addressGroup != null) {
+      return addressGroup;
+    }
+    return dbInfo.getServerAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbRequest request) {
-    return request.getDbInfo().getServerPort();
+    DbInfo dbInfo = request.getDbInfo();
+    if (emitStableDatabaseSemconv() && dbInfo.getServerAddressGroup() != null) {
+      return null;
+    }
+    return dbInfo.getServerPort();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -122,7 +122,7 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
     DbInfo dbInfo = request.getDbInfo();
     if (emitStableDatabaseSemconv()
         && (dbInfo.getServerAddressGroup() != null || dbInfo.isMultiTarget())) {
-      return dbInfo.getServerAddressGroupPort();
+      return null;
     }
     return dbInfo.getServerPort();
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -122,7 +122,7 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
     DbInfo dbInfo = request.getDbInfo();
     if (emitStableDatabaseSemconv()
         && (dbInfo.getServerAddressGroup() != null || dbInfo.isMultiTarget())) {
-      return null;
+      return dbInfo.getServerAddressGroupPort();
     }
     return dbInfo.getServerPort();
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -109,15 +110,21 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   @Override
   public String getServerAddress(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
-    return emitStableDatabaseSemconv()
-        ? dbInfo.getConfiguredServerAddress()
-        : dbInfo.getServerAddress();
+    if (!emitStableDatabaseSemconv()) {
+      return dbInfo.getLegacyServerAddress();
+    }
+    DbServerTarget target = dbInfo.getConfiguredServerTarget();
+    return target == null ? null : target.getAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
-    return emitStableDatabaseSemconv() ? dbInfo.getConfiguredServerPort() : dbInfo.getServerPort();
+    if (!emitStableDatabaseSemconv()) {
+      return dbInfo.getLegacyServerPort();
+    }
+    DbServerTarget target = dbInfo.getConfiguredServerTarget();
+    return target == null ? null : target.getPort();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetter.java
@@ -109,21 +109,15 @@ public final class JdbcAttributesGetter implements SqlClientAttributesGetter<DbR
   @Override
   public String getServerAddress(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
-    String addressGroup = dbInfo.getServerAddressGroup();
-    if (emitStableDatabaseSemconv() && (addressGroup != null || dbInfo.isMultiTarget())) {
-      return addressGroup;
-    }
-    return dbInfo.getServerAddress();
+    return emitStableDatabaseSemconv()
+        ? dbInfo.getConfiguredServerAddress()
+        : dbInfo.getServerAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbRequest request) {
     DbInfo dbInfo = request.getDbInfo();
-    if (emitStableDatabaseSemconv()
-        && (dbInfo.getServerAddressGroup() != null || dbInfo.isMultiTarget())) {
-      return null;
-    }
-    return dbInfo.getServerPort();
+    return emitStableDatabaseSemconv() ? dbInfo.getConfiguredServerPort() : dbInfo.getServerPort();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionPoolNameUtil.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionPoolNameUtil.java
@@ -21,12 +21,12 @@ public final class JdbcConnectionPoolNameUtil {
 
     String serverName = getPropertyValue(properties, "serverName");
     if (serverName != null && !serverName.isEmpty()) {
-      dbInfoBuilder.serverAddress(UrlParsingUtils.stripIpv6Brackets(serverName));
+      dbInfoBuilder.legacyServerAddress(UrlParsingUtils.stripIpv6Brackets(serverName));
     }
 
     Integer serverPort = UrlParsingUtils.parsePort(getPropertyValue(properties, "portNumber"));
     if (serverPort != null) {
-      dbInfoBuilder.serverPort(serverPort);
+      dbInfoBuilder.legacyServerPort(serverPort);
     }
 
     String databaseName = getPropertyValue(properties, "databaseName");
@@ -38,8 +38,8 @@ public final class JdbcConnectionPoolNameUtil {
   }
 
   public static String poolName(DbInfo dbInfo, String fallbackName) {
-    String serverAddress = dbInfo.getServerAddress();
-    Integer serverPort = dbInfo.getServerPort();
+    String serverAddress = dbInfo.getLegacyServerAddress();
+    Integer serverPort = dbInfo.getLegacyServerPort();
     String dbNamespace = dbInfo.getDbNamespace();
 
     StringBuilder poolName = new StringBuilder();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo.DEFAULT;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.hasMultipleTargets;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
@@ -136,6 +137,9 @@ public final class JdbcConnectionUrlParser {
     String type = jdbcUrl.substring(0, typeLoc);
     JdbcUrlParser parser = typeParsers.get(type);
     ParseContext ctx = ParseContext.of(type, props);
+    if (hasMultipleTargets(jdbcUrl)) {
+      ctx.multiTarget();
+    }
 
     try {
       if (parser == null) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParser.java
@@ -138,7 +138,7 @@ public final class JdbcConnectionUrlParser {
     JdbcUrlParser parser = typeParsers.get(type);
     ParseContext ctx = ParseContext.of(type, props);
     if (hasMultipleTargets(jdbcUrl)) {
-      ctx.multiTarget();
+      ctx.disableSingleServerFallback();
     }
 
     try {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -59,9 +59,6 @@ public abstract class DbInfo {
   @Nullable
   public abstract String getServerAddressGroup();
 
-  @Nullable
-  public abstract Integer getServerAddressGroupPort();
-
   public abstract boolean isMultiTarget();
 
   @Nullable
@@ -106,7 +103,6 @@ public abstract class DbInfo {
         .serverAddress(getServerAddress())
         .serverPort(getServerPort())
         .serverAddressGroup(getServerAddressGroup())
-        .serverAddressGroupPort(getServerAddressGroupPort())
         .multiTarget(isMultiTarget());
   }
 
@@ -141,8 +137,6 @@ public abstract class DbInfo {
     public abstract Builder serverPort(Integer serverPort);
 
     public abstract Builder serverAddressGroup(String serverAddressGroup);
-
-    public abstract Builder serverAddressGroupPort(Integer serverAddressGroupPort);
 
     public abstract Builder multiTarget(boolean multiTarget);
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -57,6 +57,9 @@ public abstract class DbInfo {
   public abstract Integer getServerPort();
 
   @Nullable
+  public abstract String getServerAddressGroup();
+
+  @Nullable
   public final String getSystem() {
     return getDbSystem() != null ? getDbSystem() : getDbSystemName();
   }
@@ -96,7 +99,8 @@ public abstract class DbInfo {
         .dbName(getDbName())
         .dbNamespace(getDbNamespace())
         .serverAddress(getServerAddress())
-        .serverPort(getServerPort());
+        .serverPort(getServerPort())
+        .serverAddressGroup(getServerAddressGroup());
   }
 
   /**
@@ -128,6 +132,8 @@ public abstract class DbInfo {
     public abstract Builder serverAddress(String serverAddress);
 
     public abstract Builder serverPort(Integer serverPort);
+
+    public abstract Builder serverAddressGroup(String serverAddressGroup);
 
     public final Builder system(String system) {
       return dbSystemName(system).dbSystem(system);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -59,6 +59,9 @@ public abstract class DbInfo {
   @Nullable
   public abstract String getServerAddressGroup();
 
+  @Nullable
+  public abstract Integer getServerAddressGroupPort();
+
   public abstract boolean isMultiTarget();
 
   @Nullable
@@ -103,6 +106,7 @@ public abstract class DbInfo {
         .serverAddress(getServerAddress())
         .serverPort(getServerPort())
         .serverAddressGroup(getServerAddressGroup())
+        .serverAddressGroupPort(getServerAddressGroupPort())
         .multiTarget(isMultiTarget());
   }
 
@@ -137,6 +141,8 @@ public abstract class DbInfo {
     public abstract Builder serverPort(Integer serverPort);
 
     public abstract Builder serverAddressGroup(String serverAddressGroup);
+
+    public abstract Builder serverAddressGroupPort(Integer serverAddressGroupPort);
 
     public abstract Builder multiTarget(boolean multiTarget);
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -18,7 +18,7 @@ public abstract class DbInfo {
   public static final DbInfo DEFAULT = builder().build();
 
   public static DbInfo.Builder builder() {
-    return new AutoValue_DbInfo.Builder();
+    return new AutoValue_DbInfo.Builder().multiTarget(false);
   }
 
   /** The stable/new db.system.name value (e.g., "h2database", "microsoft.sql_server"). */
@@ -58,6 +58,8 @@ public abstract class DbInfo {
 
   @Nullable
   public abstract String getServerAddressGroup();
+
+  public abstract boolean isMultiTarget();
 
   @Nullable
   public final String getSystem() {
@@ -100,7 +102,8 @@ public abstract class DbInfo {
         .dbNamespace(getDbNamespace())
         .serverAddress(getServerAddress())
         .serverPort(getServerPort())
-        .serverAddressGroup(getServerAddressGroup());
+        .serverAddressGroup(getServerAddressGroup())
+        .multiTarget(isMultiTarget());
   }
 
   /**
@@ -134,6 +137,8 @@ public abstract class DbInfo {
     public abstract Builder serverPort(Integer serverPort);
 
     public abstract Builder serverAddressGroup(String serverAddressGroup);
+
+    public abstract Builder multiTarget(boolean multiTarget);
 
     public final Builder system(String system) {
       return dbSystemName(system).dbSystem(system);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -18,7 +18,7 @@ public abstract class DbInfo {
   public static final DbInfo DEFAULT = builder().build();
 
   public static DbInfo.Builder builder() {
-    return new AutoValue_DbInfo.Builder().multiTarget(false);
+    return new AutoValue_DbInfo.Builder();
   }
 
   /** The stable/new db.system.name value (e.g., "h2database", "microsoft.sql_server"). */
@@ -57,9 +57,10 @@ public abstract class DbInfo {
   public abstract Integer getServerPort();
 
   @Nullable
-  public abstract String getServerAddressGroup();
+  public abstract String getConfiguredServerAddress();
 
-  public abstract boolean isMultiTarget();
+  @Nullable
+  public abstract Integer getConfiguredServerPort();
 
   @Nullable
   public final String getSystem() {
@@ -102,8 +103,8 @@ public abstract class DbInfo {
         .dbNamespace(getDbNamespace())
         .serverAddress(getServerAddress())
         .serverPort(getServerPort())
-        .serverAddressGroup(getServerAddressGroup())
-        .multiTarget(isMultiTarget());
+        .configuredServerAddress(getConfiguredServerAddress())
+        .configuredServerPort(getConfiguredServerPort());
   }
 
   /**
@@ -136,9 +137,9 @@ public abstract class DbInfo {
 
     public abstract Builder serverPort(Integer serverPort);
 
-    public abstract Builder serverAddressGroup(String serverAddressGroup);
+    public abstract Builder configuredServerAddress(String configuredServerAddress);
 
-    public abstract Builder multiTarget(boolean multiTarget);
+    public abstract Builder configuredServerPort(Integer configuredServerPort);
 
     public final Builder system(String system) {
       return dbSystemName(system).dbSystem(system);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfo.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.jdbc.internal.dbinfo;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import javax.annotation.Nullable;
 
 /**
@@ -50,17 +51,20 @@ public abstract class DbInfo {
   @Nullable
   public abstract String getDbNamespace();
 
+  /** The parser's single host, including defaults, used for legacy telemetry and pool names. */
   @Nullable
-  public abstract String getServerAddress();
+  public abstract String getLegacyServerAddress();
 
+  /** The parser's single port, including defaults, used for legacy telemetry and pool names. */
   @Nullable
-  public abstract Integer getServerPort();
+  public abstract Integer getLegacyServerPort();
 
+  /**
+   * The logical configured target for stable telemetry, or {@code null} when unavailable. This is
+   * not the endpoint that handled an individual query.
+   */
   @Nullable
-  public abstract String getConfiguredServerAddress();
-
-  @Nullable
-  public abstract Integer getConfiguredServerPort();
+  public abstract DbServerTarget getConfiguredServerTarget();
 
   @Nullable
   public final String getSystem() {
@@ -84,12 +88,12 @@ public abstract class DbInfo {
 
   @Nullable
   public final String getHost() {
-    return getServerAddress();
+    return getLegacyServerAddress();
   }
 
   @Nullable
   public final Integer getPort() {
-    return getServerPort();
+    return getLegacyServerPort();
   }
 
   public Builder toBuilder() {
@@ -101,10 +105,9 @@ public abstract class DbInfo {
         .dbUser(getDbUser())
         .dbName(getDbName())
         .dbNamespace(getDbNamespace())
-        .serverAddress(getServerAddress())
-        .serverPort(getServerPort())
-        .configuredServerAddress(getConfiguredServerAddress())
-        .configuredServerPort(getConfiguredServerPort());
+        .legacyServerAddress(getLegacyServerAddress())
+        .legacyServerPort(getLegacyServerPort())
+        .configuredServerTarget(getConfiguredServerTarget());
   }
 
   /**
@@ -133,13 +136,11 @@ public abstract class DbInfo {
 
     public abstract Builder dbNamespace(String dbNamespace);
 
-    public abstract Builder serverAddress(String serverAddress);
+    public abstract Builder legacyServerAddress(String legacyServerAddress);
 
-    public abstract Builder serverPort(Integer serverPort);
+    public abstract Builder legacyServerPort(Integer legacyServerPort);
 
-    public abstract Builder configuredServerAddress(String configuredServerAddress);
-
-    public abstract Builder configuredServerPort(Integer configuredServerPort);
+    public abstract Builder configuredServerTarget(@Nullable DbServerTarget configuredServerTarget);
 
     public final Builder system(String system) {
       return dbSystemName(system).dbSystem(system);
@@ -158,11 +159,11 @@ public abstract class DbInfo {
     }
 
     public final Builder host(String host) {
-      return serverAddress(host);
+      return legacyServerAddress(host);
     }
 
     public final Builder port(Integer port) {
-      return serverPort(port);
+      return legacyServerPort(port);
     }
 
     public abstract DbInfo build();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/Db2UrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/Db2UrlParser.java
@@ -37,7 +37,7 @@ public final class Db2UrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(IBM_DB2);
     ctx.oldSemconvSystem(DB2);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyDataSourceProperties();
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/DerbyUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/DerbyUrlParser.java
@@ -138,6 +138,7 @@ public final class DerbyUrlParser implements JdbcUrlParser {
   }
 
   private static void parseNetworkMode(String details, ParseContext ctx) {
+    ctx.defaultPort(DEFAULT_PORT);
     String url = details.substring("//".length());
 
     int instanceLoc = url.indexOf("/");
@@ -161,7 +162,6 @@ public final class DerbyUrlParser implements JdbcUrlParser {
       }
     } else {
       ctx.host(url);
-      ctx.defaultPort(DEFAULT_PORT);
     }
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/DerbyUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/DerbyUrlParser.java
@@ -161,7 +161,7 @@ public final class DerbyUrlParser implements JdbcUrlParser {
       }
     } else {
       ctx.host(url);
-      ctx.port(DEFAULT_PORT);
+      ctx.defaultPort(DEFAULT_PORT);
     }
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
 import static java.util.logging.Level.FINE;
 
 import java.net.URI;
@@ -16,6 +19,11 @@ import java.util.logging.Logger;
  *
  * <p>Used by database-specific parsers to handle standard URL formats like: {@code
  * type://host:port/db?user=username}
+ *
+ * <p>An authority that lists more than one host, e.g. {@code type://h1:5432,h2:5432/db}, is not a
+ * server-based URI. Its host list is kept as the configured group target; every other value comes
+ * from the URI parse, which reports such an authority as registry-based and therefore leaves the
+ * host and the port alone.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -36,6 +44,10 @@ public final class GenericUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     if (ctx.system() == null) {
       ctx.system(OTHER_SQL);
+    }
+
+    if (!applyHostGroup(jdbcUrl, ctx)) {
+      return;
     }
 
     URI uri;
@@ -79,5 +91,20 @@ public final class GenericUrlParser implements JdbcUrlParser {
     // 4. Query params (highest precedence)
     // URL is lowercased by JdbcConnectionUrlParser, so check lowercase param names
     ctx.applyCommonParams(jdbcUrl, "?", "&");
+  }
+
+  private static boolean applyHostGroup(String jdbcUrl, ParseContext ctx) {
+    String authority = extractAuthority(jdbcUrl);
+    if (authority == null) {
+      authority = extractAuthorityWithQueryAt(jdbcUrl);
+      if (authority == null) {
+        return jdbcUrl.indexOf("://") < 0;
+      }
+    }
+    String hostList = sanitizeHostList(authority);
+    if (hostList != null) {
+      ctx.serverAddressGroup(hostList);
+    }
+    return true;
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -7,12 +7,14 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 import static java.util.logging.Level.FINE;
 
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * Parses standard URL-like JDBC connection strings using Java's URI parser.
@@ -42,11 +44,15 @@ public final class GenericUrlParser implements JdbcUrlParser {
 
   @Override
   public void parse(String jdbcUrl, ParseContext ctx) {
+    parse(jdbcUrl, ctx, null);
+  }
+
+  public void parse(String jdbcUrl, ParseContext ctx, @Nullable Integer defaultPort) {
     if (ctx.system() == null) {
       ctx.system(OTHER_SQL);
     }
 
-    if (!applyHostGroup(jdbcUrl, ctx)) {
+    if (!applyHostGroup(jdbcUrl, ctx, defaultPort)) {
       return;
     }
 
@@ -93,7 +99,8 @@ public final class GenericUrlParser implements JdbcUrlParser {
     ctx.applyCommonParams(jdbcUrl, "?", "&");
   }
 
-  private static boolean applyHostGroup(String jdbcUrl, ParseContext ctx) {
+  private static boolean applyHostGroup(
+      String jdbcUrl, ParseContext ctx, @Nullable Integer defaultPort) {
     String authority = extractAuthority(jdbcUrl);
     if (authority == null) {
       authority = extractAuthorityWithQueryAt(jdbcUrl);
@@ -101,10 +108,8 @@ public final class GenericUrlParser implements JdbcUrlParser {
         return jdbcUrl.indexOf("://") < 0;
       }
     }
-    String hostList = sanitizeHostList(authority);
-    if (hostList != null) {
-      ctx.serverAddressGroup(hostList);
-    }
+    ServerAddressGroup hostList = parseServerAddressGroup(authority, defaultPort);
+    ctx.serverAddressGroup(hostList);
     return true;
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -8,9 +8,10 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.hasMultipleTargets;
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerTargetGroup;
 import static java.util.logging.Level.FINE;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
@@ -108,9 +109,9 @@ public final class GenericUrlParser implements JdbcUrlParser {
         return jdbcUrl.indexOf("://") < 0;
       }
     }
-    String hostList = parseServerAddressGroup(authority, defaultPort);
-    if (hostList != null || hasMultipleTargets(jdbcUrl)) {
-      ctx.configuredServerAddress(hostList);
+    DbServerTarget target = parseServerTargetGroup(authority, defaultPort);
+    if (target != null || hasMultipleTargets(jdbcUrl)) {
+      ctx.configuredServerTarget(target);
     }
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -10,7 +10,6 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 import static java.util.logging.Level.FINE;
 
-import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
@@ -108,7 +107,7 @@ public final class GenericUrlParser implements JdbcUrlParser {
         return jdbcUrl.indexOf("://") < 0;
       }
     }
-    ServerAddressGroup hostList = parseServerAddressGroup(authority, defaultPort);
+    String hostList = parseServerAddressGroup(authority, defaultPort);
     ctx.serverAddressGroup(hostList);
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -111,7 +111,7 @@ public final class GenericUrlParser implements JdbcUrlParser {
     }
     DbServerTarget target = parseServerTargetGroup(authority, defaultPort);
     if (target != null || hasMultipleTargets(jdbcUrl)) {
-      ctx.configuredServerTarget(target);
+      ctx.resolveConfiguredServerTarget(target);
     }
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.hasMultipleTargets;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 import static java.util.logging.Level.FINE;
 
@@ -108,7 +109,9 @@ public final class GenericUrlParser implements JdbcUrlParser {
       }
     }
     String hostList = parseServerAddressGroup(authority, defaultPort);
-    ctx.serverAddressGroup(hostList);
+    if (hostList != null || hasMultipleTargets(jdbcUrl)) {
+      ctx.configuredServerAddress(hostList);
+    }
     return true;
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/GenericUrlParser.java
@@ -47,7 +47,7 @@ public final class GenericUrlParser implements JdbcUrlParser {
     parse(jdbcUrl, ctx, null);
   }
 
-  public void parse(String jdbcUrl, ParseContext ctx, @Nullable Integer defaultPort) {
+  void parse(String jdbcUrl, ParseContext ctx, @Nullable Integer defaultPort) {
     if (ctx.system() == null) {
       ctx.system(OTHER_SQL);
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/H2UrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/H2UrlParser.java
@@ -80,7 +80,7 @@ public final class H2UrlParser implements JdbcUrlParser {
   }
 
   private static void parseNetworkMode(String subtype, String jdbcUrl, ParseContext ctx) {
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultPort(DEFAULT_PORT);
     ctx.subtype(subtype);
     ctx.parseUrl(jdbcUrl);
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/HsqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/HsqlUrlParser.java
@@ -99,7 +99,7 @@ public final class HsqlUrlParser implements JdbcUrlParser {
 
   private static void parseNetworkMode(
       String subtype, String jdbcUrl, int defaultPort, ParseContext ctx) {
-    ctx.port(defaultPort);
+    ctx.defaultPort(defaultPort);
     ctx.subtype(subtype);
     ctx.parseUrl(jdbcUrl);
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/InformixSqliUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/InformixSqliUrlParser.java
@@ -35,7 +35,7 @@ public final class InformixSqliUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(IBM_INFORMIX);
     ctx.oldSemconvSystem(OLD_SYSTEM);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyDataSourceProperties();
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/JtdsUrlParser.java
@@ -44,8 +44,8 @@ public final class JtdsUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(MICROSOFT_SQL_SERVER);
     ctx.oldSemconvSystem(MSSQL);
-    ctx.host(DEFAULT_HOST);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultHost(DEFAULT_HOST);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.subtype("sqlserver");
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -83,6 +83,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
         hasConfiguredPort(jdbcUrl, urlParams, ctx.props()));
   }
 
+  /** Build the configured primary and failover partner group. */
   private static void applyFailoverPartnerGroup(
       ParseContext ctx,
       Map<String, String> params,
@@ -112,6 +113,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     ctx.serverAddressGroup(serverAddressGroup);
   }
 
+  /** Returns whether a server was configured by the data source, parameters, or URL authority. */
   private static boolean hasConfiguredServer(
       String jdbcUrl, Map<String, String> params, @Nullable Properties properties) {
     if (properties != null) {
@@ -135,6 +137,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return pathLoc < 0 ? !urlServerName.isEmpty() : pathLoc > 0;
   }
 
+  /** Append the effective primary server, including its configured port or instance. */
   private static void appendPrimary(
       StringBuilder group,
       ParseContext ctx,
@@ -152,6 +155,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     appendServerAddress(group, host + "\\" + instanceName);
   }
 
+  /** Resolve the effective instance name using SQL Server property precedence. */
   @Nullable
   private static String resolveInstanceName(
       @Nullable Properties properties,
@@ -172,6 +176,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return propertyServerName == null || propertyServerName.isEmpty() ? instanceName : null;
   }
 
+  /** Returns whether a port was configured by the data source, parameters, or URL authority. */
   private static boolean hasConfiguredPort(
       String jdbcUrl, Map<String, String> params, @Nullable Properties properties) {
     if (properties != null
@@ -195,6 +200,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return UrlParsingUtils.extractHostPort(serverName).port() != null;
   }
 
+  /** Append a SQL Server address, bracketing an unbracketed IPv6 host and preserving its instance. */
   private static void appendServerAddress(StringBuilder group, String serverAddress) {
     int instanceStart = serverAddress.indexOf('\\');
     String hostPort = instanceStart < 0 ? serverAddress : serverAddress.substring(0, instanceStart);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -95,7 +95,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     StringBuilder group = new StringBuilder();
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
-    appendFailoverPartner(group, failoverPartner);
+    appendServerAddress(group, failoverPartner);
     ctx.serverAddressGroup(group.toString());
   }
 
@@ -109,7 +109,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
       UrlParsingUtils.appendHostPort(group, host, portConfigured ? ctx.port() : null);
       return;
     }
-    appendFailoverPartner(group, host + "\\" + instanceName);
+    appendServerAddress(group, host + "\\" + instanceName);
     if (portConfigured && ctx.port() != null) {
       group.append(':').append(ctx.port());
     }
@@ -158,10 +158,9 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return UrlParsingUtils.extractHostPort(serverName).port() != null;
   }
 
-  private static void appendFailoverPartner(StringBuilder group, String failoverPartner) {
-    int instanceStart = failoverPartner.indexOf('\\');
-    String hostPort =
-        instanceStart < 0 ? failoverPartner : failoverPartner.substring(0, instanceStart);
+  private static void appendServerAddress(StringBuilder group, String serverAddress) {
+    int instanceStart = serverAddress.indexOf('\\');
+    String hostPort = instanceStart < 0 ? serverAddress : serverAddress.substring(0, instanceStart);
     boolean unbracketedIpv6 =
         !hostPort.startsWith("[") && hostPort.indexOf(':') != hostPort.lastIndexOf(':');
     if (unbracketedIpv6) {
@@ -170,7 +169,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
       group.append(hostPort);
     }
     if (instanceStart >= 0) {
-      group.append(failoverPartner, instanceStart, failoverPartner.length());
+      group.append(serverAddress, instanceStart, serverAddress.length());
     }
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -105,14 +105,15 @@ public final class MssqlUrlParser implements JdbcUrlParser {
       String host,
       @Nullable String instanceName,
       boolean portConfigured) {
+    if (portConfigured) {
+      UrlParsingUtils.appendHostPort(group, host, ctx.port());
+      return;
+    }
     if (instanceName == null || instanceName.isEmpty()) {
-      UrlParsingUtils.appendHostPort(group, host, portConfigured ? ctx.port() : null);
+      UrlParsingUtils.appendHostPort(group, host, null);
       return;
     }
     appendServerAddress(group, host + "\\" + instanceName);
-    if (portConfigured && ctx.port() != null) {
-      group.append(':').append(ctx.port());
-    }
   }
 
   @Nullable

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -5,9 +5,10 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -107,10 +108,8 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
     appendServerAddress(group, failoverPartner);
-    String serverAddressGroup = sanitizeHostList(group.toString());
-    if (serverAddressGroup != null) {
-      ctx.serverAddressGroup(serverAddressGroup);
-    }
+    ServerAddressGroup serverAddressGroup = parseServerAddressGroup(group.toString(), DEFAULT_PORT);
+    ctx.serverAddressGroup(serverAddressGroup);
   }
 
   private static boolean hasConfiguredServer(

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
+
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.Map;
 import java.util.Properties;
@@ -73,13 +75,18 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     setNamespace(ctx, instanceName);
 
     applyFailoverPartnerGroup(
-        ctx, urlParams, targetInstanceName, hasConfiguredPort(jdbcUrl, urlParams, ctx.props()));
+        ctx,
+        urlParams,
+        targetInstanceName,
+        hasConfiguredServer(jdbcUrl, urlParams, ctx.props()),
+        hasConfiguredPort(jdbcUrl, urlParams, ctx.props()));
   }
 
   private static void applyFailoverPartnerGroup(
       ParseContext ctx,
       Map<String, String> params,
       @Nullable String instanceName,
+      boolean serverConfigured,
       boolean portConfigured) {
     String failoverPartner = null;
     if (ctx.props() != null) {
@@ -88,15 +95,45 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     if (failoverPartner == null || failoverPartner.isEmpty()) {
       failoverPartner = params.get("failoverpartner");
     }
+    if (failoverPartner == null || failoverPartner.isEmpty()) {
+      return;
+    }
+    ctx.multiTarget();
     String host = ctx.host();
-    if (failoverPartner == null || failoverPartner.isEmpty() || host == null) {
+    if (!serverConfigured || host == null) {
       return;
     }
     StringBuilder group = new StringBuilder();
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
     appendServerAddress(group, failoverPartner);
-    ctx.serverAddressGroup(group.toString());
+    String serverAddressGroup = sanitizeHostList(group.toString());
+    if (serverAddressGroup != null) {
+      ctx.serverAddressGroup(serverAddressGroup);
+    }
+  }
+
+  private static boolean hasConfiguredServer(
+      String jdbcUrl, Map<String, String> params, @Nullable Properties properties) {
+    if (properties != null) {
+      String serverName = properties.getProperty("serverName");
+      if (serverName != null && !serverName.isEmpty()) {
+        return true;
+      }
+    }
+    String serverName = params.get("servername");
+    if (serverName != null && !serverName.isEmpty()) {
+      return true;
+    }
+
+    String urlPart = jdbcUrl.split(";", 2)[0];
+    int hostIndex = urlPart.indexOf("://");
+    if (hostIndex <= 0) {
+      return false;
+    }
+    String urlServerName = urlPart.substring(hostIndex + 3);
+    int pathLoc = urlServerName.indexOf('/');
+    return pathLoc < 0 ? !urlServerName.isEmpty() : pathLoc > 0;
   }
 
   private static void appendPrimary(

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -70,7 +70,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     String targetInstanceName = resolveInstanceName(ctx.props(), urlParams, instanceName);
 
     // Namespace depends on the effective databaseName, so derive it after DataSource overrides.
-    setNamespace(ctx, targetInstanceName != null ? targetInstanceName : instanceName);
+    setNamespace(ctx, instanceName);
 
     applyFailoverPartnerGroup(
         ctx, urlParams, targetInstanceName, hasConfiguredPort(jdbcUrl, urlParams, ctx.props()));

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.Map;
+import java.util.Properties;
 import javax.annotation.Nullable;
 
 /**
@@ -66,9 +67,111 @@ public final class MssqlUrlParser implements JdbcUrlParser {
 
     // DataSource properties applied last — SQL Server driver gives DataSource precedence over URL
     ctx.applyDataSourceProperties();
+    String targetInstanceName = resolveInstanceName(ctx.props(), urlParams, instanceName);
 
     // Namespace depends on the effective databaseName, so derive it after DataSource overrides.
-    setNamespace(ctx, instanceName);
+    setNamespace(ctx, targetInstanceName != null ? targetInstanceName : instanceName);
+
+    applyFailoverPartnerGroup(
+        ctx, urlParams, targetInstanceName, hasConfiguredPort(jdbcUrl, urlParams, ctx.props()));
+  }
+
+  private static void applyFailoverPartnerGroup(
+      ParseContext ctx,
+      Map<String, String> params,
+      @Nullable String instanceName,
+      boolean portConfigured) {
+    String failoverPartner = null;
+    if (ctx.props() != null) {
+      failoverPartner = ctx.props().getProperty("failoverPartner");
+    }
+    if (failoverPartner == null || failoverPartner.isEmpty()) {
+      failoverPartner = params.get("failoverpartner");
+    }
+    String host = ctx.host();
+    if (failoverPartner == null || failoverPartner.isEmpty() || host == null) {
+      return;
+    }
+    StringBuilder group = new StringBuilder();
+    appendPrimary(group, ctx, host, instanceName, portConfigured);
+    group.append(',');
+    appendFailoverPartner(group, failoverPartner);
+    ctx.serverAddressGroup(group.toString());
+  }
+
+  private static void appendPrimary(
+      StringBuilder group,
+      ParseContext ctx,
+      String host,
+      @Nullable String instanceName,
+      boolean portConfigured) {
+    if (instanceName == null || instanceName.isEmpty()) {
+      UrlParsingUtils.appendHostPort(group, host, portConfigured ? ctx.port() : null);
+      return;
+    }
+    appendFailoverPartner(group, host + "\\" + instanceName);
+    if (portConfigured && ctx.port() != null) {
+      group.append(':').append(ctx.port());
+    }
+  }
+
+  @Nullable
+  private static String resolveInstanceName(
+      @Nullable Properties properties,
+      Map<String, String> params,
+      @Nullable String parsedInstanceName) {
+    String instanceName = parsedInstanceName;
+    if (instanceName == null || instanceName.isEmpty()) {
+      instanceName = params.get("instancename");
+    }
+    if (properties == null) {
+      return instanceName;
+    }
+    String propertyInstanceName = properties.getProperty("instanceName");
+    if (propertyInstanceName != null && !propertyInstanceName.isEmpty()) {
+      return propertyInstanceName;
+    }
+    String propertyServerName = properties.getProperty("serverName");
+    return propertyServerName == null || propertyServerName.isEmpty() ? instanceName : null;
+  }
+
+  private static boolean hasConfiguredPort(
+      String jdbcUrl, Map<String, String> params, @Nullable Properties properties) {
+    if (properties != null
+        && UrlParsingUtils.parsePort(properties.getProperty("portNumber")) != null) {
+      return true;
+    }
+    if (UrlParsingUtils.parsePort(params.get("portnumber")) != null) {
+      return true;
+    }
+
+    String urlPart = jdbcUrl.split(";", 2)[0];
+    int hostIndex = urlPart.indexOf("://");
+    if (hostIndex <= 0) {
+      return false;
+    }
+    String serverName = urlPart.substring(hostIndex + 3);
+    int pathLoc = serverName.indexOf('/');
+    if (pathLoc > 0) {
+      serverName = serverName.substring(0, pathLoc);
+    }
+    return UrlParsingUtils.extractHostPort(serverName).port() != null;
+  }
+
+  private static void appendFailoverPartner(StringBuilder group, String failoverPartner) {
+    int instanceStart = failoverPartner.indexOf('\\');
+    String hostPort =
+        instanceStart < 0 ? failoverPartner : failoverPartner.substring(0, instanceStart);
+    boolean unbracketedIpv6 =
+        !hostPort.startsWith("[") && hostPort.indexOf(':') != hostPort.lastIndexOf(':');
+    if (unbracketedIpv6) {
+      group.append('[').append(hostPort).append(']');
+    } else {
+      group.append(hostPort);
+    }
+    if (instanceStart >= 0) {
+      group.append(failoverPartner, instanceStart, failoverPartner.length());
+    }
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -200,7 +200,9 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     return UrlParsingUtils.extractHostPort(serverName).port() != null;
   }
 
-  /** Append a SQL Server address, bracketing an unbracketed IPv6 host and preserving its instance. */
+  /**
+   * Append a SQL Server address, bracketing an unbracketed IPv6 host and preserving its instance.
+   */
   private static void appendServerAddress(StringBuilder group, String serverAddress) {
     int instanceStart = serverAddress.indexOf('\\');
     String hostPort = instanceStart < 0 ? serverAddress : serverAddress.substring(0, instanceStart);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -99,7 +99,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     if (failoverPartner == null || failoverPartner.isEmpty()) {
       return;
     }
-    ctx.multiTarget();
+    ctx.disableSingleServerFallback();
     String host = ctx.host();
     if (!serverConfigured || host == null) {
       return;
@@ -108,7 +108,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
     appendServerAddress(group, failoverPartner);
-    ctx.configuredServerTarget(parseServerTargetGroup(group.toString(), DEFAULT_PORT));
+    ctx.resolveConfiguredServerTarget(parseServerTargetGroup(group.toString(), DEFAULT_PORT));
   }
 
   /** Returns whether a server was configured by the data source, parameters, or URL authority. */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
-import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -109,7 +108,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
     appendServerAddress(group, failoverPartner);
-    ServerAddressGroup serverAddressGroup = parseServerAddressGroup(group.toString(), DEFAULT_PORT);
+    String serverAddressGroup = parseServerAddressGroup(group.toString(), DEFAULT_PORT);
     ctx.serverAddressGroup(serverAddressGroup);
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -48,8 +48,8 @@ public final class MssqlUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(MICROSOFT_SQL_SERVER);
     ctx.oldSemconvSystem(MSSQL);
-    ctx.host(DEFAULT_HOST);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultHost(DEFAULT_HOST);
+    ctx.defaultPort(DEFAULT_PORT);
 
     // Extract subtype from URL like microsoft:sqlserver://...
     String subtype = UrlParsingUtils.extractSubtype(jdbcUrl);
@@ -109,7 +109,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     group.append(',');
     appendServerAddress(group, failoverPartner);
     String serverAddressGroup = parseServerAddressGroup(group.toString(), DEFAULT_PORT);
-    ctx.serverAddressGroup(serverAddressGroup);
+    ctx.configuredServerAddress(serverAddressGroup);
   }
 
   /** Returns whether a server was configured by the data source, parameters, or URL authority. */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MssqlUrlParser.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerTargetGroup;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.Map;
@@ -108,8 +108,7 @@ public final class MssqlUrlParser implements JdbcUrlParser {
     appendPrimary(group, ctx, host, instanceName, portConfigured);
     group.append(',');
     appendServerAddress(group, failoverPartner);
-    String serverAddressGroup = parseServerAddressGroup(group.toString(), DEFAULT_PORT);
-    ctx.configuredServerAddress(serverAddressGroup);
+    ctx.configuredServerTarget(parseServerTargetGroup(group.toString(), DEFAULT_PORT));
   }
 
   /** Returns whether a server was configured by the data source, parameters, or URL authority. */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -5,8 +5,11 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractSubtype;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -99,6 +102,21 @@ public final class MysqlUrlParser implements JdbcUrlParser {
     return -1;
   }
 
+  private static boolean applyHostGroup(String jdbcUrl, ParseContext ctx) {
+    String authority = extractAuthority("mariadb://" + jdbcUrl);
+    if (authority == null) {
+      authority = extractAuthorityWithQueryAt(jdbcUrl);
+      if (authority == null) {
+        return false;
+      }
+    }
+    String hostList = sanitizeHostList(authority);
+    if (hostList != null) {
+      ctx.serverAddressGroup(hostList);
+    }
+    return true;
+  }
+
   private static void parseNonStandardUrl(String jdbcUrl, ParseContext ctx) {
     int typeEndLoc = jdbcUrl.indexOf(':');
     int sectionEnd = indexOf(jdbcUrl, typeEndLoc + 1, ':', '/', '?');
@@ -145,6 +163,12 @@ public final class MysqlUrlParser implements JdbcUrlParser {
   }
 
   private static void parseMariaSubProtocol(String jdbcUrl, ParseContext ctx) {
+    if (!applyHostGroup(jdbcUrl, ctx)) {
+      ctx.host(null);
+      ctx.port(null);
+      return;
+    }
+
     int hostEndLoc;
     int ipv6End = jdbcUrl.startsWith("[") ? jdbcUrl.indexOf("]") : -1;
     int sectionEnd = indexOf(jdbcUrl, Math.max(0, ipv6End), ':', '/', '?', ',');

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -102,21 +102,6 @@ public final class MysqlUrlParser implements JdbcUrlParser {
     return -1;
   }
 
-  private static boolean applyHostGroup(String jdbcUrl, ParseContext ctx) {
-    String authority = extractAuthority("mariadb://" + jdbcUrl);
-    if (authority == null) {
-      authority = extractAuthorityWithQueryAt(jdbcUrl);
-      if (authority == null) {
-        return false;
-      }
-    }
-    String hostList = sanitizeHostList(authority);
-    if (hostList != null) {
-      ctx.serverAddressGroup(hostList);
-    }
-    return true;
-  }
-
   private static void parseNonStandardUrl(String jdbcUrl, ParseContext ctx) {
     int typeEndLoc = jdbcUrl.indexOf(':');
     int sectionEnd = indexOf(jdbcUrl, typeEndLoc + 1, ':', '/', '?');
@@ -233,6 +218,21 @@ public final class MysqlUrlParser implements JdbcUrlParser {
 
     // Apply query params (highest precedence)
     ctx.applyCommonParams(jdbcUrl, "?", "&");
+  }
+
+  private static boolean applyHostGroup(String jdbcUrl, ParseContext ctx) {
+    String authority = extractAuthority("mariadb://" + jdbcUrl);
+    if (authority == null) {
+      authority = extractAuthorityWithQueryAt(jdbcUrl);
+      if (authority == null) {
+        return false;
+      }
+    }
+    String hostList = sanitizeHostList(authority);
+    if (hostList != null) {
+      ctx.serverAddressGroup(hostList);
+    }
+    return true;
   }
 
   private static final Pattern HOST_PATTERN =

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -9,8 +9,9 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractSubtype;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -83,7 +84,7 @@ public final class MysqlUrlParser implements JdbcUrlParser {
       parseMariaSubProtocol(jdbcUrl.substring(protoLoc + 3), ctx);
     } else if (protoLoc > 0) {
       // Standard URL format - delegate to GenericUrlParser
-      GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx);
+      GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx, DEFAULT_PORT);
     } else {
       // Non-standard format: type/host:port/db?params
       parseNonStandardUrl(jdbcUrl, ctx);
@@ -228,10 +229,8 @@ public final class MysqlUrlParser implements JdbcUrlParser {
         return false;
       }
     }
-    String hostList = sanitizeHostList(authority);
-    if (hostList != null) {
-      ctx.serverAddressGroup(hostList);
-    }
+    ServerAddressGroup hostList = parseServerAddressGroup(authority, DEFAULT_PORT);
+    ctx.serverAddressGroup(hostList);
     return true;
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthorityWithQueryAt;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractSubtype;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.hasMultipleTargets;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 
@@ -68,8 +69,8 @@ public final class MysqlUrlParser implements JdbcUrlParser {
       system = OTHER_SQL;
     }
     ctx.system(system);
-    ctx.host(DEFAULT_HOST);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultHost(DEFAULT_HOST);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyUserProperty();
 
@@ -229,7 +230,9 @@ public final class MysqlUrlParser implements JdbcUrlParser {
       }
     }
     String hostList = parseServerAddressGroup(authority, DEFAULT_PORT);
-    ctx.serverAddressGroup(hostList);
+    if (hostList != null || hasMultipleTargets(jdbcUrl)) {
+      ctx.configuredServerAddress(hostList);
+    }
     return true;
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -10,8 +10,9 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractSubtype;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.hasMultipleTargets;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerTargetGroup;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -229,9 +230,9 @@ public final class MysqlUrlParser implements JdbcUrlParser {
         return false;
       }
     }
-    String hostList = parseServerAddressGroup(authority, DEFAULT_PORT);
-    if (hostList != null || hasMultipleTargets(jdbcUrl)) {
-      ctx.configuredServerAddress(hostList);
+    DbServerTarget target = parseServerTargetGroup(authority, DEFAULT_PORT);
+    if (target != null || hasMultipleTargets(jdbcUrl)) {
+      ctx.configuredServerTarget(target);
     }
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 
-import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -229,7 +228,7 @@ public final class MysqlUrlParser implements JdbcUrlParser {
         return false;
       }
     }
-    ServerAddressGroup hostList = parseServerAddressGroup(authority, DEFAULT_PORT);
+    String hostList = parseServerAddressGroup(authority, DEFAULT_PORT);
     ctx.serverAddressGroup(hostList);
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/MysqlUrlParser.java
@@ -232,7 +232,7 @@ public final class MysqlUrlParser implements JdbcUrlParser {
     }
     DbServerTarget target = parseServerTargetGroup(authority, DEFAULT_PORT);
     if (target != null || hasMultipleTargets(jdbcUrl)) {
-      ctx.configuredServerTarget(target);
+      ctx.resolveConfiguredServerTarget(target);
     }
     return true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -145,6 +145,15 @@ public final class OracleUrlParser implements JdbcUrlParser {
   }
 
   private static void applyAddressListGroup(String description, ParseContext ctx) {
+    Matcher targetMatcher = ADDRESS_PATTERN.matcher(description);
+    if (!targetMatcher.find()) {
+      return;
+    }
+    if (!targetMatcher.find()) {
+      return;
+    }
+    ctx.multiTarget();
+
     // A DESCRIPTION_LIST contains independent targets, not one failover/load-balancing group.
     if (DESCRIPTION_LIST_PATTERN.matcher(description).find()) {
       return;
@@ -161,10 +170,6 @@ public final class OracleUrlParser implements JdbcUrlParser {
       addresses.add(renderAddress(description.substring(addressMatcher.start(), end + 1)));
       searchFrom = end + 1;
     }
-    if (addresses.size() < 2) {
-      return;
-    }
-
     StringBuilder group = new StringBuilder("@(description=");
     boolean addressList = ADDRESS_LIST_PATTERN.matcher(description).find();
     if (addressList) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,6 +42,12 @@ public final class OracleUrlParser implements JdbcUrlParser {
   // LIMITATION: Simple regex matching across entire DESCRIPTION may extract values from
   // non-primary ADDRESS blocks when the first block has incomplete specifications.
   private static final Pattern DESCRIPTION_PATTERN = Pattern.compile("@\\s*\\(\\s*description");
+  private static final Pattern DESCRIPTION_LIST_PATTERN =
+      Pattern.compile("\\(\\s*description_list\\s*=");
+  private static final Pattern ADDRESS_LIST_PATTERN = Pattern.compile("\\(\\s*address_list\\s*=");
+  private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\(\\s*address\\s*=");
+  private static final Pattern PROTOCOL_PATTERN =
+      Pattern.compile("\\(\\s*protocol\\s*=\\s*([^ )]+)\\s*\\)");
   private static final Pattern HOST_PATTERN =
       Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
   private static final Pattern PORT_PATTERN =
@@ -65,14 +73,13 @@ public final class OracleUrlParser implements JdbcUrlParser {
     int typeEndIndex = jdbcUrl.indexOf(":", subtypeStart);
     String subtype = jdbcUrl.substring(subtypeStart, typeEndIndex);
     String remainder = jdbcUrl.substring(typeEndIndex + 1);
+    ctx.subtype(subtype);
 
     if (remainder.contains("@")) {
       parseAtFormat(remainder, ctx);
     } else {
       parseConnectInfo(remainder, ctx);
     }
-
-    ctx.subtype(subtype);
   }
 
   private static void parseAtFormat(String jdbcUrl, ParseContext ctx) {
@@ -132,6 +139,77 @@ public final class OracleUrlParser implements JdbcUrlParser {
     Matcher instanceMatcher = SERVICE_NAME_PATTERN.matcher(atSplit[1]);
     if (instanceMatcher.find()) {
       ctx.databaseName(instanceMatcher.group(1));
+    }
+
+    applyAddressListGroup(atSplit[1], ctx);
+  }
+
+  private static void applyAddressListGroup(String description, ParseContext ctx) {
+    // A DESCRIPTION_LIST contains independent targets, not one failover/load-balancing group.
+    if (DESCRIPTION_LIST_PATTERN.matcher(description).find()) {
+      return;
+    }
+
+    List<String> addresses = new ArrayList<>();
+    Matcher addressMatcher = ADDRESS_PATTERN.matcher(description);
+    int searchFrom = 0;
+    while (addressMatcher.find(searchFrom)) {
+      int end = findClosingParen(description, addressMatcher.start());
+      if (end < 0) {
+        return;
+      }
+      addresses.add(renderAddress(description.substring(addressMatcher.start(), end + 1)));
+      searchFrom = end + 1;
+    }
+    if (addresses.size() < 2) {
+      return;
+    }
+
+    StringBuilder group = new StringBuilder("@(description=");
+    boolean addressList = ADDRESS_LIST_PATTERN.matcher(description).find();
+    if (addressList) {
+      group.append("(address_list=");
+    }
+    for (String address : addresses) {
+      group.append(address);
+    }
+    if (addressList) {
+      group.append(')');
+    }
+    group.append(')');
+    ctx.opaqueServerAddressGroup(group.toString());
+  }
+
+  private static int findClosingParen(String text, int openParen) {
+    int depth = 0;
+    for (int i = openParen; i < text.length(); i++) {
+      char c = text.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+        if (depth == 0) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  private static String renderAddress(String address) {
+    StringBuilder rendered = new StringBuilder("(address=");
+    appendAttribute(rendered, "protocol", PROTOCOL_PATTERN, address);
+    appendAttribute(rendered, "host", HOST_PATTERN, address);
+    appendAttribute(rendered, "port", PORT_PATTERN, address);
+    rendered.append(')');
+    return rendered.toString();
+  }
+
+  private static void appendAttribute(
+      StringBuilder rendered, String name, Pattern pattern, String address) {
+    Matcher matcher = pattern.matcher(address);
+    if (matcher.find()) {
+      rendered.append('(').append(name).append('=').append(matcher.group(1)).append(')');
     }
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -5,12 +5,16 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractHostPort;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.indexOfAny;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * Parser for Oracle JDBC URLs.
@@ -44,10 +48,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
   private static final Pattern DESCRIPTION_PATTERN = Pattern.compile("@\\s*\\(\\s*description");
   private static final Pattern DESCRIPTION_LIST_PATTERN =
       Pattern.compile("\\(\\s*description_list\\s*=");
-  private static final Pattern ADDRESS_LIST_PATTERN = Pattern.compile("\\(\\s*address_list\\s*=");
   private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\(\\s*address\\s*=");
-  private static final Pattern PROTOCOL_PATTERN =
-      Pattern.compile("\\(\\s*protocol\\s*=\\s*([^ )]+)\\s*\\)");
   private static final Pattern HOST_PATTERN =
       Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
   private static final Pattern PORT_PATTERN =
@@ -97,16 +98,67 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
 
     String connectInfo = atSplit[1];
+    boolean ldapDiscovery = connectInfo.startsWith("ldap://");
     int hostStart;
     if (connectInfo.startsWith("//")) {
       hostStart = "//".length();
     } else if (connectInfo.startsWith("ldap://")) {
       hostStart = "ldap://".length();
+    } else if (connectInfo.startsWith("tcp://")) {
+      hostStart = "tcp://".length();
+    } else if (connectInfo.startsWith("tcps://")) {
+      hostStart = "tcps://".length();
     } else {
       hostStart = 0;
     }
 
-    parseConnectInfo(connectInfo.substring(hostStart), ctx);
+    String directConnectInfo = connectInfo.substring(hostStart);
+    if (ldapDiscovery) {
+      parseConnectInfo(directConnectInfo, ctx);
+      return;
+    }
+    String authority = applyEasyConnectGroup(directConnectInfo, ctx);
+    if (authority == null) {
+      parseConnectInfo(directConnectInfo, ctx);
+    } else {
+      parseEasyConnectList(directConnectInfo, authority, ctx);
+    }
+  }
+
+  @Nullable
+  private static String applyEasyConnectGroup(String connectInfo, ParseContext ctx) {
+    String authority = extractAuthority("oracle://" + connectInfo);
+    if (authority == null || authority.indexOf(',') < 0) {
+      return null;
+    }
+    ctx.multiTarget();
+    ServerAddressGroup group = UrlParsingUtils.parseServerAddressGroup(authority, DEFAULT_PORT);
+    ctx.serverAddressGroup(group);
+    return authority;
+  }
+
+  private static void parseEasyConnectList(String connectInfo, String authority, ParseContext ctx) {
+    String firstEndpoint = authority.substring(0, authority.indexOf(',')).trim();
+    HostPort hostPort = extractHostPort(firstEndpoint);
+    if (!hostPort.host().isEmpty()
+        && firstEndpoint.indexOf('=') < 0
+        && firstEndpoint.indexOf('@') < 0) {
+      ctx.host(hostPort.host());
+      if (hostPort.port() != null) {
+        ctx.port(hostPort.port());
+      }
+    }
+
+    int serviceStart = authority.length();
+    if (serviceStart >= connectInfo.length() || connectInfo.charAt(serviceStart) != '/') {
+      return;
+    }
+    int serviceEnd = indexOfAny(connectInfo, '?', '#');
+    serviceEnd = serviceEnd < 0 ? connectInfo.length() : serviceEnd;
+    String service = connectInfo.substring(serviceStart + 1, serviceEnd);
+    if (!service.isEmpty()) {
+      ctx.databaseName(service);
+    }
   }
 
   /**
@@ -159,7 +211,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       return;
     }
 
-    List<String> addresses = new ArrayList<>();
+    StringBuilder addresses = new StringBuilder();
     Matcher addressMatcher = ADDRESS_PATTERN.matcher(description);
     int searchFrom = 0;
     while (addressMatcher.find(searchFrom)) {
@@ -167,22 +219,15 @@ public final class OracleUrlParser implements JdbcUrlParser {
       if (end < 0) {
         return;
       }
-      addresses.add(renderAddress(description.substring(addressMatcher.start(), end + 1)));
+      if (addresses.length() > 0) {
+        addresses.append(',');
+      }
+      addresses.append(description, addressMatcher.start() + 1, end);
       searchFrom = end + 1;
     }
-    StringBuilder group = new StringBuilder("@(description=");
-    boolean addressList = ADDRESS_LIST_PATTERN.matcher(description).find();
-    if (addressList) {
-      group.append("(address_list=");
-    }
-    for (String address : addresses) {
-      group.append(address);
-    }
-    if (addressList) {
-      group.append(')');
-    }
-    group.append(')');
-    ctx.opaqueServerAddressGroup(group.toString());
+    ServerAddressGroup group =
+        UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
+    ctx.serverAddressGroup(group);
   }
 
   private static int findClosingParen(String text, int openParen) {
@@ -199,23 +244,6 @@ public final class OracleUrlParser implements JdbcUrlParser {
       }
     }
     return -1;
-  }
-
-  private static String renderAddress(String address) {
-    StringBuilder rendered = new StringBuilder("(address=");
-    appendAttribute(rendered, "protocol", PROTOCOL_PATTERN, address);
-    appendAttribute(rendered, "host", HOST_PATTERN, address);
-    appendAttribute(rendered, "port", PORT_PATTERN, address);
-    rendered.append(')');
-    return rendered.toString();
-  }
-
-  private static void appendAttribute(
-      StringBuilder rendered, String name, Pattern pattern, String address) {
-    Matcher matcher = pattern.matcher(address);
-    if (matcher.find()) {
-      rendered.append('(').append(name).append('=').append(matcher.group(1)).append(')');
-    }
   }
 
   private static void parseConnectInfo(String jdbcUrl, ParseContext ctx) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -130,8 +130,9 @@ public final class OracleUrlParser implements JdbcUrlParser {
     if (authority == null || authority.indexOf(',') < 0) {
       return null;
     }
-    ctx.multiTarget();
-    ctx.configuredServerTarget(UrlParsingUtils.parseServerTargetGroup(authority, DEFAULT_PORT));
+    ctx.disableSingleServerFallback();
+    ctx.resolveConfiguredServerTarget(
+        UrlParsingUtils.parseServerTargetGroup(authority, DEFAULT_PORT));
     return authority;
   }
 
@@ -198,7 +199,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
     if (!hasMultipleAddresses(description)) {
       return;
     }
-    ctx.multiTarget();
+    ctx.disableSingleServerFallback();
 
     // A DESCRIPTION_LIST contains independent targets, not one failover/load-balancing group.
     if (DESCRIPTION_LIST_PATTERN.matcher(description).find()) {
@@ -219,7 +220,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       addresses.append(description, addressMatcher.start() + 1, end);
       searchFrom = end + 1;
     }
-    ctx.configuredServerTarget(
+    ctx.resolveConfiguredServerTarget(
         UrlParsingUtils.parseServerTargetGroup(addresses.toString(), DEFAULT_PORT));
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.indexOfAny;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,6 +49,8 @@ public final class OracleUrlParser implements JdbcUrlParser {
   private static final Pattern DESCRIPTION_LIST_PATTERN =
       Pattern.compile("\\(\\s*description_list\\s*=");
   private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\(\\s*address\\s*=");
+  private static final Pattern SOURCE_ROUTE_PATTERN =
+      Pattern.compile("\\(\\s*source_route\\s*=\\s*(?:on|yes|true)\\s*\\)");
   private static final Pattern HOST_PATTERN =
       Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
   private static final Pattern PORT_PATTERN =
@@ -97,12 +100,18 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
 
     String connectInfo = atSplit[1];
-    boolean ldapDiscovery = connectInfo.startsWith("ldap://");
+    if (connectInfo.startsWith("ldap://")) {
+      parseLdapConnectInfo(connectInfo, "ldap", ctx);
+      return;
+    }
+    if (connectInfo.startsWith("ldaps://")) {
+      parseLdapConnectInfo(connectInfo, "ldaps", ctx);
+      return;
+    }
+
     int hostStart;
     if (connectInfo.startsWith("//")) {
       hostStart = "//".length();
-    } else if (connectInfo.startsWith("ldap://")) {
-      hostStart = "ldap://".length();
     } else if (connectInfo.startsWith("tcp://")) {
       hostStart = "tcp://".length();
     } else if (connectInfo.startsWith("tcps://")) {
@@ -112,10 +121,6 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
 
     String directConnectInfo = connectInfo.substring(hostStart);
-    if (ldapDiscovery) {
-      parseConnectInfo(directConnectInfo, ctx);
-      return;
-    }
     String authority = applyEasyConnectGroup(directConnectInfo, ctx);
     if (authority == null) {
       parseConnectInfo(directConnectInfo, ctx);
@@ -124,16 +129,78 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
   }
 
+  private static void parseLdapConnectInfo(String connectInfo, String scheme, ParseContext ctx) {
+    ctx.resolveConfiguredServerTarget(parseLdapTarget(connectInfo, scheme));
+    parseConnectInfo(connectInfo.substring(scheme.length() + "://".length()), ctx);
+  }
+
+  @Nullable
+  private static DbServerTarget parseLdapTarget(String connectInfo, String scheme) {
+    String authority = extractAuthority(connectInfo);
+    if (authority == null || authority.indexOf(',') >= 0 || authority.indexOf('@') >= 0) {
+      return null;
+    }
+
+    HostPort hostPort = extractHostPort(authority);
+    DbServerTarget discoveryEndpoint =
+        DbServerTarget.builder()
+            .setPortAlwaysInline(true)
+            .addEndpoint(hostPort.host(), hostPort.port() == null ? -1 : hostPort.port())
+            .build();
+    if (discoveryEndpoint == null) {
+      return null;
+    }
+
+    int lookupStart = scheme.length() + "://".length() + authority.length();
+    if (lookupStart >= connectInfo.length() || connectInfo.charAt(lookupStart) != '/') {
+      return null;
+    }
+    lookupStart++;
+    int lookupEnd = indexOfAny(connectInfo, '?', '#');
+    lookupEnd = lookupEnd < 0 ? connectInfo.length() : lookupEnd;
+    if (lookupStart >= lookupEnd) {
+      return null;
+    }
+    String lookup = connectInfo.substring(lookupStart, lookupEnd);
+    if (!isSafeLdapLookup(lookup)) {
+      return null;
+    }
+    return DbServerTarget.create(
+        scheme + "://" + discoveryEndpoint.getAddress() + "/" + lookup, null);
+  }
+
+  private static boolean isSafeLdapLookup(String lookup) {
+    for (int i = 0; i < lookup.length(); i++) {
+      char c = lookup.charAt(i);
+      if (c == '/'
+          || c == '\\'
+          || c == '%'
+          || c == '@'
+          || Character.isWhitespace(c)
+          || Character.isSpaceChar(c)
+          || Character.isISOControl(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   @Nullable
   private static String applyEasyConnectGroup(String connectInfo, ParseContext ctx) {
     String authority = extractAuthority("oracle://" + connectInfo);
     if (authority == null || authority.indexOf(',') < 0) {
       return null;
     }
-    ctx.disableSingleServerFallback();
     ctx.resolveConfiguredServerTarget(
-        UrlParsingUtils.parseServerTargetGroup(authority, DEFAULT_PORT));
+        isSourceRouteEnabled(connectInfo)
+            ? null
+            : UrlParsingUtils.parseServerTargetGroup(authority, DEFAULT_PORT));
     return authority;
+  }
+
+  private static boolean isSourceRouteEnabled(String connectInfo) {
+    String value = UrlParsingUtils.extractQueryParams(connectInfo, "&").get("source_route");
+    return "on".equals(value) || "yes".equals(value) || "true".equals(value);
   }
 
   private static void parseEasyConnectList(String connectInfo, String authority, ParseContext ctx) {
@@ -201,7 +268,12 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
     ctx.disableSingleServerFallback();
 
-    // A DESCRIPTION_LIST contains independent targets, not one failover/load-balancing group.
+    // SOURCE_ROUTE addresses are successive hops, not alternative database endpoints.
+    if (SOURCE_ROUTE_PATTERN.matcher(description).find()) {
+      return;
+    }
+
+    // Each DESCRIPTION may have its own CONNECT_DATA and options, which a flat list cannot retain.
     if (DESCRIPTION_LIST_PATTERN.matcher(description).find()) {
       return;
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -131,8 +131,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       return null;
     }
     ctx.multiTarget();
-    String group = UrlParsingUtils.parseServerAddressGroup(authority, DEFAULT_PORT);
-    ctx.configuredServerAddress(group);
+    ctx.configuredServerTarget(UrlParsingUtils.parseServerTargetGroup(authority, DEFAULT_PORT));
     return authority;
   }
 
@@ -220,8 +219,8 @@ public final class OracleUrlParser implements JdbcUrlParser {
       addresses.append(description, addressMatcher.start() + 1, end);
       searchFrom = end + 1;
     }
-    String group = UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
-    ctx.configuredServerAddress(group);
+    ctx.configuredServerTarget(
+        UrlParsingUtils.parseServerTargetGroup(addresses.toString(), DEFAULT_PORT));
   }
 
   private static boolean hasMultipleAddresses(String description) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -63,7 +63,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(ORACLE_DB);
     ctx.oldSemconvSystem(ORACLE);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyDataSourceProperties();
 
@@ -132,7 +132,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
     ctx.multiTarget();
     String group = UrlParsingUtils.parseServerAddressGroup(authority, DEFAULT_PORT);
-    ctx.serverAddressGroup(group);
+    ctx.configuredServerAddress(group);
     return authority;
   }
 
@@ -225,7 +225,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       searchFrom = end + 1;
     }
     String group = UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
-    ctx.serverAddressGroup(group);
+    ctx.configuredServerAddress(group);
   }
 
   private static int findClosingParen(String text, int openParen) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -196,11 +196,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
   }
 
   private static void applyAddressListGroup(String description, ParseContext ctx) {
-    Matcher targetMatcher = ADDRESS_PATTERN.matcher(description);
-    if (!targetMatcher.find()) {
-      return;
-    }
-    if (!targetMatcher.find()) {
+    if (!hasMultipleAddresses(description)) {
       return;
     }
     ctx.multiTarget();
@@ -226,6 +222,14 @@ public final class OracleUrlParser implements JdbcUrlParser {
     }
     String group = UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
     ctx.configuredServerAddress(group);
+  }
+
+  private static boolean hasMultipleAddresses(String description) {
+    Matcher addressMatcher = ADDRESS_PATTERN.matcher(description);
+    if (!addressMatcher.find()) {
+      return false;
+    }
+    return addressMatcher.find();
   }
 
   private static int findClosingParen(String text, int openParen) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/OracleUrlParser.java
@@ -11,7 +11,6 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parsePort;
 
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
-import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -132,7 +131,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       return null;
     }
     ctx.multiTarget();
-    ServerAddressGroup group = UrlParsingUtils.parseServerAddressGroup(authority, DEFAULT_PORT);
+    String group = UrlParsingUtils.parseServerAddressGroup(authority, DEFAULT_PORT);
     ctx.serverAddressGroup(group);
     return authority;
   }
@@ -225,8 +224,7 @@ public final class OracleUrlParser implements JdbcUrlParser {
       addresses.append(description, addressMatcher.start() + 1, end);
       searchFrom = end + 1;
     }
-    ServerAddressGroup group =
-        UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
+    String group = UrlParsingUtils.parseServerAddressGroup(addresses.toString(), DEFAULT_PORT);
     ctx.serverAddressGroup(group);
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -30,7 +30,6 @@ public final class ParseContext {
   @Nullable private String host;
   @Nullable private Integer port;
   @Nullable private String serverAddressGroup;
-  @Nullable private Integer serverAddressGroupPort;
   private boolean multiTarget;
   @Nullable private String user;
   @Nullable private String databaseName;
@@ -121,7 +120,6 @@ public final class ParseContext {
       return;
     }
     this.serverAddressGroup = serverAddressGroup.address();
-    this.serverAddressGroupPort = serverAddressGroup.port();
     multiTarget = true;
   }
 
@@ -357,7 +355,7 @@ public final class ParseContext {
     }
     builder.dbConnectionString(buildShortUrl(type, subtype, host, port));
     if (serverAddressGroup != null) {
-      builder.serverAddressGroup(serverAddressGroup).serverAddressGroupPort(serverAddressGroupPort);
+      builder.serverAddressGroup(serverAddressGroup);
     }
     return builder.build();
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.appendTypePrefix;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.buildShortUrl;
 
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
@@ -28,6 +29,7 @@ public final class ParseContext {
   @Nullable private String subtype;
   @Nullable private String host;
   @Nullable private Integer port;
+  @Nullable private String serverAddressGroup;
   @Nullable private String user;
   @Nullable private String databaseName;
   @Nullable private String namespace;
@@ -110,6 +112,17 @@ public final class ParseContext {
   /** Set the port value. */
   public void port(@Nullable Integer port) {
     this.port = port;
+  }
+
+  public void serverAddressGroup(@Nullable String serverAddressGroup) {
+    this.serverAddressGroup = serverAddressGroup;
+  }
+
+  public void opaqueServerAddressGroup(String target) {
+    StringBuilder groupAddress = new StringBuilder();
+    appendTypePrefix(groupAddress, type, subtype);
+    groupAddress.append(target);
+    serverAddressGroup = groupAddress.toString();
   }
 
   /** The user value accumulated so far. */
@@ -338,6 +351,9 @@ public final class ParseContext {
       builder.dbName(namespace);
     }
     builder.dbConnectionString(buildShortUrl(type, subtype, host, port));
+    if (serverAddressGroup != null) {
+      builder.serverAddressGroup(serverAddressGroup);
+    }
     return builder.build();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -30,6 +30,7 @@ public final class ParseContext {
   @Nullable private String host;
   @Nullable private Integer port;
   @Nullable private String serverAddressGroup;
+  private boolean multiTarget;
   @Nullable private String user;
   @Nullable private String databaseName;
   @Nullable private String namespace;
@@ -116,6 +117,9 @@ public final class ParseContext {
 
   public void serverAddressGroup(@Nullable String serverAddressGroup) {
     this.serverAddressGroup = serverAddressGroup;
+    if (serverAddressGroup != null) {
+      multiTarget = true;
+    }
   }
 
   public void opaqueServerAddressGroup(String target) {
@@ -123,6 +127,11 @@ public final class ParseContext {
     appendTypePrefix(groupAddress, type, subtype);
     groupAddress.append(target);
     serverAddressGroup = groupAddress.toString();
+    multiTarget = true;
+  }
+
+  public void multiTarget() {
+    multiTarget = true;
   }
 
   /** The user value accumulated so far. */
@@ -328,7 +337,8 @@ public final class ParseContext {
   public DbInfo toDbInfo() {
     // oldSemconvSystem falls back to system when not explicitly set (i.e., when both are the same)
     String oldSystem = oldSemconvSystem != null ? oldSemconvSystem : system;
-    DbInfo.Builder builder = DbInfo.builder().dbSystemName(system).dbSystem(oldSystem);
+    DbInfo.Builder builder =
+        DbInfo.builder().dbSystemName(system).dbSystem(oldSystem).multiTarget(multiTarget);
     if (host != null) {
       builder.serverAddress(host);
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.appendTypePrefix;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.buildShortUrl;
 
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
+import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.UrlParams;
 import java.util.Map;
 import java.util.Properties;
@@ -30,6 +30,7 @@ public final class ParseContext {
   @Nullable private String host;
   @Nullable private Integer port;
   @Nullable private String serverAddressGroup;
+  @Nullable private Integer serverAddressGroupPort;
   private boolean multiTarget;
   @Nullable private String user;
   @Nullable private String databaseName;
@@ -115,18 +116,12 @@ public final class ParseContext {
     this.port = port;
   }
 
-  public void serverAddressGroup(@Nullable String serverAddressGroup) {
-    this.serverAddressGroup = serverAddressGroup;
-    if (serverAddressGroup != null) {
-      multiTarget = true;
+  public void serverAddressGroup(@Nullable ServerAddressGroup serverAddressGroup) {
+    if (serverAddressGroup == null) {
+      return;
     }
-  }
-
-  public void opaqueServerAddressGroup(String target) {
-    StringBuilder groupAddress = new StringBuilder();
-    appendTypePrefix(groupAddress, type, subtype);
-    groupAddress.append(target);
-    serverAddressGroup = groupAddress.toString();
+    this.serverAddressGroup = serverAddressGroup.address();
+    this.serverAddressGroupPort = serverAddressGroup.port();
     multiTarget = true;
   }
 
@@ -362,7 +357,7 @@ public final class ParseContext {
     }
     builder.dbConnectionString(buildShortUrl(type, subtype, host, port));
     if (serverAddressGroup != null) {
-      builder.serverAddressGroup(serverAddressGroup);
+      builder.serverAddressGroup(serverAddressGroup).serverAddressGroupPort(serverAddressGroupPort);
     }
     return builder.build();
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -115,6 +115,7 @@ public final class ParseContext {
     this.port = port;
   }
 
+  /** Set a normalized configured server group when parsing succeeds. */
   public void serverAddressGroup(@Nullable ServerAddressGroup serverAddressGroup) {
     if (serverAddressGroup == null) {
       return;
@@ -123,6 +124,7 @@ public final class ParseContext {
     multiTarget = true;
   }
 
+  /** Mark the connection as having multiple configured targets. */
   public void multiTarget() {
     multiTarget = true;
   }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -28,8 +28,10 @@ public final class ParseContext {
   @Nullable private String subtype;
   @Nullable private String host;
   @Nullable private Integer port;
-  @Nullable private String serverAddressGroup;
-  private boolean multiTarget;
+  @Nullable private String configuredServerAddress;
+  @Nullable private Integer configuredServerPort;
+  private boolean multipleTargets;
+  private boolean configuredTargetResolved;
   @Nullable private String user;
   @Nullable private String databaseName;
   @Nullable private String namespace;
@@ -101,6 +103,14 @@ public final class ParseContext {
    */
   public void host(@Nullable String host) {
     this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
+    if (!configuredTargetResolved) {
+      configuredServerAddress = this.host;
+    }
+  }
+
+  /** Set a parser default host without marking it as configured. */
+  public void defaultHost(@Nullable String host) {
+    this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
   }
 
   /** The port value accumulated so far. */
@@ -112,20 +122,26 @@ public final class ParseContext {
   /** Set the port value. */
   public void port(@Nullable Integer port) {
     this.port = port;
-  }
-
-  /** Set a normalized configured server group when parsing succeeds. */
-  public void serverAddressGroup(@Nullable String serverAddressGroup) {
-    if (serverAddressGroup == null) {
-      return;
+    if (!configuredTargetResolved) {
+      configuredServerPort = port;
     }
-    this.serverAddressGroup = serverAddressGroup;
-    multiTarget = true;
   }
 
-  /** Mark the connection as having multiple configured targets. */
+  /** Set a parser default port without marking it as configured. */
+  public void defaultPort(@Nullable Integer port) {
+    this.port = port;
+  }
+
+  /** Set a normalized configured target when parsing succeeds. */
+  public void configuredServerAddress(@Nullable String configuredServerAddress) {
+    this.configuredTargetResolved = true;
+    this.configuredServerAddress = configuredServerAddress;
+    this.configuredServerPort = null;
+  }
+
+  /** Mark the connection as having multiple configured targets for parser-local validation. */
   public void multiTarget() {
-    multiTarget = true;
+    multipleTargets = true;
   }
 
   /** The user value accumulated so far. */
@@ -215,7 +231,7 @@ public final class ParseContext {
     }
     Integer port = UrlParsingUtils.parsePort(params.get("portnumber"));
     if (port != null) {
-      this.port = port;
+      port(port);
     }
     String databaseName = params.get("databasename");
     if (databaseName != null && !databaseName.isEmpty()) {
@@ -244,7 +260,7 @@ public final class ParseContext {
 
     Integer parsedPort = UrlParsingUtils.parsePort(props.getProperty("portNumber"));
     if (parsedPort != null) {
-      this.port = parsedPort;
+      port(parsedPort);
     }
 
     String databaseName = props.getProperty("databaseName");
@@ -316,7 +332,7 @@ public final class ParseContext {
     // Handle IPv6 addresses and extract host:port
     HostPort hostPort = UrlParsingUtils.extractHostPort(serverName);
     if (hostPort.port() != null) {
-      this.port = hostPort.port();
+      port(hostPort.port());
     }
     if (!hostPort.host().isEmpty()) {
       host(hostPort.host());
@@ -331,8 +347,7 @@ public final class ParseContext {
   public DbInfo toDbInfo() {
     // oldSemconvSystem falls back to system when not explicitly set (i.e., when both are the same)
     String oldSystem = oldSemconvSystem != null ? oldSemconvSystem : system;
-    DbInfo.Builder builder =
-        DbInfo.builder().dbSystemName(system).dbSystem(oldSystem).multiTarget(multiTarget);
+    DbInfo.Builder builder = DbInfo.builder().dbSystemName(system).dbSystem(oldSystem);
     if (host != null) {
       builder.serverAddress(host);
     }
@@ -354,10 +369,22 @@ public final class ParseContext {
     } else if (namespace != null) {
       builder.dbName(namespace);
     }
-    builder.dbConnectionString(buildShortUrl(type, subtype, host, port));
-    if (serverAddressGroup != null) {
-      builder.serverAddressGroup(serverAddressGroup);
+    String legacyConnectionString = buildShortUrl(type, subtype, host, port);
+    builder.dbConnectionString(legacyConnectionString);
+    String configuredAddress = configuredServerAddress;
+    Integer configuredPort = configuredServerPort;
+    if (multipleTargets && !configuredTargetResolved) {
+      configuredAddress = null;
+      configuredPort = null;
+    } else if (!multipleTargets
+        && configuredAddress != null
+        && configuredPort == null
+        && port != null) {
+      // Preserve the existing single-server default-port behavior in stable telemetry.
+      configuredPort = port;
     }
+    builder.configuredServerAddress(configuredAddress);
+    builder.configuredServerPort(configuredPort);
     return builder.build();
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.buildShortUrl;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.UrlParams;
@@ -28,8 +29,9 @@ public final class ParseContext {
   @Nullable private String subtype;
   @Nullable private String host;
   @Nullable private Integer port;
-  @Nullable private String configuredServerAddress;
-  @Nullable private Integer configuredServerPort;
+  @Nullable private String configuredHost;
+  @Nullable private Integer configuredPort;
+  @Nullable private DbServerTarget configuredServerTarget;
   private boolean multipleTargets;
   private boolean configuredTargetResolved;
   @Nullable private String user;
@@ -104,7 +106,7 @@ public final class ParseContext {
   public void host(@Nullable String host) {
     this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
     if (!configuredTargetResolved) {
-      configuredServerAddress = this.host;
+      configuredHost = this.host;
     }
   }
 
@@ -123,7 +125,7 @@ public final class ParseContext {
   public void port(@Nullable Integer port) {
     this.port = port;
     if (!configuredTargetResolved) {
-      configuredServerPort = port;
+      configuredPort = port;
     }
   }
 
@@ -132,11 +134,10 @@ public final class ParseContext {
     this.port = port;
   }
 
-  /** Set a normalized configured target when parsing succeeds. */
-  public void configuredServerAddress(@Nullable String configuredServerAddress) {
+  /** Set the resolved configured target, or {@code null} when it cannot be represented safely. */
+  public void configuredServerTarget(@Nullable DbServerTarget configuredServerTarget) {
     this.configuredTargetResolved = true;
-    this.configuredServerAddress = configuredServerAddress;
-    this.configuredServerPort = null;
+    this.configuredServerTarget = configuredServerTarget;
   }
 
   /** Mark the connection as having multiple configured targets for parser-local validation. */
@@ -349,10 +350,10 @@ public final class ParseContext {
     String oldSystem = oldSemconvSystem != null ? oldSemconvSystem : system;
     DbInfo.Builder builder = DbInfo.builder().dbSystemName(system).dbSystem(oldSystem);
     if (host != null) {
-      builder.serverAddress(host);
+      builder.legacyServerAddress(host);
     }
     if (port != null) {
-      builder.serverPort(port);
+      builder.legacyServerPort(port);
     }
     if (user != null) {
       builder.dbUser(user);
@@ -371,20 +372,19 @@ public final class ParseContext {
     }
     String legacyConnectionString = buildShortUrl(type, subtype, host, port);
     builder.dbConnectionString(legacyConnectionString);
-    String configuredAddress = configuredServerAddress;
-    Integer configuredPort = configuredServerPort;
-    if (multipleTargets && !configuredTargetResolved) {
-      configuredAddress = null;
-      configuredPort = null;
-    } else if (!multipleTargets
-        && configuredAddress != null
-        && configuredPort == null
-        && port != null) {
-      // Preserve the existing single-server default-port behavior in stable telemetry.
-      configuredPort = port;
-    }
-    builder.configuredServerAddress(configuredAddress);
-    builder.configuredServerPort(configuredPort);
+    builder.configuredServerTarget(buildConfiguredServerTarget());
     return builder.build();
+  }
+
+  @Nullable
+  private DbServerTarget buildConfiguredServerTarget() {
+    if (configuredTargetResolved) {
+      return configuredServerTarget;
+    }
+    if (multipleTargets || configuredHost == null) {
+      return null;
+    }
+    // Single-server JDBC targets include the parser's default port when none was configured.
+    return DbServerTarget.create(configuredHost, configuredPort != null ? configuredPort : port);
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -29,6 +29,7 @@ public final class ParseContext {
   @Nullable private String subtype;
   @Nullable private String legacyHost;
   @Nullable private Integer legacyPort;
+  @Nullable private Integer parserDefaultPort;
   @Nullable private String singleServerHost;
   @Nullable private Integer singleServerPort;
   @Nullable private DbServerTarget configuredServerTarget;
@@ -132,6 +133,7 @@ public final class ParseContext {
   /** Set a parser default port without marking it as configured. */
   public void defaultPort(@Nullable Integer port) {
     legacyPort = port;
+    parserDefaultPort = port;
   }
 
   /**
@@ -387,8 +389,10 @@ public final class ParseContext {
     if (singleServerHost == null) {
       return null;
     }
-    // Single-server JDBC targets include the parser's default port when none was configured.
-    return DbServerTarget.create(
-        singleServerHost, singleServerPort != null ? singleServerPort : legacyPort);
+    Integer configuredPort = singleServerPort != null ? singleServerPort : legacyPort;
+    if (parserDefaultPort != null && parserDefaultPort.equals(configuredPort)) {
+      configuredPort = null;
+    }
+    return DbServerTarget.create(singleServerHost, configuredPort);
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUt
 
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.HostPort;
-import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.ServerAddressGroup;
 import io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.UrlParams;
 import java.util.Map;
 import java.util.Properties;
@@ -116,11 +115,11 @@ public final class ParseContext {
   }
 
   /** Set a normalized configured server group when parsing succeeds. */
-  public void serverAddressGroup(@Nullable ServerAddressGroup serverAddressGroup) {
+  public void serverAddressGroup(@Nullable String serverAddressGroup) {
     if (serverAddressGroup == null) {
       return;
     }
-    this.serverAddressGroup = serverAddressGroup.address();
+    this.serverAddressGroup = serverAddressGroup;
     multiTarget = true;
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContext.java
@@ -27,13 +27,12 @@ public final class ParseContext {
   @Nullable private String system;
   @Nullable private String oldSemconvSystem;
   @Nullable private String subtype;
-  @Nullable private String host;
-  @Nullable private Integer port;
-  @Nullable private String configuredHost;
-  @Nullable private Integer configuredPort;
+  @Nullable private String legacyHost;
+  @Nullable private Integer legacyPort;
+  @Nullable private String singleServerHost;
+  @Nullable private Integer singleServerPort;
   @Nullable private DbServerTarget configuredServerTarget;
-  private boolean multipleTargets;
-  private boolean configuredTargetResolved;
+  private boolean allowSingleServerFallback = true;
   @Nullable private String user;
   @Nullable private String databaseName;
   @Nullable private String namespace;
@@ -93,56 +92,60 @@ public final class ParseContext {
     this.subtype = subtype;
   }
 
-  /** The host value accumulated so far. */
+  /** The legacy host accumulated so far, including any parser default. */
   @Nullable
   public String host() {
-    return host;
+    return legacyHost;
   }
 
   /**
-   * Set the host value. Enclosing brackets are removed from literal IPv6 addresses so that {@code
-   * server.address} always holds the address alone, regardless of which parser produced it.
+   * Record a parsed host for legacy output and, when allowed, single-server fallback. Enclosing
+   * brackets are removed from literal IPv6 addresses so that {@code server.address} holds the
+   * address alone.
    */
   public void host(@Nullable String host) {
-    this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
-    if (!configuredTargetResolved) {
-      configuredHost = this.host;
+    legacyHost = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
+    if (allowSingleServerFallback) {
+      singleServerHost = legacyHost;
     }
   }
 
   /** Set a parser default host without marking it as configured. */
   public void defaultHost(@Nullable String host) {
-    this.host = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
+    legacyHost = host == null ? null : UrlParsingUtils.stripIpv6Brackets(host);
   }
 
-  /** The port value accumulated so far. */
+  /** The legacy port accumulated so far, including any parser default. */
   @Nullable
   public Integer port() {
-    return port;
+    return legacyPort;
   }
 
-  /** Set the port value. */
+  /** Record a parsed port for legacy output and, when allowed, single-server fallback. */
   public void port(@Nullable Integer port) {
-    this.port = port;
-    if (!configuredTargetResolved) {
-      configuredPort = port;
+    legacyPort = port;
+    if (allowSingleServerFallback) {
+      singleServerPort = port;
     }
   }
 
   /** Set a parser default port without marking it as configured. */
   public void defaultPort(@Nullable Integer port) {
-    this.port = port;
+    legacyPort = port;
   }
 
-  /** Set the resolved configured target, or {@code null} when it cannot be represented safely. */
-  public void configuredServerTarget(@Nullable DbServerTarget configuredServerTarget) {
-    this.configuredTargetResolved = true;
+  /**
+   * Resolve the configured target, or {@code null} when it cannot be represented safely. Disables
+   * single-server fallback in either case.
+   */
+  public void resolveConfiguredServerTarget(@Nullable DbServerTarget configuredServerTarget) {
+    allowSingleServerFallback = false;
     this.configuredServerTarget = configuredServerTarget;
   }
 
-  /** Mark the connection as having multiple configured targets for parser-local validation. */
-  public void multiTarget() {
-    multipleTargets = true;
+  /** Prevent single-server fallback without discarding an already resolved target. */
+  public void disableSingleServerFallback() {
+    allowSingleServerFallback = false;
   }
 
   /** The user value accumulated so far. */
@@ -349,11 +352,11 @@ public final class ParseContext {
     // oldSemconvSystem falls back to system when not explicitly set (i.e., when both are the same)
     String oldSystem = oldSemconvSystem != null ? oldSemconvSystem : system;
     DbInfo.Builder builder = DbInfo.builder().dbSystemName(system).dbSystem(oldSystem);
-    if (host != null) {
-      builder.legacyServerAddress(host);
+    if (legacyHost != null) {
+      builder.legacyServerAddress(legacyHost);
     }
-    if (port != null) {
-      builder.legacyServerPort(port);
+    if (legacyPort != null) {
+      builder.legacyServerPort(legacyPort);
     }
     if (user != null) {
       builder.dbUser(user);
@@ -370,7 +373,7 @@ public final class ParseContext {
     } else if (namespace != null) {
       builder.dbName(namespace);
     }
-    String legacyConnectionString = buildShortUrl(type, subtype, host, port);
+    String legacyConnectionString = buildShortUrl(type, subtype, legacyHost, legacyPort);
     builder.dbConnectionString(legacyConnectionString);
     builder.configuredServerTarget(buildConfiguredServerTarget());
     return builder.build();
@@ -378,13 +381,14 @@ public final class ParseContext {
 
   @Nullable
   private DbServerTarget buildConfiguredServerTarget() {
-    if (configuredTargetResolved) {
+    if (!allowSingleServerFallback) {
       return configuredServerTarget;
     }
-    if (multipleTargets || configuredHost == null) {
+    if (singleServerHost == null) {
       return null;
     }
     // Single-server JDBC targets include the parser's default port when none was configured.
-    return DbServerTarget.create(configuredHost, configuredPort != null ? configuredPort : port);
+    return DbServerTarget.create(
+        singleServerHost, singleServerPort != null ? singleServerPort : legacyPort);
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PolardbUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PolardbUrlParser.java
@@ -29,6 +29,6 @@ public final class PolardbUrlParser implements JdbcUrlParser {
 
     ctx.applyUserProperty();
 
-    GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx);
+    GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx, DEFAULT_PORT);
   }
 }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PolardbUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PolardbUrlParser.java
@@ -25,7 +25,7 @@ public final class PolardbUrlParser implements JdbcUrlParser {
   @Override
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(SYSTEM);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyUserProperty();
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PostgresqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PostgresqlUrlParser.java
@@ -50,7 +50,7 @@ public final class PostgresqlUrlParser implements JdbcUrlParser {
     ctx.applyUserProperty();
 
     // Delegate to generic parser for standard URL parsing
-    GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx);
+    GenericUrlParser.INSTANCE.parse(jdbcUrl, ctx, DEFAULT_PORT);
 
     String schema = extractCurrentSchema(jdbcUrl);
     if (schema == null) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PostgresqlUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/PostgresqlUrlParser.java
@@ -44,8 +44,8 @@ public final class PostgresqlUrlParser implements JdbcUrlParser {
   @Override
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(POSTGRESQL);
-    ctx.host(DEFAULT_HOST);
-    ctx.port(DEFAULT_PORT);
+    ctx.defaultHost(DEFAULT_HOST);
+    ctx.defaultPort(DEFAULT_PORT);
 
     ctx.applyUserProperty();
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/SapUrlParser.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/SapUrlParser.java
@@ -36,7 +36,7 @@ public final class SapUrlParser implements JdbcUrlParser {
   public void parse(String jdbcUrl, ParseContext ctx) {
     ctx.system(SAP_HANA);
     ctx.oldSemconvSystem(HANADB);
-    ctx.host(DEFAULT_HOST);
+    ctx.defaultHost(DEFAULT_HOST);
 
     // SAP HANA driver doesn't support serverName/portNumber/databaseName DataSource properties
     ctx.applyUserProperty();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -228,7 +228,7 @@ public final class UrlParsingUtils {
     return indexOfAny(str, 0, chars);
   }
 
-  public static int indexOfAny(String str, int fromIndex, char... chars) {
+  private static int indexOfAny(String str, int fromIndex, char... chars) {
     for (int i = Math.max(fromIndex, 0); i < str.length(); i++) {
       char c = str.charAt(i);
       for (char match : chars) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -323,7 +323,9 @@ public final class UrlParsingUtils {
   }
 
   private static boolean isEndpointAuthority(String authority) {
-    return hasValidHostPorts(authority) || sanitizeHostList(authority) != null;
+    return hasValidHostPorts(authority)
+        || isSingleEndpointAuthority(authority)
+        || sanitizeHostList(authority) != null;
   }
 
   private static boolean isSingleEndpointAuthority(String authority) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -294,11 +294,17 @@ public final class UrlParsingUtils {
     if (!hasValidHostPorts(authority)) {
       return null;
     }
+    String suffix = url.substring(credentialsEnd + 1, parameterEnd);
+    int suffixAuthorityEnd = indexOfAny(suffix, '/', '?', '#');
+    String suffixAuthority =
+        suffixAuthorityEnd < 0 ? suffix : suffix.substring(0, suffixAuthorityEnd);
+    if (hasValidHostPorts(suffixAuthority)) {
+      return null;
+    }
     if (authority.indexOf(',') >= 0) {
       return authority;
     }
 
-    String suffix = url.substring(credentialsEnd + 1, parameterEnd);
     return suffix.indexOf('/') < 0 && suffix.indexOf(',') < 0 ? authority : null;
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -326,6 +326,11 @@ public final class UrlParsingUtils {
     return hasValidHostPorts(authority) || sanitizeHostList(authority) != null;
   }
 
+  private static boolean isSingleEndpointAuthority(String authority) {
+    List<String> endpoints = splitHostList(stripUserInfo(authority));
+    return endpoints.size() == 1 && sanitizeHostEntry(endpoints.get(0)) != null;
+  }
+
   private static boolean isAtInQueryParameter(String url, int authorityEnd, int at) {
     int queryStart = url.indexOf('?', authorityEnd);
     if (queryStart < 0 || queryStart > at) {
@@ -340,7 +345,10 @@ public final class UrlParsingUtils {
     if (equals < parameterStart || equals > at) {
       return false;
     }
-    if (queryStart > authorityEnd) {
+    int protocol = url.indexOf("://");
+    int authorityStart = protocol < 0 ? 0 : protocol + 3;
+    if (queryStart > authorityEnd
+        || isSingleEndpointAuthority(url.substring(authorityStart, authorityEnd))) {
       return true;
     }
     int parameterEnd = indexOfAny(url, at + 1, '&', '#');

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -8,6 +8,8 @@ package io.opentelemetry.instrumentation.jdbc.internal.parser;
 import static java.util.Collections.emptyMap;
 import static java.util.logging.Level.FINE;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -509,10 +511,33 @@ public final class UrlParsingUtils {
 
     List<String> entries = splitHostList(sanitized);
     List<HostPort> endpoints = new ArrayList<>();
-    boolean hasNonDefaultPort = false;
-    boolean hasUnknownPort = false;
+    boolean hasSpecialTarget = defaultPort == null;
     for (String entry : entries) {
       HostPort endpoint = extractSanitizedHostPort(entry);
+      endpoints.add(endpoint);
+      if (endpoint.host().startsWith("/") || endpoint.host().indexOf('\\') >= 0) {
+        hasSpecialTarget = true;
+      }
+    }
+    if (!hasSpecialTarget) {
+      DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort).setSorted(false);
+      for (HostPort endpoint : endpoints) {
+        builder.addEndpoint(endpoint.host(), endpoint.port() == null ? -1 : endpoint.port());
+      }
+      DbServerTarget target = builder.build();
+      return target == null ? null : new ServerAddressGroup(target.getAddress());
+    }
+
+    return renderSpecialServerAddressGroup(entries, endpoints, defaultPort);
+  }
+
+  @Nullable
+  private static ServerAddressGroup renderSpecialServerAddressGroup(
+      List<String> entries, List<HostPort> endpoints, @Nullable Integer defaultPort) {
+    boolean hasNonDefaultPort = false;
+    boolean hasUnknownPort = false;
+    for (int i = 0; i < endpoints.size(); i++) {
+      HostPort endpoint = endpoints.get(i);
       if (endpoint.host().startsWith("/")) {
         return new ServerAddressGroup(joinFirstEndpoints(entries));
       }
@@ -524,7 +549,7 @@ public final class UrlParsingUtils {
           effectivePort = defaultPort;
         }
       }
-      endpoints.add(new HostPort(endpoint.host(), effectivePort, endpoint.ipv6Address()));
+      endpoints.set(i, new HostPort(endpoint.host(), effectivePort, endpoint.ipv6Address()));
       if (defaultPort != null && effectivePort != null && !defaultPort.equals(effectivePort)) {
         hasNonDefaultPort = true;
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -520,7 +520,7 @@ public final class UrlParsingUtils {
       }
     }
     if (!hasSpecialTarget) {
-      DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort).setSorted(false);
+      DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort);
       for (HostPort endpoint : endpoints) {
         builder.addEndpoint(endpoint.host(), endpoint.port() == null ? -1 : endpoint.port());
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -528,6 +528,17 @@ public final class UrlParsingUtils {
       return target == null ? null : new ServerAddressGroup(target.getAddress());
     }
 
+    for (HostPort endpoint : endpoints) {
+      String host = endpoint.host();
+      if (host.startsWith("/")) {
+        continue;
+      }
+      int instanceStart = host.indexOf('\\');
+      String networkHost = instanceStart < 0 ? host : host.substring(0, instanceStart);
+      if (!DbServerTargetBuilder.isValidHost(networkHost)) {
+        return null;
+      }
+    }
     return renderSpecialServerAddressGroup(entries, endpoints, defaultPort);
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -291,14 +291,14 @@ public final class UrlParsingUtils {
     }
 
     String authority = url.substring(authorityStart, authorityEnd);
-    if (!hasValidHostPorts(authority)) {
+    if (!isEndpointAuthority(authority)) {
       return null;
     }
     String suffix = url.substring(credentialsEnd + 1, parameterEnd);
     int suffixAuthorityEnd = indexOfAny(suffix, '/', '?', '#');
     String suffixAuthority =
         suffixAuthorityEnd < 0 ? suffix : suffix.substring(0, suffixAuthorityEnd);
-    if (hasValidHostPorts(suffixAuthority)) {
+    if (isEndpointAuthority(suffixAuthority)) {
       return null;
     }
     if (authority.indexOf(',') >= 0) {
@@ -306,6 +306,10 @@ public final class UrlParsingUtils {
     }
 
     return suffix.indexOf('/') < 0 && suffix.indexOf(',') < 0 ? authority : null;
+  }
+
+  private static boolean isEndpointAuthority(String authority) {
+    return hasValidHostPorts(authority) || sanitizeHostList(authority) != null;
   }
 
   private static boolean isAtInQueryParameter(String url, int authorityEnd, int at) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 public final class UrlParsingUtils {
 
   private static final Logger logger = Logger.getLogger(UrlParsingUtils.class.getName());
+  private static final int MAX_SERVER_ADDRESS_ENDPOINTS = 5;
 
   // Source: Regular Expressions Cookbook 2nd edition - 8.17.
   // Matches Standard, Mixed or Compressed notation in a wider body of text
@@ -370,9 +371,22 @@ public final class UrlParsingUtils {
     if (lastAt < authorityStart || lastAt < authorityEnd) {
       return false;
     }
+    if (isAtInQueryParameter(jdbcUrl, authorityEnd, lastAt)
+        || isAtInSemicolonParameter(jdbcUrl, authorityEnd, lastAt)) {
+      return false;
+    }
     int targetEnd = indexOfAny(jdbcUrl, lastAt + 1, '/', '?', '#', '&', ';');
     targetEnd = targetEnd < 0 ? jdbcUrl.length() : targetEnd;
     return splitHostList(jdbcUrl.substring(lastAt + 1, targetEnd)).size() > 1;
+  }
+
+  private static boolean isAtInSemicolonParameter(String url, int authorityEnd, int at) {
+    int parameterStart = Math.max(url.lastIndexOf(';', at), url.lastIndexOf('&', at));
+    if (parameterStart < authorityEnd) {
+      return false;
+    }
+    int equals = url.indexOf('=', parameterStart + 1);
+    return equals > parameterStart && equals < at;
   }
 
   // IPv6 brackets and address=(...) blocks may contain commas.
@@ -470,36 +484,49 @@ public final class UrlParsingUtils {
   public static ServerAddressGroup parseServerAddressGroup(
       String authority, @Nullable Integer defaultPort) {
     String sanitized = sanitizeHostList(authority);
-    if (sanitized == null || defaultPort == null) {
-      return sanitized == null ? null : new ServerAddressGroup(sanitized, null);
+    if (sanitized == null) {
+      return null;
     }
 
+    List<String> entries = splitHostList(sanitized);
     List<HostPort> endpoints = new ArrayList<>();
-    Integer commonPort = null;
-    boolean samePort = true;
-    for (String entry : splitHostList(sanitized)) {
+    boolean hasNonDefaultPort = false;
+    for (String entry : entries) {
       HostPort endpoint = extractSanitizedHostPort(entry);
-      if (endpoint.host().indexOf('\\') >= 0 || endpoint.host().startsWith("/")) {
-        return new ServerAddressGroup(sanitized, null);
+      if (endpoint.host().startsWith("/")) {
+        return new ServerAddressGroup(joinFirstEndpoints(entries));
       }
-      Integer effectivePort = endpoint.port() != null ? endpoint.port() : defaultPort;
+      Integer effectivePort =
+          endpoint.port() != null || defaultPort == null ? endpoint.port() : defaultPort;
       endpoints.add(new HostPort(endpoint.host(), effectivePort, endpoint.ipv6Address()));
-      if (commonPort == null) {
-        commonPort = effectivePort;
-      } else if (!commonPort.equals(effectivePort)) {
-        samePort = false;
+      if (defaultPort != null && !defaultPort.equals(effectivePort)) {
+        hasNonDefaultPort = true;
       }
     }
 
     StringBuilder address = new StringBuilder();
-    for (HostPort endpoint : endpoints) {
+    for (int i = 0; i < endpoints.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+      HostPort endpoint = endpoints.get(i);
       if (address.length() > 0) {
         address.append(',');
       }
-      appendHostPort(address, endpoint.host(), samePort ? null : endpoint.port());
+      appendHostPort(
+          address,
+          endpoint.host(),
+          defaultPort == null || hasNonDefaultPort ? endpoint.port() : null);
     }
-    Integer port = samePort && !defaultPort.equals(commonPort) ? commonPort : null;
-    return new ServerAddressGroup(address.toString(), port);
+    return new ServerAddressGroup(address.toString());
+  }
+
+  private static String joinFirstEndpoints(List<String> entries) {
+    StringBuilder address = new StringBuilder();
+    for (int i = 0; i < entries.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+      if (address.length() > 0) {
+        address.append(',');
+      }
+      address.append(entries.get(i));
+    }
+    return address.toString();
   }
 
   private static HostPort extractSanitizedHostPort(String entry) {
@@ -522,20 +549,13 @@ public final class UrlParsingUtils {
    */
   public static final class ServerAddressGroup {
     private final String address;
-    @Nullable private final Integer port;
 
-    private ServerAddressGroup(String address, @Nullable Integer port) {
+    private ServerAddressGroup(String address) {
       this.address = address;
-      this.port = port;
     }
 
     public String address() {
       return address;
-    }
-
-    @Nullable
-    public Integer port() {
-      return port;
     }
   }
 

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -491,17 +491,27 @@ public final class UrlParsingUtils {
     List<String> entries = splitHostList(sanitized);
     List<HostPort> endpoints = new ArrayList<>();
     boolean hasNonDefaultPort = false;
+    boolean hasUnknownPort = false;
     for (String entry : entries) {
       HostPort endpoint = extractSanitizedHostPort(entry);
       if (endpoint.host().startsWith("/")) {
         return new ServerAddressGroup(joinFirstEndpoints(entries));
       }
-      Integer effectivePort =
-          endpoint.port() != null || defaultPort == null ? endpoint.port() : defaultPort;
+      Integer effectivePort = endpoint.port();
+      if (effectivePort == null && defaultPort != null) {
+        if (endpoint.host().indexOf('\\') >= 0) {
+          hasUnknownPort = true;
+        } else {
+          effectivePort = defaultPort;
+        }
+      }
       endpoints.add(new HostPort(endpoint.host(), effectivePort, endpoint.ipv6Address()));
-      if (defaultPort != null && !defaultPort.equals(effectivePort)) {
+      if (defaultPort != null && effectivePort != null && !defaultPort.equals(effectivePort)) {
         hasNonDefaultPort = true;
       }
+    }
+    if (hasNonDefaultPort && hasUnknownPort) {
+      return null;
     }
 
     StringBuilder address = new StringBuilder();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -387,7 +387,7 @@ public final class UrlParsingUtils {
     }
 
     int lastAt = jdbcUrl.lastIndexOf('@');
-    if (lastAt < authorityStart || lastAt < authorityEnd) {
+    if (lastAt < authorityEnd) {
       return false;
     }
     if (isAtInQueryParameter(jdbcUrl, authorityEnd, lastAt)

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -440,7 +440,7 @@ public final class UrlParsingUtils {
       return null;
     }
     String addressHost = hostMatcher.group(1).trim();
-    if (addressHost.isEmpty()) {
+    if (!isValidHostPort(addressHost)) {
       return null;
     }
     StringBuilder sanitized = new StringBuilder("address=(host=");
@@ -474,7 +474,7 @@ public final class UrlParsingUtils {
     int colon = value.lastIndexOf(':');
     return colon < 0
         || value.indexOf(':') != colon
-        || parsePort(value.substring(colon + 1)) != null;
+        || (colon > 0 && parsePort(value.substring(colon + 1)) != null);
   }
 
   @Nullable

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -275,6 +275,7 @@ public final class UrlParsingUtils {
       return null;
     }
     int queryStart = url.indexOf('?', authorityEnd);
+    int fragmentStart = url.indexOf('#', authorityEnd);
     int credentialsEnd = url.lastIndexOf('@');
     int parameterStart =
         queryStart < 0 ? -1 : Math.max(queryStart, url.lastIndexOf('&', credentialsEnd)) + 1;
@@ -284,6 +285,7 @@ public final class UrlParsingUtils {
     }
     int equals = parameterStart < 0 ? -1 : url.indexOf('=', parameterStart);
     if (queryStart < 0
+        || (fragmentStart >= 0 && fragmentStart < queryStart)
         || credentialsEnd < queryStart
         || equals < parameterStart
         || equals > credentialsEnd) {
@@ -317,7 +319,7 @@ public final class UrlParsingUtils {
     if (queryStart < 0 || queryStart > at) {
       return false;
     }
-    int fragmentStart = url.indexOf('#', queryStart);
+    int fragmentStart = url.indexOf('#', authorityEnd);
     if (fragmentStart >= 0 && fragmentStart < at) {
       return false;
     }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -163,6 +163,15 @@ public final class UrlParsingUtils {
     }
   }
 
+  private static void appendServerAddress(
+      StringBuilder builder, String host, @Nullable Integer port) {
+    if (port == null) {
+      builder.append(host);
+      return;
+    }
+    appendHostPort(builder, host, port);
+  }
+
   /**
    * Extract parameters from a JDBC URL.
    *
@@ -520,7 +529,7 @@ public final class UrlParsingUtils {
       if (address.length() > 0) {
         address.append(',');
       }
-      appendHostPort(
+      appendServerAddress(
           address,
           endpoint.host(),
           defaultPort == null || hasNonDefaultPort ? endpoint.port() : null);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -10,7 +10,9 @@ import static java.util.logging.Level.FINE;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -54,6 +56,11 @@ public final class UrlParsingUtils {
               // Compressed with 8 colons
               + "|(?:[A-F0-9]{1,4}:){7}:|:(:[A-F0-9]{1,4}){7})(?![:.\\w])",
           Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern ADDRESS_HOST_PATTERN =
+      Pattern.compile("\\(\\s*host\\s*=\\s*([^)]*?)\\s*\\)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern ADDRESS_PORT_PATTERN =
+      Pattern.compile("\\(\\s*port\\s*=\\s*([\\d]+)\\s*\\)", Pattern.CASE_INSENSITIVE);
 
   private UrlParsingUtils() {}
 
@@ -119,27 +126,38 @@ public final class UrlParsingUtils {
    */
   public static String buildShortUrl(
       String type, @Nullable String subtype, @Nullable String host, @Nullable Integer port) {
-    StringBuilder url = new StringBuilder(type);
-    url.append(':');
-    if (subtype != null) {
-      url.append(subtype);
-      url.append(':');
-    }
+    StringBuilder url = new StringBuilder();
+    appendTypePrefix(url, type, subtype);
     if (host != null) {
       url.append("//");
-      if (host.contains(":") && !host.startsWith("[")) {
-        url.append('[');
-        url.append(host);
-        url.append(']');
-      } else {
-        url.append(host);
-      }
-      if (port != null) {
-        url.append(':');
-        url.append(port);
-      }
+      appendHostPort(url, host, port);
     }
     return url.toString();
+  }
+
+  public static void appendTypePrefix(
+      StringBuilder builder, String type, @Nullable String subtype) {
+    builder.append(type);
+    builder.append(':');
+    if (subtype != null) {
+      builder.append(subtype);
+      builder.append(':');
+    }
+  }
+
+  public static void appendHostPort(StringBuilder builder, String host, @Nullable Integer port) {
+    // Brackets keep an IPv6 literal unambiguous when a port follows.
+    if (host.contains(":") && !host.startsWith("[")) {
+      builder.append('[');
+      builder.append(host);
+      builder.append(']');
+    } else {
+      builder.append(host);
+    }
+    if (port != null) {
+      builder.append(':');
+      builder.append(port);
+    }
   }
 
   /**
@@ -207,14 +225,208 @@ public final class UrlParsingUtils {
    * @return the index of the first occurrence, or -1 if none found
    */
   public static int indexOfAny(String str, char... chars) {
-    int minIndex = -1;
-    for (char c : chars) {
-      int idx = str.indexOf(c);
-      if (idx >= 0 && (minIndex < 0 || idx < minIndex)) {
-        minIndex = idx;
+    return indexOfAny(str, 0, chars);
+  }
+
+  public static int indexOfAny(String str, int fromIndex, char... chars) {
+    for (int i = Math.max(fromIndex, 0); i < str.length(); i++) {
+      char c = str.charAt(i);
+      for (char match : chars) {
+        if (c == match) {
+          return i;
+        }
       }
     }
-    return minIndex;
+    return -1;
+  }
+
+  @Nullable
+  public static String extractAuthority(String url) {
+    int protoLoc = url.indexOf("://");
+    if (protoLoc < 0) {
+      return null;
+    }
+    int start = protoLoc + 3;
+    int end = indexOfAny(url, start, '/', '?', '#');
+    int lastAt = url.lastIndexOf('@');
+    if (lastAt >= start && end >= 0 && lastAt > end) {
+      int possibleAuthorityEnd = indexOfAny(url, lastAt + 1, '/', '?', '#');
+      possibleAuthorityEnd = possibleAuthorityEnd < 0 ? url.length() : possibleAuthorityEnd;
+      int commaAfterAt = url.indexOf(',', lastAt + 1);
+      int commaBeforeEnd = url.indexOf(',', start);
+      boolean atInQueryParameter = isAtInQueryParameter(url, end, lastAt);
+      if (!atInQueryParameter
+          && ((commaAfterAt >= 0 && commaAfterAt < possibleAuthorityEnd)
+              || (commaBeforeEnd >= 0 && commaBeforeEnd < end))) {
+        // Comma-separated text around an early delimiter may be part of a malformed password.
+        // Dropping the group is safer than reporting credential text as a host.
+        return null;
+      }
+    }
+    return end < 0 ? url.substring(start) : url.substring(start, end);
+  }
+
+  @Nullable
+  public static String extractAuthorityWithQueryAt(String url) {
+    int authorityStart = url.indexOf("://");
+    authorityStart = authorityStart < 0 ? 0 : authorityStart + 3;
+    int authorityEnd = indexOfAny(url, authorityStart, '/', '?', '#');
+    if (authorityEnd < 0) {
+      return null;
+    }
+    int queryStart = url.indexOf('?', authorityEnd);
+    int credentialsEnd = url.lastIndexOf('@');
+    int parameterStart =
+        queryStart < 0 ? -1 : Math.max(queryStart, url.lastIndexOf('&', credentialsEnd)) + 1;
+    int parameterEnd = url.indexOf('&', credentialsEnd);
+    if (parameterEnd < 0) {
+      parameterEnd = url.length();
+    }
+    int equals = parameterStart < 0 ? -1 : url.indexOf('=', parameterStart);
+    if (queryStart < 0
+        || credentialsEnd < queryStart
+        || equals < parameterStart
+        || equals > credentialsEnd) {
+      return null;
+    }
+
+    String authority = url.substring(authorityStart, authorityEnd);
+    if (!hasValidHostPorts(authority)) {
+      return null;
+    }
+    if (authority.indexOf(',') >= 0) {
+      return authority;
+    }
+
+    String suffix = url.substring(credentialsEnd + 1, parameterEnd);
+    return suffix.indexOf('/') < 0 && suffix.indexOf(',') < 0 ? authority : null;
+  }
+
+  private static boolean isAtInQueryParameter(String url, int authorityEnd, int at) {
+    int queryStart = url.indexOf('?', authorityEnd);
+    if (queryStart < 0 || queryStart > at) {
+      return false;
+    }
+    int fragmentStart = url.indexOf('#', queryStart);
+    if (fragmentStart >= 0 && fragmentStart < at) {
+      return false;
+    }
+    int parameterStart = Math.max(queryStart, url.lastIndexOf('&', at)) + 1;
+    int equals = url.indexOf('=', parameterStart);
+    if (equals < parameterStart || equals > at) {
+      return false;
+    }
+    if (queryStart > authorityEnd) {
+      return true;
+    }
+    int parameterEnd = indexOfAny(url, at + 1, '&', '#');
+    parameterEnd = parameterEnd < 0 ? url.length() : parameterEnd;
+    String suffix = url.substring(at + 1, parameterEnd);
+    return suffix.indexOf('/') < 0 && suffix.indexOf(',') < 0;
+  }
+
+  private static String stripUserInfo(String authority) {
+    // address=(...) credentials use key/value syntax, where '@' belongs to the value.
+    if (!isUrlShapedAuthority(authority)) {
+      return authority;
+    }
+    int at = authority.lastIndexOf('@');
+    return at < 0 ? authority : authority.substring(at + 1);
+  }
+
+  private static boolean isUrlShapedAuthority(String authority) {
+    return authority.indexOf('(') < 0;
+  }
+
+  // IPv6 brackets and address=(...) blocks may contain commas.
+  private static List<String> splitHostList(String hostList) {
+    List<String> entries = new ArrayList<>();
+    int depth = 0;
+    int start = 0;
+    for (int i = 0; i < hostList.length(); i++) {
+      char c = hostList.charAt(i);
+      if (c == '[' || c == '(') {
+        depth++;
+      } else if (c == ']' || c == ')') {
+        depth--;
+      } else if (c == ',' && depth <= 0) {
+        entries.add(hostList.substring(start, i));
+        start = i + 1;
+      }
+    }
+    entries.add(hostList.substring(start));
+    return entries;
+  }
+
+  @Nullable
+  private static String sanitizeHostEntry(String entry) {
+    String host = entry.trim();
+    if (!host.regionMatches(true, 0, "address=", 0, "address=".length())) {
+      return host.indexOf('=') < 0 && isValidHostPort(host) ? host : null;
+    }
+
+    Matcher hostMatcher = ADDRESS_HOST_PATTERN.matcher(host);
+    if (!hostMatcher.find()) {
+      return null;
+    }
+    String addressHost = hostMatcher.group(1).trim();
+    if (addressHost.isEmpty()) {
+      return null;
+    }
+    StringBuilder sanitized = new StringBuilder("address=(host=");
+    sanitized.append(addressHost).append(')');
+
+    Matcher portMatcher = ADDRESS_PORT_PATTERN.matcher(host);
+    if (portMatcher.find()) {
+      sanitized.append("(port=").append(portMatcher.group(1)).append(')');
+    }
+    return sanitized.toString();
+  }
+
+  private static boolean hasValidHostPorts(String authority) {
+    for (String endpoint : authority.split(",")) {
+      if (!isValidHostPort(endpoint.trim())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isValidHostPort(String value) {
+    if (value.isEmpty() || value.indexOf('=') >= 0) {
+      return false;
+    }
+    int closingBracket = value.startsWith("[") ? value.indexOf(']') : -1;
+    if (closingBracket >= 0) {
+      String rest = value.substring(closingBracket + 1);
+      return rest.isEmpty() || (rest.startsWith(":") && parsePort(rest.substring(1)) != null);
+    }
+    int colon = value.lastIndexOf(':');
+    return colon < 0
+        || value.indexOf(':') != colon
+        || parsePort(value.substring(colon + 1)) != null;
+  }
+
+  @Nullable
+  public static String sanitizeHostList(String authority) {
+    String hostList = stripUserInfo(authority);
+    List<String> entries = splitHostList(hostList);
+    if (entries.size() < 2) {
+      return null;
+    }
+    StringBuilder group = new StringBuilder();
+    for (String entry : entries) {
+      String host = sanitizeHostEntry(entry);
+      if (host == null || host.indexOf('@') >= 0) {
+        // Do not risk reporting unrecognized credential text as a host.
+        return null;
+      }
+      if (group.length() > 0) {
+        group.append(',');
+      }
+      group.append(host);
+    }
+    return group.toString();
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -150,6 +150,7 @@ public final class UrlParsingUtils {
     }
   }
 
+  /** Append a host and optional port, adding brackets around an unbracketed IPv6 address. */
   public static void appendHostPort(StringBuilder builder, String host, @Nullable Integer port) {
     // Brackets keep an IPv6 literal unambiguous when a port follows.
     if (host.contains(":") && !host.startsWith("[")) {
@@ -254,6 +255,7 @@ public final class UrlParsingUtils {
     return -1;
   }
 
+  /** Extract the authority from a JDBC URL without reporting ambiguous credential text. */
   @Nullable
   public static String extractAuthority(String url) {
     int protoLoc = url.indexOf("://");
@@ -280,6 +282,7 @@ public final class UrlParsingUtils {
     return end < 0 ? url.substring(start) : url.substring(start, end);
   }
 
+  /** Extract an authority when an at sign in a later query parameter obscures its boundary. */
   @Nullable
   public static String extractAuthorityWithQueryAt(String url) {
     int authorityStart = url.indexOf("://");
@@ -374,6 +377,7 @@ public final class UrlParsingUtils {
     return authority.indexOf('(') < 0;
   }
 
+  /** Returns whether a JDBC URL contains more than one configured target. */
   public static boolean hasMultipleTargets(String jdbcUrl) {
     int protocol = jdbcUrl.indexOf("://");
     if (protocol < 0) {
@@ -479,6 +483,7 @@ public final class UrlParsingUtils {
         || (colon > 0 && parsePort(value.substring(colon + 1)) != null);
   }
 
+  /** Sanitize a comma-separated host list, returning {@code null} when it is not valid. */
   @Nullable
   public static String sanitizeHostList(String authority) {
     String hostList = stripUserInfo(authority);
@@ -501,6 +506,7 @@ public final class UrlParsingUtils {
     return group.toString();
   }
 
+  /** Parse and normalize a comma-separated configured server group. */
   @Nullable
   public static ServerAddressGroup parseServerAddressGroup(
       String authority, @Nullable Integer defaultPort) {

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -531,6 +531,9 @@ public final class UrlParsingUtils {
     for (HostPort endpoint : endpoints) {
       String host = endpoint.host();
       if (host.startsWith("/")) {
+        if (DbServerTarget.unixSocket(host) == null) {
+          return null;
+        }
         continue;
       }
       int instanceStart = host.indexOf('\\');

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -138,7 +138,7 @@ public final class UrlParsingUtils {
     return url.toString();
   }
 
-  public static void appendTypePrefix(
+  private static void appendTypePrefix(
       StringBuilder builder, String type, @Nullable String subtype) {
     builder.append(type);
     builder.append(':');

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -61,6 +61,8 @@ public final class UrlParsingUtils {
       Pattern.compile("\\(\\s*host\\s*=\\s*([^)]*?)\\s*\\)", Pattern.CASE_INSENSITIVE);
   private static final Pattern ADDRESS_PORT_PATTERN =
       Pattern.compile("\\(\\s*port\\s*=\\s*([\\d]+)\\s*\\)", Pattern.CASE_INSENSITIVE);
+  private static final Pattern ADDRESS_ENTRY_PATTERN =
+      Pattern.compile("^address\\s*=", Pattern.CASE_INSENSITIVE);
 
   private UrlParsingUtils() {}
 
@@ -396,7 +398,7 @@ public final class UrlParsingUtils {
   @Nullable
   private static String sanitizeHostEntry(String entry) {
     String host = entry.trim();
-    if (!host.regionMatches(true, 0, "address=", 0, "address=".length())) {
+    if (!ADDRESS_ENTRY_PATTERN.matcher(host).find()) {
       return host.indexOf('=') < 0 && isValidHostPort(host) ? host : null;
     }
 
@@ -462,6 +464,79 @@ public final class UrlParsingUtils {
       group.append(host);
     }
     return group.toString();
+  }
+
+  @Nullable
+  public static ServerAddressGroup parseServerAddressGroup(
+      String authority, @Nullable Integer defaultPort) {
+    String sanitized = sanitizeHostList(authority);
+    if (sanitized == null || defaultPort == null) {
+      return sanitized == null ? null : new ServerAddressGroup(sanitized, null);
+    }
+
+    List<HostPort> endpoints = new ArrayList<>();
+    Integer commonPort = null;
+    boolean samePort = true;
+    for (String entry : splitHostList(sanitized)) {
+      HostPort endpoint = extractSanitizedHostPort(entry);
+      if (endpoint.host().indexOf('\\') >= 0 || endpoint.host().startsWith("/")) {
+        return new ServerAddressGroup(sanitized, null);
+      }
+      Integer effectivePort = endpoint.port() != null ? endpoint.port() : defaultPort;
+      endpoints.add(new HostPort(endpoint.host(), effectivePort, endpoint.ipv6Address()));
+      if (commonPort == null) {
+        commonPort = effectivePort;
+      } else if (!commonPort.equals(effectivePort)) {
+        samePort = false;
+      }
+    }
+
+    StringBuilder address = new StringBuilder();
+    for (HostPort endpoint : endpoints) {
+      if (address.length() > 0) {
+        address.append(',');
+      }
+      appendHostPort(address, endpoint.host(), samePort ? null : endpoint.port());
+    }
+    Integer port = samePort && !defaultPort.equals(commonPort) ? commonPort : null;
+    return new ServerAddressGroup(address.toString(), port);
+  }
+
+  private static HostPort extractSanitizedHostPort(String entry) {
+    if (!ADDRESS_ENTRY_PATTERN.matcher(entry).find()) {
+      return extractHostPort(entry);
+    }
+    Matcher hostMatcher = ADDRESS_HOST_PATTERN.matcher(entry);
+    hostMatcher.find();
+    Matcher portMatcher = ADDRESS_PORT_PATTERN.matcher(entry);
+    Integer port = portMatcher.find() ? parsePort(portMatcher.group(1)) : null;
+    String host = hostMatcher.group(1).trim();
+    return new HostPort(stripIpv6Brackets(host), port, host.indexOf(':') >= 0 ? host : null);
+  }
+
+  /**
+   * A normalized configured server address group.
+   *
+   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+   * at any time.
+   */
+  public static final class ServerAddressGroup {
+    private final String address;
+    @Nullable private final Integer port;
+
+    private ServerAddressGroup(String address, @Nullable Integer port) {
+      this.address = address;
+      this.port = port;
+    }
+
+    public String address() {
+      return address;
+    }
+
+    @Nullable
+    public Integer port() {
+      return port;
+    }
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -350,6 +350,29 @@ public final class UrlParsingUtils {
     return authority.indexOf('(') < 0;
   }
 
+  public static boolean hasMultipleTargets(String jdbcUrl) {
+    int protocol = jdbcUrl.indexOf("://");
+    if (protocol < 0) {
+      return false;
+    }
+
+    int authorityStart = protocol + 3;
+    int authorityEnd = indexOfAny(jdbcUrl, authorityStart, '/', '?', '#', ';');
+    authorityEnd = authorityEnd < 0 ? jdbcUrl.length() : authorityEnd;
+    String authority = jdbcUrl.substring(authorityStart, authorityEnd);
+    if (splitHostList(stripUserInfo(authority)).size() > 1) {
+      return true;
+    }
+
+    int lastAt = jdbcUrl.lastIndexOf('@');
+    if (lastAt < authorityStart || lastAt < authorityEnd) {
+      return false;
+    }
+    int targetEnd = indexOfAny(jdbcUrl, lastAt + 1, '/', '?', '#', '&', ';');
+    targetEnd = targetEnd < 0 ? jdbcUrl.length() : targetEnd;
+    return splitHostList(jdbcUrl.substring(lastAt + 1, targetEnd)).size() > 1;
+  }
+
   // IPv6 brackets and address=(...) blocks may contain commas.
   private static List<String> splitHostList(String hostList) {
     List<String> entries = new ArrayList<>();

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -152,7 +152,7 @@ public final class UrlParsingUtils {
   }
 
   /** Append a host and optional port, adding brackets around an unbracketed IPv6 address. */
-  public static void appendHostPort(StringBuilder builder, String host, @Nullable Integer port) {
+  static void appendHostPort(StringBuilder builder, String host, @Nullable Integer port) {
     // Brackets keep an IPv6 literal unambiguous when a port follows.
     if (host.contains(":") && !host.startsWith("[")) {
       builder.append('[');
@@ -285,7 +285,7 @@ public final class UrlParsingUtils {
 
   /** Extract an authority when an at sign in a later query parameter obscures its boundary. */
   @Nullable
-  public static String extractAuthorityWithQueryAt(String url) {
+  static String extractAuthorityWithQueryAt(String url) {
     int authorityStart = url.indexOf("://");
     authorityStart = authorityStart < 0 ? 0 : authorityStart + 3;
     int authorityEnd = indexOfAny(url, authorityStart, '/', '?', '#');

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 public final class UrlParsingUtils {
 
   private static final Logger logger = Logger.getLogger(UrlParsingUtils.class.getName());
-  private static final int MAX_SERVER_ADDRESS_ENDPOINTS = 5;
 
   // Source: Regular Expressions Cookbook 2nd edition - 8.17.
   // Matches Standard, Mixed or Compressed notation in a wider body of text
@@ -579,7 +578,9 @@ public final class UrlParsingUtils {
     }
 
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < endpoints.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+    for (int i = 0;
+        i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS;
+        i++) {
       HostPort endpoint = endpoints.get(i);
       if (address.length() > 0) {
         address.append(',');
@@ -594,7 +595,9 @@ public final class UrlParsingUtils {
 
   private static String joinFirstEndpoints(List<String> entries) {
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < entries.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+    for (int i = 0;
+        i < entries.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS;
+        i++) {
       if (address.length() > 0) {
         address.append(',');
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -553,7 +553,6 @@ public final class UrlParsingUtils {
   private static String renderSpecialServerAddressGroup(
       List<String> entries, List<HostPort> endpoints, @Nullable Integer defaultPort) {
     boolean hasNonDefaultPort = false;
-    boolean hasUnknownPort = false;
     for (int i = 0; i < endpoints.size(); i++) {
       HostPort endpoint = endpoints.get(i);
       if (endpoint.host().startsWith("/")) {
@@ -561,9 +560,7 @@ public final class UrlParsingUtils {
       }
       Integer effectivePort = endpoint.port();
       if (effectivePort == null && defaultPort != null) {
-        if (endpoint.host().indexOf('\\') >= 0) {
-          hasUnknownPort = true;
-        } else {
+        if (endpoint.host().indexOf('\\') < 0) {
           effectivePort = defaultPort;
         }
       }
@@ -572,10 +569,6 @@ public final class UrlParsingUtils {
         hasNonDefaultPort = true;
       }
     }
-    if (hasNonDefaultPort && hasUnknownPort) {
-      return null;
-    }
-
     StringBuilder address = new StringBuilder();
     for (int i = 0; i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
       HostPort endpoint = endpoints.get(i);

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -578,9 +578,7 @@ public final class UrlParsingUtils {
     }
 
     StringBuilder address = new StringBuilder();
-    for (int i = 0;
-        i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS;
-        i++) {
+    for (int i = 0; i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
       HostPort endpoint = endpoints.get(i);
       if (address.length() > 0) {
         address.append(',');
@@ -595,9 +593,7 @@ public final class UrlParsingUtils {
 
   private static String joinFirstEndpoints(List<String> entries) {
     StringBuilder address = new StringBuilder();
-    for (int i = 0;
-        i < entries.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS;
-        i++) {
+    for (int i = 0; i < entries.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
       if (address.length() > 0) {
         address.append(',');
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -529,7 +529,8 @@ public final class UrlParsingUtils {
 
   /** Parse and normalize a comma-separated configured server group. */
   @Nullable
-  public static String parseServerAddressGroup(String authority, @Nullable Integer defaultPort) {
+  public static DbServerTarget parseServerTargetGroup(
+      String authority, @Nullable Integer defaultPort) {
     String sanitized = sanitizeHostList(authority);
     if (sanitized == null) {
       return null;
@@ -550,8 +551,7 @@ public final class UrlParsingUtils {
       for (HostPort endpoint : endpoints) {
         builder.addEndpoint(endpoint.host(), endpoint.port() == null ? -1 : endpoint.port());
       }
-      DbServerTarget target = builder.build();
-      return target == null ? null : target.getAddress();
+      return builder.build();
     }
 
     for (HostPort endpoint : endpoints) {
@@ -568,10 +568,10 @@ public final class UrlParsingUtils {
         return null;
       }
     }
-    return renderSpecialServerAddressGroup(entries, endpoints, defaultPort);
+    return DbServerTarget.create(
+        renderSpecialServerAddressGroup(entries, endpoints, defaultPort), null);
   }
 
-  @Nullable
   private static String renderSpecialServerAddressGroup(
       List<String> entries, List<HostPort> endpoints, @Nullable Integer defaultPort) {
     boolean hasNonDefaultPort = false;

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -507,8 +507,7 @@ public final class UrlParsingUtils {
 
   /** Parse and normalize a comma-separated configured server group. */
   @Nullable
-  public static ServerAddressGroup parseServerAddressGroup(
-      String authority, @Nullable Integer defaultPort) {
+  public static String parseServerAddressGroup(String authority, @Nullable Integer defaultPort) {
     String sanitized = sanitizeHostList(authority);
     if (sanitized == null) {
       return null;
@@ -530,7 +529,7 @@ public final class UrlParsingUtils {
         builder.addEndpoint(endpoint.host(), endpoint.port() == null ? -1 : endpoint.port());
       }
       DbServerTarget target = builder.build();
-      return target == null ? null : new ServerAddressGroup(target.getAddress());
+      return target == null ? null : target.getAddress();
     }
 
     for (HostPort endpoint : endpoints) {
@@ -551,14 +550,14 @@ public final class UrlParsingUtils {
   }
 
   @Nullable
-  private static ServerAddressGroup renderSpecialServerAddressGroup(
+  private static String renderSpecialServerAddressGroup(
       List<String> entries, List<HostPort> endpoints, @Nullable Integer defaultPort) {
     boolean hasNonDefaultPort = false;
     boolean hasUnknownPort = false;
     for (int i = 0; i < endpoints.size(); i++) {
       HostPort endpoint = endpoints.get(i);
       if (endpoint.host().startsWith("/")) {
-        return new ServerAddressGroup(joinFirstEndpoints(entries));
+        return joinFirstEndpoints(entries);
       }
       Integer effectivePort = endpoint.port();
       if (effectivePort == null && defaultPort != null) {
@@ -588,7 +587,7 @@ public final class UrlParsingUtils {
           endpoint.host(),
           defaultPort == null || hasNonDefaultPort ? endpoint.port() : null);
     }
-    return new ServerAddressGroup(address.toString());
+    return address.toString();
   }
 
   private static String joinFirstEndpoints(List<String> entries) {
@@ -612,24 +611,6 @@ public final class UrlParsingUtils {
     Integer port = portMatcher.find() ? parsePort(portMatcher.group(1)) : null;
     String host = hostMatcher.group(1).trim();
     return new HostPort(stripIpv6Brackets(host), port, host.indexOf(':') >= 0 ? host : null);
-  }
-
-  /**
-   * A normalized configured server address group.
-   *
-   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
-   * at any time.
-   */
-  public static final class ServerAddressGroup {
-    private final String address;
-
-    private ServerAddressGroup(String address) {
-      this.address = address;
-    }
-
-    public String address() {
-      return address;
-    }
   }
 
   /**

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 public final class UrlParsingUtils {
 
   private static final Logger logger = Logger.getLogger(UrlParsingUtils.class.getName());
+  private static final int MAX_SERVER_ADDRESS_ENDPOINTS = 5;
 
   // Source: Regular Expressions Cookbook 2nd edition - 8.17.
   // Matches Standard, Mixed or Compressed notation in a wider body of text
@@ -577,7 +578,7 @@ public final class UrlParsingUtils {
     }
 
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
+    for (int i = 0; i < endpoints.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
       HostPort endpoint = endpoints.get(i);
       if (address.length() > 0) {
         address.append(',');
@@ -592,7 +593,7 @@ public final class UrlParsingUtils {
 
   private static String joinFirstEndpoints(List<String> entries) {
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < entries.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
+    for (int i = 0; i < entries.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
       if (address.length() > 0) {
         address.append(',');
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -476,10 +476,12 @@ public final class UrlParsingUtils {
       String rest = value.substring(closingBracket + 1);
       return rest.isEmpty() || (rest.startsWith(":") && parsePort(rest.substring(1)) != null);
     }
-    int colon = value.lastIndexOf(':');
-    return colon < 0
-        || value.indexOf(':') != colon
-        || (colon > 0 && parsePort(value.substring(colon + 1)) != null);
+    int firstColon = value.indexOf(':');
+    int lastColon = value.lastIndexOf(':');
+    if (firstColon != lastColon) {
+      return DbServerTargetBuilder.isValidHost(value);
+    }
+    return firstColon < 0 || (firstColon > 0 && parsePort(value.substring(firstColon + 1)) != null);
   }
 
   /** Sanitize a comma-separated host list, returning {@code null} when it is not valid. */

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -447,7 +447,7 @@ public final class UrlParsingUtils {
       return null;
     }
     String addressHost = hostMatcher.group(1).trim();
-    if (!isValidHostPort(addressHost)) {
+    if (!isValidHostPort(addressHost) || hostMatcher.find()) {
       return null;
     }
     StringBuilder sanitized = new StringBuilder("address=(host=");

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 public final class UrlParsingUtils {
 
   private static final Logger logger = Logger.getLogger(UrlParsingUtils.class.getName());
-  private static final int MAX_SERVER_ADDRESS_ENDPOINTS = 5;
 
   // Source: Regular Expressions Cookbook 2nd edition - 8.17.
   // Matches Standard, Mixed or Compressed notation in a wider body of text
@@ -578,7 +577,7 @@ public final class UrlParsingUtils {
     }
 
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < endpoints.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+    for (int i = 0; i < endpoints.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
       HostPort endpoint = endpoints.get(i);
       if (address.length() > 0) {
         address.append(',');
@@ -593,7 +592,7 @@ public final class UrlParsingUtils {
 
   private static String joinFirstEndpoints(List<String> entries) {
     StringBuilder address = new StringBuilder();
-    for (int i = 0; i < entries.size() && i < MAX_SERVER_ADDRESS_ENDPOINTS; i++) {
+    for (int i = 0; i < entries.size() && i < DbServerTargetBuilder.MAX_ENDPOINTS; i++) {
       if (address.length() > 0) {
         address.append(',');
       }

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/parser/UrlParsingUtils.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
  */
 public final class UrlParsingUtils {
 
+  private static final int MIN_PORT = 1;
+  private static final int MAX_PORT = 65535;
   private static final Logger logger = Logger.getLogger(UrlParsingUtils.class.getName());
 
   // Source: Regular Expressions Cookbook 2nd edition - 8.17.
@@ -62,7 +64,7 @@ public final class UrlParsingUtils {
   private static final Pattern ADDRESS_HOST_PATTERN =
       Pattern.compile("\\(\\s*host\\s*=\\s*([^)]*?)\\s*\\)", Pattern.CASE_INSENSITIVE);
   private static final Pattern ADDRESS_PORT_PATTERN =
-      Pattern.compile("\\(\\s*port\\s*=\\s*([\\d]+)\\s*\\)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("\\(\\s*port\\s*=\\s*([^)]*?)\\s*\\)", Pattern.CASE_INSENSITIVE);
   private static final Pattern ADDRESS_ENTRY_PATTERN =
       Pattern.compile("^address\\s*=", Pattern.CASE_INSENSITIVE);
 
@@ -453,7 +455,11 @@ public final class UrlParsingUtils {
 
     Matcher portMatcher = ADDRESS_PORT_PATTERN.matcher(host);
     if (portMatcher.find()) {
-      sanitized.append("(port=").append(portMatcher.group(1)).append(')');
+      String addressPort = portMatcher.group(1).trim();
+      if (!isValidPort(addressPort) || portMatcher.find()) {
+        return null;
+      }
+      sanitized.append("(port=").append(addressPort).append(')');
     }
     return sanitized.toString();
   }
@@ -474,14 +480,28 @@ public final class UrlParsingUtils {
     int closingBracket = value.startsWith("[") ? value.indexOf(']') : -1;
     if (closingBracket >= 0) {
       String rest = value.substring(closingBracket + 1);
-      return rest.isEmpty() || (rest.startsWith(":") && parsePort(rest.substring(1)) != null);
+      return rest.isEmpty() || (rest.startsWith(":") && isValidPort(rest.substring(1)));
     }
     int firstColon = value.indexOf(':');
     int lastColon = value.lastIndexOf(':');
     if (firstColon != lastColon) {
       return DbServerTargetBuilder.isValidHost(value);
     }
-    return firstColon < 0 || (firstColon > 0 && parsePort(value.substring(firstColon + 1)) != null);
+    return firstColon < 0 || (firstColon > 0 && isValidPort(value.substring(firstColon + 1)));
+  }
+
+  private static boolean isValidPort(String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9') {
+        return false;
+      }
+    }
+    Integer port = parsePort(value);
+    return port != null && port >= MIN_PORT && port <= MAX_PORT;
   }
 
   /** Sanitize a comma-separated host list, returning {@code null} when it is not valid. */

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -126,8 +126,8 @@ class JdbcTelemetryTest {
         argumentSet(
             "shared non-default port",
             "jdbc:postgresql://pg.host1:15432,pg.host2:15432/dbname",
-            "pg.host1,pg.host2",
-            15432L),
+            "pg.host1:15432,pg.host2:15432",
+            null),
         argumentSet(
             "mixed ports",
             "jdbc:postgresql://pg.host1:5432,pg.host2:15432/dbname",
@@ -152,7 +152,9 @@ class JdbcTelemetryTest {
                 span -> span.hasName("parent"),
                 span ->
                     span.hasName(
-                        emitStableDatabaseSemconv() ? "pg.host1,pg.host2:15432" : "DB Query")));
+                        emitStableDatabaseSemconv()
+                            ? "pg.host1:15432,pg.host2:15432"
+                            : "DB Query")));
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -81,11 +81,12 @@ class JdbcTelemetryTest {
         SERVER_PORT);
   }
 
-  @Test
-  void groupTargetSuppressesPortInStableSemconv() throws SQLException {
+  @ParameterizedTest
+  @MethodSource("groupTargets")
+  void groupTargetUsesNormalizedPortsOnlyInStableSemconv(
+      String url, String stableAddress, Long stablePort) throws SQLException {
     JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
-    DataSource dataSource =
-        telemetry.wrap(new TestDataSource("jdbc:postgresql://pg.host1:5432,pg.host2:5433/dbname"));
+    DataSource dataSource = telemetry.wrap(new TestDataSource(url));
 
     testing.runWithSpan(
         "parent", () -> dataSource.getConnection().createStatement().execute("SELECT 1;"));
@@ -109,17 +110,36 @@ class JdbcTelemetryTest {
                         // server
                         equalTo(
                             SERVER_ADDRESS,
-                            emitStableDatabaseSemconv()
-                                ? "pg.host1:5432,pg.host2:5433"
-                                : "localhost"),
-                        equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : 5432L))));
+                            emitStableDatabaseSemconv() ? stableAddress : "localhost"),
+                        equalTo(
+                            SERVER_PORT,
+                            emitStableDatabaseSemconv() ? stablePort : Long.valueOf(5432)))));
+  }
+
+  private static Stream<Arguments> groupTargets() {
+    return Stream.of(
+        argumentSet(
+            "default ports",
+            "jdbc:postgresql://pg.host1,pg.host2:5432/dbname",
+            "pg.host1,pg.host2",
+            null),
+        argumentSet(
+            "shared non-default port",
+            "jdbc:postgresql://pg.host1:15432,pg.host2:15432/dbname",
+            "pg.host1,pg.host2",
+            15432L),
+        argumentSet(
+            "mixed ports",
+            "jdbc:postgresql://pg.host1:5432,pg.host2:15432/dbname",
+            "pg.host1:5432,pg.host2:15432",
+            null));
   }
 
   @Test
   void spanNameFallsBackToGroupTarget() throws SQLException {
     JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
     DataSource dataSource =
-        telemetry.wrap(new TestDataSource("jdbc:postgresql://pg.host1:5432,pg.host2:5433"));
+        telemetry.wrap(new TestDataSource("jdbc:postgresql://pg.host1:15432,pg.host2:15432"));
 
     testing.runWithSpan(
         "parent", () -> dataSource.getConnection().createStatement().execute("invalid"));
@@ -132,7 +152,7 @@ class JdbcTelemetryTest {
                 span -> span.hasName("parent"),
                 span ->
                     span.hasName(
-                        emitStableDatabaseSemconv() ? "pg.host1:5432,pg.host2:5433" : "DB Query")));
+                        emitStableDatabaseSemconv() ? "pg.host1,pg.host2:15432" : "DB Query")));
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_CONNECTION_STRING;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
@@ -78,6 +79,60 @@ class JdbcTelemetryTest {
         DB_SYSTEM_NAME,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @Test
+  void groupTargetSuppressesPortInStableSemconv() throws SQLException {
+    JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
+    DataSource dataSource =
+        telemetry.wrap(new TestDataSource("jdbc:postgresql://pg.host1:5432,pg.host2:5433/dbname"));
+
+    testing.runWithSpan(
+        "parent", () -> dataSource.getConnection().createStatement().execute("SELECT 1;"));
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent"),
+                span ->
+                    span.hasAttributesSatisfyingExactly(
+                        equalTo(maybeStable(DB_SYSTEM), POSTGRESQL),
+                        equalTo(maybeStable(DB_NAME), "dbname"),
+                        equalTo(
+                            DB_CONNECTION_STRING,
+                            emitStableDatabaseSemconv() ? null : "postgresql://localhost:5432"),
+                        equalTo(maybeStable(DB_STATEMENT), "SELECT ?;"),
+                        equalTo(DB_OPERATION, emitStableDatabaseSemconv() ? null : "SELECT"),
+                        equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "SELECT" : null),
+                        // the old semconv value is the one the parser has always reported for a
+                        // multi host url: the driver default, because such a url names no single
+                        // server
+                        equalTo(
+                            SERVER_ADDRESS,
+                            emitStableDatabaseSemconv()
+                                ? "pg.host1:5432,pg.host2:5433"
+                                : "localhost"),
+                        equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : 5432L))));
+  }
+
+  @Test
+  void spanNameFallsBackToGroupTarget() throws SQLException {
+    JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
+    DataSource dataSource =
+        telemetry.wrap(new TestDataSource("jdbc:postgresql://pg.host1:5432,pg.host2:5433"));
+
+    testing.runWithSpan(
+        "parent", () -> dataSource.getConnection().createStatement().execute("invalid"));
+
+    // span naming is unchanged: a query that has no summary and no namespace falls back to
+    // server.address, which now holds the whole configured target
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent"),
+                span ->
+                    span.hasName(
+                        emitStableDatabaseSemconv() ? "pg.host1:5432,pg.host2:5433" : "DB Query")));
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -83,8 +83,8 @@ class JdbcTelemetryTest {
 
   @ParameterizedTest
   @MethodSource("groupTargets")
-  void groupTargetUsesNormalizedPortsOnlyInStableSemconv(
-      String url, String stableAddress, Long stablePort) throws SQLException {
+  void groupTargetUsesNormalizedPortsOnlyInStableSemconv(String url, String stableAddress)
+      throws SQLException {
     JdbcTelemetry telemetry = JdbcTelemetry.builder(testing.getOpenTelemetry()).build();
     DataSource dataSource = telemetry.wrap(new TestDataSource(url));
 
@@ -113,7 +113,7 @@ class JdbcTelemetryTest {
                             emitStableDatabaseSemconv() ? stableAddress : "localhost"),
                         equalTo(
                             SERVER_PORT,
-                            emitStableDatabaseSemconv() ? stablePort : Long.valueOf(5432)))));
+                            emitStableDatabaseSemconv() ? null : Long.valueOf(5432)))));
   }
 
   private static Stream<Arguments> groupTargets() {
@@ -121,18 +121,15 @@ class JdbcTelemetryTest {
         argumentSet(
             "default ports",
             "jdbc:postgresql://pg.host1,pg.host2:5432/dbname",
-            "pg.host1,pg.host2",
-            null),
+            "pg.host1,pg.host2"),
         argumentSet(
             "shared non-default port",
             "jdbc:postgresql://pg.host1:15432,pg.host2:15432/dbname",
-            "pg.host1:15432,pg.host2:15432",
-            null),
+            "pg.host1:15432,pg.host2:15432"),
         argumentSet(
             "mixed ports",
             "jdbc:postgresql://pg.host1:5432,pg.host2:15432/dbname",
-            "pg.host1:5432,pg.host2:15432",
-            null));
+            "pg.host1:5432,pg.host2:15432"));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/JdbcTelemetryTest.java
@@ -77,8 +77,7 @@ class JdbcTelemetryTest {
         DB_NAMESPACE,
         DB_QUERY_SUMMARY,
         DB_SYSTEM_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+        SERVER_ADDRESS);
   }
 
   @ParameterizedTest
@@ -190,7 +189,7 @@ class JdbcTelemetryTest {
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "SELECT" : null),
                             equalTo(SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(SERVER_PORT, 5432),
+                            equalTo(SERVER_PORT, null),
                             equalTo(ERROR_TYPE, expectedErrorType))));
 
     assertDurationMetric(
@@ -200,8 +199,7 @@ class JdbcTelemetryTest {
         DB_QUERY_SUMMARY,
         DB_SYSTEM_NAME,
         ERROR_TYPE,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+        SERVER_ADDRESS);
     testing.waitAndAssertMetrics(
         "io.opentelemetry.jdbc",
         metric ->
@@ -333,8 +331,7 @@ class JdbcTelemetryTest {
         DB_NAMESPACE,
         DB_OPERATION_NAME,
         DB_SYSTEM_NAME,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+        SERVER_ADDRESS);
   }
 
   @Test
@@ -408,6 +405,8 @@ class JdbcTelemetryTest {
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "BATCH INSERT test" : null),
                             equalTo(SERVER_ADDRESS, "127.0.0.1"),
-                            equalTo(SERVER_PORT, 5432))));
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(5432)))));
   }
 }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/OpenTelemetryDataSourceTest.java
@@ -107,7 +107,7 @@ class OpenTelemetryDataSourceTest {
     assertThat(dbInfo.getDbUser()).isNull();
     assertThat(dbInfo.getDbName()).isEqualTo("dbname");
     assertThat(dbInfo.getDbNamespace()).isEqualTo("dbname");
-    assertThat(dbInfo.getServerAddress()).isEqualTo("127.0.0.1");
-    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("127.0.0.1");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
   }
 }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/TestDataSource.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/datasource/TestDataSource.java
@@ -15,14 +15,24 @@ import javax.sql.DataSource;
 
 class TestDataSource implements DataSource {
 
+  private final String url;
+
+  TestDataSource() {
+    this(null);
+  }
+
+  TestDataSource(String url) {
+    this.url = url;
+  }
+
   @Override
   public Connection getConnection() {
-    return new TestConnection();
+    return new TestConnection(url);
   }
 
   @Override
   public Connection getConnection(String username, String password) {
-    return new TestConnection();
+    return new TestConnection(url);
   }
 
   @Override

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.semconv.DbAttributes.DbSystemNameValues.MARIADB;
 import static io.opentelemetry.semconv.DbAttributes.DbSystemNameValues.MICROSOFT_SQL_SERVER;
 import static io.opentelemetry.semconv.DbAttributes.DbSystemNameValues.MYSQL;
 import static io.opentelemetry.semconv.DbAttributes.DbSystemNameValues.POSTGRESQL;
@@ -22,6 +24,7 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.sql.SQLException;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -86,5 +89,35 @@ class JdbcAttributesGetterTest {
         argumentSet("null SQLSTATE is unavailable", 0, null, null),
         argumentSet("empty SQLSTATE is unavailable", 0, "", null),
         argumentSet("successful completion SQLSTATE is unavailable", 0, "00000", null));
+  }
+
+  @Test
+  void groupTargetReplacesHostAndPortOnlyInStableSemconv() {
+    DbInfo dbInfo =
+        DbInfo.builder()
+            .dbSystemName(MARIADB)
+            .serverAddress("h1")
+            .serverPort(3306)
+            .serverAddressGroup("h1:3306,h2:3306")
+            .build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1:3306,h2:3306");
+      assertThat(attributesGetter.getServerPort(request)).isNull();
+    } else {
+      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1");
+      assertThat(attributesGetter.getServerPort(request)).isEqualTo(3306);
+    }
+  }
+
+  @Test
+  void singularTargetKeepsHostAndPortInEveryMode() {
+    DbInfo dbInfo =
+        DbInfo.builder().dbSystemName(MARIADB).serverAddress("h1").serverPort(3306).build();
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1");
+    assertThat(attributesGetter.getServerPort(request)).isEqualTo(3306);
   }
 }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -92,20 +92,19 @@ class JdbcAttributesGetterTest {
   }
 
   @Test
-  void groupTargetReplacesHostAndPortOnlyInStableSemconv() {
+  void groupTargetReplacesHostAndOmitsPortOnlyInStableSemconv() {
     DbInfo dbInfo =
         DbInfo.builder()
             .dbSystemName(MARIADB)
             .serverAddress("h1")
             .serverPort(3306)
-            .serverAddressGroup("h1,h2")
-            .serverAddressGroupPort(15432)
+            .serverAddressGroup("h1:15432,h2:15432")
             .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
     if (emitStableDatabaseSemconv()) {
-      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1,h2");
-      assertThat(attributesGetter.getServerPort(request)).isEqualTo(15432);
+      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1:15432,h2:15432");
+      assertThat(attributesGetter.getServerPort(request)).isNull();
     } else {
       assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1");
       assertThat(attributesGetter.getServerPort(request)).isEqualTo(3306);

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -111,6 +111,50 @@ class JdbcAttributesGetterTest {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("incompleteMultiTargets")
+  void incompleteMultiTargetOmitsHostAndPortOnlyInStableSemconv(
+      String url, String legacyHost, int legacyPort) {
+    DbInfo dbInfo = JdbcConnectionUrlParser.parse(url, null);
+    DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
+
+    assertThat(dbInfo.isMultiTarget()).isTrue();
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    if (emitStableDatabaseSemconv()) {
+      assertThat(attributesGetter.getServerAddress(request)).isNull();
+      assertThat(attributesGetter.getServerPort(request)).isNull();
+    } else {
+      assertThat(attributesGetter.getServerAddress(request)).isEqualTo(legacyHost);
+      assertThat(attributesGetter.getServerPort(request)).isEqualTo(legacyPort);
+    }
+  }
+
+  private static Stream<Arguments> incompleteMultiTargets() {
+    return Stream.of(
+        argumentSet(
+            "malformed PostgreSQL host list",
+            "jdbc:postgresql://h1:5432,unexpected=value/db",
+            "localhost",
+            5432),
+        argumentSet("unsupported H2 host list", "jdbc:h2:tcp://h1:8082,h2:8083/db", "h1", 8082),
+        argumentSet(
+            "SQL Server failover without primary",
+            "jdbc:sqlserver://;failoverPartner=h2",
+            "localhost",
+            1433),
+        argumentSet(
+            "malformed SQL Server failover target",
+            "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
+            "h1",
+            1433),
+        argumentSet(
+            "malformed Oracle address list",
+            "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"
+                + "(address=(host=h2)(port=1522)",
+            "h1",
+            1521));
+  }
+
   @Test
   void singularTargetKeepsHostAndPortInEveryMode() {
     DbInfo dbInfo =

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -148,6 +148,11 @@ class JdbcAttributesGetterTest {
             "h1",
             1433),
         argumentSet(
+            "SQL Server named instance with unknown port",
+            "jdbc:sqlserver://h1:1444;failoverPartner=h2\\instance2",
+            "h1",
+            1444),
+        argumentSet(
             "malformed Oracle Easy Connect list",
             "jdbc:oracle:thin:@//h1,unexpected=value/service",
             "h1",

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -98,13 +98,14 @@ class JdbcAttributesGetterTest {
             .dbSystemName(MARIADB)
             .serverAddress("h1")
             .serverPort(3306)
-            .serverAddressGroup("h1:3306,h2:3306")
+            .serverAddressGroup("h1,h2")
+            .serverAddressGroupPort(15432)
             .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
     if (emitStableDatabaseSemconv()) {
-      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1:3306,h2:3306");
-      assertThat(attributesGetter.getServerPort(request)).isNull();
+      assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1,h2");
+      assertThat(attributesGetter.getServerPort(request)).isEqualTo(15432);
     } else {
       assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1");
       assertThat(attributesGetter.getServerPort(request)).isEqualTo(3306);
@@ -147,6 +148,11 @@ class JdbcAttributesGetterTest {
             "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
             "h1",
             1433),
+        argumentSet(
+            "malformed Oracle Easy Connect list",
+            "jdbc:oracle:thin:@//h1,unexpected=value/service",
+            "h1",
+            1521),
         argumentSet(
             "malformed Oracle address list",
             "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -98,7 +98,7 @@ class JdbcAttributesGetterTest {
             .dbSystemName(MARIADB)
             .serverAddress("h1")
             .serverPort(3306)
-            .serverAddressGroup("h1:15432,h2:15432")
+            .configuredServerAddress("h1:15432,h2:15432")
             .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
@@ -118,8 +118,8 @@ class JdbcAttributesGetterTest {
     DbInfo dbInfo = JdbcConnectionUrlParser.parse(url, null);
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
-    assertThat(dbInfo.isMultiTarget()).isTrue();
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerPort()).isNull();
     if (emitStableDatabaseSemconv()) {
       assertThat(attributesGetter.getServerAddress(request)).isNull();
       assertThat(attributesGetter.getServerPort(request)).isNull();
@@ -168,7 +168,13 @@ class JdbcAttributesGetterTest {
   @Test
   void singularTargetKeepsHostAndPortInEveryMode() {
     DbInfo dbInfo =
-        DbInfo.builder().dbSystemName(MARIADB).serverAddress("h1").serverPort(3306).build();
+        DbInfo.builder()
+            .dbSystemName(MARIADB)
+            .serverAddress("h1")
+            .serverPort(3306)
+            .configuredServerAddress("h1")
+            .configuredServerPort(3306)
+            .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
     assertThat(attributesGetter.getServerAddress(request)).isEqualTo("h1");

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.sql.SQLException;
 import java.util.stream.Stream;
@@ -96,9 +97,9 @@ class JdbcAttributesGetterTest {
     DbInfo dbInfo =
         DbInfo.builder()
             .dbSystemName(MARIADB)
-            .serverAddress("h1")
-            .serverPort(3306)
-            .configuredServerAddress("h1:15432,h2:15432")
+            .legacyServerAddress("h1")
+            .legacyServerPort(3306)
+            .configuredServerTarget(DbServerTarget.create("h1:15432,h2:15432", null))
             .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
@@ -118,8 +119,7 @@ class JdbcAttributesGetterTest {
     DbInfo dbInfo = JdbcConnectionUrlParser.parse(url, null);
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
-    assertThat(dbInfo.getConfiguredServerPort()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
     if (emitStableDatabaseSemconv()) {
       assertThat(attributesGetter.getServerAddress(request)).isNull();
       assertThat(attributesGetter.getServerPort(request)).isNull();
@@ -165,10 +165,9 @@ class JdbcAttributesGetterTest {
     DbInfo dbInfo =
         DbInfo.builder()
             .dbSystemName(MARIADB)
-            .serverAddress("h1")
-            .serverPort(3306)
-            .configuredServerAddress("h1")
-            .configuredServerPort(3306)
+            .legacyServerAddress("h1")
+            .legacyServerPort(3306)
+            .configuredServerTarget(DbServerTarget.create("h1", 3306))
             .build();
     DbRequest request = DbRequest.create(dbInfo, "SELECT 1", false);
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcAttributesGetterTest.java
@@ -148,11 +148,6 @@ class JdbcAttributesGetterTest {
             "h1",
             1433),
         argumentSet(
-            "SQL Server named instance with unknown port",
-            "jdbc:sqlserver://h1:1444;failoverPartner=h2\\instance2",
-            "h1",
-            1444),
-        argumentSet(
             "malformed Oracle Easy Connect list",
             "jdbc:oracle:thin:@//h1,unexpected=value/service",
             "h1",

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionPoolNameUtilTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionPoolNameUtilTest.java
@@ -77,34 +77,36 @@ class JdbcConnectionPoolNameUtilTest {
         argumentSet(
             "address, port, and namespace",
             DbInfo.builder()
-                .serverAddress("db.example")
-                .serverPort(5432)
+                .legacyServerAddress("db.example")
+                .legacyServerPort(5432)
                 .dbNamespace("orders")
                 .build(),
             "db.example:5432/orders"),
         argumentSet(
             "IPv6 address, port, and namespace",
             DbInfo.builder()
-                .serverAddress("2001:db8::1")
-                .serverPort(5432)
+                .legacyServerAddress("2001:db8::1")
+                .legacyServerPort(5432)
                 .dbNamespace("orders")
                 .build(),
             "[2001:db8::1]:5432/orders"),
         argumentSet(
-            "address only", DbInfo.builder().serverAddress("db.example").build(), "db.example"),
+            "address only",
+            DbInfo.builder().legacyServerAddress("db.example").build(),
+            "db.example"),
         argumentSet(
             "address and port",
-            DbInfo.builder().serverAddress("db.example").serverPort(5432).build(),
+            DbInfo.builder().legacyServerAddress("db.example").legacyServerPort(5432).build(),
             "db.example:5432"),
         argumentSet(
             "address and namespace",
-            DbInfo.builder().serverAddress("db.example").dbNamespace("orders").build(),
+            DbInfo.builder().legacyServerAddress("db.example").dbNamespace("orders").build(),
             "db.example/orders"),
         argumentSet("namespace only", DbInfo.builder().dbNamespace("orders").build(), "orders"),
-        argumentSet("port only", DbInfo.builder().serverPort(5432).build(), FALLBACK_NAME),
+        argumentSet("port only", DbInfo.builder().legacyServerPort(5432).build(), FALLBACK_NAME),
         argumentSet(
             "port and namespace",
-            DbInfo.builder().serverPort(5432).dbNamespace("orders").build(),
+            DbInfo.builder().legacyServerPort(5432).dbNamespace("orders").build(),
             "orders"),
         argumentSet("no address, port, or namespace", DbInfo.DEFAULT, FALLBACK_NAME));
   }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -2190,7 +2190,7 @@ class JdbcConnectionUrlParserTest {
             .setOldSystem("mssql")
             .setHost("2001:db8::1")
             .setPort(1433)
-            .setServerAddressGroup("[2001:db8::1],[2001:db8::2]")
+            .setServerAddressGroup("2001:db8::1,2001:db8::2")
             .build(),
         // an ADDRESS_LIST is optional, a DESCRIPTION may hold the addresses directly
         arg("jdbc:oracle:thin:@(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
@@ -2284,6 +2284,10 @@ class JdbcConnectionUrlParserTest {
             "PostgreSQL default ports",
             "jdbc:postgresql://pg.host1,pg.host2:5432/pgdb",
             "pg.host1,pg.host2"),
+        argumentSet(
+            "PostgreSQL IPv6 default ports",
+            "jdbc:postgresql://[2001:db8::1],[2001:db8::2]/pgdb",
+            "2001:db8::1,2001:db8::2"),
         argumentSet(
             "PostgreSQL mixed IPv6 ports",
             "jdbc:postgresql://[2001:db8::1],[2001:db8::2]:15432/pgdb",

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -126,6 +126,9 @@ class JdbcConnectionUrlParserTest {
   @ValueSource(
       strings = {
         "jdbc:postgresql://h1:5432,unexpected=value/db",
+        "jdbc:unknown://valid.host:1234,evil host:1234/db",
+        "jdbc:unknown://address=(host=valid.host)(port=1234),"
+            + "address=(host=evil host)(port=1234)/db",
         "jdbc:h2:tcp://h1:8082,h2:8083/db",
         "jdbc:sqlserver://;failoverPartner=h2",
         "jdbc:sqlserver://h1;failoverPartner=unexpected=value",

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -228,6 +228,8 @@ class JdbcConnectionUrlParserTest {
   @Test
   void malformedHostEntriesAreExcludedFromConfiguredTargets() {
     assertThat(sanitizeHostList("h1:3306,unexpected=value")).isNull();
+    assertThat(sanitizeHostList("address=(host=h1),address=(host=unexpected=value)")).isNull();
+    assertThat(sanitizeHostList("h1:5432,:5433")).isNull();
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -86,7 +86,8 @@ class JdbcConnectionUrlParserTest {
       strings = {
         "jdbc:mariadb:failover://user:p,a/ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:p,a?ss@h1:3306,h2:3306/db",
-        "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db"
+        "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db",
+        "jdbc:mariadb:failover://user:123,a?x=y@h1:3306,h2:3306/db"
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -111,6 +111,8 @@ class JdbcConnectionUrlParserTest {
         "jdbc:h2:tcp://h1:8082,h2:8083/db",
         "jdbc:sqlserver://;failoverPartner=h2",
         "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
+        "jdbc:oracle:thin:@//h1,unexpected=value/service",
+        "jdbc:oracle:thin:@ldap://ldap1:389,ldap2:389/cn=oraclecontext",
         "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"
             + "(address=(host=h2)(port=1522)"
       })
@@ -167,7 +169,7 @@ class JdbcConnectionUrlParserTest {
     DbInfo dbInfo =
         parse("jdbc:postgresql://h1:5432,h2:5432?options=email=user@example.com,mode=strict", null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1:5432,h2:5432");
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
   }
 
   @ParameterizedTest
@@ -188,7 +190,7 @@ class JdbcConnectionUrlParserTest {
 
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1:3306,h2:3306");
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
     assertThat(dbInfo.getName()).isEqualTo("db");
     assertThat(dbInfo.getDbUser()).isEqualTo("admin@corp.com");
@@ -228,7 +230,7 @@ class JdbcConnectionUrlParserTest {
                 + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
             null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("address=(host=h1),address=(host=h2)");
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
@@ -328,7 +330,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(3306)
             .setName("mdbdb")
-            .setServerAddressGroup("127.0.0.1,127.0.0.1:3306")
+            .setServerAddressGroup("127.0.0.1,127.0.0.1")
             .build(),
         arg("jdbc:mysql:replication://address=(HOST=127.0.0.1)(port=33)(user=mdbuser)(password=PW),address=(host=mdb.host)(port=3306)(user=otheruser)(password=PW)/mdbdb?user=wrong&password=PW")
             .setShortUrl("mysql:replication://127.0.0.1:33")
@@ -338,8 +340,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(33)
             .setName("mdbdb")
-            .setServerAddressGroup(
-                "address=(host=127.0.0.1)(port=33),address=(host=mdb.host)(port=3306)")
+            .setServerAddressGroup("127.0.0.1:33,mdb.host:3306")
             .build(),
         arg("jdbc:mysql:replication://address=(HOST=mdb.host),address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW")
             .setShortUrl("mysql:replication://mdb.host:3306")
@@ -349,7 +350,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host")
             .setPort(3306)
             .setName("mdbdb")
-            .setServerAddressGroup("address=(host=mdb.host),address=(host=anotherhost)(port=3306)")
+            .setServerAddressGroup("mdb.host,anotherhost")
             .build(),
         arg("jdbc:mysql:replication://address=(host=::1)(port=33)/mydb")
             .setShortUrl("mysql:replication://[::1]:33")
@@ -628,7 +629,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host1")
             .setPort(33)
             .setName("mdbdb")
-            .setServerAddressGroup("mdb.host1:33,mdb.host")
+            .setServerAddressGroup("mdb.host1:33,mdb.host:3306")
             .build(),
         arg("jdbc:mariadb:sequential://mdb.host1,mdb.host2:33/mdbdb")
             .setShortUrl("mariadb:sequential://mdb.host1:3306")
@@ -637,7 +638,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host1")
             .setPort(3306)
             .setName("mdbdb")
-            .setServerAddressGroup("mdb.host1,mdb.host2:33")
+            .setServerAddressGroup("mdb.host1:3306,mdb.host2:33")
             .build(),
         arg("jdbc:mariadb:loadbalance://127.0.0.1:33,mdb.host/mdbdb")
             .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
@@ -646,7 +647,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(33)
             .setName("mdbdb")
-            .setServerAddressGroup("127.0.0.1:33,mdb.host")
+            .setServerAddressGroup("127.0.0.1:33,mdb.host:3306")
             .build(),
         arg("jdbc:mariadb:loadbalance://127.0.0.1:33/mdbdb")
             .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
@@ -663,7 +664,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
             .setPort(33)
             .setName("mdbdb")
-            .setServerAddressGroup("[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host")
+            .setServerAddressGroup("[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host:3306")
             .build(),
         arg("jdbc:mariadb:replication://localhost:33,anotherhost:3306/mdbdb")
             .setShortUrl("mariadb:replication://localhost:33")
@@ -997,7 +998,22 @@ class JdbcConnectionUrlParserTest {
 
     assertThat(info.getServerAddress()).isEqualTo("property.host1");
     assertThat(info.getServerPort()).isEqualTo(1444);
-    assertThat(info.getServerAddressGroup()).isEqualTo("property.host1:1444,property.host2");
+    assertThat(info.getServerAddressGroup()).isEqualTo("property.host1:1444,property.host2:1433");
+  }
+
+  @Test
+  void oracleEasyConnectListParsesFirstEndpointAndService() {
+    DbInfo info =
+        parse(
+            "jdbc:oracle:thin:@tcps://[2001:db8::1]:2521,"
+                + "[2001:db8::2]:2521/orclsn?retry_count=3",
+            null);
+
+    assertThat(info.getServerAddress()).isEqualTo("2001:db8::1");
+    assertThat(info.getServerPort()).isEqualTo(2521);
+    assertThat(info.getDbNamespace()).isEqualTo("orclsn");
+    assertThat(info.getServerAddressGroup()).isEqualTo("[2001:db8::1],[2001:db8::2]");
+    assertThat(info.getServerAddressGroupPort()).isEqualTo(2521);
   }
 
   private static Stream<Arguments> oracleArguments() {
@@ -1100,12 +1116,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("orcl.host1")
             .setPort(1521)
             .setName("orclsn")
-            .setServerAddressGroup(
-                "oracle:thin:@(description=(address_list="
-                    + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
-                    + "(address=(protocol=tcp)(host=orcl.host2)(port=1521))"
-                    + "(address=(protocol=tcp)(host=orcl.host3)(port=1521))"
-                    + "(address=(protocol=tcp)(host=orcl.host4)(port=1521))))")
+            .setServerAddressGroup("orcl.host1,orcl.host2,orcl.host3,orcl.host4")
             .build(),
 
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
@@ -2082,7 +2093,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("localhost")
             .setPort(5432)
             .setName("pgdb")
-            .setServerAddressGroup("pg.host1:5432,pg.host2:5432")
+            .setServerAddressGroup("pg.host1,pg.host2")
             .build(),
         // the user info of a url shaped authority ends at its last '@', so a password that holds a
         // comma cannot leave a fragment of itself among the hosts
@@ -2124,8 +2135,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host1")
             .setPort(33)
             .setName("mdbdb")
-            .setServerAddressGroup(
-                "address=(host=mdb.host1)(port=33)," + "address=(host=mdb.host2)(port=3306)")
+            .setServerAddressGroup("mdb.host1:33,mdb.host2:3306")
             .build(),
         // https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties
         arg("jdbc:sqlserver://ss.host1:1433;databaseName=ssdb;failoverPartner=ss.host2")
@@ -2135,7 +2145,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("ss.host1")
             .setPort(1433)
             .setName("ssdb")
-            .setServerAddressGroup("ss.host1:1433,ss.host2")
+            .setServerAddressGroup("ss.host1,ss.host2")
             .build(),
         arg("jdbc:sqlserver://ss.host1\\instance1:1433;databaseName=ssdb;"
                 + "failoverPartner=ss.host2\\instance2")
@@ -2162,7 +2172,7 @@ class JdbcConnectionUrlParserTest {
             .setOldSystem("mssql")
             .setHost("2001:db8::1")
             .setPort(1433)
-            .setServerAddressGroup("[2001:db8::1]:1433,[2001:db8::2]")
+            .setServerAddressGroup("[2001:db8::1],[2001:db8::2]")
             .build(),
         // an ADDRESS_LIST is optional, a DESCRIPTION may hold the addresses directly
         arg("jdbc:oracle:thin:@(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
@@ -2175,9 +2185,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("orcl.host1")
             .setPort(1521)
             .setName("orclsn")
-            .setServerAddressGroup(
-                "oracle:thin:@(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
-                    + "(address=(protocol=tcp)(host=orcl.host2)(port=1522)))")
+            .setServerAddressGroup("orcl.host1:1521,orcl.host2:1522")
             .build(),
         // a DESCRIPTION_LIST holds independent descriptions, so its addresses are not one group
         arg("jdbc:oracle:thin:@(description_list="
@@ -2229,7 +2237,7 @@ class JdbcConnectionUrlParserTest {
             "MySQL replication target order",
             "jdbc:mysql:replication://address=(host=replica.host)(port=3307),"
                 + "address=(host=source.host)(port=3306)/mydb",
-            "address=(host=replica.host)(port=3307)," + "address=(host=source.host)(port=3306)"),
+            "replica.host:3307,source.host:3306"),
         argumentSet(
             "SQL Server principal and failover partner order",
             "jdbc:sqlserver://principal.host:1433;failoverPartner=partner.host:1444",
@@ -2245,10 +2253,80 @@ class JdbcConnectionUrlParserTest {
                 + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
                 + "(address=(protocol=tcp)(host=orcl.host2)(port=1522)))"
                 + "(connect_data=(service_name=orclsn)))",
-            "oracle:thin:@(description=(address_list="
-                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))"
-                + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
-                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))))"));
+            "orcl.host2:1522,orcl.host1:1521,orcl.host2:1522"));
+  }
+
+  private static Stream<Arguments> normalizedServerAddressGroupArguments() {
+    return Stream.of(
+        argumentSet(
+            "PostgreSQL shared non-default port",
+            "jdbc:postgresql://pg.host1:15432,pg.host2:15432/pgdb",
+            "pg.host1,pg.host2",
+            15432),
+        argumentSet(
+            "PostgreSQL default ports",
+            "jdbc:postgresql://pg.host1,pg.host2:5432/pgdb",
+            "pg.host1,pg.host2",
+            null),
+        argumentSet(
+            "PostgreSQL mixed IPv6 ports",
+            "jdbc:postgresql://[2001:db8::1],[2001:db8::2]:15432/pgdb",
+            "[2001:db8::1]:5432,[2001:db8::2]:15432",
+            null),
+        argumentSet(
+            "MySQL address blocks on default ports",
+            "jdbc:mysql:replication://address=(host=source.host)(port=3306),"
+                + "address=(host=replica.host)/mydb",
+            "source.host,replica.host",
+            null),
+        argumentSet(
+            "MariaDB shared non-default port",
+            "jdbc:mariadb:failover://mdb.host1:13306,mdb.host2:13306/mdbdb",
+            "mdb.host1,mdb.host2",
+            13306),
+        argumentSet(
+            "SQL Server shared non-default port",
+            "jdbc:sqlserver://primary.host:1444;failoverPartner=partner.host:1444",
+            "primary.host,partner.host",
+            1444),
+        argumentSet(
+            "Oracle shared non-default port",
+            "jdbc:oracle:thin:@(description="
+                + "(address=(protocol=tcp)(host=orcl.host1)(port=2521))"
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=2521))"
+                + "(connect_data=(service_name=orclsn)))",
+            "orcl.host1,orcl.host2",
+            2521),
+        argumentSet(
+            "Oracle Easy Connect default ports",
+            "jdbc:oracle:thin:@//orcl.host1,orcl.host2/orclsn",
+            "orcl.host1,orcl.host2",
+            null),
+        argumentSet(
+            "Oracle Easy Connect shared non-default port",
+            "jdbc:oracle:thin:@tcps://orcl.host1:2521,orcl.host2:2521/orclsn",
+            "orcl.host1,orcl.host2",
+            2521),
+        argumentSet(
+            "Oracle Easy Connect mixed IPv6 ports",
+            "jdbc:oracle:thin:@//[2001:db8::1],[2001:db8::2]:2521/orclsn",
+            "[2001:db8::1]:1521,[2001:db8::2]:2521",
+            null),
+        argumentSet(
+            "unknown database default keeps explicit ports",
+            "jdbc:unknown://unknown.host1:1234,unknown.host2:1234/db",
+            "unknown.host1:1234,unknown.host2:1234",
+            null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("normalizedServerAddressGroupArguments")
+  void normalizesServerAddressGroupPorts(
+      String url, String expectedServerAddressGroup, Integer expectedServerAddressGroupPort) {
+    DbInfo dbInfo = parse(url, null);
+
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
+    assertThat(dbInfo.getServerAddressGroupPort()).isEqualTo(expectedServerAddressGroupPort);
   }
 
   @ParameterizedTest
@@ -2296,6 +2374,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
     assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
     assertThat(info.getServerAddressGroup()).isEqualTo(expected.getServerAddressGroup());
+    assertThat(info.getServerAddressGroupPort()).isEqualTo(expected.getServerAddressGroupPort());
     assertThat(info.isMultiTarget()).isEqualTo(expected.isMultiTarget());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
@@ -2327,6 +2406,7 @@ class JdbcConnectionUrlParserTest {
               .serverAddress(builder.host)
               .serverPort(builder.port)
               .serverAddressGroup(builder.serverAddressGroup)
+              .serverAddressGroupPort(builder.serverAddressGroupPort)
               .multiTarget(builder.multiTarget || builder.serverAddressGroup != null)
               .build();
     }
@@ -2349,6 +2429,7 @@ class JdbcConnectionUrlParserTest {
     String namespace;
     String name;
     String serverAddressGroup;
+    Integer serverAddressGroupPort;
     boolean multiTarget;
 
     ParseTestArgumentBuilder(String url) {
@@ -2410,6 +2491,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setServerAddressGroup(String serverAddressGroup) {
       this.serverAddressGroup = serverAddressGroup;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setServerAddressGroupPort(int serverAddressGroupPort) {
+      this.serverAddressGroupPort = serverAddressGroupPort;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -81,6 +81,45 @@ class JdbcConnectionUrlParserTest {
             .build());
   }
 
+  @Test
+  void singletonUrlIsNotMarkedAsMultiTarget() {
+    DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db", null);
+
+    assertThat(dbInfo.isMultiTarget()).isFalse();
+    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+  }
+
+  @Test
+  void commasOutsideAuthorityDoNotMarkSingletonAsMultiTarget() {
+    DbInfo dbInfo =
+        parse(
+            "jdbc:postgresql://pg.host:5432/db"
+                + "?user=admin@corp.com&options=search_path=test,public",
+            null);
+
+    assertThat(dbInfo.isMultiTarget()).isFalse();
+    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:postgresql://h1:5432,unexpected=value/db",
+        "jdbc:h2:tcp://h1:8082,h2:8083/db",
+        "jdbc:sqlserver://;failoverPartner=h2",
+        "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
+        "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"
+            + "(address=(host=h2)(port=1522)"
+      })
+  void incompleteMultiTargetIsMarkedWithoutAConfiguredTarget(String url) {
+    DbInfo dbInfo = parse(url, null);
+
+    assertThat(dbInfo.isMultiTarget()).isTrue();
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {
@@ -2062,6 +2101,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("localhost")
             .setPort(5432)
             .setName("pgdb")
+            .setMultiTarget()
             .build(),
         // https://dev.mysql.com/doc/connector-j/en/connector-j-multi-host-connections.html
         arg("jdbc:mysql://mysql.host1:3306,mysql.host2:3307/mydb")
@@ -2151,6 +2191,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("orcl.host1")
             .setPort(1521)
             .setName("orclsn")
+            .setMultiTarget()
             .build(),
         arg("jdbc:mariadb:failover://mdb.host:3306/mdbdb")
             .setShortUrl("mariadb:failover://mdb.host:3306")
@@ -2212,6 +2253,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
     assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
     assertThat(info.getServerAddressGroup()).isEqualTo(expected.getServerAddressGroup());
+    assertThat(info.isMultiTarget()).isEqualTo(expected.isMultiTarget());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
     assertThat(info.getDbName()).isEqualTo(expected.getDbName());
@@ -2242,6 +2284,7 @@ class JdbcConnectionUrlParserTest {
               .serverAddress(builder.host)
               .serverPort(builder.port)
               .serverAddressGroup(builder.serverAddressGroup)
+              .multiTarget(builder.multiTarget || builder.serverAddressGroup != null)
               .build();
     }
 
@@ -2263,6 +2306,7 @@ class JdbcConnectionUrlParserTest {
     String namespace;
     String name;
     String serverAddressGroup;
+    boolean multiTarget;
 
     ParseTestArgumentBuilder(String url) {
       this.url = url;
@@ -2323,6 +2367,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setServerAddressGroup(String serverAddressGroup) {
       this.serverAddressGroup = serverAddressGroup;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setMultiTarget() {
+      this.multiTarget = true;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -951,8 +951,7 @@ class JdbcConnectionUrlParserTest {
 
     assertThat(info.getServerAddress()).isEqualTo("property.host1");
     assertThat(info.getServerPort()).isEqualTo(1444);
-    assertThat(info.getServerAddressGroup())
-        .isEqualTo("property.host1\\propertyInstance:1444,property.host2");
+    assertThat(info.getServerAddressGroup()).isEqualTo("property.host1:1444,property.host2");
   }
 
   private static Stream<Arguments> oracleArguments() {
@@ -2100,7 +2099,7 @@ class JdbcConnectionUrlParserTest {
             .setPort(1433)
             .setNamespace("instance1|ssdb")
             .setName("instance1")
-            .setServerAddressGroup("ss.host1\\instance1:1433,ss.host2\\instance2")
+            .setServerAddressGroup("ss.host1:1433,ss.host2\\instance2")
             .build(),
         arg("jdbc:sqlserver://ss.host1;instanceName=instance1;failoverPartner=ss.host2")
             .setShortUrl("sqlserver://ss.host1:1433")

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -150,6 +150,7 @@ class JdbcConnectionUrlParserTest {
         "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:123,a?x=y@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:123,a?x=y@address=(host=h1),address=(host=h2)/db",
+        "jdbc:mariadb:failover://user:123,a?x=y@address=(host=h1)/db",
         "jdbc:mariadb:failover://user:123,a#ignored?x=y@/db"
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -16,6 +16,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.MYSQL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.POSTGRESQL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
@@ -2212,6 +2213,48 @@ class JdbcConnectionUrlParserTest {
             .setPort(3306)
             .setName("mdbdb")
             .build());
+  }
+
+  private static Stream<Arguments> orderedServerAddressGroupArguments() {
+    return Stream.of(
+        argumentSet(
+            "reversed PostgreSQL targets with a duplicate",
+            "jdbc:postgresql://pg.host2:5433,pg.host1:5432,pg.host2:5433/pgdb",
+            "pg.host2:5433,pg.host1:5432,pg.host2:5433"),
+        argumentSet(
+            "reversed MariaDB sequential targets",
+            "jdbc:mariadb:sequential://mdb.host2:3307,mdb.host1:3306/mdbdb",
+            "mdb.host2:3307,mdb.host1:3306"),
+        argumentSet(
+            "MySQL replication target order",
+            "jdbc:mysql:replication://address=(host=replica.host)(port=3307),"
+                + "address=(host=source.host)(port=3306)/mydb",
+            "address=(host=replica.host)(port=3307)," + "address=(host=source.host)(port=3306)"),
+        argumentSet(
+            "SQL Server principal and failover partner order",
+            "jdbc:sqlserver://principal.host:1433;failoverPartner=partner.host:1444",
+            "principal.host:1433,partner.host:1444"),
+        argumentSet(
+            "SQL Server IPv6 ports",
+            "jdbc:sqlserver://[2001:db8::1]:1433;failoverPartner=[2001:db8::2]:1444",
+            "[2001:db8::1]:1433,[2001:db8::2]:1444"),
+        argumentSet(
+            "Oracle address list order with a duplicate",
+            "jdbc:oracle:thin:@(description=(address_list="
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))"
+                + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522)))"
+                + "(connect_data=(service_name=orclsn)))",
+            "oracle:thin:@(description=(address_list="
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))"
+                + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))))"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("orderedServerAddressGroupArguments")
+  void preservesOrderedServerAddressGroups(String url, String expectedServerAddressGroup) {
+    assertThat(parse(url, null).getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
   }
 
   @ParameterizedTest(name = "{index}: {0}")

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 import static io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser.parse;
 import static io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo.DEFAULT;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.CLICKHOUSE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DERBY;
@@ -2423,7 +2424,7 @@ class JdbcConnectionUrlParserTest {
 
   @Test
   void invalidUnixSocketInServerAddressGroupFailsClosed() {
-    assertThat(UrlParsingUtils.parseServerAddressGroup("/valid.sock,/invalid?sock", null)).isNull();
+    assertThat(parseServerAddressGroup("/valid.sock,/invalid?sock", null)).isNull();
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -88,7 +88,8 @@ class JdbcConnectionUrlParserTest {
         "jdbc:mariadb:failover://user:p,a?ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:123,a?x=y@h1:3306,h2:3306/db",
-        "jdbc:mariadb:failover://user:123,a?x=y@address=(host=h1),address=(host=h2)/db"
+        "jdbc:mariadb:failover://user:123,a?x=y@address=(host=h1),address=(host=h2)/db",
+        "jdbc:mariadb:failover://user:123,a#ignored?x=y@/db"
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
@@ -97,9 +98,14 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getName()).isNull();
   }
 
-  @Test
-  void ambiguousPostgresCredentialsDoNotBecomeAConfiguredTarget() {
-    DbInfo dbInfo = parse("jdbc:postgresql://user:123,a/ss@pg.host:5432", null);
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:postgresql://user:123,a/ss@pg.host:5432",
+        "jdbc:postgresql://user:123,a#ignored?x=y@pg.host:5432,pg2:5432/db"
+      })
+  void ambiguousPostgresCredentialsDoNotBecomeAConfiguredTarget(String url) {
+    DbInfo dbInfo = parse(url, null);
     assertThat(dbInfo.getServerAddressGroup()).isNull();
     assertThat(dbInfo.getHost()).isEqualTo("localhost");
     assertThat(dbInfo.getName()).isNull();

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser.parse;
 import static io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo.DEFAULT;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.CLICKHOUSE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DERBY;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.HSQLDB;
@@ -77,6 +79,97 @@ class JdbcConnectionUrlParserTest {
             .setPort(9999)
             .setName("stdDatabaseName")
             .build());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:mariadb:failover://user:p,a/ss@h1:3306,h2:3306/db",
+        "jdbc:mariadb:failover://user:p,a?ss@h1:3306,h2:3306/db",
+        "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db"
+      })
+  void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
+    DbInfo dbInfo = parse(url, null);
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getHost()).isNull();
+    assertThat(dbInfo.getName()).isNull();
+  }
+
+  @Test
+  void ambiguousPostgresCredentialsDoNotBecomeAConfiguredTarget() {
+    DbInfo dbInfo = parse("jdbc:postgresql://user:123,a/ss@pg.host:5432", null);
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getHost()).isEqualTo("localhost");
+    assertThat(dbInfo.getName()).isNull();
+  }
+
+  @Test
+  void atInPostgresQueryDoesNotDisableConfiguredTargetParsing() {
+    DbInfo dbInfo =
+        parse(
+            "jdbc:postgresql://pg.host1:5432,pg.host2:5433/pgdb"
+                + "?user=admin@corp.com&currentSchema=test,public",
+            null);
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("pg.host1:5432,pg.host2:5433");
+    assertThat(dbInfo.getName()).isEqualTo("pgdb");
+  }
+
+  @Test
+  void atInPostgresQueryWithoutDatabaseDoesNotDisableConfiguredTargetParsing() {
+    DbInfo dbInfo =
+        parse("jdbc:postgresql://h1:5432,h2:5432?options=email=user@example.com,mode=strict", null);
+
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1:5432,h2:5432");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "&serverSslCert=/etc/ssl/ca.pem",
+        "&sessionVariables=sql_mode=ANSI,time_zone=UTC",
+        "&sessionVariables=email='user@example.com',sql_mode=ANSI"
+      })
+  void atInMariaDbQueryDoesNotDisableConfiguredTargetParsing(String trailingParameters) {
+    String url =
+        "jdbc:mariadb:failover://h1:3306,h2:3306/db?user="
+            + "admin"
+            + "@"
+            + "corp.com"
+            + trailingParameters;
+
+    DbInfo dbInfo = parse(url, null);
+
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1:3306,h2:3306");
+    assertThat(dbInfo.getHost()).isEqualTo("h1");
+    assertThat(dbInfo.getName()).isEqualTo("db");
+    assertThat(dbInfo.getDbUser()).isEqualTo("admin@corp.com");
+  }
+
+  @Test
+  void hostSpecificPropertiesAreExcludedFromConfiguredTargets() {
+    assertThat(
+            sanitizeHostList(
+                "address=(host=h1)(port=3306)(trustCertificateKeyStorePassword=secret),"
+                    + "address=(host=h2)(port=3307)(customProperty=value)"))
+        .isEqualTo("address=(host=h1)(port=3306),address=(host=h2)(port=3307)");
+  }
+
+  @Test
+  void malformedHostEntriesAreExcludedFromConfiguredTargets() {
+    assertThat(sanitizeHostList("h1:3306,unexpected=value")).isNull();
+  }
+
+  @Test
+  void atInMariaDbQueryWithoutDatabaseDoesNotDisableConfiguredTargetParsing() {
+    DbInfo dbInfo =
+        parse(
+            "jdbc:mariadb:failover://h1,h2"
+                + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
+            null);
+
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
   private static Stream<Arguments> mySqlArguments() {
@@ -175,6 +268,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(3306)
             .setName("mdbdb")
+            .setServerAddressGroup("127.0.0.1,127.0.0.1:3306")
             .build(),
         arg("jdbc:mysql:replication://address=(HOST=127.0.0.1)(port=33)(user=mdbuser)(password=PW),address=(host=mdb.host)(port=3306)(user=otheruser)(password=PW)/mdbdb?user=wrong&password=PW")
             .setShortUrl("mysql:replication://127.0.0.1:33")
@@ -184,6 +278,8 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(33)
             .setName("mdbdb")
+            .setServerAddressGroup(
+                "address=(host=127.0.0.1)(port=33),address=(host=mdb.host)(port=3306)")
             .build(),
         arg("jdbc:mysql:replication://address=(HOST=mdb.host),address=(host=anotherhost)(port=3306)(user=wrong)(password=PW)/mdbdb?user=mdbuser&password=PW")
             .setShortUrl("mysql:replication://mdb.host:3306")
@@ -193,6 +289,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host")
             .setPort(3306)
             .setName("mdbdb")
+            .setServerAddressGroup("address=(host=mdb.host),address=(host=anotherhost)(port=3306)")
             .build(),
         arg("jdbc:mysql:replication://address=(host=::1)(port=33)/mydb")
             .setShortUrl("mysql:replication://[::1]:33")
@@ -471,6 +568,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host1")
             .setPort(33)
             .setName("mdbdb")
+            .setServerAddressGroup("mdb.host1:33,mdb.host")
             .build(),
         arg("jdbc:mariadb:sequential://mdb.host1,mdb.host2:33/mdbdb")
             .setShortUrl("mariadb:sequential://mdb.host1:3306")
@@ -479,6 +577,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("mdb.host1")
             .setPort(3306)
             .setName("mdbdb")
+            .setServerAddressGroup("mdb.host1,mdb.host2:33")
             .build(),
         arg("jdbc:mariadb:loadbalance://127.0.0.1:33,mdb.host/mdbdb")
             .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
@@ -487,6 +586,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("127.0.0.1")
             .setPort(33)
             .setName("mdbdb")
+            .setServerAddressGroup("127.0.0.1:33,mdb.host")
             .build(),
         arg("jdbc:mariadb:loadbalance://127.0.0.1:33/mdbdb")
             .setShortUrl("mariadb:loadbalance://127.0.0.1:33")
@@ -503,6 +603,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("2001:0660:7401:0200:0000:0000:0edf:bdd7")
             .setPort(33)
             .setName("mdbdb")
+            .setServerAddressGroup("[2001:0660:7401:0200:0000:0000:0edf:bdd7]:33,mdb.host")
             .build(),
         arg("jdbc:mariadb:replication://localhost:33,anotherhost:3306/mdbdb")
             .setShortUrl("mariadb:replication://localhost:33")
@@ -511,6 +612,7 @@ class JdbcConnectionUrlParserTest {
             .setHost("localhost")
             .setPort(33)
             .setName("mdbdb")
+            .setServerAddressGroup("localhost:33,anotherhost:3306")
             .build(),
         arg("jdbc:mariadb:loadbalance://localhost")
             .setShortUrl("mariadb:loadbalance://localhost:3306")
@@ -815,6 +917,22 @@ class JdbcConnectionUrlParserTest {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
+  @Test
+  void sqlServerDataSourceFailoverPartnerOverridesUrlPartner() {
+    Properties properties = new Properties();
+    properties.setProperty("serverName", "property.host1");
+    properties.setProperty("instanceName", "propertyInstance");
+    properties.setProperty("portNumber", "1444");
+    properties.setProperty("failoverPartner", "property.host2");
+
+    DbInfo info = parse("jdbc:sqlserver://url.host1:1433;failoverPartner=url.host2", properties);
+
+    assertThat(info.getServerAddress()).isEqualTo("property.host1");
+    assertThat(info.getServerPort()).isEqualTo(1444);
+    assertThat(info.getServerAddressGroup())
+        .isEqualTo("property.host1\\propertyInstance:1444,property.host2");
+  }
+
   private static Stream<Arguments> oracleArguments() {
     return args(
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
@@ -915,6 +1033,12 @@ class JdbcConnectionUrlParserTest {
             .setHost("orcl.host1")
             .setPort(1521)
             .setName("orclsn")
+            .setServerAddressGroup(
+                "oracle:thin:@(description=(address_list="
+                    + "(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                    + "(address=(protocol=tcp)(host=orcl.host2)(port=1521))"
+                    + "(address=(protocol=tcp)(host=orcl.host3)(port=1521))"
+                    + "(address=(protocol=tcp)(host=orcl.host4)(port=1521))))")
             .build(),
 
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
@@ -1854,6 +1978,207 @@ class JdbcConnectionUrlParserTest {
     testVerifySystemSubtypeParsingOfUrl(argument);
   }
 
+  private static Stream<Arguments> serverAddressGroupArguments() {
+    // the legacy fields hold what the parser reports today. An authority that lists more than one
+    // host is not a server-based uri, so the host, the port and the connection string keep the
+    // driver defaults, and only the group target names every configured host.
+    return args(
+        // https://jdbc.postgresql.org/documentation/use/#connection-fail-over
+        arg("jdbc:postgresql://pg.host1:5432,pg.host2:5433/pgdb")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setName("pgdb")
+            .setServerAddressGroup("pg.host1:5432,pg.host2:5433")
+            .build(),
+        arg("jdbc:postgresql://pg.host1,pg.host2/pgdb")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setName("pgdb")
+            .setServerAddressGroup("pg.host1,pg.host2")
+            .build(),
+        // a bracketed ipv6 host list is not a legal registry-based authority either, so the uri
+        // parse fails and the database name is not read
+        arg("jdbc:postgresql://[2001:db8::1]:5432,[2001:db8::2]:5433/pgdb")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setServerAddressGroup("[2001:db8::1]:5432,[2001:db8::2]:5433")
+            .build(),
+        arg("jdbc:postgresql://pguser:pgpass@pg.host1:5432,pg.host2:5432/pgdb?ssl=true#frag")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setName("pgdb")
+            .setServerAddressGroup("pg.host1:5432,pg.host2:5432")
+            .build(),
+        // the user info of a url shaped authority ends at its last '@', so a password that holds a
+        // comma cannot leave a fragment of itself among the hosts
+        arg("jdbc:postgresql://pguser:p,ss@pg.host1:5432,pg.host2:5433/pgdb")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setName("pgdb")
+            .setServerAddressGroup("pg.host1:5432,pg.host2:5433")
+            .build(),
+        // a password that holds a parenthesis makes the authority look like an address block, and
+        // an entry that still carries an '@' is dropped rather than reported
+        arg("jdbc:postgresql://pguser:p(x)y@pg.host1:5432,pg.host2:5433/pgdb")
+            .setShortUrl("postgresql://localhost:5432")
+            .setSystem(POSTGRESQL)
+            .setHost("localhost")
+            .setPort(5432)
+            .setName("pgdb")
+            .build(),
+        // https://dev.mysql.com/doc/connector-j/en/connector-j-multi-host-connections.html
+        arg("jdbc:mysql://mysql.host1:3306,mysql.host2:3307/mydb")
+            .setShortUrl("mysql://localhost:3306")
+            .setSystem(MYSQL)
+            .setHost("localhost")
+            .setPort(3306)
+            .setName("mydb")
+            .setServerAddressGroup("mysql.host1:3306,mysql.host2:3307")
+            .build(),
+        // an address block spells its credentials out as attributes, so a password may hold an '@'
+        // and characters that look like delimiters; none of it may reach the group target
+        arg("jdbc:mysql:replication://address=(host=mdb.host1)(port=33)(user=mdbuser)"
+                + "(password=p@ss,w0rd),address=(host=mdb.host2)(port=3306)/mdbdb")
+            .setShortUrl("mysql:replication://mdb.host1:33")
+            .setSystem(MYSQL)
+            .setSubtype("replication")
+            .setUser("mdbuser")
+            .setHost("mdb.host1")
+            .setPort(33)
+            .setName("mdbdb")
+            .setServerAddressGroup(
+                "address=(host=mdb.host1)(port=33)," + "address=(host=mdb.host2)(port=3306)")
+            .build(),
+        // https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties
+        arg("jdbc:sqlserver://ss.host1:1433;databaseName=ssdb;failoverPartner=ss.host2")
+            .setShortUrl("sqlserver://ss.host1:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host1")
+            .setPort(1433)
+            .setName("ssdb")
+            .setServerAddressGroup("ss.host1:1433,ss.host2")
+            .build(),
+        arg("jdbc:sqlserver://ss.host1\\instance1:1433;databaseName=ssdb;"
+                + "failoverPartner=ss.host2\\instance2")
+            .setShortUrl("sqlserver://ss.host1:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host1")
+            .setPort(1433)
+            .setNamespace("instance1|ssdb")
+            .setName("instance1")
+            .setServerAddressGroup("ss.host1\\instance1:1433,ss.host2\\instance2")
+            .build(),
+        arg("jdbc:sqlserver://ss.host1;instanceName=instance1;failoverPartner=ss.host2")
+            .setShortUrl("sqlserver://ss.host1:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host1")
+            .setPort(1433)
+            .setNamespace("instance1")
+            .setName("instance1")
+            .setServerAddressGroup("ss.host1\\instance1,ss.host2")
+            .build(),
+        arg("jdbc:sqlserver://[2001:db8::1]:1433;failoverPartner=2001:db8::2")
+            .setShortUrl("sqlserver://[2001:db8::1]:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("2001:db8::1")
+            .setPort(1433)
+            .setServerAddressGroup("[2001:db8::1]:1433,[2001:db8::2]")
+            .build(),
+        // an ADDRESS_LIST is optional, a DESCRIPTION may hold the addresses directly
+        arg("jdbc:oracle:thin:@(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                + "(address=(protocol=tcp)(host=orcl.host2)(port=1522))"
+                + "(connect_data=(service_name=orclsn)))")
+            .setShortUrl("oracle:thin://orcl.host1:1521")
+            .setSystem("oracle.db")
+            .setOldSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host1")
+            .setPort(1521)
+            .setName("orclsn")
+            .setServerAddressGroup(
+                "oracle:thin:@(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                    + "(address=(protocol=tcp)(host=orcl.host2)(port=1522)))")
+            .build(),
+        // a DESCRIPTION_LIST holds independent descriptions, so its addresses are not one group
+        arg("jdbc:oracle:thin:@(description_list="
+                + "(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
+                + "(connect_data=(service_name=orclsn)))"
+                + "(description=(address=(protocol=tcp)(host=orcl.host2)(port=1522))"
+                + "(connect_data=(service_name=orclsn))))")
+            .setShortUrl("oracle:thin://orcl.host1:1521")
+            .setSystem("oracle.db")
+            .setOldSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host1")
+            .setPort(1521)
+            .setName("orclsn")
+            .build(),
+        arg("jdbc:mariadb:failover://mdb.host:3306/mdbdb")
+            .setShortUrl("mariadb:failover://mdb.host:3306")
+            .setSystem(MARIADB)
+            .setSubtype("failover")
+            .setHost("mdb.host")
+            .setPort(3306)
+            .setName("mdbdb")
+            .build(),
+        // a single address block is not a group either, and its password stays out of every field
+        arg("jdbc:mariadb:failover://address=(host=mdb.host)(port=3306)(user=mdbuser)"
+                + "(password=p@ss,w0rd)/mdbdb")
+            .setShortUrl("mariadb:failover://mdb.host:3306")
+            .setSystem(MARIADB)
+            .setSubtype("failover")
+            .setUser("mdbuser")
+            .setHost("mdb.host")
+            .setPort(3306)
+            .setName("mdbdb")
+            .build());
+  }
+
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("serverAddressGroupArguments")
+  void testServerAddressGroupParsing(ParseTestArgument argument) {
+    testVerifySystemSubtypeParsingOfUrl(argument);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "postgresql://user:123,a/ss@pg.host:5432",
+        "postgresql://user:p,a/ss@pg.host:5432/db",
+        "postgresql://user:p,a/ss@pg.host:5432",
+        "postgresql://user:pa,ss/word@pg.host1:5432,pg.host2:5433/pgdb",
+        "postgresql://user:p@ss,w/ord@pg.host1:5432,pg.host2:5433/pgdb"
+      })
+  void testAmbiguousUserInfoIsNotExtractedAsAuthority(String url) {
+    assertThat(extractAuthority(url)).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"postgresql://h1,h2/db/admin@corp.com", "postgresql://h1,h2/db#admin@corp.com"})
+  void testAtAfterCommaSeparatedAuthorityIsAmbiguous(String url) {
+    assertThat(extractAuthority(url)).isNull();
+  }
+
+  @Test
+  void testAtInQueryParameterDoesNotHideAuthority() {
+    assertThat(extractAuthority("postgresql://h1,h2/db?user=admin@corp.com")).isEqualTo("h1,h2");
+  }
+
   private static void testVerifySystemSubtypeParsingOfUrl(ParseTestArgument argument) {
     DbInfo info = parse(argument.url, argument.properties);
     DbInfo expected = argument.dbInfo;
@@ -1861,6 +2186,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getDbSystemName()).isEqualTo(expected.getDbSystemName());
     assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
     assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
+    assertThat(info.getServerAddressGroup()).isEqualTo(expected.getServerAddressGroup());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
     assertThat(info.getDbName()).isEqualTo(expected.getDbName());
@@ -1890,6 +2216,7 @@ class JdbcConnectionUrlParserTest {
               .dbName(oldDbName)
               .serverAddress(builder.host)
               .serverPort(builder.port)
+              .serverAddressGroup(builder.serverAddressGroup)
               .build();
     }
 
@@ -1910,6 +2237,7 @@ class JdbcConnectionUrlParserTest {
     Integer port;
     String namespace;
     String name;
+    String serverAddressGroup;
 
     ParseTestArgumentBuilder(String url) {
       this.url = url;
@@ -1965,6 +2293,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setName(String name) {
       this.name = name;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setServerAddressGroup(String serverAddressGroup) {
+      this.serverAddressGroup = serverAddressGroup;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -129,6 +129,7 @@ class JdbcConnectionUrlParserTest {
         "jdbc:h2:tcp://h1:8082,h2:8083/db",
         "jdbc:sqlserver://;failoverPartner=h2",
         "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
+        "jdbc:sqlserver://h1:1444;failoverPartner=h2\\instance2",
         "jdbc:oracle:thin:@//h1,unexpected=value/service",
         "jdbc:oracle:thin:@ldap://ldap1:389,ldap2:389/cn=oraclecontext",
         "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -2421,6 +2421,11 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getServerAddressGroup()).isNull();
   }
 
+  @Test
+  void invalidUnixSocketInServerAddressGroupFailsClosed() {
+    assertThat(UrlParsingUtils.parseServerAddressGroup("/valid.sock,/invalid?sock", null)).isNull();
+  }
+
   @ParameterizedTest
   @MethodSource("configuredOrderServerAddressGroupArguments")
   void preservesConfiguredServerAddressGroupOrder(String url, String expectedServerAddressGroup) {

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -2260,20 +2260,32 @@ class JdbcConnectionUrlParserTest {
             .build());
   }
 
-  private static Stream<Arguments> orderedServerAddressGroupArguments() {
+  private static Stream<Arguments> configuredOrderServerAddressGroupArguments() {
     return Stream.of(
         argumentSet(
             "reversed PostgreSQL targets with a duplicate",
             "jdbc:postgresql://pg.host2:5433,pg.host1:5432,pg.host2:5433/pgdb",
             "pg.host2:5433,pg.host1:5432,pg.host2:5433"),
         argumentSet(
+            "PostgreSQL target-server selection order",
+            "jdbc:postgresql://preferred.host,fallback.host/pgdb?targetServerType=primary",
+            "preferred.host,fallback.host"),
+        argumentSet(
+            "MariaDB failover targets",
+            "jdbc:mariadb:failover://primary.host:3306,secondary.host:3307/mdbdb",
+            "primary.host:3306,secondary.host:3307"),
+        argumentSet(
             "reversed MariaDB sequential targets",
             "jdbc:mariadb:sequential://mdb.host2:3307,mdb.host1:3306/mdbdb",
             "mdb.host2:3307,mdb.host1:3306"),
         argumentSet(
-            "MySQL replication target order",
-            "jdbc:mysql:replication://address=(host=replica.host)(port=3307),"
-                + "address=(host=source.host)(port=3306)/mydb",
+            "MariaDB replication targets",
+            "jdbc:mariadb:replication://primary.host:3306,replica.host:3307/mdbdb",
+            "primary.host:3306,replica.host:3307"),
+        argumentSet(
+            "MySQL configured replication roles",
+            "jdbc:mysql:replication://address=(host=replica.host)(port=3307)(type=REPLICA),"
+                + "address=(host=source.host)(port=3306)(type=SOURCE)/mydb",
             "replica.host:3307,source.host:3306"),
         argumentSet(
             "SQL Server principal and failover partner order",
@@ -2407,8 +2419,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   @ParameterizedTest
-  @MethodSource("orderedServerAddressGroupArguments")
-  void preservesOrderedServerAddressGroups(String url, String expectedServerAddressGroup) {
+  @MethodSource("configuredOrderServerAddressGroupArguments")
+  void preservesConfiguredServerAddressGroupOrder(String url, String expectedServerAddressGroup) {
     assertThat(parse(url, null).getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -241,6 +241,22 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "jdbc:mariadb:failover://h1" + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
+        "jdbc:mariadb:failover://address=(host=h1)"
+            + "?sessionVariables=email='user@example.com',sql_mode=ANSI"
+      })
+  void atInMariaDbSingletonQueryPreservesOrdinaryParsing(String url) {
+    DbInfo dbInfo = parse(url, null);
+
+    assertThat(dbInfo.isMultiTarget()).isFalse();
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getHost()).isEqualTo("h1");
+    assertThat(dbInfo.getServerPort()).isEqualTo(3306);
+  }
+
   @Test
   void atInMariaDbAddressBlockQueryWithoutDatabaseDoesNotDisableConfiguredTargetParsing() {
     DbInfo dbInfo =

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -709,6 +709,14 @@ class JdbcConnectionUrlParserTest {
             .setPort(1433)
             .setName("ssdb")
             .build(),
+        arg("jdbc:sqlserver://ss.host1;instanceName=instance1;databaseName=ssdb")
+            .setShortUrl("sqlserver://ss.host1:1433")
+            .setSystem("microsoft.sql_server")
+            .setOldSystem("mssql")
+            .setHost("ss.host1")
+            .setPort(1433)
+            .setName("ssdb")
+            .build(),
         arg("jdbc:microsoft:sqlserver://;")
             .setProperties(stdProps())
             .setShortUrl("microsoft:sqlserver://stdServerName:9999")
@@ -2087,8 +2095,6 @@ class JdbcConnectionUrlParserTest {
             .setOldSystem("mssql")
             .setHost("ss.host1")
             .setPort(1433)
-            .setNamespace("instance1")
-            .setName("instance1")
             .setServerAddressGroup("ss.host1\\instance1,ss.host2")
             .build(),
         arg("jdbc:sqlserver://[2001:db8::1]:1433;failoverPartner=2001:db8::2")

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -104,6 +104,24 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getServerPort()).isEqualTo(5432);
   }
 
+  @Test
+  void commaAfterAtInFinalQueryParameterDoesNotMarkSingletonAsMultiTarget() {
+    DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db?password=prefix@domain,suffix", null);
+
+    assertThat(dbInfo.isMultiTarget()).isFalse();
+    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+  }
+
+  @Test
+  void commaAfterAtInSqlServerPropertyDoesNotMarkSingletonAsMultiTarget() {
+    DbInfo dbInfo = parse("jdbc:sqlserver://ss.host;password=prefix@domain,suffix", null);
+
+    assertThat(dbInfo.isMultiTarget()).isFalse();
+    assertThat(dbInfo.getServerAddress()).isEqualTo("ss.host");
+    assertThat(dbInfo.getServerPort()).isEqualTo(1433);
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {
@@ -1012,8 +1030,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getServerAddress()).isEqualTo("2001:db8::1");
     assertThat(info.getServerPort()).isEqualTo(2521);
     assertThat(info.getDbNamespace()).isEqualTo("orclsn");
-    assertThat(info.getServerAddressGroup()).isEqualTo("[2001:db8::1],[2001:db8::2]");
-    assertThat(info.getServerAddressGroupPort()).isEqualTo(2521);
+    assertThat(info.getServerAddressGroup()).isEqualTo("[2001:db8::1]:2521,[2001:db8::2]:2521");
   }
 
   private static Stream<Arguments> oracleArguments() {
@@ -2156,7 +2173,7 @@ class JdbcConnectionUrlParserTest {
             .setPort(1433)
             .setNamespace("instance1|ssdb")
             .setName("instance1")
-            .setServerAddressGroup("ss.host1:1433,ss.host2\\instance2")
+            .setServerAddressGroup("ss.host1,ss.host2\\instance2")
             .build(),
         arg("jdbc:sqlserver://ss.host1;instanceName=instance1;failoverPartner=ss.host2")
             .setShortUrl("sqlserver://ss.host1:1433")
@@ -2261,72 +2278,108 @@ class JdbcConnectionUrlParserTest {
         argumentSet(
             "PostgreSQL shared non-default port",
             "jdbc:postgresql://pg.host1:15432,pg.host2:15432/pgdb",
-            "pg.host1,pg.host2",
-            15432),
+            "pg.host1:15432,pg.host2:15432"),
         argumentSet(
             "PostgreSQL default ports",
             "jdbc:postgresql://pg.host1,pg.host2:5432/pgdb",
-            "pg.host1,pg.host2",
-            null),
+            "pg.host1,pg.host2"),
         argumentSet(
             "PostgreSQL mixed IPv6 ports",
             "jdbc:postgresql://[2001:db8::1],[2001:db8::2]:15432/pgdb",
-            "[2001:db8::1]:5432,[2001:db8::2]:15432",
-            null),
+            "[2001:db8::1]:5432,[2001:db8::2]:15432"),
         argumentSet(
             "MySQL address blocks on default ports",
             "jdbc:mysql:replication://address=(host=source.host)(port=3306),"
                 + "address=(host=replica.host)/mydb",
-            "source.host,replica.host",
-            null),
+            "source.host,replica.host"),
         argumentSet(
             "MariaDB shared non-default port",
             "jdbc:mariadb:failover://mdb.host1:13306,mdb.host2:13306/mdbdb",
-            "mdb.host1,mdb.host2",
-            13306),
+            "mdb.host1:13306,mdb.host2:13306"),
         argumentSet(
             "SQL Server shared non-default port",
             "jdbc:sqlserver://primary.host:1444;failoverPartner=partner.host:1444",
-            "primary.host,partner.host",
-            1444),
+            "primary.host:1444,partner.host:1444"),
         argumentSet(
             "Oracle shared non-default port",
             "jdbc:oracle:thin:@(description="
                 + "(address=(protocol=tcp)(host=orcl.host1)(port=2521))"
                 + "(address=(protocol=tcp)(host=orcl.host2)(port=2521))"
                 + "(connect_data=(service_name=orclsn)))",
-            "orcl.host1,orcl.host2",
-            2521),
+            "orcl.host1:2521,orcl.host2:2521"),
         argumentSet(
             "Oracle Easy Connect default ports",
             "jdbc:oracle:thin:@//orcl.host1,orcl.host2/orclsn",
-            "orcl.host1,orcl.host2",
-            null),
+            "orcl.host1,orcl.host2"),
         argumentSet(
             "Oracle Easy Connect shared non-default port",
             "jdbc:oracle:thin:@tcps://orcl.host1:2521,orcl.host2:2521/orclsn",
-            "orcl.host1,orcl.host2",
-            2521),
+            "orcl.host1:2521,orcl.host2:2521"),
         argumentSet(
             "Oracle Easy Connect mixed IPv6 ports",
             "jdbc:oracle:thin:@//[2001:db8::1],[2001:db8::2]:2521/orclsn",
-            "[2001:db8::1]:1521,[2001:db8::2]:2521",
-            null),
+            "[2001:db8::1]:1521,[2001:db8::2]:2521"),
         argumentSet(
             "unknown database default keeps explicit ports",
             "jdbc:unknown://unknown.host1:1234,unknown.host2:1234/db",
-            "unknown.host1:1234,unknown.host2:1234",
-            null));
+            "unknown.host1:1234,unknown.host2:1234"),
+        argumentSet(
+            "unknown database address blocks become endpoints",
+            "jdbc:unknown://address=(host=unknown.host1)(port=1234),"
+                + "address=(host=unknown.host2)(port=1234)/db",
+            "unknown.host1:1234,unknown.host2:1234"),
+        argumentSet(
+            "PolarDB default ports",
+            "jdbc:polardb://polardb.host1:1521,polardb.host2/db",
+            "polardb.host1,polardb.host2"));
   }
 
   @ParameterizedTest
   @MethodSource("normalizedServerAddressGroupArguments")
-  void normalizesServerAddressGroupPorts(
-      String url, String expectedServerAddressGroup, Integer expectedServerAddressGroupPort) {
+  void normalizesServerAddressGroupPorts(String url, String expectedServerAddressGroup) {
     DbInfo dbInfo = parse(url, null);
 
     assertThat(dbInfo.getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
-    assertThat(dbInfo.getServerAddressGroupPort()).isEqualTo(expectedServerAddressGroupPort);
+  }
+
+  private static Stream<Arguments> limitedServerAddressGroupArguments() {
+    return Stream.of(
+        argumentSet(
+            "exactly five PostgreSQL endpoints",
+            "jdbc:postgresql://h1,h2,h3,h4,h5/db",
+            "h1,h2,h3,h4,h5"),
+        argumentSet(
+            "six PostgreSQL endpoints", "jdbc:postgresql://h1,h2,h3,h4,h5,h6/db", "h1,h2,h3,h4,h5"),
+        argumentSet(
+            "non-default MariaDB port after the fifth endpoint",
+            "jdbc:mariadb:failover://h1,h2,h3,h4,h5,h6:13306/db",
+            "h1:3306,h2:3306,h3:3306,h4:3306,h5:3306"),
+        argumentSet(
+            "six Oracle address blocks",
+            "jdbc:oracle:thin:@(description=(address_list="
+                + "(address=(host=h1)(port=1521))"
+                + "(address=(host=h2)(port=1521))"
+                + "(address=(host=h3)(port=1521))"
+                + "(address=(host=h4)(port=1521))"
+                + "(address=(host=h5)(port=1521))"
+                + "(address=(host=h6)(port=1521)))"
+                + "(connect_data=(service_name=orclsn)))",
+            "h1,h2,h3,h4,h5"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("limitedServerAddressGroupArguments")
+  void limitsServerAddressGroupAfterInspectingTheCompleteList(
+      String url, String expectedServerAddressGroup) {
+    assertThat(parse(url, null).getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
+  }
+
+  @Test
+  void invalidEndpointAfterTheFifthEndpointFailsClosed() {
+    DbInfo dbInfo = parse("jdbc:postgresql://h1,h2,h3,h4,h5,unexpected=value/db", null);
+
+    assertThat(dbInfo.isMultiTarget()).isTrue();
+    assertThat(dbInfo.getServerAddressGroup()).isNull();
   }
 
   @ParameterizedTest
@@ -2374,7 +2427,6 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
     assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
     assertThat(info.getServerAddressGroup()).isEqualTo(expected.getServerAddressGroup());
-    assertThat(info.getServerAddressGroupPort()).isEqualTo(expected.getServerAddressGroupPort());
     assertThat(info.isMultiTarget()).isEqualTo(expected.isMultiTarget());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
@@ -2406,7 +2458,6 @@ class JdbcConnectionUrlParserTest {
               .serverAddress(builder.host)
               .serverPort(builder.port)
               .serverAddressGroup(builder.serverAddressGroup)
-              .serverAddressGroupPort(builder.serverAddressGroupPort)
               .multiTarget(builder.multiTarget || builder.serverAddressGroup != null)
               .build();
     }
@@ -2429,7 +2480,6 @@ class JdbcConnectionUrlParserTest {
     String namespace;
     String name;
     String serverAddressGroup;
-    Integer serverAddressGroupPort;
     boolean multiTarget;
 
     ParseTestArgumentBuilder(String url) {
@@ -2491,11 +2541,6 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setServerAddressGroup(String serverAddressGroup) {
       this.serverAddressGroup = serverAddressGroup;
-      return this;
-    }
-
-    ParseTestArgumentBuilder setServerAddressGroupPort(int serverAddressGroupPort) {
-      this.serverAddressGroupPort = serverAddressGroupPort;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -87,7 +87,8 @@ class JdbcConnectionUrlParserTest {
         "jdbc:mariadb:failover://user:p,a/ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:p,a?ss@h1:3306,h2:3306/db",
         "jdbc:mariadb:failover://user:p,a#ss@h1:3306,h2:3306/db",
-        "jdbc:mariadb:failover://user:123,a?x=y@h1:3306,h2:3306/db"
+        "jdbc:mariadb:failover://user:123,a?x=y@h1:3306,h2:3306/db",
+        "jdbc:mariadb:failover://user:123,a?x=y@address=(host=h1),address=(host=h2)/db"
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
@@ -170,6 +171,18 @@ class JdbcConnectionUrlParserTest {
             null);
 
     assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getHost()).isEqualTo("h1");
+  }
+
+  @Test
+  void atInMariaDbAddressBlockQueryWithoutDatabaseDoesNotDisableConfiguredTargetParsing() {
+    DbInfo dbInfo =
+        parse(
+            "jdbc:mariadb:failover://address=(host=h1),address=(host=h2)"
+                + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
+            null);
+
+    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("address=(host=h1),address=(host=h2)");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.instrumentation.jdbc.internal;
 import static io.opentelemetry.instrumentation.jdbc.internal.JdbcConnectionUrlParser.parse;
 import static io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo.DEFAULT;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.extractAuthority;
-import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerAddressGroup;
+import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.parseServerTargetGroup;
 import static io.opentelemetry.instrumentation.jdbc.internal.parser.UrlParsingUtils.sanitizeHostList;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.CLICKHOUSE;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemIncubatingValues.DERBY;
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import java.util.ArrayList;
 import java.util.List;
@@ -87,10 +88,10 @@ class JdbcConnectionUrlParserTest {
   void singletonUrlIsNotMarkedAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db", null);
 
-    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", 5432));
   }
 
   @Test
@@ -101,30 +102,30 @@ class JdbcConnectionUrlParserTest {
                 + "?user=admin@corp.com&options=search_path=test,public",
             null);
 
-    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", 5432));
   }
 
   @Test
   void commaAfterAtInFinalQueryParameterDoesNotMarkSingletonAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db?password=prefix@domain,suffix", null);
 
-    assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getServerPort()).isEqualTo(5432);
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
-    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", 5432));
   }
 
   @Test
   void commaAfterAtInSqlServerPropertyDoesNotMarkSingletonAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:sqlserver://ss.host;password=prefix@domain,suffix", null);
 
-    assertThat(dbInfo.getServerAddress()).isEqualTo("ss.host");
-    assertThat(dbInfo.getServerPort()).isEqualTo(1433);
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("ss.host");
-    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(1433);
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("ss.host");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(1433);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("ss.host", 1433));
   }
 
   @ParameterizedTest
@@ -145,8 +146,7 @@ class JdbcConnectionUrlParserTest {
   void incompleteMultiTargetIsMarkedWithoutAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
-    assertThat(dbInfo.getConfiguredServerPort()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
   }
 
   @ParameterizedTest
@@ -162,7 +162,7 @@ class JdbcConnectionUrlParserTest {
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
     assertThat(dbInfo.getHost()).isNull();
     assertThat(dbInfo.getName()).isNull();
   }
@@ -175,7 +175,7 @@ class JdbcConnectionUrlParserTest {
       })
   void ambiguousPostgresCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
     assertThat(dbInfo.getHost()).isEqualTo("localhost");
     assertThat(dbInfo.getName()).isNull();
   }
@@ -187,7 +187,8 @@ class JdbcConnectionUrlParserTest {
             "jdbc:postgresql://pg.host1:5432,pg.host2:5433/pgdb"
                 + "?user=admin@corp.com&currentSchema=test,public",
             null);
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host1:5432,pg.host2:5433");
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host1:5432,pg.host2:5433", null));
     assertThat(dbInfo.getName()).isEqualTo("pgdb");
   }
 
@@ -196,7 +197,7 @@ class JdbcConnectionUrlParserTest {
     DbInfo dbInfo =
         parse("jdbc:postgresql://h1:5432,h2:5432?options=email=user@example.com,mode=strict", null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1,h2", null));
   }
 
   @ParameterizedTest
@@ -217,7 +218,7 @@ class JdbcConnectionUrlParserTest {
 
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1,h2", null));
     assertThat(dbInfo.getHost()).isEqualTo("h1");
     assertThat(dbInfo.getName()).isEqualTo("db");
     assertThat(dbInfo.getDbUser()).isEqualTo("admin@corp.com");
@@ -260,7 +261,7 @@ class JdbcConnectionUrlParserTest {
                 + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
             null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1,h2", null));
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
@@ -274,10 +275,9 @@ class JdbcConnectionUrlParserTest {
   void atInMariaDbSingletonQueryPreservesOrdinaryParsing(String url) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1");
-    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(3306);
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1", 3306));
     assertThat(dbInfo.getHost()).isEqualTo("h1");
-    assertThat(dbInfo.getServerPort()).isEqualTo(3306);
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(3306);
   }
 
   @Test
@@ -288,7 +288,7 @@ class JdbcConnectionUrlParserTest {
                 + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
             null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1,h2", null));
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
@@ -1056,10 +1056,10 @@ class JdbcConnectionUrlParserTest {
 
     DbInfo info = parse("jdbc:sqlserver://url.host1:1433;failoverPartner=url.host2", properties);
 
-    assertThat(info.getServerAddress()).isEqualTo("property.host1");
-    assertThat(info.getServerPort()).isEqualTo(1444);
-    assertThat(info.getConfiguredServerAddress())
-        .isEqualTo("property.host1:1444,property.host2:1433");
+    assertThat(info.getLegacyServerAddress()).isEqualTo("property.host1");
+    assertThat(info.getLegacyServerPort()).isEqualTo(1444);
+    assertThat(info.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("property.host1:1444,property.host2:1433", null));
   }
 
   @Test
@@ -1070,11 +1070,11 @@ class JdbcConnectionUrlParserTest {
                 + "[2001:db8::2]:2521/orclsn?retry_count=3",
             null);
 
-    assertThat(info.getServerAddress()).isEqualTo("2001:db8::1");
-    assertThat(info.getServerPort()).isEqualTo(2521);
+    assertThat(info.getLegacyServerAddress()).isEqualTo("2001:db8::1");
+    assertThat(info.getLegacyServerPort()).isEqualTo(2521);
     assertThat(info.getDbNamespace()).isEqualTo("orclsn");
-    assertThat(info.getConfiguredServerAddress())
-        .isEqualTo("[2001:db8::1]:2521,[2001:db8::2]:2521");
+    assertThat(info.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("[2001:db8::1]:2521,[2001:db8::2]:2521", null));
   }
 
   private static Stream<Arguments> oracleArguments() {
@@ -2407,7 +2407,8 @@ class JdbcConnectionUrlParserTest {
   void normalizesServerAddressGroupPorts(String url, String expectedServerAddressGroup) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create(expectedServerAddressGroup, null));
   }
 
   private static Stream<Arguments> limitedServerAddressGroupArguments() {
@@ -2439,34 +2440,34 @@ class JdbcConnectionUrlParserTest {
   @MethodSource("limitedServerAddressGroupArguments")
   void limitsServerAddressGroupAfterInspectingTheCompleteList(
       String url, String expectedServerAddressGroup) {
-    assertThat(parse(url, null).getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
+    assertThat(parse(url, null).getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create(expectedServerAddressGroup, null));
   }
 
   @Test
   void invalidEndpointAfterTheFifthEndpointFailsClosed() {
     DbInfo dbInfo = parse("jdbc:postgresql://h1,h2,h3,h4,h5,unexpected=value/db", null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
-    assertThat(dbInfo.getConfiguredServerPort()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
   }
 
   @Test
   void invalidUnixSocketInServerAddressGroupFailsClosed() {
-    assertThat(parseServerAddressGroup("/valid.sock,/invalid?sock", null)).isNull();
+    assertThat(parseServerTargetGroup("/valid.sock,/invalid?sock", null)).isNull();
   }
 
   @Test
   void invalidExplicitPortsInServerAddressGroupFailClosed() {
     DbInfo dbInfo = parse("jdbc:unknown://h1:70000,h2:70000/db", null);
 
-    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
-    assertThat(dbInfo.getConfiguredServerPort()).isNull();
+    assertThat(dbInfo.getConfiguredServerTarget()).isNull();
   }
 
   @ParameterizedTest
   @MethodSource("configuredOrderServerAddressGroupArguments")
   void preservesConfiguredServerAddressGroupOrder(String url, String expectedServerAddressGroup) {
-    assertThat(parse(url, null).getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
+    assertThat(parse(url, null).getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create(expectedServerAddressGroup, null));
   }
 
   @ParameterizedTest(name = "{index}: {0}")
@@ -2505,10 +2506,9 @@ class JdbcConnectionUrlParserTest {
     DbInfo expected = argument.dbInfo;
     assertThat(info.getDbConnectionString()).isEqualTo(expected.getDbConnectionString());
     assertThat(info.getDbSystemName()).isEqualTo(expected.getDbSystemName());
-    assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
-    assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
-    assertThat(info.getConfiguredServerAddress()).isEqualTo(expected.getConfiguredServerAddress());
-    assertThat(info.getConfiguredServerPort()).isEqualTo(expected.getConfiguredServerPort());
+    assertThat(info.getLegacyServerAddress()).isEqualTo(expected.getLegacyServerAddress());
+    assertThat(info.getLegacyServerPort()).isEqualTo(expected.getLegacyServerPort());
+    assertThat(info.getConfiguredServerTarget()).isEqualTo(expected.getConfiguredServerTarget());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
     assertThat(info.getDbName()).isEqualTo(expected.getDbName());
@@ -2536,21 +2536,16 @@ class JdbcConnectionUrlParserTest {
               .dbUser(builder.user)
               .dbNamespace(namespace)
               .dbName(oldDbName)
-              .serverAddress(builder.host)
-              .serverPort(builder.port)
-              .configuredServerAddress(
-                  !builder.configuredTarget || builder.multiTarget
-                      ? null
-                      : builder.serverAddressGroup != null
-                          ? builder.serverAddressGroup
-                          : builder.host)
-              .configuredServerPort(
+              .legacyServerAddress(builder.host)
+              .legacyServerPort(builder.port)
+              .configuredServerTarget(
                   !builder.configuredTarget
                           || builder.multiTarget
-                          || builder.serverAddressGroup != null
-                          || builder.host == null
+                          || (builder.serverAddressGroup == null && builder.host == null)
                       ? null
-                      : builder.port)
+                      : builder.serverAddressGroup != null
+                          ? DbServerTarget.create(builder.serverAddressGroup, null)
+                          : DbServerTarget.create(builder.host, builder.port))
               .build();
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -87,9 +87,10 @@ class JdbcConnectionUrlParserTest {
   void singletonUrlIsNotMarkedAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db", null);
 
-    assertThat(dbInfo.isMultiTarget()).isFalse();
     assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
   }
 
   @Test
@@ -100,27 +101,30 @@ class JdbcConnectionUrlParserTest {
                 + "?user=admin@corp.com&options=search_path=test,public",
             null);
 
-    assertThat(dbInfo.isMultiTarget()).isFalse();
     assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
   }
 
   @Test
   void commaAfterAtInFinalQueryParameterDoesNotMarkSingletonAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:postgresql://pg.host:5432/db?password=prefix@domain,suffix", null);
 
-    assertThat(dbInfo.isMultiTarget()).isFalse();
     assertThat(dbInfo.getServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(5432);
   }
 
   @Test
   void commaAfterAtInSqlServerPropertyDoesNotMarkSingletonAsMultiTarget() {
     DbInfo dbInfo = parse("jdbc:sqlserver://ss.host;password=prefix@domain,suffix", null);
 
-    assertThat(dbInfo.isMultiTarget()).isFalse();
     assertThat(dbInfo.getServerAddress()).isEqualTo("ss.host");
     assertThat(dbInfo.getServerPort()).isEqualTo(1433);
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("ss.host");
+    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(1433);
   }
 
   @ParameterizedTest
@@ -142,8 +146,8 @@ class JdbcConnectionUrlParserTest {
   void incompleteMultiTargetIsMarkedWithoutAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.isMultiTarget()).isTrue();
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest
@@ -159,7 +163,7 @@ class JdbcConnectionUrlParserTest {
       })
   void ambiguousMariaDbCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
     assertThat(dbInfo.getHost()).isNull();
     assertThat(dbInfo.getName()).isNull();
   }
@@ -172,7 +176,7 @@ class JdbcConnectionUrlParserTest {
       })
   void ambiguousPostgresCredentialsDoNotBecomeAConfiguredTarget(String url) {
     DbInfo dbInfo = parse(url, null);
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
     assertThat(dbInfo.getHost()).isEqualTo("localhost");
     assertThat(dbInfo.getName()).isNull();
   }
@@ -184,7 +188,7 @@ class JdbcConnectionUrlParserTest {
             "jdbc:postgresql://pg.host1:5432,pg.host2:5433/pgdb"
                 + "?user=admin@corp.com&currentSchema=test,public",
             null);
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("pg.host1:5432,pg.host2:5433");
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("pg.host1:5432,pg.host2:5433");
     assertThat(dbInfo.getName()).isEqualTo("pgdb");
   }
 
@@ -193,7 +197,7 @@ class JdbcConnectionUrlParserTest {
     DbInfo dbInfo =
         parse("jdbc:postgresql://h1:5432,h2:5432?options=email=user@example.com,mode=strict", null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
   }
 
   @ParameterizedTest
@@ -214,7 +218,7 @@ class JdbcConnectionUrlParserTest {
 
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
     assertThat(dbInfo.getName()).isEqualTo("db");
     assertThat(dbInfo.getDbUser()).isEqualTo("admin@corp.com");
@@ -244,7 +248,7 @@ class JdbcConnectionUrlParserTest {
                 + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
             null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
@@ -258,8 +262,8 @@ class JdbcConnectionUrlParserTest {
   void atInMariaDbSingletonQueryPreservesOrdinaryParsing(String url) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.isMultiTarget()).isFalse();
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1");
+    assertThat(dbInfo.getConfiguredServerPort()).isEqualTo(3306);
     assertThat(dbInfo.getHost()).isEqualTo("h1");
     assertThat(dbInfo.getServerPort()).isEqualTo(3306);
   }
@@ -272,7 +276,7 @@ class JdbcConnectionUrlParserTest {
                 + "?sessionVariables=email='user@example.com',sql_mode=ANSI",
             null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo("h1,h2");
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo("h1,h2");
     assertThat(dbInfo.getHost()).isEqualTo("h1");
   }
 
@@ -285,6 +289,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(MYSQL)
             .setHost("localhost")
             .setPort(3306)
+            .setConfiguredTarget(false)
             .build(),
         arg("jdbc:mysql:///")
             .setProperties(stdProps())
@@ -505,6 +510,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(POSTGRESQL)
             .setHost("localhost")
             .setPort(5432)
+            .setConfiguredTarget(false)
             .build(),
         arg("jdbc:postgresql:///")
             .setProperties(stdProps())
@@ -1040,7 +1046,8 @@ class JdbcConnectionUrlParserTest {
 
     assertThat(info.getServerAddress()).isEqualTo("property.host1");
     assertThat(info.getServerPort()).isEqualTo(1444);
-    assertThat(info.getServerAddressGroup()).isEqualTo("property.host1:1444,property.host2:1433");
+    assertThat(info.getConfiguredServerAddress())
+        .isEqualTo("property.host1:1444,property.host2:1433");
   }
 
   @Test
@@ -1054,7 +1061,8 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getServerAddress()).isEqualTo("2001:db8::1");
     assertThat(info.getServerPort()).isEqualTo(2521);
     assertThat(info.getDbNamespace()).isEqualTo("orclsn");
-    assertThat(info.getServerAddressGroup()).isEqualTo("[2001:db8::1]:2521,[2001:db8::2]:2521");
+    assertThat(info.getConfiguredServerAddress())
+        .isEqualTo("[2001:db8::1]:2521,[2001:db8::2]:2521");
   }
 
   private static Stream<Arguments> oracleArguments() {
@@ -1177,6 +1185,7 @@ class JdbcConnectionUrlParserTest {
             .setOldSystem("oracle")
             .setSubtype("oci8")
             .setPort(1521)
+            .setConfiguredTarget(false)
             .build(),
         arg("jdbc:oracle:oci8:@")
             .setProperties(stdProps())
@@ -1196,6 +1205,7 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("oci8")
             .setPort(1521)
             .setName("orclsn")
+            .setConfiguredTarget(false)
             .build(),
         arg("jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=orcl.host)(PORT=55))(CONNECT_DATA=(SERVICE_NAME=orclsn)))")
             .setShortUrl("oracle:oci://orcl.host:55")
@@ -2036,6 +2046,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(MYSQL)
             .setHost("localhost")
             .setPort(3306)
+            .setConfiguredTarget(false)
             .build(),
         arg("jdbc:aws-wrapper:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
             .setShortUrl("mariadb://mdb.host:33")
@@ -2051,6 +2062,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(POSTGRESQL)
             .setHost("localhost")
             .setPort(5432)
+            .setConfiguredTarget(false)
             .build());
   }
 
@@ -2379,7 +2391,7 @@ class JdbcConnectionUrlParserTest {
   void normalizesServerAddressGroupPorts(String url, String expectedServerAddressGroup) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
+    assertThat(dbInfo.getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
   }
 
   private static Stream<Arguments> limitedServerAddressGroupArguments() {
@@ -2411,15 +2423,15 @@ class JdbcConnectionUrlParserTest {
   @MethodSource("limitedServerAddressGroupArguments")
   void limitsServerAddressGroupAfterInspectingTheCompleteList(
       String url, String expectedServerAddressGroup) {
-    assertThat(parse(url, null).getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
+    assertThat(parse(url, null).getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
   }
 
   @Test
   void invalidEndpointAfterTheFifthEndpointFailsClosed() {
     DbInfo dbInfo = parse("jdbc:postgresql://h1,h2,h3,h4,h5,unexpected=value/db", null);
 
-    assertThat(dbInfo.isMultiTarget()).isTrue();
-    assertThat(dbInfo.getServerAddressGroup()).isNull();
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerPort()).isNull();
   }
 
   @Test
@@ -2430,7 +2442,7 @@ class JdbcConnectionUrlParserTest {
   @ParameterizedTest
   @MethodSource("configuredOrderServerAddressGroupArguments")
   void preservesConfiguredServerAddressGroupOrder(String url, String expectedServerAddressGroup) {
-    assertThat(parse(url, null).getServerAddressGroup()).isEqualTo(expectedServerAddressGroup);
+    assertThat(parse(url, null).getConfiguredServerAddress()).isEqualTo(expectedServerAddressGroup);
   }
 
   @ParameterizedTest(name = "{index}: {0}")
@@ -2471,8 +2483,8 @@ class JdbcConnectionUrlParserTest {
     assertThat(info.getDbSystemName()).isEqualTo(expected.getDbSystemName());
     assertThat(info.getServerAddress()).isEqualTo(expected.getServerAddress());
     assertThat(info.getServerPort()).isEqualTo(expected.getServerPort());
-    assertThat(info.getServerAddressGroup()).isEqualTo(expected.getServerAddressGroup());
-    assertThat(info.isMultiTarget()).isEqualTo(expected.isMultiTarget());
+    assertThat(info.getConfiguredServerAddress()).isEqualTo(expected.getConfiguredServerAddress());
+    assertThat(info.getConfiguredServerPort()).isEqualTo(expected.getConfiguredServerPort());
     assertThat(info.getDbUser()).isEqualTo(expected.getDbUser());
     assertThat(info.getDbNamespace()).isEqualTo(expected.getDbNamespace());
     assertThat(info.getDbName()).isEqualTo(expected.getDbName());
@@ -2502,8 +2514,19 @@ class JdbcConnectionUrlParserTest {
               .dbName(oldDbName)
               .serverAddress(builder.host)
               .serverPort(builder.port)
-              .serverAddressGroup(builder.serverAddressGroup)
-              .multiTarget(builder.multiTarget || builder.serverAddressGroup != null)
+              .configuredServerAddress(
+                  !builder.configuredTarget || builder.multiTarget
+                      ? null
+                      : builder.serverAddressGroup != null
+                          ? builder.serverAddressGroup
+                          : builder.host)
+              .configuredServerPort(
+                  !builder.configuredTarget
+                          || builder.multiTarget
+                          || builder.serverAddressGroup != null
+                          || builder.host == null
+                      ? null
+                      : builder.port)
               .build();
     }
 
@@ -2526,6 +2549,7 @@ class JdbcConnectionUrlParserTest {
     String name;
     String serverAddressGroup;
     boolean multiTarget;
+    boolean configuredTarget = true;
 
     ParseTestArgumentBuilder(String url) {
       this.url = url;
@@ -2591,6 +2615,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setMultiTarget() {
       this.multiTarget = true;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setConfiguredTarget(boolean configuredTarget) {
+      this.configuredTarget = configuredTarget;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -237,6 +237,13 @@ class JdbcConnectionUrlParserTest {
     assertThat(sanitizeHostList("h1:3306,unexpected=value")).isNull();
     assertThat(sanitizeHostList("address=(host=h1),address=(host=unexpected=value)")).isNull();
     assertThat(sanitizeHostList("h1:5432,:5433")).isNull();
+    assertThat(sanitizeHostList("not:an:address,h2")).isNull();
+  }
+
+  @Test
+  void ipv6ZoneIdentifiersArePreservedInConfiguredTargets() {
+    assertThat(sanitizeHostList("fe80::1%eth0,fe80::2%eth1"))
+        .isEqualTo("fe80::1%eth0,fe80::2%eth1");
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -91,7 +91,17 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
     assertThat(dbInfo.getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("pg.host", 5432));
+        .isEqualTo(DbServerTarget.create("pg.host", null));
+  }
+
+  @Test
+  void omittedDefaultPortIsNotReportedInConfiguredTarget() {
+    DbInfo dbInfo = parse("jdbc:postgresql://pg.host/db", null);
+
+    assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
+    assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(dbInfo.getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", null));
   }
 
   @Test
@@ -105,7 +115,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
     assertThat(dbInfo.getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("pg.host", 5432));
+        .isEqualTo(DbServerTarget.create("pg.host", null));
   }
 
   @Test
@@ -115,7 +125,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("pg.host");
     assertThat(dbInfo.getLegacyServerPort()).isEqualTo(5432);
     assertThat(dbInfo.getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("pg.host", 5432));
+        .isEqualTo(DbServerTarget.create("pg.host", null));
   }
 
   @Test
@@ -125,7 +135,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(dbInfo.getLegacyServerAddress()).isEqualTo("ss.host");
     assertThat(dbInfo.getLegacyServerPort()).isEqualTo(1433);
     assertThat(dbInfo.getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("ss.host", 1433));
+        .isEqualTo(DbServerTarget.create("ss.host", null));
   }
 
   @ParameterizedTest
@@ -276,7 +286,7 @@ class JdbcConnectionUrlParserTest {
   void atInMariaDbSingletonQueryPreservesOrdinaryParsing(String url) {
     DbInfo dbInfo = parse(url, null);
 
-    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1", 3306));
+    assertThat(dbInfo.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("h1", null));
     assertThat(dbInfo.getHost()).isEqualTo("h1");
     assertThat(dbInfo.getLegacyServerPort()).isEqualTo(3306);
   }
@@ -294,7 +304,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> mySqlArguments() {
-    return args(
+    return argsWithDefaultPort(
+        3306,
         // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html
         // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
         arg("jdbc:mysql:///")
@@ -516,7 +527,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> postgresArguments() {
-    return args(
+    return argsWithDefaultPort(
+        5432,
         // https://jdbc.postgresql.org/documentation/94/connect.html
         arg("jdbc:postgresql:///")
             .setShortUrl("postgresql://localhost:5432")
@@ -633,7 +645,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> mariaDbArguments() {
-    return args(
+    return argsWithDefaultPort(
+        3306,
         // https://mariadb.com/kb/en/library/about-mariadb-connector-j/#connection-strings
         arg("jdbc:mariadb:127.0.0.1:33/mdbdb")
             .setShortUrl("mariadb://127.0.0.1:33")
@@ -766,7 +779,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> sqlServerArguments() {
-    return args(
+    return argsWithDefaultPort(
+        1433,
         // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
         arg("jdbc:microsoft:sqlserver://;")
             .setShortUrl("microsoft:sqlserver://localhost:1433")
@@ -1092,7 +1106,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> oracleArguments() {
-    return args(
+    return argsWithDefaultPort(
+        1521,
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
         arg("jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn")
@@ -1262,7 +1277,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> db2Arguments() {
-    return args(
+    return argsWithDefaultPort(
+        50000,
         // https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/java/src/tpc/imjcc_tjvjcccn.html
         // https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_r0052342.html
         arg("jdbc:db2://db2.host")
@@ -1364,7 +1380,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> informixArguments() {
-    return args(
+    return argsWithDefaultPort(
+        9088,
         // https://www.ibm.com/support/pages/how-configure-informix-jdbc-connection-string-connect-group
         arg("jdbc:informix-sqli://infxhost:99/infxdb:INFORMIXSERVER=infxsn;user=infxuser;password=PW")
             .setSystem("ibm.informix")
@@ -1630,6 +1647,7 @@ class JdbcConnectionUrlParserTest {
             .setUser("SA")
             .setHost("hs.host")
             .setPort(9001)
+            .setConfiguredServerTarget("hs.host", null)
             .setName("hsdb")
             .build(),
         arg("jdbc:hsqldb:http://hs.host")
@@ -1639,6 +1657,7 @@ class JdbcConnectionUrlParserTest {
             .setUser("SA")
             .setHost("hs.host")
             .setPort(80)
+            .setConfiguredServerTarget("hs.host", null)
             .build(),
         arg("jdbc:hsqldb:http://hs.host:333/hsdb")
             .setShortUrl("hsqldb:http://hs.host:333")
@@ -1656,6 +1675,7 @@ class JdbcConnectionUrlParserTest {
             .setUser("SA")
             .setHost("127.0.0.1")
             .setPort(443)
+            .setConfiguredServerTarget("127.0.0.1", null)
             .setName("hsdb")
             .build());
   }
@@ -1667,7 +1687,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> derbyArguments() {
-    return args(
+    return argsWithDefaultPort(
+        1527,
         // https://db.apache.org/derby/papers/DerbyClientSpec.html#Connection+URL+Format
         // https://db.apache.org/derby/docs/10.8/devguide/cdevdvlp34964.html
         arg("jdbc:derby:derbydb")
@@ -2037,7 +2058,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> polardbArguments() {
-    return args(
+    return argsWithDefaultPort(
+        1521,
         arg("jdbc:polardb://example.com:1901")
             .setShortUrl("polardb://example.com:1901")
             .setSystem("polardb")
@@ -2059,7 +2081,8 @@ class JdbcConnectionUrlParserTest {
   }
 
   private static Stream<Arguments> amazonAuroraArguments() {
-    return args(
+    return argsWithDefaultPort(
+        5432,
         // https://docs.aws.amazon.com/aurora-dsql/latest/userguide/SECTION_program-with-jdbc-connector.html
         arg("jdbc:aws-dsql:postgresql://your-cluster.dsql.us-east-1.on.aws/postgres")
             .setShortUrl("postgresql://your-cluster.dsql.us-east-1.on.aws:5432")
@@ -2321,6 +2344,7 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("failover")
             .setHost("mdb.host")
             .setPort(3306)
+            .setConfiguredServerTarget("mdb.host", null)
             .setName("mdbdb")
             .build(),
         // a single address block is not a group either, and its password stays out of every field
@@ -2332,6 +2356,7 @@ class JdbcConnectionUrlParserTest {
             .setUser("mdbuser")
             .setHost("mdb.host")
             .setPort(3306)
+            .setConfiguredServerTarget("mdb.host", null)
             .setName("mdbdb")
             .build());
   }
@@ -2599,6 +2624,25 @@ class JdbcConnectionUrlParserTest {
               .build();
     }
 
+    private ParseTestArgument(String url, Properties properties, DbInfo dbInfo) {
+      this.url = url;
+      this.properties = properties;
+      this.dbInfo = dbInfo;
+    }
+
+    private ParseTestArgument withoutConfiguredDefaultPort(int defaultPort) {
+      DbServerTarget target = dbInfo.getConfiguredServerTarget();
+      if (target == null || !Integer.valueOf(defaultPort).equals(target.getPort())) {
+        return this;
+      }
+      return new ParseTestArgument(
+          url,
+          properties,
+          dbInfo.toBuilder()
+              .configuredServerTarget(DbServerTarget.create(target.getAddress(), null))
+              .build());
+    }
+
     @Override
     public String toString() {
       return dbInfo.getDbSystemName() + " parsing of " + url;
@@ -2711,6 +2755,15 @@ class JdbcConnectionUrlParserTest {
     List<Arguments> list = new ArrayList<>();
     for (ParseTestArgument arg : testArguments) {
       list.add(arguments(arg));
+    }
+    return list.stream();
+  }
+
+  private static Stream<Arguments> argsWithDefaultPort(
+      int defaultPort, ParseTestArgument... testArguments) {
+    List<Arguments> list = new ArrayList<>();
+    for (ParseTestArgument arg : testArguments) {
+      list.add(arguments(arg.withoutConfiguredDefaultPort(defaultPort)));
     }
     return list.stream();
   }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -137,7 +137,6 @@ class JdbcConnectionUrlParserTest {
         "jdbc:h2:tcp://h1:8082,h2:8083/db",
         "jdbc:sqlserver://;failoverPartner=h2",
         "jdbc:sqlserver://h1;failoverPartner=unexpected=value",
-        "jdbc:sqlserver://h1:1444;failoverPartner=h2\\instance2",
         "jdbc:oracle:thin:@//h1,unexpected=value/service",
         "jdbc:oracle:thin:@ldap://ldap1:389,ldap2:389/cn=oraclecontext",
         "jdbc:oracle:thin:@(description=(address=(host=h1)(port=1521))"
@@ -2352,6 +2351,10 @@ class JdbcConnectionUrlParserTest {
             "SQL Server shared non-default port",
             "jdbc:sqlserver://primary.host:1444;failoverPartner=partner.host:1444",
             "primary.host:1444,partner.host:1444"),
+        argumentSet(
+            "SQL Server mixed port and named instance",
+            "jdbc:sqlserver://primary.host:1444;failoverPartner=partner.host\\instance",
+            "primary.host:1444,partner.host\\instance"),
         argumentSet(
             "Oracle shared non-default port",
             "jdbc:oracle:thin:@(description="

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -250,6 +250,7 @@ class JdbcConnectionUrlParserTest {
     assertThat(sanitizeHostList("address=(host=h1),address=(host=unexpected=value)")).isNull();
     assertThat(sanitizeHostList("h1:5432,:5433")).isNull();
     assertThat(sanitizeHostList("not:an:address,h2")).isNull();
+    assertThat(sanitizeHostList("address=(host=h1)(host=h2),address=(host=h3)")).isNull();
     assertThat(sanitizeHostList("address=(host=h1)(port=secret),address=(host=h2)(port=3306)"))
         .isNull();
     assertThat(

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -238,6 +238,12 @@ class JdbcConnectionUrlParserTest {
     assertThat(sanitizeHostList("address=(host=h1),address=(host=unexpected=value)")).isNull();
     assertThat(sanitizeHostList("h1:5432,:5433")).isNull();
     assertThat(sanitizeHostList("not:an:address,h2")).isNull();
+    assertThat(sanitizeHostList("address=(host=h1)(port=secret),address=(host=h2)(port=3306)"))
+        .isNull();
+    assertThat(
+            sanitizeHostList(
+                "address=(host=h1)(port=3306)(port=3307),address=(host=h2)(port=3306)"))
+        .isNull();
   }
 
   @Test
@@ -2447,6 +2453,14 @@ class JdbcConnectionUrlParserTest {
   @Test
   void invalidUnixSocketInServerAddressGroupFailsClosed() {
     assertThat(parseServerAddressGroup("/valid.sock,/invalid?sock", null)).isNull();
+  }
+
+  @Test
+  void invalidExplicitPortsInServerAddressGroupFailClosed() {
+    DbInfo dbInfo = parse("jdbc:unknown://h1:70000,h2:70000/db", null);
+
+    assertThat(dbInfo.getConfiguredServerAddress()).isNull();
+    assertThat(dbInfo.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -301,7 +301,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(MYSQL)
             .setHost("localhost")
             .setPort(3306)
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build(),
         arg("jdbc:mysql:///")
             .setProperties(stdProps())
@@ -522,7 +522,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(POSTGRESQL)
             .setHost("localhost")
             .setPort(5432)
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build(),
         arg("jdbc:postgresql:///")
             .setProperties(stdProps())
@@ -1197,7 +1197,7 @@ class JdbcConnectionUrlParserTest {
             .setOldSystem("oracle")
             .setSubtype("oci8")
             .setPort(1521)
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build(),
         arg("jdbc:oracle:oci8:@")
             .setProperties(stdProps())
@@ -1217,7 +1217,7 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("oci8")
             .setPort(1521)
             .setName("orclsn")
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build(),
         arg("jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=orcl.host)(PORT=55))(CONNECT_DATA=(SERVICE_NAME=orclsn)))")
             .setShortUrl("oracle:oci://orcl.host:55")
@@ -2058,7 +2058,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(MYSQL)
             .setHost("localhost")
             .setPort(3306)
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build(),
         arg("jdbc:aws-wrapper:mariadb://mdb.host:33/mdbdb?user=mdbuser&password=PW")
             .setShortUrl("mariadb://mdb.host:33")
@@ -2074,7 +2074,7 @@ class JdbcConnectionUrlParserTest {
             .setSystem(POSTGRESQL)
             .setHost("localhost")
             .setPort(5432)
-            .setConfiguredTarget(false)
+            .setNoConfiguredTarget()
             .build());
   }
 
@@ -2539,7 +2539,7 @@ class JdbcConnectionUrlParserTest {
               .legacyServerAddress(builder.host)
               .legacyServerPort(builder.port)
               .configuredServerTarget(
-                  !builder.configuredTarget
+                  builder.noConfiguredTarget
                           || builder.multiTarget
                           || (builder.serverAddressGroup == null && builder.host == null)
                       ? null
@@ -2568,7 +2568,7 @@ class JdbcConnectionUrlParserTest {
     String name;
     String serverAddressGroup;
     boolean multiTarget;
-    boolean configuredTarget = true;
+    boolean noConfiguredTarget;
 
     ParseTestArgumentBuilder(String url) {
       this.url = url;
@@ -2637,8 +2637,8 @@ class JdbcConnectionUrlParserTest {
       return this;
     }
 
-    ParseTestArgumentBuilder setConfiguredTarget(boolean configuredTarget) {
-      this.configuredTarget = configuredTarget;
+    ParseTestArgumentBuilder setNoConfiguredTarget() {
+      this.noConfiguredTarget = true;
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcConnectionUrlParserTest.java
@@ -132,6 +132,7 @@ class JdbcConnectionUrlParserTest {
   @ValueSource(
       strings = {
         "jdbc:postgresql://h1:5432,unexpected=value/db",
+        "jdbc:mariadb:failover://h1:3306,unexpected=value/db",
         "jdbc:unknown://valid.host:1234,evil host:1234/db",
         "jdbc:unknown://address=(host=valid.host)(port=1234),"
             + "address=(host=evil host)(port=1234)/db",
@@ -1077,6 +1078,19 @@ class JdbcConnectionUrlParserTest {
         .isEqualTo(DbServerTarget.create("[2001:db8::1]:2521,[2001:db8::2]:2521", null));
   }
 
+  @Test
+  void oracleLdapDiscoveryTargetOmitsConnectionParameters() {
+    DbInfo info =
+        parse(
+            "jdbc:oracle:thin:@ldap://orcl.host:389/some,cn=OracleContext,dc=com"
+                + "?connect_timeout=5",
+            null);
+
+    assertThat(info.getConfiguredServerTarget())
+        .isEqualTo(
+            DbServerTarget.create("ldap://orcl.host:389/some,cn=oraclecontext,dc=com", null));
+  }
+
   private static Stream<Arguments> oracleArguments() {
     return args(
         // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
@@ -1138,6 +1152,17 @@ class JdbcConnectionUrlParserTest {
             .setHost("orcl.host")
             .setPort(55)
             .setName("some,cn=oraclecontext,dc=com")
+            .setConfiguredServerTarget("ldap://orcl.host:55/some,cn=oraclecontext,dc=com", null)
+            .build(),
+        arg("jdbc:oracle:thin:@ldaps://orcl.host:636/some,cn=OracleContext,dc=com")
+            .setShortUrl("oracle:thin://orcl.host:636")
+            .setSystem("oracle.db")
+            .setOldSystem("oracle")
+            .setSubtype("thin")
+            .setHost("orcl.host")
+            .setPort(636)
+            .setName("some,cn=oraclecontext,dc=com")
+            .setConfiguredServerTarget("ldaps://orcl.host:636/some,cn=oraclecontext,dc=com", null)
             .build(),
         arg("jdbc:oracle:thin:127.0.0.1:orclsn")
             .setShortUrl("oracle:thin://127.0.0.1:1521")
@@ -2252,7 +2277,7 @@ class JdbcConnectionUrlParserTest {
             .setName("orclsn")
             .setServerAddressGroup("orcl.host1:1521,orcl.host2:1522")
             .build(),
-        // a DESCRIPTION_LIST holds independent descriptions, so its addresses are not one group
+        // flattening a DESCRIPTION_LIST would lose each DESCRIPTION's CONNECT_DATA and options
         arg("jdbc:oracle:thin:@(description_list="
                 + "(description=(address=(protocol=tcp)(host=orcl.host1)(port=1521))"
                 + "(connect_data=(service_name=orclsn)))"
@@ -2264,6 +2289,29 @@ class JdbcConnectionUrlParserTest {
             .setSubtype("thin")
             .setHost("orcl.host1")
             .setPort(1521)
+            .setName("orclsn")
+            .setMultiTarget()
+            .build(),
+        arg("jdbc:oracle:thin:@(description=(source_route=on)"
+                + "(address=(protocol=tcp)(host=cman.host)(port=1630))"
+                + "(address=(protocol=tcp)(host=orcl.host)(port=1521))"
+                + "(connect_data=(service_name=orclsn)))")
+            .setShortUrl("oracle:thin://cman.host:1630")
+            .setSystem("oracle.db")
+            .setOldSystem("oracle")
+            .setSubtype("thin")
+            .setHost("cman.host")
+            .setPort(1630)
+            .setName("orclsn")
+            .setMultiTarget()
+            .build(),
+        arg("jdbc:oracle:thin:@//cman.host:1630,orcl.host:1521/orclsn?source_route=on")
+            .setShortUrl("oracle:thin://cman.host:1630")
+            .setSystem("oracle.db")
+            .setOldSystem("oracle")
+            .setSubtype("thin")
+            .setHost("cman.host")
+            .setPort(1630)
             .setName("orclsn")
             .setMultiTarget()
             .build(),
@@ -2539,13 +2587,15 @@ class JdbcConnectionUrlParserTest {
               .legacyServerAddress(builder.host)
               .legacyServerPort(builder.port)
               .configuredServerTarget(
-                  builder.noConfiguredTarget
-                          || builder.multiTarget
-                          || (builder.serverAddressGroup == null && builder.host == null)
+                  builder.noConfiguredTarget || builder.multiTarget
                       ? null
-                      : builder.serverAddressGroup != null
-                          ? DbServerTarget.create(builder.serverAddressGroup, null)
-                          : DbServerTarget.create(builder.host, builder.port))
+                      : builder.configuredServerTarget != null
+                          ? builder.configuredServerTarget
+                          : builder.serverAddressGroup == null && builder.host == null
+                              ? null
+                              : builder.serverAddressGroup != null
+                                  ? DbServerTarget.create(builder.serverAddressGroup, null)
+                                  : DbServerTarget.create(builder.host, builder.port))
               .build();
     }
 
@@ -2567,6 +2617,7 @@ class JdbcConnectionUrlParserTest {
     String namespace;
     String name;
     String serverAddressGroup;
+    DbServerTarget configuredServerTarget;
     boolean multiTarget;
     boolean noConfiguredTarget;
 
@@ -2629,6 +2680,11 @@ class JdbcConnectionUrlParserTest {
 
     ParseTestArgumentBuilder setServerAddressGroup(String serverAddressGroup) {
       this.serverAddressGroup = serverAddressGroup;
+      return this;
+    }
+
+    ParseTestArgumentBuilder setConfiguredServerTarget(String address, Integer port) {
+      this.configuredServerTarget = DbServerTarget.create(address, port);
       return this;
     }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.Test;
 class JdbcServicePeerTest {
 
   private static final String GROUP_TARGET = "pg.host1:5432,pg.host2:5433";
-  private static final String OPAQUE_GROUP_TARGET =
-      "oracle:thin:@(description=(address=(protocol=tcp)(host=h1)(port=1521))"
-          + "(address=(protocol=tcp)(host=h2)(port=1521)))";
+  private static final String DEFAULT_PORT_GROUP_TARGET = "orcl.host1,orcl.host2";
 
   @Test
   void groupTargetCanBeMatchedExactly() {
@@ -70,21 +68,42 @@ class JdbcServicePeerTest {
   }
 
   @Test
-  void opaqueGroupTargetCanBeMatchedExactly() {
+  void defaultPortGroupTargetCanBeMatchedExactly() {
     DbRequest request =
         request(
             DbInfo.builder()
                 .dbSystemName("oracle.db")
-                .serverAddress("oracle")
+                .serverAddress("orcl.host1")
                 .serverPort(1521)
-                .serverAddressGroup(OPAQUE_GROUP_TARGET)
+                .serverAddressGroup(DEFAULT_PORT_GROUP_TARGET)
                 .build());
 
     if (emitStableDatabaseSemconv()) {
-      assertThat(resolve(request, OPAQUE_GROUP_TARGET))
+      assertThat(resolve(request, DEFAULT_PORT_GROUP_TARGET))
           .containsOnly(entry(maybeStablePeerService(), "myService"));
     } else {
-      assertThat(resolve(request, OPAQUE_GROUP_TARGET)).isEmpty();
+      assertThat(resolve(request, DEFAULT_PORT_GROUP_TARGET)).isEmpty();
+    }
+  }
+
+  @Test
+  void commonPortGroupTargetCanBeMatchedExactly() {
+    String target = "pg.host1,pg.host2";
+    DbRequest request =
+        request(
+            DbInfo.builder()
+                .dbSystemName(POSTGRESQL)
+                .serverAddress("localhost")
+                .serverPort(5432)
+                .serverAddressGroup(target)
+                .serverAddressGroupPort(15432)
+                .build());
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(resolve(request, target + ":15432"))
+          .containsOnly(entry(maybeStablePeerService(), "myService"));
+    } else {
+      assertThat(resolve(request, target + ":15432")).isEmpty();
     }
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jdbc.internal;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DbAttributes.DbSystemNameValues.POSTGRESQL;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JdbcServicePeerTest {
+
+  private static final String GROUP_TARGET = "pg.host1:5432,pg.host2:5433";
+  private static final String OPAQUE_GROUP_TARGET =
+      "oracle:thin:@(description=(address=(protocol=tcp)(host=h1)(port=1521))"
+          + "(address=(protocol=tcp)(host=h2)(port=1521)))";
+
+  @Test
+  void groupTargetCanBeMatchedExactly() {
+    DbRequest request =
+        request(
+            DbInfo.builder()
+                .dbSystemName(POSTGRESQL)
+                .serverAddress("localhost")
+                .serverPort(5432)
+                .serverAddressGroup(GROUP_TARGET)
+                .build());
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(resolve(request, "localhost")).isEmpty();
+      assertThat(resolve(request, GROUP_TARGET))
+          .containsOnly(entry(maybeStablePeerService(), "myService"));
+    } else {
+      assertThat(resolve(request, "localhost"))
+          .containsOnly(entry(maybeStablePeerService(), "myService"));
+      assertThat(resolve(request, GROUP_TARGET)).isEmpty();
+    }
+  }
+
+  @Test
+  void singleHostIsMatchedByAHostKeyedMappingInEveryMode() {
+    DbRequest request =
+        request(
+            DbInfo.builder()
+                .dbSystemName(POSTGRESQL)
+                .serverAddress("localhost")
+                .serverPort(5432)
+                .build());
+
+    assertThat(resolve(request, "localhost"))
+        .containsOnly(entry(maybeStablePeerService(), "myService"));
+  }
+
+  @Test
+  void opaqueGroupTargetCanBeMatchedExactly() {
+    DbRequest request =
+        request(
+            DbInfo.builder()
+                .dbSystemName("oracle.db")
+                .serverAddress("oracle")
+                .serverPort(1521)
+                .serverAddressGroup(OPAQUE_GROUP_TARGET)
+                .build());
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(resolve(request, OPAQUE_GROUP_TARGET))
+          .containsOnly(entry(maybeStablePeerService(), "myService"));
+    } else {
+      assertThat(resolve(request, OPAQUE_GROUP_TARGET)).isEmpty();
+    }
+  }
+
+  private static DbRequest request(DbInfo dbInfo) {
+    return DbRequest.create(dbInfo, "SELECT 1", false);
+  }
+
+  private static Attributes resolve(DbRequest request, String peer) {
+    AttributesExtractor<DbRequest, Void> extractor =
+        ServicePeerAttributesExtractor.create(new JdbcAttributesGetter(), openTelemetry(peer));
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onEnd(attributes, Context.root(), request, null, null);
+    return attributes.build();
+  }
+
+  private static ExtendedOpenTelemetry openTelemetry(String peer) {
+    DeclarativeConfigProperties entry = mock(DeclarativeConfigProperties.class);
+    when(entry.getString("peer")).thenReturn(peer);
+    when(entry.getString("service_name")).thenReturn("myService");
+    when(entry.getString("service_namespace")).thenReturn(null);
+
+    List<DeclarativeConfigProperties> entries = asList(entry);
+    DeclarativeConfigProperties commonConfig = mock(DeclarativeConfigProperties.class);
+    when(commonConfig.getStructuredList("service_peer_mapping", emptyList())).thenReturn(entries);
+
+    ExtendedOpenTelemetry openTelemetry = mock(ExtendedOpenTelemetry.class);
+    when(openTelemetry.getInstrumentationConfig("common")).thenReturn(commonConfig);
+    return openTelemetry;
+  }
+}

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
@@ -86,27 +86,6 @@ class JdbcServicePeerTest {
     }
   }
 
-  @Test
-  void commonPortGroupTargetCanBeMatchedExactly() {
-    String target = "pg.host1,pg.host2";
-    DbRequest request =
-        request(
-            DbInfo.builder()
-                .dbSystemName(POSTGRESQL)
-                .serverAddress("localhost")
-                .serverPort(5432)
-                .serverAddressGroup(target)
-                .serverAddressGroupPort(15432)
-                .build());
-
-    if (emitStableDatabaseSemconv()) {
-      assertThat(resolve(request, target + ":15432"))
-          .containsOnly(entry(maybeStablePeerService(), "myService"));
-    } else {
-      assertThat(resolve(request, target + ":15432")).isEmpty();
-    }
-  }
-
   private static DbRequest request(DbInfo dbInfo) {
     return DbRequest.create(dbInfo, "SELECT 1", false);
   }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
@@ -39,7 +39,7 @@ class JdbcServicePeerTest {
                 .dbSystemName(POSTGRESQL)
                 .serverAddress("localhost")
                 .serverPort(5432)
-                .serverAddressGroup(GROUP_TARGET)
+                .configuredServerAddress(GROUP_TARGET)
                 .build());
 
     if (emitStableDatabaseSemconv()) {
@@ -61,6 +61,8 @@ class JdbcServicePeerTest {
                 .dbSystemName(POSTGRESQL)
                 .serverAddress("localhost")
                 .serverPort(5432)
+                .configuredServerAddress("localhost")
+                .configuredServerPort(5432)
                 .build());
 
     assertThat(resolve(request, "localhost"))
@@ -75,7 +77,7 @@ class JdbcServicePeerTest {
                 .dbSystemName("oracle.db")
                 .serverAddress("orcl.host1")
                 .serverPort(1521)
-                .serverAddressGroup(DEFAULT_PORT_GROUP_TARGET)
+                .configuredServerAddress(DEFAULT_PORT_GROUP_TARGET)
                 .build());
 
     if (emitStableDatabaseSemconv()) {

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcServicePeerTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.api.incubator.semconv.service.peer.ServicePeerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
@@ -37,9 +38,9 @@ class JdbcServicePeerTest {
         request(
             DbInfo.builder()
                 .dbSystemName(POSTGRESQL)
-                .serverAddress("localhost")
-                .serverPort(5432)
-                .configuredServerAddress(GROUP_TARGET)
+                .legacyServerAddress("localhost")
+                .legacyServerPort(5432)
+                .configuredServerTarget(DbServerTarget.create(GROUP_TARGET, null))
                 .build());
 
     if (emitStableDatabaseSemconv()) {
@@ -59,10 +60,9 @@ class JdbcServicePeerTest {
         request(
             DbInfo.builder()
                 .dbSystemName(POSTGRESQL)
-                .serverAddress("localhost")
-                .serverPort(5432)
-                .configuredServerAddress("localhost")
-                .configuredServerPort(5432)
+                .legacyServerAddress("localhost")
+                .legacyServerPort(5432)
+                .configuredServerTarget(DbServerTarget.create("localhost", 5432))
                 .build());
 
     assertThat(resolve(request, "localhost"))
@@ -75,9 +75,9 @@ class JdbcServicePeerTest {
         request(
             DbInfo.builder()
                 .dbSystemName("oracle.db")
-                .serverAddress("orcl.host1")
-                .serverPort(1521)
-                .configuredServerAddress(DEFAULT_PORT_GROUP_TARGET)
+                .legacyServerAddress("orcl.host1")
+                .legacyServerPort(1521)
+                .configuredServerTarget(DbServerTarget.create(DEFAULT_PORT_GROUP_TARGET, null))
                 .build());
 
     if (emitStableDatabaseSemconv()) {

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/OpenTelemetryConnectionTest.java
@@ -108,8 +108,8 @@ class OpenTelemetryConnectionTest {
         .dbUser("my_user")
         .dbName("my_name")
         .dbNamespace("my_name")
-        .serverAddress("my_host")
-        .serverPort(1234)
+        .legacyServerAddress("my_host")
+        .legacyServerPort(1234)
         .build();
   }
 

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfoTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/dbinfo/DbInfoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jdbc.internal.dbinfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import org.junit.jupiter.api.Test;
+
+class DbInfoTest {
+
+  @Test
+  void copyPreservesLegacyEndpointAndConfiguredTarget() {
+    DbServerTarget target = DbServerTarget.create("h1:5432,h2:5433", null);
+    DbInfo info =
+        DbInfo.builder()
+            .legacyServerAddress("localhost")
+            .legacyServerPort(5432)
+            .configuredServerTarget(target)
+            .build();
+
+    DbInfo copy = info.toBuilder().build();
+
+    assertThat(copy).isEqualTo(info).hasSameHashCodeAs(info);
+    assertThat(copy.getConfiguredServerTarget()).isSameAs(target);
+    assertThat(copy.getHost()).isEqualTo("localhost");
+    assertThat(copy.getPort()).isEqualTo(5432);
+    assertThat(copy.toBuilder().configuredServerTarget(null).build().getConfiguredServerTarget())
+        .isNull();
+  }
+
+  @Test
+  void independentlyBuiltTargetsHaveValueEquality() {
+    DbInfo info =
+        DbInfo.builder()
+            .configuredServerTarget(DbServerTarget.create("h1:5432,h2:5433", null))
+            .build();
+
+    assertThat(
+            DbInfo.builder()
+                .configuredServerTarget(DbServerTarget.create("h1:5432,h2:5433", null))
+                .build())
+        .isEqualTo(info)
+        .hasSameHashCodeAs(info);
+  }
+}

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
@@ -51,11 +51,26 @@ class ParseContextTest {
   }
 
   @Test
+  void singleServerFallbackPreservesConfiguredValuesWhenDefaultsChange() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.host("pg.host");
+    context.port(5433);
+    context.defaultHost("localhost");
+    context.defaultPort(5432);
+
+    DbInfo info = context.toDbInfo();
+
+    assertThat(info.getLegacyServerAddress()).isEqualTo("localhost");
+    assertThat(info.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(info.getConfiguredServerTarget()).isEqualTo(DbServerTarget.create("pg.host", 5433));
+  }
+
+  @Test
   void resolvedGroupIsNotOverwrittenByLegacyEndpoint() {
     ParseContext context = ParseContext.of("postgresql", null);
     DbServerTarget target = DbServerTarget.create("h1:5432,h2:5433", null);
-    context.multiTarget();
-    context.configuredServerTarget(target);
+    context.disableSingleServerFallback();
+    context.resolveConfiguredServerTarget(target);
     context.host("h1");
     context.port(5432);
 
@@ -63,11 +78,32 @@ class ParseContextTest {
   }
 
   @Test
+  void disablingFallbackPreservesResolvedTarget() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    DbServerTarget target = DbServerTarget.create("h1:5432,h2:5433", null);
+    context.resolveConfiguredServerTarget(target);
+    context.disableSingleServerFallback();
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget()).isSameAs(target);
+  }
+
+  @Test
   void rejectedTargetDoesNotFallBackToLegacyEndpoint() {
     ParseContext context = ParseContext.of("postgresql", null);
-    context.configuredServerTarget(null);
+    context.resolveConfiguredServerTarget(null);
     context.host("h1");
     context.port(5432);
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget()).isNull();
+  }
+
+  @Test
+  void resolvingNullClearsTargetWithoutRestoringFallback() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.host("h1");
+    context.port(5432);
+    context.resolveConfiguredServerTarget(DbServerTarget.create("h1:5432,h2:5433", null));
+    context.resolveConfiguredServerTarget(null);
 
     assertThat(context.toDbInfo().getConfiguredServerTarget()).isNull();
   }
@@ -77,7 +113,7 @@ class ParseContextTest {
     ParseContext context = ParseContext.of("postgresql", null);
     context.host("h1");
     context.port(5432);
-    context.multiTarget();
+    context.disableSingleServerFallback();
 
     assertThat(context.toDbInfo().getConfiguredServerTarget()).isNull();
   }

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
@@ -10,8 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class ParseContextTest {
 
@@ -29,25 +27,45 @@ class ParseContextTest {
   }
 
   @Test
-  void configuredHostKeepsParserDefaultPort() {
+  void configuredHostOmitsParserDefaultPort() {
     ParseContext context = ParseContext.of("postgresql", null);
     context.defaultPort(5432);
     context.host("[2001:db8::1]");
 
     assertThat(context.toDbInfo().getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("2001:db8::1", 5432));
+        .isEqualTo(DbServerTarget.create("2001:db8::1", null));
   }
 
-  @ParameterizedTest
-  @ValueSource(ints = {5432, 5433})
-  void configuredPortIsPreservedWhenSetBeforeHost(int port) {
+  @Test
+  void configuredDefaultPortIsOmittedWhenSetBeforeHost() {
     ParseContext context = ParseContext.of("postgresql", null);
     context.defaultPort(5432);
-    context.port(port);
+    context.port(5432);
     context.host("pg.host");
 
     assertThat(context.toDbInfo().getConfiguredServerTarget())
-        .isEqualTo(DbServerTarget.create("pg.host", port));
+        .isEqualTo(DbServerTarget.create("pg.host", null));
+  }
+
+  @Test
+  void configuredNonDefaultPortIsPreservedWhenSetBeforeHost() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.defaultPort(5432);
+    context.port(5433);
+    context.host("pg.host");
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", 5433));
+  }
+
+  @Test
+  void configuredPortIsPreservedWithoutParserDefault() {
+    ParseContext context = ParseContext.of("unknown", null);
+    context.port(5432);
+    context.host("db.host");
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("db.host", 5432));
   }
 
   @Test

--- a/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
+++ b/instrumentation/jdbc/library/src/test/java/io/opentelemetry/instrumentation/jdbc/internal/parser/ParseContextTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.jdbc.internal.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.jdbc.internal.dbinfo.DbInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ParseContextTest {
+
+  @Test
+  void parserDefaultsDoNotCreateConfiguredTarget() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.defaultHost("localhost");
+    context.defaultPort(5432);
+
+    DbInfo info = context.toDbInfo();
+
+    assertThat(info.getLegacyServerAddress()).isEqualTo("localhost");
+    assertThat(info.getLegacyServerPort()).isEqualTo(5432);
+    assertThat(info.getConfiguredServerTarget()).isNull();
+  }
+
+  @Test
+  void configuredHostKeepsParserDefaultPort() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.defaultPort(5432);
+    context.host("[2001:db8::1]");
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("2001:db8::1", 5432));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {5432, 5433})
+  void configuredPortIsPreservedWhenSetBeforeHost(int port) {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.defaultPort(5432);
+    context.port(port);
+    context.host("pg.host");
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget())
+        .isEqualTo(DbServerTarget.create("pg.host", port));
+  }
+
+  @Test
+  void resolvedGroupIsNotOverwrittenByLegacyEndpoint() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    DbServerTarget target = DbServerTarget.create("h1:5432,h2:5433", null);
+    context.multiTarget();
+    context.configuredServerTarget(target);
+    context.host("h1");
+    context.port(5432);
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget()).isSameAs(target);
+  }
+
+  @Test
+  void rejectedTargetDoesNotFallBackToLegacyEndpoint() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.configuredServerTarget(null);
+    context.host("h1");
+    context.port(5432);
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget()).isNull();
+  }
+
+  @Test
+  void unresolvedGroupDoesNotFallBackToSingleEndpoint() {
+    ParseContext context = ParseContext.of("postgresql", null);
+    context.host("h1");
+    context.port(5432);
+    context.multiTarget();
+
+    assertThat(context.toDbInfo().getConfiguredServerTarget()).isNull();
+  }
+}

--- a/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -298,7 +298,7 @@
     {
       "name": "otel.instrumentation.common.peer-service-mapping",
       "type": "java.util.Map<java.lang.String, java.lang.String>",
-      "description": "Used to specify a mapping from host names or IP addresses to peer services, as a comma-separated list of <code>host_or_ip=user_assigned_name</code> pairs. The peer service is added as an attribute to a span whose host or IP address match the mapping. See https://opentelemetry.io/docs/zero-code/java/agent/configuration/#peer-service-name."
+      "description": "Used to specify a mapping from server addresses or configured targets to peer services, as a comma-separated list of <code>server_address_or_configured_target=user_assigned_name</code> pairs. Configured targets containing commas or equals signs cannot be represented in this flat property; map them with declarative <code>service_peer_mapping</code> instead. The peer service is added as an attribute to a span whose server address or configured target matches the mapping. See https://opentelemetry.io/docs/zero-code/java/agent/configuration/#peer-service-name."
     },
     {
       "name": "otel.instrumentation.common.thread-details.enabled",


### PR DESCRIPTION
Stable JDBC telemetry now reports the configured database target in `server.address`. Multi-target connections produce a normalized, comma-separated address and omit `server.port`. Single-target connections omit `server.port` when the port is absent or matches the DBMS default, while preserving a configured non-default port. Service-discovery targets retain their canonical configured identity, including Oracle LDAP and LDAPS scheme, endpoint, and lookup path. Routing chains that include intermediaries are omitted when the database target cannot be represented safely.

Malformed or unsupported target groups leave both attributes unset instead of reporting a parser default, and so does a URL that names no server at all, such as `jdbc:postgresql://`.

Configured targets can also match a peer service exactly through declarative configuration:

```yaml
instrumentation/development:
  java:
    common:
      service_peer_mapping:
        - peer: pg.host1:5432,pg.host2:5433
          service_name: orders-db
```

The flat `otel.instrumentation.common.peer-service-mapping` property cannot represent targets that contain commas or equals signs. Legacy database attributes keep their current values, except that previously misparsed Oracle LDAPS URLs now report the directory host and port instead of treating `ldaps` as the host.

When a query has no summary or database namespace, the stable span name can fall back to the configured target.