### PR TITLE
Report configured ClickHouse and R2DBC targets in server.address

### DIFF
--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
@@ -62,9 +62,12 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
   @Nullable
   @Override
   public String getServerAddress(ClickHouseDbRequest request) {
-    String addressGroup = request.getServerAddressGroup();
-    if (emitStableDatabaseSemconv() && addressGroup != null) {
-      return addressGroup;
+    if (emitStableDatabaseSemconv()) {
+      String addressGroup = request.getServerAddressGroup();
+      if (addressGroup != null) {
+        return addressGroup;
+      }
+      return request.getConfiguredHost();
     }
     return request.getHost();
   }
@@ -72,8 +75,8 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
   @Nullable
   @Override
   public Integer getServerPort(ClickHouseDbRequest request) {
-    if (emitStableDatabaseSemconv() && request.getServerAddressGroup() != null) {
-      return null;
+    if (emitStableDatabaseSemconv()) {
+      return request.getServerAddressGroup() == null ? request.getConfiguredPort() : null;
     }
     return request.getPort();
   }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singletonList;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
@@ -61,12 +62,19 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
   @Nullable
   @Override
   public String getServerAddress(ClickHouseDbRequest request) {
+    String addressGroup = request.getServerAddressGroup();
+    if (emitStableDatabaseSemconv() && addressGroup != null) {
+      return addressGroup;
+    }
     return request.getHost();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(ClickHouseDbRequest request) {
+    if (emitStableDatabaseSemconv() && request.getServerAddressGroup() != null) {
+      return null;
+    }
     return request.getPort();
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
@@ -76,7 +76,7 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
   @Override
   public Integer getServerPort(ClickHouseDbRequest request) {
     if (emitStableDatabaseSemconv()) {
-      return request.getServerAddressGroup() == null ? request.getConfiguredPort() : null;
+      return request.getConfiguredPort();
     }
     return request.getPort();
   }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
@@ -80,4 +80,16 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
     }
     return request.getPort();
   }
+
+  @Nullable
+  @Override
+  public String getNetworkPeerAddress(ClickHouseDbRequest request, @Nullable Void response) {
+    return emitStableDatabaseSemconv() ? request.getPeerAddress() : null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(ClickHouseDbRequest request, @Nullable Void response) {
+    return emitStableDatabaseSemconv() ? request.getPeerPort() : null;
+  }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
@@ -12,8 +12,12 @@ import javax.annotation.Nullable;
 public abstract class ClickHouseDbRequest {
 
   public static ClickHouseDbRequest create(
-      @Nullable String host, @Nullable Integer port, @Nullable String namespace, String sql) {
-    return new AutoValue_ClickHouseDbRequest(host, port, namespace, sql);
+      @Nullable String host,
+      @Nullable Integer port,
+      @Nullable String serverAddressGroup,
+      @Nullable String namespace,
+      String sql) {
+    return new AutoValue_ClickHouseDbRequest(host, port, serverAddressGroup, namespace, sql);
   }
 
   @Nullable
@@ -21,6 +25,9 @@ public abstract class ClickHouseDbRequest {
 
   @Nullable
   public abstract Integer getPort();
+
+  @Nullable
+  public abstract String getServerAddressGroup();
 
   @Nullable
   public abstract String getNamespace();

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
@@ -14,10 +14,13 @@ public abstract class ClickHouseDbRequest {
   public static ClickHouseDbRequest create(
       @Nullable String host,
       @Nullable Integer port,
+      @Nullable String configuredHost,
+      @Nullable Integer configuredPort,
       @Nullable String serverAddressGroup,
       @Nullable String namespace,
       String sql) {
-    return new AutoValue_ClickHouseDbRequest(host, port, serverAddressGroup, namespace, sql);
+    return new AutoValue_ClickHouseDbRequest(
+        host, port, configuredHost, configuredPort, serverAddressGroup, namespace, sql);
   }
 
   @Nullable
@@ -25,6 +28,12 @@ public abstract class ClickHouseDbRequest {
 
   @Nullable
   public abstract Integer getPort();
+
+  @Nullable
+  public abstract String getConfiguredHost();
+
+  @Nullable
+  public abstract Integer getConfiguredPort();
 
   @Nullable
   public abstract String getServerAddressGroup();

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
@@ -14,13 +14,18 @@ public abstract class ClickHouseDbRequest {
   public static ClickHouseDbRequest create(
       @Nullable String host,
       @Nullable Integer port,
+      Endpoint peer,
       @Nullable String configuredHost,
       @Nullable Integer configuredPort,
       @Nullable String serverAddressGroup,
       @Nullable String namespace,
       String sql) {
     return new AutoValue_ClickHouseDbRequest(
-        host, port, configuredHost, configuredPort, serverAddressGroup, namespace, sql);
+        host, port, peer, configuredHost, configuredPort, serverAddressGroup, namespace, sql);
+  }
+
+  public static Endpoint endpoint(@Nullable String address, @Nullable Integer port) {
+    return new Endpoint(address, port);
   }
 
   @Nullable
@@ -28,6 +33,22 @@ public abstract class ClickHouseDbRequest {
 
   @Nullable
   public abstract Integer getPort();
+
+  abstract Endpoint getPeer();
+
+  @Nullable
+  public final String getPeerAddress() {
+    return getPeer().address;
+  }
+
+  @Nullable
+  public final Integer getPeerPort() {
+    return getPeer().port;
+  }
+
+  public final void setPeer(@Nullable String address, @Nullable Integer port) {
+    getPeer().set(address, port);
+  }
 
   @Nullable
   public abstract String getConfiguredHost();
@@ -42,4 +63,19 @@ public abstract class ClickHouseDbRequest {
   public abstract String getNamespace();
 
   public abstract String getSql();
+
+  public static class Endpoint {
+    @Nullable private volatile String address;
+    @Nullable private volatile Integer port;
+
+    private Endpoint(@Nullable String address, @Nullable Integer port) {
+      this.address = address;
+      this.port = port;
+    }
+
+    private void set(@Nullable String address, @Nullable Integer port) {
+      this.address = address;
+      this.port = port;
+    }
+  }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
@@ -56,9 +56,9 @@ public class ClickHouseScope {
     return Context.current().get(REQUEST_KEY);
   }
 
-  public CompletableFuture<?> endOnCompletion(CompletableFuture<?> future) {
+  public void endOnCompletion(CompletableFuture<?> future) {
     scope.close();
-    return future.whenComplete(
+    future.whenComplete(
         (result, throwable) ->
             instrumenter.end(context, clickHouseDbRequest, null, unwrap(throwable)));
   }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
@@ -6,12 +6,19 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
 /** Container used to carry state between enter and exit advices */
 public class ClickHouseScope {
+  private static final ContextKey<ClickHouseDbRequest> REQUEST_KEY =
+      ContextKey.named("clickhouse-db-request");
+
   private final ClickHouseDbRequest clickHouseDbRequest;
   private final Context context;
   private final Scope scope;
@@ -37,12 +44,36 @@ public class ClickHouseScope {
       return null;
     }
 
-    Context context = instrumenter.start(parentContext, clickHouseDbRequest);
+    Context context =
+        instrumenter
+            .start(parentContext, clickHouseDbRequest)
+            .with(REQUEST_KEY, clickHouseDbRequest);
     return new ClickHouseScope(clickHouseDbRequest, context, context.makeCurrent(), instrumenter);
+  }
+
+  @Nullable
+  public static ClickHouseDbRequest currentRequest() {
+    return Context.current().get(REQUEST_KEY);
+  }
+
+  public CompletableFuture<?> endOnCompletion(CompletableFuture<?> future) {
+    scope.close();
+    return future.whenComplete(
+        (result, throwable) ->
+            instrumenter.end(context, clickHouseDbRequest, null, unwrap(throwable)));
   }
 
   public void end(@Nullable Throwable throwable) {
     scope.close();
     instrumenter.end(context, clickHouseDbRequest, null, throwable);
+  }
+
+  @Nullable
+  private static Throwable unwrap(@Nullable Throwable throwable) {
+    if ((throwable instanceof CompletionException || throwable instanceof ExecutionException)
+        && throwable.getCause() != null) {
+      return throwable.getCause();
+    }
+    return throwable;
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/com/clickhouse/client/ClickHouseRequestAccess.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/com/clickhouse/client/ClickHouseRequestAccess.java
@@ -21,5 +21,12 @@ public class ClickHouseRequestAccess {
         : null;
   }
 
+  @Nullable
+  public static ClickHouseNode getDirectNode(ClickHouseRequest<?> clickHouseRequest) {
+    return clickHouseRequest.server instanceof ClickHouseNode
+        ? (ClickHouseNode) clickHouseRequest.server
+        : null;
+  }
+
   private ClickHouseRequestAccess() {}
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/com/clickhouse/client/ClickHouseRequestAccess.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/com/clickhouse/client/ClickHouseRequestAccess.java
@@ -5,11 +5,20 @@
 
 package com.clickhouse.client;
 
+import javax.annotation.Nullable;
+
 // helper class for accessing package private members in com.clickhouse.client package
 public class ClickHouseRequestAccess {
 
   public static String getQuery(ClickHouseRequest<?> clickHouseRequest) {
     return clickHouseRequest.getQuery();
+  }
+
+  @Nullable
+  public static ClickHouseNodes getNodes(ClickHouseRequest<?> clickHouseRequest) {
+    return clickHouseRequest.server instanceof ClickHouseNodes
+        ? (ClickHouseNodes) clickHouseRequest.server
+        : null;
   }
 
   private ClickHouseRequestAccess() {}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -62,6 +62,8 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
           ClickHouseDbRequest.create(
               clickHouseRequest.getServer().getHost(),
               clickHouseRequest.getServer().getPort(),
+              ClickHouseClientV1Singletons.serverAddress(clickHouseRequest),
+              ClickHouseClientV1Singletons.serverPort(clickHouseRequest),
               ClickHouseClientV1Singletons.serverAddressGroup(clickHouseRequest),
               clickHouseRequest
                   .getServer()

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -62,6 +62,7 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
           ClickHouseDbRequest.create(
               clickHouseRequest.getServer().getHost(),
               clickHouseRequest.getServer().getPort(),
+              ClickHouseClientV1Singletons.serverAddressGroup(clickHouseRequest),
               clickHouseRequest
                   .getServer()
                   .getDatabase()

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -62,6 +62,8 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
           ClickHouseDbRequest.create(
               clickHouseRequest.getServer().getHost(),
               clickHouseRequest.getServer().getPort(),
+              ClickHouseDbRequest.endpoint(
+                  clickHouseRequest.getServer().getHost(), clickHouseRequest.getServer().getPort()),
               ClickHouseClientV1Singletons.serverAddress(clickHouseRequest),
               ClickHouseClientV1Singletons.serverPort(clickHouseRequest),
               ClickHouseClientV1Singletons.serverAddressGroup(clickHouseRequest),

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
@@ -40,6 +40,9 @@ public class ClickHouseClientV1InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return asList(new ClickHouseClientV1Instrumentation(), new ClickHouseNodesInstrumentation());
+    return asList(
+        new ClickHouseClientV1Instrumentation(),
+        new ClickHouseNodesInstrumentation(),
+        new ClickHouseRequestInstrumentation());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1InstrumentationModule.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
@@ -39,6 +40,6 @@ public class ClickHouseClientV1InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ClickHouseClientV1Instrumentation());
+    return asList(new ClickHouseClientV1Instrumentation(), new ClickHouseNodesInstrumentation());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -16,7 +16,9 @@ import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class ClickHouseClientV1Singletons {
@@ -108,18 +110,18 @@ public class ClickHouseClientV1Singletons {
         return create(nodes.iterator().next());
       }
 
-      StringBuilder addressGroup = new StringBuilder();
+      List<String> addresses = new ArrayList<>(nodes.size());
       for (ClickHouseNode node : nodes) {
-        if (addressGroup.length() > 0) {
-          addressGroup.append(',');
-        }
         String host = sanitizeHost(node.getHost());
         if (host == null) {
           return UNCONFIGURED;
         }
-        appendAddress(addressGroup, host, node.getPort());
+        StringBuilder address = new StringBuilder();
+        appendAddress(address, host, node.getPort());
+        addresses.add(address.toString());
       }
-      return new ServerTarget(null, null, addressGroup.toString());
+      addresses.sort(String::compareTo);
+      return new ServerTarget(null, null, String.join(",", addresses));
     }
 
     private static ServerTarget create(ClickHouseNode node) {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -137,7 +137,9 @@ public class ClickHouseClientV1Singletons {
 
     private static ServerTarget create(ClickHouseNode node) {
       String host = sanitizeHost(node.getHost());
-      return host == null ? UNCONFIGURED : new ServerTarget(host, node.getPort(), null);
+      return host == null
+          ? UNCONFIGURED
+          : new ServerTarget(host, isDefaultPort(node) ? null : node.getPort(), null);
     }
 
     private static ServerTarget createConfiguredNode(ClickHouseNode node) {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -11,15 +11,13 @@ import com.clickhouse.client.ClickHouseNodes;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseRequestAccess;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import javax.annotation.Nullable;
 
 public class ClickHouseClientV1Singletons {
@@ -51,22 +49,25 @@ public class ClickHouseClientV1Singletons {
 
   @Nullable
   public static String serverAddressGroup(ClickHouseRequest<?> request) {
-    return serverTarget(request).addressGroup;
+    ServerTarget target = serverTarget(request);
+    return target == null || !target.addressGroup ? null : target.target.getAddress();
   }
 
   @Nullable
   public static String serverAddress(ClickHouseRequest<?> request) {
-    return serverTarget(request).address;
+    ServerTarget target = serverTarget(request);
+    return target == null || target.addressGroup ? null : target.target.getAddress();
   }
 
   @Nullable
   public static Integer serverPort(ClickHouseRequest<?> request) {
-    return serverTarget(request).port;
+    ServerTarget target = serverTarget(request);
+    return target == null ? null : target.target.getPort();
   }
 
   public static void captureConfiguredNodes(
       ClickHouseNodes nodes, Collection<ClickHouseNode> configuredNodes) {
-    NODES_SERVER_TARGET.set(nodes, ServerTarget.create(configuredNodes));
+    NODES_SERVER_TARGET.set(nodes, createServerTarget(configuredNodes));
   }
 
   public static void copyServerTarget(
@@ -74,6 +75,7 @@ public class ClickHouseClientV1Singletons {
     REQUEST_SERVER_TARGET.set(copiedRequest, serverTarget(request));
   }
 
+  @Nullable
   private static ServerTarget serverTarget(ClickHouseRequest<?> request) {
     ServerTarget target = REQUEST_SERVER_TARGET.get(request);
     if (target != null) {
@@ -81,152 +83,60 @@ public class ClickHouseClientV1Singletons {
     }
     ClickHouseNodes nodes = ClickHouseRequestAccess.getNodes(request);
     if (nodes != null) {
-      target = NODES_SERVER_TARGET.get(nodes);
-      return target == null ? ServerTarget.UNCONFIGURED : target;
+      return NODES_SERVER_TARGET.get(nodes);
     }
     ClickHouseNode node = ClickHouseRequestAccess.getDirectNode(request);
-    return node == null ? ServerTarget.UNCONFIGURED : ServerTarget.create(node);
+    return node == null ? null : createServerTarget(node);
+  }
+
+  @Nullable
+  private static ServerTarget createServerTarget(Collection<ClickHouseNode> nodes) {
+    DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(false);
+    for (ClickHouseNode node : nodes) {
+      addEndpoint(builder, node);
+    }
+    DbServerTarget target = builder.build();
+    return target == null ? null : new ServerTarget(target, nodes.size() > 1);
+  }
+
+  @Nullable
+  private static ServerTarget createServerTarget(ClickHouseNode node) {
+    DbServerTargetBuilder builder = DbServerTarget.builder(-1);
+    addEndpoint(builder, node);
+    DbServerTarget target = builder.build();
+    return target == null ? null : new ServerTarget(target, false);
+  }
+
+  private static void addEndpoint(DbServerTargetBuilder builder, ClickHouseNode node) {
+    ClickHouseProtocol protocol = node.getProtocol();
+    int defaultPort =
+        node.getConfig().isSsl() ? protocol.getDefaultSecurePort() : protocol.getDefaultPort();
+    builder.addEndpoint(extractHost(node.getHost()), node.getPort(), defaultPort);
+  }
+
+  @Nullable
+  private static String extractHost(String host) {
+    if (host.indexOf('/') >= 0
+        || host.indexOf('?') >= 0
+        || host.indexOf('#') >= 0
+        || host.indexOf(',') >= 0
+        || host.indexOf('=') >= 0) {
+      return null;
+    }
+    int userInfoEnd = host.indexOf('@');
+    if (userInfoEnd < 0) {
+      return host;
+    }
+    return userInfoEnd == host.lastIndexOf('@') ? host.substring(userInfoEnd + 1) : null;
   }
 
   private static class ServerTarget {
+    private final DbServerTarget target;
+    private final boolean addressGroup;
 
-    private static final int MAX_ENDPOINTS = 5;
-    private static final ServerTarget UNCONFIGURED = new ServerTarget(null, null, null);
-
-    @Nullable private final String address;
-    @Nullable private final Integer port;
-    @Nullable private final String addressGroup;
-
-    private ServerTarget(
-        @Nullable String address, @Nullable Integer port, @Nullable String addressGroup) {
-      this.address = address;
-      this.port = port;
+    private ServerTarget(DbServerTarget target, boolean addressGroup) {
+      this.target = target;
       this.addressGroup = addressGroup;
-    }
-
-    private static ServerTarget create(Collection<ClickHouseNode> nodes) {
-      if (nodes.isEmpty()) {
-        return UNCONFIGURED;
-      }
-      if (nodes.size() == 1) {
-        return createConfiguredNode(nodes.iterator().next());
-      }
-
-      List<NodeTarget> targets = new ArrayList<>(Math.min(nodes.size(), MAX_ENDPOINTS));
-      boolean hasNonDefaultPort = false;
-      for (ClickHouseNode node : nodes) {
-        String host = sanitizeHost(node.getHost());
-        if (host == null) {
-          return UNCONFIGURED;
-        }
-        if (targets.size() < MAX_ENDPOINTS) {
-          targets.add(new NodeTarget(host, node.getPort()));
-        }
-        hasNonDefaultPort |= !isDefaultPort(node);
-      }
-
-      StringBuilder addressGroup = new StringBuilder();
-      for (NodeTarget target : targets) {
-        if (addressGroup.length() > 0) {
-          addressGroup.append(',');
-        }
-        appendAddress(addressGroup, target.host, hasNonDefaultPort ? target.port : null);
-      }
-      return new ServerTarget(null, null, addressGroup.toString());
-    }
-
-    private static ServerTarget create(ClickHouseNode node) {
-      String host = sanitizeHost(node.getHost());
-      return host == null
-          ? UNCONFIGURED
-          : new ServerTarget(host, isDefaultPort(node) ? null : node.getPort(), null);
-    }
-
-    private static ServerTarget createConfiguredNode(ClickHouseNode node) {
-      String host = sanitizeHost(node.getHost());
-      return host == null
-          ? UNCONFIGURED
-          : new ServerTarget(host, isDefaultPort(node) ? null : node.getPort(), null);
-    }
-
-    private static boolean isDefaultPort(ClickHouseNode node) {
-      ClickHouseProtocol protocol = node.getProtocol();
-      int defaultPort =
-          node.getConfig().isSsl() ? protocol.getDefaultSecurePort() : protocol.getDefaultPort();
-      return defaultPort > 0 && node.getPort() == defaultPort;
-    }
-
-    private static void appendAddress(
-        StringBuilder addressGroup, String host, @Nullable Integer port) {
-      if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
-        addressGroup.append('[').append(host).append(']');
-      } else {
-        addressGroup.append(host);
-      }
-      if (port != null) {
-        addressGroup.append(':').append(port);
-      }
-    }
-
-    @Nullable
-    private static String sanitizeHost(String host) {
-      if (host.indexOf('/') >= 0
-          || host.indexOf('?') >= 0
-          || host.indexOf('#') >= 0
-          || host.indexOf(',') >= 0
-          || host.indexOf('=') >= 0) {
-        return null;
-      }
-
-      int at = host.indexOf('@');
-      if (at >= 0) {
-        if (at != host.lastIndexOf('@')) {
-          return null;
-        }
-        host = host.substring(at + 1);
-      }
-      if (host.isEmpty()) {
-        return null;
-      }
-
-      if (host.startsWith("[")) {
-        if (!host.endsWith("]") || host.indexOf(':') < 0) {
-          return null;
-        }
-        host = host.substring(1, host.length() - 1);
-      } else if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
-        return null;
-      }
-
-      for (int i = 0; i < host.length(); i++) {
-        if (Character.isWhitespace(host.charAt(i))) {
-          return null;
-        }
-      }
-      int firstColon = host.indexOf(':');
-      if (host.indexOf('%') >= 0 && firstColon == host.lastIndexOf(':')) {
-        return null;
-      }
-      if (firstColon >= 0) {
-        try {
-          if (new URI(null, null, host, -1, null, null, null).getHost() == null) {
-            return null;
-          }
-        } catch (URISyntaxException ignored) {
-          return null;
-        }
-      }
-      return host;
-    }
-  }
-
-  private static class NodeTarget {
-    private final String host;
-    private final int port;
-
-    private NodeTarget(String host, int port) {
-      this.host = host;
-      this.port = port;
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseNodes;
+import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseRequestAccess;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -107,20 +108,42 @@ public class ClickHouseClientV1Singletons {
         return UNCONFIGURED;
       }
       if (nodes.size() == 1) {
-        return create(nodes.iterator().next());
+        return createConfiguredNode(nodes.iterator().next());
       }
 
-      List<String> addresses = new ArrayList<>(nodes.size());
+      List<NodeTarget> targets = new ArrayList<>(nodes.size());
+      boolean allDefaultPorts = true;
+      boolean commonNonDefaultPort = true;
+      Integer commonPort = null;
       for (ClickHouseNode node : nodes) {
         String host = sanitizeHost(node.getHost());
         if (host == null) {
           return UNCONFIGURED;
         }
-        StringBuilder address = new StringBuilder();
-        appendAddress(address, host, node.getPort());
-        addresses.add(address.toString());
+        boolean defaultPort = isDefaultPort(node);
+        targets.add(new NodeTarget(host, node.getPort()));
+        if (defaultPort) {
+          commonNonDefaultPort = false;
+        } else {
+          allDefaultPorts = false;
+          if (commonPort == null) {
+            commonPort = node.getPort();
+          } else if (!commonPort.equals(node.getPort())) {
+            commonNonDefaultPort = false;
+          }
+        }
       }
-      return new ServerTarget(null, null, String.join(",", addresses));
+
+      StringBuilder addressGroup = new StringBuilder();
+      boolean inlinePorts = !allDefaultPorts && !commonNonDefaultPort;
+      for (NodeTarget target : targets) {
+        if (addressGroup.length() > 0) {
+          addressGroup.append(',');
+        }
+        appendAddress(addressGroup, target.host, inlinePorts ? target.port : null);
+      }
+      return new ServerTarget(
+          null, commonNonDefaultPort ? commonPort : null, addressGroup.toString());
     }
 
     private static ServerTarget create(ClickHouseNode node) {
@@ -128,13 +151,30 @@ public class ClickHouseClientV1Singletons {
       return host == null ? UNCONFIGURED : new ServerTarget(host, node.getPort(), null);
     }
 
-    private static void appendAddress(StringBuilder addressGroup, String host, int port) {
+    private static ServerTarget createConfiguredNode(ClickHouseNode node) {
+      String host = sanitizeHost(node.getHost());
+      return host == null
+          ? UNCONFIGURED
+          : new ServerTarget(host, isDefaultPort(node) ? null : node.getPort(), null);
+    }
+
+    private static boolean isDefaultPort(ClickHouseNode node) {
+      ClickHouseProtocol protocol = node.getProtocol();
+      int defaultPort =
+          node.getConfig().isSsl() ? protocol.getDefaultSecurePort() : protocol.getDefaultPort();
+      return defaultPort > 0 && node.getPort() == defaultPort;
+    }
+
+    private static void appendAddress(
+        StringBuilder addressGroup, String host, @Nullable Integer port) {
       if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
         addressGroup.append('[').append(host).append(']');
       } else {
         addressGroup.append(host);
       }
-      addressGroup.append(':').append(port);
+      if (port != null) {
+        addressGroup.append(':').append(port);
+      }
     }
 
     @Nullable
@@ -186,6 +226,16 @@ public class ClickHouseClientV1Singletons {
         }
       }
       return host;
+    }
+  }
+
+  private static class NodeTarget {
+    private final String host;
+    private final int port;
+
+    private NodeTarget(String host, int port) {
+      this.host = host;
+      this.port = port;
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -24,6 +24,8 @@ public class ClickHouseClientV1Singletons {
 
   private static final VirtualField<ClickHouseNodes, String> NODES_ADDRESS_GROUP =
       VirtualField.find(ClickHouseNodes.class, String.class);
+  private static final VirtualField<ClickHouseRequest<?>, String> REQUEST_ADDRESS_GROUP =
+      VirtualField.find(ClickHouseRequest.class, String.class);
 
   static {
     instrumenter =
@@ -44,6 +46,10 @@ public class ClickHouseClientV1Singletons {
 
   @Nullable
   public static String serverAddressGroup(ClickHouseRequest<?> request) {
+    String addressGroup = REQUEST_ADDRESS_GROUP.get(request);
+    if (addressGroup != null) {
+      return addressGroup;
+    }
     ClickHouseNodes nodes = ClickHouseRequestAccess.getNodes(request);
     if (nodes == null) {
       return null;
@@ -54,6 +60,11 @@ public class ClickHouseClientV1Singletons {
   public static void captureConfiguredNodes(
       ClickHouseNodes nodes, Collection<ClickHouseNode> configuredNodes) {
     NODES_ADDRESS_GROUP.set(nodes, renderAddressGroup(configuredNodes));
+  }
+
+  public static void captureSealedRequest(
+      ClickHouseRequest<?> request, ClickHouseRequest<?> sealedRequest) {
+    REQUEST_ADDRESS_GROUP.set(sealedRequest, serverAddressGroup(request));
   }
 
   @Nullable

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -172,7 +172,11 @@ public class ClickHouseClientV1Singletons {
           return null;
         }
       }
-      if (host.indexOf(':') >= 0) {
+      int firstColon = host.indexOf(':');
+      if (host.indexOf('%') >= 0 && firstColon == host.lastIndexOf(':')) {
+        return null;
+      }
+      if (firstColon >= 0) {
         try {
           if (new URI(null, null, host, -1, null, null, null).getHost() == null) {
             return null;

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -150,6 +150,7 @@ public class ClickHouseClientV1Singletons {
           || host.indexOf('/') >= 0
           || host.indexOf('?') >= 0
           || host.indexOf('#') >= 0
+          || host.indexOf(',') >= 0
           || host.indexOf('=') >= 0) {
         return null;
       }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -14,6 +14,8 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
@@ -111,23 +113,70 @@ public class ClickHouseClientV1Singletons {
         if (addressGroup.length() > 0) {
           addressGroup.append(',');
         }
-        appendAddress(addressGroup, node);
+        String host = sanitizeHost(node.getHost());
+        if (host == null) {
+          return UNCONFIGURED;
+        }
+        appendAddress(addressGroup, host, node.getPort());
       }
       return new ServerTarget(null, null, addressGroup.toString());
     }
 
     private static ServerTarget create(ClickHouseNode node) {
-      return new ServerTarget(node.getHost(), node.getPort(), null);
+      String host = sanitizeHost(node.getHost());
+      return host == null ? UNCONFIGURED : new ServerTarget(host, node.getPort(), null);
     }
 
-    private static void appendAddress(StringBuilder addressGroup, ClickHouseNode node) {
-      String host = node.getHost();
+    private static void appendAddress(StringBuilder addressGroup, String host, int port) {
       if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
         addressGroup.append('[').append(host).append(']');
       } else {
         addressGroup.append(host);
       }
-      addressGroup.append(':').append(node.getPort());
+      addressGroup.append(':').append(port);
+    }
+
+    @Nullable
+    private static String sanitizeHost(String host) {
+      int at = host.indexOf('@');
+      if (at >= 0) {
+        if (at != host.lastIndexOf('@')) {
+          return null;
+        }
+        host = host.substring(at + 1);
+      }
+      if (host.isEmpty()
+          || host.indexOf('/') >= 0
+          || host.indexOf('?') >= 0
+          || host.indexOf('#') >= 0
+          || host.indexOf('=') >= 0) {
+        return null;
+      }
+
+      if (host.startsWith("[")) {
+        if (!host.endsWith("]")) {
+          return null;
+        }
+        host = host.substring(1, host.length() - 1);
+      } else if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
+        return null;
+      }
+
+      for (int i = 0; i < host.length(); i++) {
+        if (Character.isWhitespace(host.charAt(i))) {
+          return null;
+        }
+      }
+      if (host.indexOf(':') >= 0) {
+        try {
+          if (new URI(null, null, host, -1, null, null, null).getHost() == null) {
+            return null;
+          }
+        } catch (URISyntaxException ignored) {
+          return null;
+        }
+      }
+      return host;
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -22,9 +22,6 @@ public class ClickHouseClientV1Singletons {
   private static final String INSTRUMENTER_NAME = "io.opentelemetry.clickhouse-client-v1-0.5";
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
 
-  // "" marks a configuration that names a single node, which has no group target
-  private static final String NO_GROUP = "";
-
   private static final VirtualField<ClickHouseNodes, String> NODES_ADDRESS_GROUP =
       VirtualField.find(ClickHouseNodes.class, String.class);
 
@@ -51,8 +48,7 @@ public class ClickHouseClientV1Singletons {
     if (nodes == null) {
       return null;
     }
-    String addressGroup = NODES_ADDRESS_GROUP.get(nodes);
-    return addressGroup == null || NO_GROUP.equals(addressGroup) ? null : addressGroup;
+    return NODES_ADDRESS_GROUP.get(nodes);
   }
 
   public static void captureConfiguredNodes(
@@ -60,9 +56,10 @@ public class ClickHouseClientV1Singletons {
     NODES_ADDRESS_GROUP.set(nodes, renderAddressGroup(configuredNodes));
   }
 
+  @Nullable
   private static String renderAddressGroup(Collection<ClickHouseNode> nodes) {
     if (nodes.size() < 2) {
-      return NO_GROUP;
+      return null;
     }
 
     StringBuilder addressGroup = new StringBuilder();

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -159,7 +159,7 @@ public class ClickHouseClientV1Singletons {
       }
 
       if (host.startsWith("[")) {
-        if (!host.endsWith("]")) {
+        if (!host.endsWith("]") || host.indexOf(':') < 0) {
           return null;
         }
         host = host.substring(1, host.length() - 1);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -22,10 +22,10 @@ public class ClickHouseClientV1Singletons {
   private static final String INSTRUMENTER_NAME = "io.opentelemetry.clickhouse-client-v1-0.5";
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
 
-  private static final VirtualField<ClickHouseNodes, String> NODES_ADDRESS_GROUP =
-      VirtualField.find(ClickHouseNodes.class, String.class);
-  private static final VirtualField<ClickHouseRequest<?>, String> REQUEST_ADDRESS_GROUP =
-      VirtualField.find(ClickHouseRequest.class, String.class);
+  private static final VirtualField<ClickHouseNodes, ServerTarget> NODES_SERVER_TARGET =
+      VirtualField.find(ClickHouseNodes.class, ServerTarget.class);
+  private static final VirtualField<ClickHouseRequest<?>, ServerTarget> REQUEST_SERVER_TARGET =
+      VirtualField.find(ClickHouseRequest.class, ServerTarget.class);
 
   static {
     instrumenter =
@@ -46,38 +46,81 @@ public class ClickHouseClientV1Singletons {
 
   @Nullable
   public static String serverAddressGroup(ClickHouseRequest<?> request) {
-    String addressGroup = REQUEST_ADDRESS_GROUP.get(request);
-    if (addressGroup != null) {
-      return addressGroup;
-    }
-    ClickHouseNodes nodes = ClickHouseRequestAccess.getNodes(request);
-    if (nodes == null) {
-      return null;
-    }
-    return NODES_ADDRESS_GROUP.get(nodes);
+    return serverTarget(request).addressGroup;
+  }
+
+  @Nullable
+  public static String serverAddress(ClickHouseRequest<?> request) {
+    return serverTarget(request).address;
+  }
+
+  @Nullable
+  public static Integer serverPort(ClickHouseRequest<?> request) {
+    return serverTarget(request).port;
   }
 
   public static void captureConfiguredNodes(
       ClickHouseNodes nodes, Collection<ClickHouseNode> configuredNodes) {
-    NODES_ADDRESS_GROUP.set(nodes, renderAddressGroup(configuredNodes));
+    NODES_SERVER_TARGET.set(nodes, ServerTarget.create(configuredNodes));
   }
 
   public static void captureSealedRequest(
       ClickHouseRequest<?> request, ClickHouseRequest<?> sealedRequest) {
-    REQUEST_ADDRESS_GROUP.set(sealedRequest, serverAddressGroup(request));
+    REQUEST_SERVER_TARGET.set(sealedRequest, serverTarget(request));
   }
 
-  @Nullable
-  private static String renderAddressGroup(Collection<ClickHouseNode> nodes) {
-    if (nodes.size() < 2) {
-      return null;
+  private static ServerTarget serverTarget(ClickHouseRequest<?> request) {
+    ServerTarget target = REQUEST_SERVER_TARGET.get(request);
+    if (target != null) {
+      return target;
+    }
+    ClickHouseNodes nodes = ClickHouseRequestAccess.getNodes(request);
+    if (nodes != null) {
+      target = NODES_SERVER_TARGET.get(nodes);
+      return target == null ? ServerTarget.UNCONFIGURED : target;
+    }
+    ClickHouseNode node = ClickHouseRequestAccess.getDirectNode(request);
+    return node == null ? ServerTarget.UNCONFIGURED : ServerTarget.create(node);
+  }
+
+  private static class ServerTarget {
+
+    private static final ServerTarget UNCONFIGURED = new ServerTarget(null, null, null);
+
+    @Nullable private final String address;
+    @Nullable private final Integer port;
+    @Nullable private final String addressGroup;
+
+    private ServerTarget(
+        @Nullable String address, @Nullable Integer port, @Nullable String addressGroup) {
+      this.address = address;
+      this.port = port;
+      this.addressGroup = addressGroup;
     }
 
-    StringBuilder addressGroup = new StringBuilder();
-    for (ClickHouseNode node : nodes) {
-      if (addressGroup.length() > 0) {
-        addressGroup.append(',');
+    private static ServerTarget create(Collection<ClickHouseNode> nodes) {
+      if (nodes.isEmpty()) {
+        return UNCONFIGURED;
       }
+      if (nodes.size() == 1) {
+        return create(nodes.iterator().next());
+      }
+
+      StringBuilder addressGroup = new StringBuilder();
+      for (ClickHouseNode node : nodes) {
+        if (addressGroup.length() > 0) {
+          addressGroup.append(',');
+        }
+        appendAddress(addressGroup, node);
+      }
+      return new ServerTarget(null, null, addressGroup.toString());
+    }
+
+    private static ServerTarget create(ClickHouseNode node) {
+      return new ServerTarget(node.getHost(), node.getPort(), null);
+    }
+
+    private static void appendAddress(StringBuilder addressGroup, ClickHouseNode node) {
       String host = node.getHost();
       if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
         addressGroup.append('[').append(host).append(']');
@@ -86,7 +129,6 @@ public class ClickHouseClientV1Singletons {
       }
       addressGroup.append(':').append(node.getPort());
     }
-    return addressGroup.toString();
   }
 
   private ClickHouseClientV1Singletons() {}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -64,9 +64,9 @@ public class ClickHouseClientV1Singletons {
     NODES_SERVER_TARGET.set(nodes, ServerTarget.create(configuredNodes));
   }
 
-  public static void captureSealedRequest(
-      ClickHouseRequest<?> request, ClickHouseRequest<?> sealedRequest) {
-    REQUEST_SERVER_TARGET.set(sealedRequest, serverTarget(request));
+  public static void copyServerTarget(
+      ClickHouseRequest<?> request, ClickHouseRequest<?> copiedRequest) {
+    REQUEST_SERVER_TARGET.set(copiedRequest, serverTarget(request));
   }
 
   private static ServerTarget serverTarget(ClickHouseRequest<?> request) {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -120,7 +120,6 @@ public class ClickHouseClientV1Singletons {
         appendAddress(address, host, node.getPort());
         addresses.add(address.toString());
       }
-      addresses.sort(String::compareTo);
       return new ServerTarget(null, null, String.join(",", addresses));
     }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -6,14 +6,27 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseNodes;
+import com.clickhouse.client.ClickHouseRequest;
+import com.clickhouse.client.ClickHouseRequestAccess;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
+import java.util.Collection;
+import javax.annotation.Nullable;
 
 public class ClickHouseClientV1Singletons {
 
   private static final String INSTRUMENTER_NAME = "io.opentelemetry.clickhouse-client-v1-0.5";
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
+
+  // "" marks a configuration that names a single node, which has no group target
+  private static final String NO_GROUP = "";
+
+  private static final VirtualField<ClickHouseNodes, String> NODES_ADDRESS_GROUP =
+      VirtualField.find(ClickHouseNodes.class, String.class);
 
   static {
     instrumenter =
@@ -30,6 +43,42 @@ public class ClickHouseClientV1Singletons {
 
   public static Instrumenter<ClickHouseDbRequest, Void> instrumenter() {
     return instrumenter;
+  }
+
+  @Nullable
+  public static String serverAddressGroup(ClickHouseRequest<?> request) {
+    ClickHouseNodes nodes = ClickHouseRequestAccess.getNodes(request);
+    if (nodes == null) {
+      return null;
+    }
+    String addressGroup = NODES_ADDRESS_GROUP.get(nodes);
+    return addressGroup == null || NO_GROUP.equals(addressGroup) ? null : addressGroup;
+  }
+
+  public static void captureConfiguredNodes(
+      ClickHouseNodes nodes, Collection<ClickHouseNode> configuredNodes) {
+    NODES_ADDRESS_GROUP.set(nodes, renderAddressGroup(configuredNodes));
+  }
+
+  private static String renderAddressGroup(Collection<ClickHouseNode> nodes) {
+    if (nodes.size() < 2) {
+      return NO_GROUP;
+    }
+
+    StringBuilder addressGroup = new StringBuilder();
+    for (ClickHouseNode node : nodes) {
+      if (addressGroup.length() > 0) {
+        addressGroup.append(',');
+      }
+      String host = node.getHost();
+      if (host.indexOf(':') >= 0 && !host.startsWith("[")) {
+        addressGroup.append('[').append(host).append(']');
+      } else {
+        addressGroup.append(host);
+      }
+      addressGroup.append(':').append(node.getPort());
+    }
+    return addressGroup.toString();
   }
 
   private ClickHouseClientV1Singletons() {}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -90,6 +90,7 @@ public class ClickHouseClientV1Singletons {
 
   private static class ServerTarget {
 
+    private static final int MAX_ENDPOINTS = 5;
     private static final ServerTarget UNCONFIGURED = new ServerTarget(null, null, null);
 
     @Nullable private final String address;
@@ -111,39 +112,27 @@ public class ClickHouseClientV1Singletons {
         return createConfiguredNode(nodes.iterator().next());
       }
 
-      List<NodeTarget> targets = new ArrayList<>(nodes.size());
-      boolean allDefaultPorts = true;
-      boolean commonNonDefaultPort = true;
-      Integer commonPort = null;
+      List<NodeTarget> targets = new ArrayList<>(Math.min(nodes.size(), MAX_ENDPOINTS));
+      boolean hasNonDefaultPort = false;
       for (ClickHouseNode node : nodes) {
         String host = sanitizeHost(node.getHost());
         if (host == null) {
           return UNCONFIGURED;
         }
-        boolean defaultPort = isDefaultPort(node);
-        targets.add(new NodeTarget(host, node.getPort()));
-        if (defaultPort) {
-          commonNonDefaultPort = false;
-        } else {
-          allDefaultPorts = false;
-          if (commonPort == null) {
-            commonPort = node.getPort();
-          } else if (!commonPort.equals(node.getPort())) {
-            commonNonDefaultPort = false;
-          }
+        if (targets.size() < MAX_ENDPOINTS) {
+          targets.add(new NodeTarget(host, node.getPort()));
         }
+        hasNonDefaultPort |= !isDefaultPort(node);
       }
 
       StringBuilder addressGroup = new StringBuilder();
-      boolean inlinePorts = !allDefaultPorts && !commonNonDefaultPort;
       for (NodeTarget target : targets) {
         if (addressGroup.length() > 0) {
           addressGroup.append(',');
         }
-        appendAddress(addressGroup, target.host, inlinePorts ? target.port : null);
+        appendAddress(addressGroup, target.host, hasNonDefaultPort ? target.port : null);
       }
-      return new ServerTarget(
-          null, commonNonDefaultPort ? commonPort : null, addressGroup.toString());
+      return new ServerTarget(null, null, addressGroup.toString());
     }
 
     private static ServerTarget create(ClickHouseNode node) {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -91,7 +91,7 @@ public class ClickHouseClientV1Singletons {
 
   @Nullable
   private static ServerTarget createServerTarget(Collection<ClickHouseNode> nodes) {
-    DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(false);
+    DbServerTargetBuilder builder = DbServerTarget.builder(-1);
     for (ClickHouseNode node : nodes) {
       addEndpoint(builder, node);
     }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -139,6 +139,14 @@ public class ClickHouseClientV1Singletons {
 
     @Nullable
     private static String sanitizeHost(String host) {
+      if (host.indexOf('/') >= 0
+          || host.indexOf('?') >= 0
+          || host.indexOf('#') >= 0
+          || host.indexOf(',') >= 0
+          || host.indexOf('=') >= 0) {
+        return null;
+      }
+
       int at = host.indexOf('@');
       if (at >= 0) {
         if (at != host.lastIndexOf('@')) {
@@ -146,12 +154,7 @@ public class ClickHouseClientV1Singletons {
         }
         host = host.substring(at + 1);
       }
-      if (host.isEmpty()
-          || host.indexOf('/') >= 0
-          || host.indexOf('?') >= 0
-          || host.indexOf('#') >= 0
-          || host.indexOf(',') >= 0
-          || host.indexOf('=') >= 0) {
+      if (host.isEmpty()) {
         return null;
       }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseNodesInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseNodesInstrumentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseNodes;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.util.Collection;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+// Capture the target before health checks and load-balancing tags reduce the visible node set.
+class ClickHouseNodesInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.clickhouse.client.ClickHouseNodes");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(0, named("java.util.Collection"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This ClickHouseNodes nodes,
+        @Advice.Argument(0) Collection<ClickHouseNode> configuredNodes) {
+      ClickHouseClientV1Singletons.captureConfiguredNodes(nodes, configuredNodes);
+    }
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
-import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
@@ -28,16 +27,17 @@ class ClickHouseRequestInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        named("seal").and(takesNoArguments()), getClass().getName() + "$SealAdvice");
+        namedOneOf("copy", "seal").and(takesNoArguments()),
+        getClass().getName() + "$CopyTargetAdvice");
   }
 
   @SuppressWarnings("unused")
-  public static class SealAdvice {
+  public static class CopyTargetAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.This ClickHouseRequest<?> request,
-        @Advice.Return ClickHouseRequest<?> sealedRequest) {
-      ClickHouseClientV1Singletons.captureSealedRequest(request, sealedRequest);
+        @Advice.Return ClickHouseRequest<?> copiedRequest) {
+      ClickHouseClientV1Singletons.copyServerTarget(request, copiedRequest);
     }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import com.clickhouse.client.ClickHouseRequest;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class ClickHouseRequestInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.clickhouse.client.ClickHouseRequest");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("seal").and(takesNoArguments()), getClass().getName() + "$SealAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class SealAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This ClickHouseRequest<?> request,
+        @Advice.Return ClickHouseRequest<?> sealedRequest) {
+      ClickHouseClientV1Singletons.captureSealedRequest(request, sealedRequest);
+    }
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.clickhouse.client.ClickHouseRequest;
@@ -19,7 +20,9 @@ class ClickHouseRequestInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    return named("com.clickhouse.client.ClickHouseRequest");
+    return namedOneOf(
+        "com.clickhouse.client.ClickHouseRequest",
+        "com.clickhouse.client.ClickHouseRequest$Mutation");
   }
 
   @Override

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseRequestInstrumentation.java
@@ -27,7 +27,7 @@ class ClickHouseRequestInstrumentation implements TypeInstrumentation {
   @Override
   public void transform(TypeTransformer transformer) {
     transformer.applyAdviceToMethod(
-        namedOneOf("copy", "seal").and(takesNoArguments()),
+        namedOneOf("copy", "seal", "write").and(takesNoArguments()),
         getClass().getName() + "$CopyTargetAdvice");
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -752,6 +752,41 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testConfiguredNodeHostsRejectCommas() throws Exception {
+    ClickHouseNode malformedNode = ClickHouseNode.builder(server).host("host1,host2").build();
+    ClickHouseNodes nodes = createNodes(ImmutableList.of(server, malformedNode));
+    nodes.update(malformedNode, ClickHouseNode.Status.FAULTY);
+
+    ClickHouseResponse response =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .executeAndWait();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testCopiedSealedNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -123,6 +125,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -137,6 +144,8 @@ class ClickHouseClientV1Test {
         DB_SYSTEM_NAME,
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -180,6 +189,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -200,6 +214,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -239,6 +258,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -280,6 +304,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from non_existent_table"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -296,6 +325,8 @@ class ClickHouseClientV1Test {
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
         ERROR_TYPE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
     if (emitStableDatabaseSemconv()) {
@@ -338,6 +369,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -374,6 +410,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -416,6 +457,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -436,6 +482,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -493,6 +544,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(:val1)(:val2)(:val3)"),
                             equalTo(
@@ -513,6 +569,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where s=:val"),
@@ -563,6 +624,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where s={s:String}"),
                             equalTo(
@@ -604,6 +670,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -682,6 +753,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -714,6 +790,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -749,6 +830,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -785,6 +871,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -827,6 +918,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -865,6 +961,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -905,6 +1006,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)"),
@@ -950,6 +1056,11 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -712,6 +712,18 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testSealedMutationPreservesConfiguredTarget() {
+    String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
+    String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
+    ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
+
+    ClickHouseRequest<?> request =
+        client.read(nodes).write().table(DATABASE_NAME, TABLE_NAME).seal();
+
+    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request)).isEqualTo(addressGroup);
+  }
+
+  @Test
   void testFaultyNodeStaysInTheConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 2);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 2);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -591,7 +591,11 @@ class ClickHouseClientV1Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasKind(SpanKind.CLIENT)
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "select test_table"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
@@ -610,13 +614,54 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testConfiguredNodeDefaultsOmitPortsAcrossProtocolAndSslVariants() throws Exception {
+    ClickHouseRequest<?> request =
+        requestWithNodes(
+            ImmutableList.of(
+                ClickHouseNode.of("http://http.example"),
+                ClickHouseNode.of("https://https.example"),
+                ClickHouseNode.of("tcp://tcp.example"),
+                ClickHouseNode.of("tcps://tcps.example")));
+
+    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
+        .isEqualTo("http.example,https.example,tcp.example,tcps.example");
+    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isNull();
+  }
+
+  @Test
+  void testConfiguredNodesExtractCommonNonDefaultPort() throws Exception {
+    ClickHouseNode httpNode =
+        ClickHouseNode.builder(ClickHouseNode.of("http://http.example")).port(12345).build();
+    ClickHouseNode tcpNode =
+        ClickHouseNode.builder(ClickHouseNode.of("tcp://tcp.example"))
+            .host("2001:db8::2")
+            .port(12345)
+            .build();
+    ClickHouseRequest<?> request = requestWithNodes(ImmutableList.of(httpNode, tcpNode));
+
+    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
+        .isEqualTo("http.example,[2001:db8::2]");
+    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isEqualTo(12345);
+  }
+
+  @Test
+  void testConfiguredNodesInlineMixedPorts() throws Exception {
+    ClickHouseNode httpNode = ClickHouseNode.of("http://http.example");
+    ClickHouseNode httpsNode = ClickHouseNode.of("https://https.example:9444");
+    ClickHouseRequest<?> request = requestWithNodes(ImmutableList.of(httpNode, httpsNode));
+
+    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
+        .isEqualTo("http.example:8123,https.example:9444");
+    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isNull();
+  }
+
+  @Test
   void testConfiguredNodeOrderPreservesPriorityAndDuplicates() throws Exception {
     ClickHouseNode ipv6Node = ClickHouseNode.builder(server).host("2001:db8::2").build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(ipv6Node, server, ipv6Node));
     nodes.update(ipv6Node, ClickHouseNode.Status.FAULTY);
-    String ipv6Address = "[2001:db8::2]:" + port;
-    String hostAddress = host + ":" + port;
-    String addressGroup = ipv6Address + "," + hostAddress + "," + ipv6Address;
+    String ipv6Address = "[2001:db8::2]";
+    String addressGroup = ipv6Address + "," + host + "," + ipv6Address;
 
     ClickHouseResponse response =
         client
@@ -636,9 +681,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -721,7 +764,7 @@ class ClickHouseClientV1Test {
         ClickHouseNode.builder(server).host("user:secret@configured.example").build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(server, credentialNode));
     nodes.update(credentialNode, ClickHouseNode.Status.FAULTY);
-    String addressGroup = host + ":" + port + ",configured.example:" + port;
+    String addressGroup = host + ",configured.example";
 
     ClickHouseResponse response =
         client
@@ -741,9 +784,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -923,5 +964,10 @@ class ClickHouseClientV1Test {
         ClickHouseNodes.class.getDeclaredConstructor(Collection.class);
     constructor.setAccessible(true);
     return constructor.newInstance(nodes);
+  }
+
+  private static ClickHouseRequest<?> requestWithNodes(Collection<ClickHouseNode> nodes)
+      throws Exception {
+    return client.read(createNodes(nodes));
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -33,6 +33,7 @@ import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.ClickHouseResponseSummary;
 import com.clickhouse.data.ClickHouseFormat;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
@@ -40,7 +41,9 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -672,6 +675,44 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testConfiguredNodeHostsRemoveCredentials() throws Exception {
+    ClickHouseNode credentialNode =
+        ClickHouseNode.builder(server).host("user:secret@configured.example").build();
+    ClickHouseNodes nodes = createNodes(ImmutableList.of(server, credentialNode));
+    nodes.update(credentialNode, ClickHouseNode.Status.FAULTY);
+    String addressGroup = host + ":" + port + ",configured.example:" + port;
+
+    ClickHouseResponse response =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .executeAndWait();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testCopiedSealedNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
@@ -792,5 +833,12 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  private static ClickHouseNodes createNodes(Collection<ClickHouseNode> nodes) throws Exception {
+    Constructor<ClickHouseNodes> constructor =
+        ClickHouseNodes.class.getDeclaredConstructor(Collection.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(nodes);
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -754,7 +754,13 @@ class ClickHouseClientV1Test {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"host1,host2", "host?email=user@example.com", "[configured.example]"})
+  @ValueSource(
+      strings = {
+        "host1,host2",
+        "host?email=user@example.com",
+        "configured.example%3Fpassword%3Dsecret",
+        "[configured.example]"
+      })
   void testConfiguredNodeHostsRejectMalformedValues(String configuredHost) throws Exception {
     ClickHouseNode malformedNode = ClickHouseNode.builder(server).host(configuredHost).build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(server, malformedNode));

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -710,13 +710,19 @@ class ClickHouseClientV1Test {
   }
 
   @Test
-  void testSealedMutationPreservesConfiguredTarget() throws ClickHouseException {
+  void testCopiedSealedMutationPreservesConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
     ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
 
     ClickHouseRequest<?> request =
-        client.read(nodes).write().query("insert into " + TABLE_NAME + " values('4')").seal();
+        client
+            .read(nodes)
+            .seal()
+            .copy()
+            .write()
+            .query("insert into " + TABLE_NAME + " values('4')")
+            .seal();
 
     ClickHouseResponse response = client.executeAndWait(request);
     response.close();

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -608,6 +608,48 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testConfiguredNodeOrderIsCanonicalAndKeepsDuplicates() throws Exception {
+    ClickHouseNode ipv6Node = ClickHouseNode.builder(server).host("2001:db8::2").build();
+    ClickHouseNodes nodes = createNodes(ImmutableList.of(server, ipv6Node, ipv6Node));
+    nodes.update(ipv6Node, ClickHouseNode.Status.FAULTY);
+    String ipv6Address = "[2001:db8::2]:" + port;
+    String hostAddress = host + ":" + port;
+    String addressGroup =
+        hostAddress.compareTo(ipv6Address) < 0
+            ? hostAddress + "," + ipv6Address + "," + ipv6Address
+            : ipv6Address + "," + ipv6Address + "," + hostAddress;
+
+    ClickHouseResponse response =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .executeAndWait();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testSingleNodeListRetainsConfiguredTarget() throws ClickHouseException {
     ClickHouseNodes nodes =
         ClickHouseNodes.of("single-node", "http://" + host + ":" + port, ImmutableMap.of());

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -669,9 +669,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -836,9 +834,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -913,9 +909,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -956,9 +950,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -1003,9 +995,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -1046,9 +1036,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -1091,9 +1079,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -1141,9 +1127,7 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseNodeSelector;
 import com.clickhouse.client.ClickHouseNodes;
 import com.clickhouse.client.ClickHouseParameterizedQuery;
 import com.clickhouse.client.ClickHouseRequest;
@@ -38,9 +39,11 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -589,6 +592,76 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testSingleNodeListRetainsConfiguredTarget() throws ClickHouseException {
+    ClickHouseNodes nodes =
+        ClickHouseNodes.of("single-node", "http://" + host + ":" + port, ImmutableMap.of());
+    ClickHouseRequest<?> request =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME);
+
+    assertThat(ClickHouseClientV1Singletons.serverAddress(request)).isEqualTo(host);
+    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isEqualTo(port);
+
+    ClickHouseResponse response = client.executeAndWait(request);
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testSelectorOutputIsNotAConfiguredTarget() throws ClickHouseException {
+    ClickHouseRequest<?> request =
+        client
+            .read(
+                (Function<ClickHouseNodeSelector, ClickHouseNode> & Serializable)
+                    selector -> server,
+                ImmutableMap.of())
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME);
+
+    ClickHouseResponse response = client.executeAndWait(request);
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -602,6 +602,43 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testSealedNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
+    String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
+    String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
+    ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
+    ClickHouseRequest<?> request =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .seal();
+
+    ClickHouseResponse response = client.executeAndWait(request);
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testFaultyNodeStaysInTheConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 2);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 2);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -614,9 +614,6 @@ class ClickHouseClientV1Test {
             .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
             .query("select * from " + TABLE_NAME);
 
-    assertThat(ClickHouseClientV1Singletons.serverAddress(request)).isEqualTo(host);
-    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isEqualTo(port);
-
     ClickHouseResponse response = client.executeAndWait(request);
     response.close();
 
@@ -713,15 +710,39 @@ class ClickHouseClientV1Test {
   }
 
   @Test
-  void testSealedMutationPreservesConfiguredTarget() {
+  void testSealedMutationPreservesConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
     ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
 
     ClickHouseRequest<?> request =
-        client.read(nodes).write().table(DATABASE_NAME, TABLE_NAME).seal();
+        client.read(nodes).write().query("insert into " + TABLE_NAME + " values('4')").seal();
 
-    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request)).isEqualTo(addressGroup);
+    ClickHouseResponse response = client.executeAndWait(request);
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                maybeStable(DB_STATEMENT),
+                                "insert into " + TABLE_NAME + " values(?)"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "insert test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "INSERT"))));
   }
 
   @Test

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseNodes;
 import com.clickhouse.client.ClickHouseParameterizedQuery;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseResponse;
@@ -556,6 +557,85 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where s={s:String}"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
+    String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
+    String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
+    ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
+
+    ClickHouseResponse response =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .executeAndWait();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testFaultyNodeStaysInTheConfiguredTarget() throws ClickHouseException {
+    String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 2);
+    String addressGroup = host + ":" + port + "," + host + ":" + (port + 2);
+    ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
+
+    for (ClickHouseNode node : nodes.getNodes()) {
+      if (node.getPort() == port + 2) {
+        nodes.update(node, ClickHouseNode.Status.FAULTY);
+      }
+    }
+    assertThat(nodes.getNodes()).hasSize(1);
+
+    ClickHouseResponse response =
+        client
+            .read(nodes)
+            .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .query("select * from " + TABLE_NAME)
+            .executeAndWait();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
                                 emitStableDatabaseSemconv() ? "select test_table" : null),

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -41,9 +41,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -694,9 +696,9 @@ class ClickHouseClientV1Test {
                 ClickHouseNode.of("tcp://tcp.example"),
                 ClickHouseNode.of("tcps://tcps.example")));
 
-    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
+    assertThat(serverAddressGroup(request))
         .isEqualTo("http.example,https.example,tcp.example,tcps.example");
-    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isNull();
+    assertThat(serverPort(request)).isNull();
   }
 
   @Test
@@ -710,9 +712,8 @@ class ClickHouseClientV1Test {
             .build();
     ClickHouseRequest<?> request = requestWithNodes(ImmutableList.of(httpNode, tcpNode));
 
-    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
-        .isEqualTo("http.example,[2001:db8::2]");
-    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isEqualTo(12345);
+    assertThat(serverAddressGroup(request)).isEqualTo("http.example,[2001:db8::2]");
+    assertThat(serverPort(request)).isEqualTo(12345);
   }
 
   @Test
@@ -721,9 +722,8 @@ class ClickHouseClientV1Test {
     ClickHouseNode httpsNode = ClickHouseNode.of("https://https.example:9444");
     ClickHouseRequest<?> request = requestWithNodes(ImmutableList.of(httpNode, httpsNode));
 
-    assertThat(ClickHouseClientV1Singletons.serverAddressGroup(request))
-        .isEqualTo("http.example:8123,https.example:9444");
-    assertThat(ClickHouseClientV1Singletons.serverPort(request)).isNull();
+    assertThat(serverAddressGroup(request)).isEqualTo("http.example:8123,https.example:9444");
+    assertThat(serverPort(request)).isNull();
   }
 
   @Test
@@ -1080,5 +1080,41 @@ class ClickHouseClientV1Test {
   private static ClickHouseRequest<?> requestWithNodes(Collection<ClickHouseNode> nodes)
       throws Exception {
     return client.read(createNodes(nodes));
+  }
+
+  private static String serverAddressGroup(ClickHouseRequest<?> request) throws Exception {
+    return (String)
+        singletons(request)
+            .getMethod("serverAddressGroup", ClickHouseRequest.class)
+            .invoke(null, request);
+  }
+
+  private static Integer serverPort(ClickHouseRequest<?> request) throws Exception {
+    return (Integer)
+        singletons(request).getMethod("serverPort", ClickHouseRequest.class).invoke(null, request);
+  }
+
+  private static Class<?> singletons(ClickHouseRequest<?> request) throws Exception {
+    String singletonsName =
+        "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5."
+            + "ClickHouseClientV1Singletons";
+    ClassLoader requestClassLoader = request.getClass().getClassLoader();
+    try {
+      return Class.forName(singletonsName, true, requestClassLoader);
+    } catch (ClassNotFoundException ignored) {
+      Class<?> registry =
+          AgentClassLoaderAccess.loadClass(
+              "io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyModuleRegistry");
+      Method getInstrumentationClassLoader =
+          registry.getMethod("getInstrumentationClassLoader", String.class, ClassLoader.class);
+      ClassLoader instrumentationClassLoader =
+          (ClassLoader)
+              getInstrumentationClassLoader.invoke(
+                  null,
+                  "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5."
+                      + "ClickHouseClientV1InstrumentationModule",
+                  requestClassLoader);
+      return Class.forName(singletonsName, true, instrumentationClassLoader);
+    }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -701,6 +701,29 @@ class ClickHouseClientV1Test {
     assertThat(serverPort(request)).isNull();
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://http.example",
+        "https://https.example",
+        "tcp://tcp.example",
+        "tcps://tcps.example"
+      })
+  void testDirectNodeDefaultPortsAreOmitted(String nodeUrl) throws Exception {
+    ClickHouseRequest<?> request = client.read(ClickHouseNode.of(nodeUrl));
+
+    assertThat(serverPort(request)).isNull();
+  }
+
+  @Test
+  void testDirectNodeNonDefaultPortIsPreserved() throws Exception {
+    ClickHouseNode node =
+        ClickHouseNode.builder(ClickHouseNode.of("http://http.example")).port(12345).build();
+    ClickHouseRequest<?> request = client.read(node);
+
+    assertThat(serverPort(request)).isEqualTo(12345);
+  }
+
   @Test
   void testConfiguredNodesInlineSharedNonDefaultPort() throws Exception {
     ClickHouseNode httpNode =

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -702,7 +702,7 @@ class ClickHouseClientV1Test {
   }
 
   @Test
-  void testConfiguredNodesExtractCommonNonDefaultPort() throws Exception {
+  void testConfiguredNodesInlineSharedNonDefaultPort() throws Exception {
     ClickHouseNode httpNode =
         ClickHouseNode.builder(ClickHouseNode.of("http://http.example")).port(12345).build();
     ClickHouseNode tcpNode =
@@ -712,8 +712,8 @@ class ClickHouseClientV1Test {
             .build();
     ClickHouseRequest<?> request = requestWithNodes(ImmutableList.of(httpNode, tcpNode));
 
-    assertThat(serverAddressGroup(request)).isEqualTo("http.example,[2001:db8::2]");
-    assertThat(serverPort(request)).isEqualTo(12345);
+    assertThat(serverAddressGroup(request)).isEqualTo("http.example:12345,[2001:db8::2]:12345");
+    assertThat(serverPort(request)).isNull();
   }
 
   @Test
@@ -727,12 +727,73 @@ class ClickHouseClientV1Test {
   }
 
   @Test
+  void testConfiguredNodesIncludeAtMostFiveEndpoints() throws Exception {
+    ClickHouseNode first = ClickHouseNode.of("http://host1.example");
+    ClickHouseNode second = ClickHouseNode.of("http://host2.example");
+    ClickHouseNode third = ClickHouseNode.of("http://host3.example");
+    ClickHouseNode fourth = ClickHouseNode.of("http://host4.example");
+    ClickHouseNode fifth = ClickHouseNode.of("http://host5.example");
+    ClickHouseNode sixth = ClickHouseNode.of("http://host6.example");
+    String expected = "host1.example,host2.example,host3.example,host4.example,host5.example";
+
+    assertThat(
+            serverAddressGroup(
+                requestWithNodes(ImmutableList.of(first, second, third, fourth, fifth))))
+        .isEqualTo(expected);
+    assertThat(
+            serverAddressGroup(
+                requestWithNodes(ImmutableList.of(first, second, third, fourth, fifth, sixth))))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void testConfiguredNodesUsePortModeFromAllEndpoints() throws Exception {
+    ClickHouseNode nonDefaultSixth =
+        ClickHouseNode.builder(ClickHouseNode.of("http://host6.example")).port(9123).build();
+    ClickHouseRequest<?> request =
+        requestWithNodes(
+            ImmutableList.of(
+                ClickHouseNode.of("http://host1.example"),
+                ClickHouseNode.of("http://host2.example"),
+                ClickHouseNode.of("http://host3.example"),
+                ClickHouseNode.of("http://host4.example"),
+                ClickHouseNode.of("http://host5.example"),
+                nonDefaultSixth));
+
+    assertThat(serverAddressGroup(request))
+        .isEqualTo(
+            "host1.example:8123,host2.example:8123,host3.example:8123,"
+                + "host4.example:8123,host5.example:8123");
+    assertThat(serverPort(request)).isNull();
+  }
+
+  @Test
+  void testConfiguredNodesValidateEndpointsAfterTheLimit() throws Exception {
+    ClickHouseNode invalidSixth =
+        ClickHouseNode.builder(ClickHouseNode.of("http://host6.example"))
+            .host("invalid.example/path")
+            .build();
+    ClickHouseRequest<?> request =
+        requestWithNodes(
+            ImmutableList.of(
+                ClickHouseNode.of("http://host1.example"),
+                ClickHouseNode.of("http://host2.example"),
+                ClickHouseNode.of("http://host3.example"),
+                ClickHouseNode.of("http://host4.example"),
+                ClickHouseNode.of("http://host5.example"),
+                invalidSixth));
+
+    assertThat(serverAddressGroup(request)).isNull();
+    assertThat(serverPort(request)).isNull();
+  }
+
+  @Test
   void testConfiguredNodeOrderPreservesPriorityAndDuplicates() throws Exception {
     ClickHouseNode ipv6Node = ClickHouseNode.builder(server).host("2001:db8::2").build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(ipv6Node, server, ipv6Node));
     nodes.update(ipv6Node, ClickHouseNode.Status.FAULTY);
-    String ipv6Address = "[2001:db8::2]";
-    String addressGroup = ipv6Address + "," + host + "," + ipv6Address;
+    String ipv6Address = "[2001:db8::2]:" + port;
+    String addressGroup = ipv6Address + "," + host + ":" + port + "," + ipv6Address;
 
     ClickHouseResponse response =
         client
@@ -752,7 +813,9 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -850,7 +913,7 @@ class ClickHouseClientV1Test {
         ClickHouseNode.builder(server).host("user:secret@configured.example").build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(server, credentialNode));
     nodes.update(credentialNode, ClickHouseNode.Status.FAULTY);
-    String addressGroup = host + ",configured.example";
+    String addressGroup = host + ":" + port + ",configured.example:" + port;
 
     ClickHouseResponse response =
         client
@@ -870,7 +933,9 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? addressGroup : host),
-                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -50,6 +50,8 @@ import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.GenericContainer;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
@@ -751,9 +753,10 @@ class ClickHouseClientV1Test {
                                 emitStableDatabaseSemconv() ? null : "SELECT"))));
   }
 
-  @Test
-  void testConfiguredNodeHostsRejectCommas() throws Exception {
-    ClickHouseNode malformedNode = ClickHouseNode.builder(server).host("host1,host2").build();
+  @ParameterizedTest
+  @ValueSource(strings = {"host1,host2", "host?email=user@example.com"})
+  void testConfiguredNodeHostsRejectMalformedValues(String configuredHost) throws Exception {
+    ClickHouseNode malformedNode = ClickHouseNode.builder(server).host(configuredHost).build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(server, malformedNode));
     nodes.update(malformedNode, ClickHouseNode.Status.FAULTY);
 

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -754,7 +754,7 @@ class ClickHouseClientV1Test {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"host1,host2", "host?email=user@example.com"})
+  @ValueSource(strings = {"host1,host2", "host?email=user@example.com", "[configured.example]"})
   void testConfiguredNodeHostsRejectMalformedValues(String configuredHost) throws Exception {
     ClickHouseNode malformedNode = ClickHouseNode.builder(server).host(configuredHost).build();
     ClickHouseNodes nodes = createNodes(ImmutableList.of(server, malformedNode));

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -675,7 +675,7 @@ class ClickHouseClientV1Test {
   }
 
   @Test
-  void testSealedNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
+  void testCopiedSealedNodeListReportsTheWholeConfiguredTarget() throws ClickHouseException {
     String nodeList = "http://" + host + ":" + port + "," + host + ":" + (port + 1);
     String addressGroup = host + ":" + port + "," + host + ":" + (port + 1);
     ClickHouseNodes nodes = ClickHouseNodes.of(nodeList + "/" + DATABASE_NAME + "?compress=0");
@@ -684,7 +684,8 @@ class ClickHouseClientV1Test {
             .read(nodes)
             .format(ClickHouseFormat.RowBinaryWithNamesAndTypes)
             .query("select * from " + TABLE_NAME)
-            .seal();
+            .seal()
+            .copy();
 
     ClickHouseResponse response = client.executeAndWait(request);
     response.close();

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -608,16 +608,13 @@ class ClickHouseClientV1Test {
   }
 
   @Test
-  void testConfiguredNodeOrderIsCanonicalAndKeepsDuplicates() throws Exception {
+  void testConfiguredNodeOrderPreservesPriorityAndDuplicates() throws Exception {
     ClickHouseNode ipv6Node = ClickHouseNode.builder(server).host("2001:db8::2").build();
-    ClickHouseNodes nodes = createNodes(ImmutableList.of(server, ipv6Node, ipv6Node));
+    ClickHouseNodes nodes = createNodes(ImmutableList.of(ipv6Node, server, ipv6Node));
     nodes.update(ipv6Node, ClickHouseNode.Status.FAULTY);
     String ipv6Address = "[2001:db8::2]:" + port;
     String hostAddress = host + ":" + port;
-    String addressGroup =
-        hostAddress.compareTo(ipv6Address) < 0
-            ? hostAddress + "," + ipv6Address + "," + ipv6Address
-            : ipv6Address + "," + ipv6Address + "," + hostAddress;
+    String addressGroup = ipv6Address + "," + hostAddress + "," + ipv6Address;
 
     ClickHouseResponse response =
         client

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -691,13 +691,13 @@ class ClickHouseClientV1Test {
     ClickHouseRequest<?> request =
         requestWithNodes(
             ImmutableList.of(
-                ClickHouseNode.of("http://http.example"),
-                ClickHouseNode.of("https://https.example"),
+                ClickHouseNode.of("tcps://tcps.example"),
                 ClickHouseNode.of("tcp://tcp.example"),
-                ClickHouseNode.of("tcps://tcps.example")));
+                ClickHouseNode.of("https://https.example"),
+                ClickHouseNode.of("http://http.example")));
 
     assertThat(serverAddressGroup(request))
-        .isEqualTo("http.example,https.example,tcp.example,tcps.example");
+        .isEqualTo("tcps.example,tcp.example,https.example,http.example");
     assertThat(serverPort(request)).isNull();
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -64,9 +64,11 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
+      // the constructor advice snapshots the configured target, so a missing snapshot means the
+      // client was built before this instrumentation was applied
       ServerInfo serverInfo = ClickHouseClientV2Singletons.serverInfo(client);
       if (serverInfo == null) {
-        return null;
+        serverInfo = ServerInfo.empty();
       }
 
       String database = client.getConfiguration().get("database");

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -76,6 +76,8 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
           ClickHouseDbRequest.create(
               serverInfo.getAddress(),
               serverInfo.getPort(),
+              serverInfo.getAddress(),
+              serverInfo.getPort(),
               serverInfo.getAddressGroup(),
               database,
               sqlQuery);

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8.ClickHouseClientV2Singletons.instrumenter;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -14,12 +15,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.clickhouse.client.api.Client;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8.ClickHouseClientV2Singletons.ServerInfo;
 import java.util.Map;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -34,6 +35,7 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
 
   @Override
   public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(isConstructor(), getClass().getName() + "$ConstructAdvice");
     transformer.applyAdviceToMethod(
         isPublic()
             .and(named("query"))
@@ -41,6 +43,14 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
             .and(takesArgument(1, isSubTypeOf(Map.class)))
             .and(takesArgument(2, named("com.clickhouse.client.api.query.QuerySettings"))),
         getClass().getName() + "$QueryAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This Client client) {
+      ClickHouseClientV2Singletons.captureServerInfo(client);
+    }
   }
 
   @SuppressWarnings("unused")
@@ -54,20 +64,20 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
-      // https://clickhouse.com/docs/integrations/language-clients/java/client#client-configuration
-      // Currently, clientv2 supports only one endpoint. Since the endpoint is not going to change
-      // we'll cache it in a virtual field.
-      AddressAndPort addressAndPort = ClickHouseClientV2Singletons.getAddressAndPort(client);
-      if (addressAndPort == null) {
-        String endpoint = client.getEndpoints().stream().findFirst().orElse(null);
-        addressAndPort = ClickHouseClientV2Singletons.setAddressAndPort(client, endpoint);
+      ServerInfo serverInfo = ClickHouseClientV2Singletons.serverInfo(client);
+      if (serverInfo == null) {
+        return null;
       }
 
       String database = client.getConfiguration().get("database");
       Context parentContext = currentContext();
       ClickHouseDbRequest request =
           ClickHouseDbRequest.create(
-              addressAndPort.getAddress(), addressAndPort.getPort(), database, sqlQuery);
+              serverInfo.getAddress(),
+              serverInfo.getPort(),
+              serverInfo.getAddressGroup(),
+              database,
+              sqlQuery);
 
       return ClickHouseScope.start(instrumenter(), parentContext, request);
     }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -22,6 +22,7 @@ import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8.ClickHouseClientV2Singletons.ServerInfo;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -76,6 +77,8 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
           ClickHouseDbRequest.create(
               currentServerInfo.getAddress(),
               currentServerInfo.getPort(),
+              ClickHouseDbRequest.endpoint(
+                  currentServerInfo.getPeerAddress(), currentServerInfo.getPeerPort()),
               configuredServerInfo.getAddress(),
               configuredServerInfo.getPort(),
               configuredServerInfo.getAddressGroup(),
@@ -88,13 +91,18 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Return(readOnly = false) @Nullable CompletableFuture<?> future,
         @Advice.Enter @Nullable ClickHouseScope scope) {
       CallDepth callDepth = CallDepth.forClass(Client.class);
       if (callDepth.decrementAndGet() > 0 || scope == null) {
         return;
       }
 
-      scope.end(throwable);
+      if (throwable != null || future == null) {
+        scope.end(throwable);
+      } else {
+        future = scope.endOnCompletion(future);
+      }
     }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -91,7 +91,7 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
-        @Advice.Return(readOnly = false) @Nullable CompletableFuture<?> future,
+        @Advice.Return @Nullable CompletableFuture<?> future,
         @Advice.Enter @Nullable ClickHouseScope scope) {
       CallDepth callDepth = CallDepth.forClass(Client.class);
       if (callDepth.decrementAndGet() > 0 || scope == null) {
@@ -101,7 +101,7 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
       if (throwable != null || future == null) {
         scope.end(throwable);
       } else {
-        future = scope.endOnCompletion(future);
+        scope.endOnCompletion(future);
       }
     }
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -64,8 +64,7 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
-      // the constructor advice snapshots the configured target, so a missing snapshot means the
-      // client was built before this instrumentation was applied
+      // the constructor advice is the only writer of this snapshot; fall back when it is missing
       ServerInfo serverInfo = ClickHouseClientV2Singletons.serverInfo(client);
       if (serverInfo == null) {
         serverInfo = ServerInfo.empty();

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -65,20 +65,22 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
       }
 
       // the constructor advice is the only writer of this snapshot; fall back when it is missing
-      ServerInfo serverInfo = ClickHouseClientV2Singletons.serverInfo(client);
-      if (serverInfo == null) {
-        serverInfo = ServerInfo.empty();
+      ServerInfo configuredServerInfo = ClickHouseClientV2Singletons.serverInfo(client);
+      ServerInfo currentServerInfo = configuredServerInfo;
+      if (configuredServerInfo == null) {
+        configuredServerInfo = ServerInfo.empty();
+        currentServerInfo = ServerInfo.ofCurrentEndpoint(client.getEndpoints());
       }
 
       String database = client.getConfiguration().get("database");
       Context parentContext = currentContext();
       ClickHouseDbRequest request =
           ClickHouseDbRequest.create(
-              serverInfo.getAddress(),
-              serverInfo.getPort(),
-              serverInfo.getAddress(),
-              serverInfo.getPort(),
-              serverInfo.getAddressGroup(),
+              currentServerInfo.getAddress(),
+              currentServerInfo.getPort(),
+              configuredServerInfo.getAddress(),
+              configuredServerInfo.getPort(),
+              configuredServerInfo.getAddressGroup(),
               database,
               sqlQuery);
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -64,13 +64,11 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
-      // the constructor advice is the only writer of this snapshot; fall back when it is missing
       ServerInfo configuredServerInfo = ClickHouseClientV2Singletons.serverInfo(client);
-      ServerInfo currentServerInfo = configuredServerInfo;
       if (configuredServerInfo == null) {
         configuredServerInfo = ServerInfo.empty();
-        currentServerInfo = ServerInfo.ofCurrentEndpoint(client.getEndpoints());
       }
+      ServerInfo currentServerInfo = ClickHouseClientV2Singletons.currentServerInfo(client);
 
       String database = client.getConfiguration().get("database");
       Context parentContext = currentContext();

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
@@ -22,6 +22,8 @@ public class ClickHouseClientV2InstrumentationModule extends InstrumentationModu
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
-        new ClickHouseClientV2Instrumentation(), new ClickHouseClientV2NodeInstrumentation());
+        new ClickHouseClientV2Instrumentation(),
+        new ClickHouseClientV2NodeInstrumentation(),
+        new ClickHouseClientV2NodeSelectorInstrumentation());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -21,6 +21,7 @@ public class ClickHouseClientV2InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ClickHouseClientV2Instrumentation());
+    return asList(
+        new ClickHouseClientV2Instrumentation(), new ClickHouseClientV2NodeInstrumentation());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeInstrumentation.java
@@ -17,7 +17,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class ClickHouseClientV2NodeInstrumentation implements TypeInstrumentation {
+class ClickHouseClientV2NodeInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeInstrumentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class ClickHouseClientV2NodeInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.clickhouse.client.api.Client");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getNextAliveNode").and(takesArguments(0)),
+        getClass().getName() + "$SelectNodeAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class SelectNodeAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.Return @Nullable Object selectedNode) throws Exception {
+      ClickHouseDbRequest request = ClickHouseScope.currentRequest();
+      if (request != null && selectedNode != null) {
+        ClickHouseClientV2Singletons.capturePeer(request, selectedNode);
+      }
+    }
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeSelectorInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeSelectorInstrumentation.java
@@ -17,7 +17,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public class ClickHouseClientV2NodeSelectorInstrumentation implements TypeInstrumentation {
+class ClickHouseClientV2NodeSelectorInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeSelectorInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2NodeSelectorInstrumentation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class ClickHouseClientV2NodeSelectorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.clickhouse.client.api.transport.ClientNodeSelector");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("getEndpoint")
+            .and(takesArguments(0))
+            .or(named("getNextAliveNode").and(takesArguments(1))),
+        getClass().getName() + "$SelectNodeAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class SelectNodeAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.Return @Nullable Object selectedNode) throws Exception {
+      ClickHouseDbRequest request = ClickHouseScope.currentRequest();
+      if (request != null && selectedNode != null) {
+        ClickHouseClientV2Singletons.capturePeer(request, selectedNode);
+      }
+    }
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -68,6 +68,15 @@ public class ClickHouseClientV2Singletons {
     return currentServerInfo.serverInfo;
   }
 
+  public static void capturePeer(ClickHouseDbRequest request, Object selectedNode)
+      throws Exception {
+    Class<?> selectedNodeClass = selectedNode.getClass();
+    String host = (String) selectedNodeClass.getMethod("getHost").invoke(selectedNode);
+    int port = (Integer) selectedNodeClass.getMethod("getPort").invoke(selectedNode);
+    EndpointTarget endpoint = ServerInfo.sanitizeEndpoint(host);
+    request.setPeer(endpoint == null ? null : endpoint.address, endpoint == null ? null : port);
+  }
+
   public static class ServerInfo {
 
     private static final ServerInfo EMPTY = new ServerInfo(null, null, null);
@@ -75,12 +84,25 @@ public class ClickHouseClientV2Singletons {
     @Nullable private final String address;
     @Nullable private final Integer port;
     @Nullable private final String addressGroup;
+    @Nullable private final String peerAddress;
+    @Nullable private final Integer peerPort;
 
     private ServerInfo(
         @Nullable String address, @Nullable Integer port, @Nullable String addressGroup) {
+      this(address, port, addressGroup, address, port);
+    }
+
+    private ServerInfo(
+        @Nullable String address,
+        @Nullable Integer port,
+        @Nullable String addressGroup,
+        @Nullable String peerAddress,
+        @Nullable Integer peerPort) {
       this.address = address;
       this.port = port;
       this.addressGroup = addressGroup;
+      this.peerAddress = peerAddress;
+      this.peerPort = peerPort;
     }
 
     public static ServerInfo empty() {
@@ -92,32 +114,51 @@ public class ClickHouseClientV2Singletons {
         return EMPTY;
       }
       if (endpoints.size() == 1) {
-        String endpoint = sanitizeEndpoint(endpoints.iterator().next());
+        EndpointTarget endpoint = sanitizeEndpoint(endpoints.iterator().next());
         if (endpoint == null) {
           return EMPTY;
         }
-        return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
+        return new ServerInfo(
+            endpoint.address, endpoint.isDefaultPort() ? null : endpoint.port, null);
       }
 
       // Endpoint iteration order is unspecified, so canonicalize the configured target.
-      List<String> sanitized = new ArrayList<>(endpoints.size());
+      List<EndpointTarget> sanitized = new ArrayList<>(endpoints.size());
+      boolean allDefaultPorts = true;
+      boolean commonNonDefaultPort = true;
+      Integer commonPort = null;
       for (String endpoint : endpoints) {
-        String sanitizedEndpoint = sanitizeEndpoint(endpoint);
+        EndpointTarget sanitizedEndpoint = sanitizeEndpoint(endpoint);
         if (sanitizedEndpoint == null) {
           return EMPTY;
         }
         sanitized.add(sanitizedEndpoint);
+        if (sanitizedEndpoint.isDefaultPort()) {
+          commonNonDefaultPort = false;
+        } else {
+          allDefaultPorts = false;
+          if (sanitizedEndpoint.port == null) {
+            commonNonDefaultPort = false;
+          } else if (commonPort == null) {
+            commonPort = sanitizedEndpoint.port;
+          } else if (!commonPort.equals(sanitizedEndpoint.port)) {
+            commonNonDefaultPort = false;
+          }
+        }
       }
-      sanitized.sort(String::compareTo);
+      boolean inlinePorts = !allDefaultPorts && !commonNonDefaultPort;
+      sanitized.sort(
+          (left, right) -> left.render(inlinePorts).compareTo(right.render(inlinePorts)));
 
       StringBuilder addressGroup = new StringBuilder();
-      for (String endpoint : sanitized) {
+      for (EndpointTarget endpoint : sanitized) {
         if (addressGroup.length() > 0) {
           addressGroup.append(',');
         }
-        addressGroup.append(endpoint);
+        addressGroup.append(endpoint.render(inlinePorts));
       }
-      return new ServerInfo(null, null, addressGroup.toString());
+      return new ServerInfo(
+          null, commonNonDefaultPort ? commonPort : null, addressGroup.toString());
     }
 
     public static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
@@ -125,7 +166,13 @@ public class ClickHouseClientV2Singletons {
         return EMPTY;
       }
       String endpoint = endpoints.iterator().next();
-      return new ServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), null);
+      EndpointTarget peer = sanitizeEndpoint(endpoint);
+      return new ServerInfo(
+          UrlParser.getHost(endpoint),
+          UrlParser.getPort(endpoint),
+          null,
+          peer == null ? null : peer.address,
+          peer == null ? null : peer.port);
     }
 
     private static String endpointAddress(String endpoint) {
@@ -165,9 +212,15 @@ public class ClickHouseClientV2Singletons {
     }
 
     @Nullable
-    private static String sanitizeEndpoint(String endpoint) {
+    private static EndpointTarget sanitizeEndpoint(String endpoint) {
+      String scheme = null;
       int authorityStart = endpoint.indexOf("://");
-      authorityStart = authorityStart < 0 ? 0 : authorityStart + 3;
+      if (authorityStart < 0) {
+        authorityStart = 0;
+      } else {
+        scheme = endpoint.substring(0, authorityStart);
+        authorityStart += 3;
+      }
       int authorityEnd = endpoint.length();
       for (int i = authorityStart; i < endpoint.length(); i++) {
         char c = endpoint.charAt(i);
@@ -184,7 +237,11 @@ public class ClickHouseClientV2Singletons {
       if (authority.indexOf('=') >= 0 || hasUnsafePercentEscape(authority)) {
         return null;
       }
-      return authority;
+      String address = endpointAddress(authority);
+      if (address.isEmpty()) {
+        return null;
+      }
+      return new EndpointTarget(scheme, address, endpointPort(authority));
     }
 
     private static boolean hasUnsafePercentEscape(String authority) {
@@ -211,6 +268,49 @@ public class ClickHouseClientV2Singletons {
     @Nullable
     public String getAddressGroup() {
       return addressGroup;
+    }
+
+    @Nullable
+    public String getPeerAddress() {
+      return peerAddress;
+    }
+
+    @Nullable
+    public Integer getPeerPort() {
+      return peerPort;
+    }
+  }
+
+  private static class EndpointTarget {
+    @Nullable private final String scheme;
+    private final String address;
+    @Nullable private final Integer port;
+
+    private EndpointTarget(@Nullable String scheme, String address, @Nullable Integer port) {
+      this.scheme = scheme;
+      this.address = address;
+      this.port = port;
+    }
+
+    private boolean isDefaultPort() {
+      if (port == null || scheme == null) {
+        return false;
+      }
+      return ("http".equalsIgnoreCase(scheme) && port == 8123)
+          || ("https".equalsIgnoreCase(scheme) && port == 8443);
+    }
+
+    private String render(boolean includePort) {
+      StringBuilder rendered = new StringBuilder();
+      if (address.indexOf(':') >= 0) {
+        rendered.append('[').append(address).append(']');
+      } else {
+        rendered.append(address);
+      }
+      if (includePort && port != null) {
+        rendered.append(':').append(port);
+      }
+      return rendered.toString();
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -13,7 +13,6 @@ import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -100,7 +99,7 @@ public class ClickHouseClientV2Singletons {
       for (String endpoint : endpoints) {
         sanitized.add(sanitizeEndpoint(endpoint));
       }
-      Collections.sort(sanitized);
+      sanitized.sort(String::compareTo);
 
       StringBuilder addressGroup = new StringBuilder();
       for (String endpoint : sanitized) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -47,6 +47,8 @@ public class ClickHouseClientV2Singletons {
     SERVER_INFO_FIELD.set(client, ServerInfo.of(client.getEndpoints()));
   }
 
+  // ClickHouseClientV2Test calls this reflectively to simulate a client whose endpoints were never
+  // captured
   static void clearServerInfo(Client client) {
     SERVER_INFO_FIELD.set(client, null);
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -45,6 +45,10 @@ public class ClickHouseClientV2Singletons {
     SERVER_INFO_FIELD.set(client, ServerInfo.of(client.getEndpoints()));
   }
 
+  static void clearServerInfo(Client client) {
+    SERVER_INFO_FIELD.set(client, null);
+  }
+
   @Nullable
   public static ServerInfo serverInfo(Client client) {
     return SERVER_INFO_FIELD.get(client);
@@ -65,7 +69,7 @@ public class ClickHouseClientV2Singletons {
       this.addressGroup = addressGroup;
     }
 
-    static ServerInfo empty() {
+    public static ServerInfo empty() {
       return EMPTY;
     }
 
@@ -74,8 +78,7 @@ public class ClickHouseClientV2Singletons {
         return EMPTY;
       }
       if (endpoints.size() == 1) {
-        String endpoint = sanitizeEndpoint(endpoints.iterator().next());
-        return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
+        return ofCurrentEndpoint(endpoints);
       }
 
       String first = sanitizeEndpoint(endpoints.iterator().next());
@@ -95,6 +98,14 @@ public class ClickHouseClientV2Singletons {
         addressGroup.append(endpoint);
       }
       return new ServerInfo(endpointAddress(first), endpointPort(first), addressGroup.toString());
+    }
+
+    public static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
+      if (endpoints.isEmpty()) {
+        return EMPTY;
+      }
+      String endpoint = sanitizeEndpoint(endpoints.iterator().next());
+      return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
     }
 
     private static String endpointAddress(String endpoint) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -52,6 +52,8 @@ public class ClickHouseClientV2Singletons {
 
   public static class ServerInfo {
 
+    private static final ServerInfo EMPTY = new ServerInfo(null, null, null);
+
     @Nullable private final String address;
     @Nullable private final Integer port;
     @Nullable private final String addressGroup;
@@ -63,9 +65,13 @@ public class ClickHouseClientV2Singletons {
       this.addressGroup = addressGroup;
     }
 
+    static ServerInfo empty() {
+      return EMPTY;
+    }
+
     static ServerInfo of(Set<String> endpoints) {
       if (endpoints.isEmpty()) {
-        return new ServerInfo(null, null, null);
+        return EMPTY;
       }
       if (endpoints.size() == 1) {
         String endpoint = sanitizeEndpoint(endpoints.iterator().next());

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
+import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
@@ -90,7 +91,8 @@ public class ClickHouseClientV2Singletons {
         return EMPTY;
       }
       if (endpoints.size() == 1) {
-        return ofCurrentEndpoint(endpoints);
+        String endpoint = sanitizeEndpoint(endpoints.iterator().next());
+        return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
       }
 
       String first = sanitizeEndpoint(endpoints.iterator().next());
@@ -116,8 +118,8 @@ public class ClickHouseClientV2Singletons {
       if (endpoints.isEmpty()) {
         return EMPTY;
       }
-      String endpoint = sanitizeEndpoint(endpoints.iterator().next());
-      return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
+      String endpoint = endpoints.iterator().next();
+      return new ServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), null);
     }
 
     private static String endpointAddress(String endpoint) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -79,6 +79,7 @@ public class ClickHouseClientV2Singletons {
 
   public static class ServerInfo {
 
+    private static final int MAX_ENDPOINTS = 5;
     private static final ServerInfo EMPTY = new ServerInfo(null, null, null);
 
     @Nullable private final String address;
@@ -124,41 +125,27 @@ public class ClickHouseClientV2Singletons {
 
       // Endpoint iteration order is unspecified, so canonicalize the configured target.
       List<EndpointTarget> sanitized = new ArrayList<>(endpoints.size());
-      boolean allDefaultPorts = true;
-      boolean commonNonDefaultPort = true;
-      Integer commonPort = null;
+      boolean hasNonDefaultPort = false;
       for (String endpoint : endpoints) {
         EndpointTarget sanitizedEndpoint = sanitizeEndpoint(endpoint);
         if (sanitizedEndpoint == null) {
           return EMPTY;
         }
         sanitized.add(sanitizedEndpoint);
-        if (sanitizedEndpoint.isDefaultPort()) {
-          commonNonDefaultPort = false;
-        } else {
-          allDefaultPorts = false;
-          if (sanitizedEndpoint.port == null) {
-            commonNonDefaultPort = false;
-          } else if (commonPort == null) {
-            commonPort = sanitizedEndpoint.port;
-          } else if (!commonPort.equals(sanitizedEndpoint.port)) {
-            commonNonDefaultPort = false;
-          }
-        }
+        hasNonDefaultPort |= !sanitizedEndpoint.isDefaultPort();
       }
-      boolean inlinePorts = !allDefaultPorts && !commonNonDefaultPort;
+      boolean inlinePorts = hasNonDefaultPort;
       sanitized.sort(
           (left, right) -> left.render(inlinePorts).compareTo(right.render(inlinePorts)));
 
       StringBuilder addressGroup = new StringBuilder();
-      for (EndpointTarget endpoint : sanitized) {
+      for (int i = 0; i < Math.min(sanitized.size(), MAX_ENDPOINTS); i++) {
         if (addressGroup.length() > 0) {
           addressGroup.append(',');
         }
-        addressGroup.append(endpoint.render(inlinePorts));
+        addressGroup.append(sanitized.get(i).render(inlinePorts));
       }
-      return new ServerInfo(
-          null, commonNonDefaultPort ? commonPort : null, addressGroup.toString());
+      return new ServerInfo(null, null, addressGroup.toString());
     }
 
     public static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
@@ -293,11 +280,19 @@ public class ClickHouseClientV2Singletons {
     }
 
     private boolean isDefaultPort() {
-      if (port == null || scheme == null) {
-        return false;
+      Integer defaultPort = defaultPort();
+      return defaultPort != null && (port == null || defaultPort.equals(port));
+    }
+
+    @Nullable
+    private Integer defaultPort() {
+      if ("http".equalsIgnoreCase(scheme)) {
+        return 8123;
       }
-      return ("http".equalsIgnoreCase(scheme) && port == 8123)
-          || ("https".equalsIgnoreCase(scheme) && port == 8443);
+      if ("https".equalsIgnoreCase(scheme)) {
+        return 8443;
+      }
+      return null;
     }
 
     private String render(boolean includePort) {
@@ -307,8 +302,9 @@ public class ClickHouseClientV2Singletons {
       } else {
         rendered.append(address);
       }
-      if (includePort && port != null) {
-        rendered.append(':').append(port);
+      Integer renderedPort = port != null ? port : defaultPort();
+      if (includePort && renderedPort != null) {
+        rendered.append(':').append(renderedPort);
       }
       return rendered.toString();
     }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -23,6 +23,8 @@ public class ClickHouseClientV2Singletons {
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
   private static final VirtualField<Client, ServerInfo> SERVER_INFO_FIELD =
       VirtualField.find(Client.class, ServerInfo.class);
+  private static final VirtualField<Client, CurrentServerInfo> CURRENT_SERVER_INFO_FIELD =
+      VirtualField.find(Client.class, CurrentServerInfo.class);
 
   static {
     instrumenter =
@@ -52,6 +54,16 @@ public class ClickHouseClientV2Singletons {
   @Nullable
   public static ServerInfo serverInfo(Client client) {
     return SERVER_INFO_FIELD.get(client);
+  }
+
+  public static ServerInfo currentServerInfo(Client client) {
+    CurrentServerInfo currentServerInfo = CURRENT_SERVER_INFO_FIELD.get(client);
+    if (currentServerInfo == null) {
+      currentServerInfo =
+          new CurrentServerInfo(ServerInfo.ofCurrentEndpoint(client.getEndpoints()));
+      CURRENT_SERVER_INFO_FIELD.set(client, currentServerInfo);
+    }
+    return currentServerInfo.serverInfo;
   }
 
   public static class ServerInfo {
@@ -175,6 +187,14 @@ public class ClickHouseClientV2Singletons {
     @Nullable
     public String getAddressGroup() {
       return addressGroup;
+    }
+  }
+
+  private static class CurrentServerInfo {
+    private final ServerInfo serverInfo;
+
+    private CurrentServerInfo(ServerInfo serverInfo) {
+      this.serverInfo = serverInfo;
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -221,7 +221,9 @@ public class ClickHouseClientV2Singletons {
         authorityStart = userInfoEnd + 1;
       }
       String authority = endpoint.substring(authorityStart, authorityEnd);
-      if (authority.indexOf('=') >= 0 || hasUnsafePercentEscape(authority)) {
+      if (authority.indexOf('=') >= 0
+          || hasUnsafePercentEscape(authority)
+          || !hasValidPortSyntax(authority)) {
         return null;
       }
       String address = endpointAddress(authority);
@@ -229,6 +231,43 @@ public class ClickHouseClientV2Singletons {
         return null;
       }
       return new EndpointTarget(scheme, address, endpointPort(authority));
+    }
+
+    private static boolean hasValidPortSyntax(String authority) {
+      if (authority.startsWith("[")) {
+        int bracketEnd = authority.indexOf(']');
+        if (bracketEnd <= 1 || authority.indexOf(']', bracketEnd + 1) >= 0) {
+          return false;
+        }
+        String rest = authority.substring(bracketEnd + 1);
+        return rest.isEmpty() || (rest.startsWith(":") && isPort(rest.substring(1)));
+      }
+      if (authority.indexOf('[') >= 0 || authority.indexOf(']') >= 0) {
+        return false;
+      }
+      int firstColon = authority.indexOf(':');
+      int lastColon = authority.lastIndexOf(':');
+      return firstColon < 0
+          || firstColon != lastColon
+          || (firstColon > 0 && isPort(authority.substring(firstColon + 1)));
+    }
+
+    private static boolean isPort(String value) {
+      if (value.isEmpty()) {
+        return false;
+      }
+      int port = 0;
+      for (int i = 0; i < value.length(); i++) {
+        char c = value.charAt(i);
+        if (c < '0' || c > '9') {
+          return false;
+        }
+        port = port * 10 + c - '0';
+        if (port > 65535) {
+          return false;
+        }
+      }
+      return true;
     }
 
     private static boolean hasUnsafePercentEscape(String authority) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -110,7 +110,7 @@ public class ClickHouseClientV2Singletons {
     }
 
     static ServerInfo of(Set<String> endpoints) {
-      DbServerTargetBuilder builder = DbServerTarget.builder(-1);
+      DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(true);
       boolean inlinePorts = false;
       for (String endpoint : endpoints) {
         EndpointTarget extracted = extractEndpoint(endpoint);

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -7,7 +7,6 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
-import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
@@ -69,8 +68,8 @@ public class ClickHouseClientV2Singletons {
         return new ServerInfo(null, null, null);
       }
       if (endpoints.size() == 1) {
-        String endpoint = endpoints.iterator().next();
-        return new ServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), null);
+        String endpoint = sanitizeEndpoint(endpoints.iterator().next());
+        return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
       }
 
       String first = sanitizeEndpoint(endpoints.iterator().next());

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -214,6 +214,8 @@ public class ClickHouseClientV2Singletons {
     }
   }
 
+  // VirtualField keys its storage by the owner class and the field type, so this wrapper is what
+  // keeps CURRENT_SERVER_INFO_FIELD separate from SERVER_INFO_FIELD.
   private static class CurrentServerInfo {
     private final ServerInfo serverInfo;
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -7,13 +7,13 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -73,13 +73,12 @@ public class ClickHouseClientV2Singletons {
     Class<?> selectedNodeClass = selectedNode.getClass();
     String host = (String) selectedNodeClass.getMethod("getHost").invoke(selectedNode);
     int port = (Integer) selectedNodeClass.getMethod("getPort").invoke(selectedNode);
-    EndpointTarget endpoint = ServerInfo.sanitizeEndpoint(host);
-    request.setPeer(endpoint == null ? null : endpoint.address, endpoint == null ? null : port);
+    DbServerTarget target = DbServerTarget.builder(port).addEndpoint(host, -1).build();
+    request.setPeer(target == null ? null : target.getAddress(), target == null ? null : port);
   }
 
   public static class ServerInfo {
 
-    private static final int MAX_ENDPOINTS = 5;
     private static final ServerInfo EMPTY = new ServerInfo(null, null, null);
 
     @Nullable private final String address;
@@ -111,41 +110,28 @@ public class ClickHouseClientV2Singletons {
     }
 
     static ServerInfo of(Set<String> endpoints) {
-      if (endpoints.isEmpty()) {
+      DbServerTargetBuilder builder = DbServerTarget.builder(-1);
+      boolean inlinePorts = false;
+      for (String endpoint : endpoints) {
+        EndpointTarget extracted = extractEndpoint(endpoint);
+        if (extracted == null) {
+          return EMPTY;
+        }
+        int defaultPort = extracted.defaultPort();
+        builder.addEndpoint(
+            extracted.address, extracted.port == null ? -1 : extracted.port, defaultPort);
+        inlinePorts |= extracted.port != null && extracted.port != defaultPort;
+      }
+      DbServerTarget target = builder.build();
+      if (target == null) {
         return EMPTY;
       }
-      if (endpoints.size() == 1) {
-        EndpointTarget endpoint = sanitizeEndpoint(endpoints.iterator().next());
-        if (endpoint == null) {
-          return EMPTY;
-        }
-        return new ServerInfo(
-            endpoint.address, endpoint.isDefaultPort() ? null : endpoint.port, null);
-      }
-
-      // Endpoint iteration order is unspecified, so canonicalize the configured target.
-      List<EndpointTarget> sanitized = new ArrayList<>(endpoints.size());
-      boolean hasNonDefaultPort = false;
-      for (String endpoint : endpoints) {
-        EndpointTarget sanitizedEndpoint = sanitizeEndpoint(endpoint);
-        if (sanitizedEndpoint == null) {
-          return EMPTY;
-        }
-        sanitized.add(sanitizedEndpoint);
-        hasNonDefaultPort |= !sanitizedEndpoint.isDefaultPort();
-      }
-      boolean inlinePorts = hasNonDefaultPort;
-      sanitized.sort(
-          (left, right) -> left.render(inlinePorts).compareTo(right.render(inlinePorts)));
-
-      StringBuilder addressGroup = new StringBuilder();
-      for (int i = 0; i < Math.min(sanitized.size(), MAX_ENDPOINTS); i++) {
-        if (addressGroup.length() > 0) {
-          addressGroup.append(',');
-        }
-        addressGroup.append(sanitized.get(i).render(inlinePorts));
-      }
-      return new ServerInfo(null, null, addressGroup.toString());
+      return endpoints.size() == 1
+          ? new ServerInfo(target.getAddress(), target.getPort(), null)
+          : new ServerInfo(
+              null,
+              null,
+              inlinePorts ? target.getAddress() : bracketIpv6Endpoints(target.getAddress()));
     }
 
     private static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
@@ -153,53 +139,23 @@ public class ClickHouseClientV2Singletons {
         return EMPTY;
       }
       String endpoint = endpoints.iterator().next();
-      EndpointTarget peer = sanitizeEndpoint(endpoint);
+      EndpointTarget extracted = extractEndpoint(endpoint);
+      DbServerTarget peer =
+          extracted == null
+              ? null
+              : DbServerTarget.builder(extracted.defaultPort())
+                  .addEndpoint(extracted.address, extracted.port == null ? -1 : extracted.port)
+                  .build();
       return new ServerInfo(
           UrlParser.getHost(endpoint),
           UrlParser.getPort(endpoint),
           null,
-          peer == null ? null : peer.address,
-          peer == null ? null : peer.port);
-    }
-
-    private static String endpointAddress(String endpoint) {
-      if (endpoint.startsWith("[")) {
-        int bracketEnd = endpoint.indexOf(']');
-        if (bracketEnd > 0) {
-          return endpoint.substring(1, bracketEnd);
-        }
-      }
-      int colon = endpoint.lastIndexOf(':');
-      return colon >= 0 && colon == endpoint.indexOf(':') ? endpoint.substring(0, colon) : endpoint;
+          peer == null ? null : peer.getAddress(),
+          extracted == null ? null : extracted.port);
     }
 
     @Nullable
-    private static Integer endpointPort(String endpoint) {
-      int portStart;
-      if (endpoint.startsWith("[")) {
-        int bracketEnd = endpoint.indexOf(']');
-        portStart =
-            bracketEnd >= 0
-                    && bracketEnd + 1 < endpoint.length()
-                    && endpoint.charAt(bracketEnd + 1) == ':'
-                ? bracketEnd + 2
-                : -1;
-      } else {
-        int colon = endpoint.lastIndexOf(':');
-        portStart = colon >= 0 && colon == endpoint.indexOf(':') ? colon + 1 : -1;
-      }
-      if (portStart < 0 || portStart == endpoint.length()) {
-        return null;
-      }
-      try {
-        return Integer.valueOf(endpoint.substring(portStart));
-      } catch (NumberFormatException ignored) {
-        return null;
-      }
-    }
-
-    @Nullable
-    private static EndpointTarget sanitizeEndpoint(String endpoint) {
+    private static EndpointTarget extractEndpoint(String endpoint) {
       String scheme = null;
       int authorityStart = endpoint.indexOf("://");
       if (authorityStart < 0) {
@@ -221,53 +177,67 @@ public class ClickHouseClientV2Singletons {
         authorityStart = userInfoEnd + 1;
       }
       String authority = endpoint.substring(authorityStart, authorityEnd);
-      if (authority.indexOf('=') >= 0
-          || hasUnsafePercentEscape(authority)
-          || !hasValidPortSyntax(authority)) {
+      if (authority.indexOf('=') >= 0 || hasUnsafePercentEscape(authority)) {
         return null;
       }
-      String address = endpointAddress(authority);
-      if (address.isEmpty()) {
-        return null;
-      }
-      return new EndpointTarget(scheme, address, endpointPort(authority));
-    }
-
-    private static boolean hasValidPortSyntax(String authority) {
       if (authority.startsWith("[")) {
         int bracketEnd = authority.indexOf(']');
         if (bracketEnd <= 1 || authority.indexOf(']', bracketEnd + 1) >= 0) {
-          return false;
+          return null;
         }
         String rest = authority.substring(bracketEnd + 1);
-        return rest.isEmpty() || (rest.startsWith(":") && isPort(rest.substring(1)));
+        Integer port =
+            rest.isEmpty() ? null : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
+        return !rest.isEmpty() && port == null
+            ? null
+            : new EndpointTarget(scheme, authority.substring(1, bracketEnd), port);
       }
       if (authority.indexOf('[') >= 0 || authority.indexOf(']') >= 0) {
-        return false;
+        return null;
       }
       int firstColon = authority.indexOf(':');
       int lastColon = authority.lastIndexOf(':');
-      return firstColon < 0
-          || firstColon != lastColon
-          || (firstColon > 0 && isPort(authority.substring(firstColon + 1)));
+      if (firstColon >= 0 && firstColon == lastColon) {
+        Integer port = parsePort(authority.substring(firstColon + 1));
+        return firstColon == 0 || port == null
+            ? null
+            : new EndpointTarget(scheme, authority.substring(0, firstColon), port);
+      }
+      return new EndpointTarget(scheme, authority, null);
     }
 
-    private static boolean isPort(String value) {
+    @Nullable
+    private static Integer parsePort(String value) {
       if (value.isEmpty()) {
-        return false;
+        return null;
       }
       int port = 0;
       for (int i = 0; i < value.length(); i++) {
         char c = value.charAt(i);
         if (c < '0' || c > '9') {
-          return false;
+          return null;
         }
         port = port * 10 + c - '0';
         if (port > 65535) {
-          return false;
+          return null;
         }
       }
-      return true;
+      return port;
+    }
+
+    private static String bracketIpv6Endpoints(String addressGroup) {
+      StringBuilder result = new StringBuilder();
+      for (String endpoint : addressGroup.split(",", -1)) {
+        if (result.length() > 0) {
+          result.append(',');
+        }
+        if (endpoint.indexOf(':') >= 0) {
+          result.append('[').append(endpoint).append(']');
+        } else {
+          result.append(endpoint);
+        }
+      }
+      return result.toString();
     }
 
     private static boolean hasUnsafePercentEscape(String authority) {
@@ -318,34 +288,14 @@ public class ClickHouseClientV2Singletons {
       this.port = port;
     }
 
-    private boolean isDefaultPort() {
-      Integer defaultPort = defaultPort();
-      return defaultPort != null && (port == null || defaultPort.equals(port));
-    }
-
-    @Nullable
-    private Integer defaultPort() {
+    private int defaultPort() {
       if ("http".equalsIgnoreCase(scheme)) {
         return 8123;
       }
       if ("https".equalsIgnoreCase(scheme)) {
         return 8443;
       }
-      return null;
-    }
-
-    private String render(boolean includePort) {
-      StringBuilder rendered = new StringBuilder();
-      if (address.indexOf(':') >= 0) {
-        rendered.append('[').append(address).append(']');
-      } else {
-        rendered.append(address);
-      }
-      Integer renderedPort = port != null ? port : defaultPort();
-      if (includePort && renderedPort != null) {
-        rendered.append(':').append(renderedPort);
-      }
-      return rendered.toString();
+      return -1;
     }
   }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -93,13 +93,20 @@ public class ClickHouseClientV2Singletons {
       }
       if (endpoints.size() == 1) {
         String endpoint = sanitizeEndpoint(endpoints.iterator().next());
+        if (endpoint == null) {
+          return EMPTY;
+        }
         return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
       }
 
       // Endpoint iteration order is unspecified, so canonicalize the configured target.
       List<String> sanitized = new ArrayList<>(endpoints.size());
       for (String endpoint : endpoints) {
-        sanitized.add(sanitizeEndpoint(endpoint));
+        String sanitizedEndpoint = sanitizeEndpoint(endpoint);
+        if (sanitizedEndpoint == null) {
+          return EMPTY;
+        }
+        sanitized.add(sanitizedEndpoint);
       }
       sanitized.sort(String::compareTo);
 
@@ -157,6 +164,7 @@ public class ClickHouseClientV2Singletons {
       }
     }
 
+    @Nullable
     private static String sanitizeEndpoint(String endpoint) {
       int authorityStart = endpoint.indexOf("://");
       authorityStart = authorityStart < 0 ? 0 : authorityStart + 3;
@@ -172,7 +180,22 @@ public class ClickHouseClientV2Singletons {
       if (userInfoEnd >= authorityStart) {
         authorityStart = userInfoEnd + 1;
       }
-      return endpoint.substring(authorityStart, authorityEnd);
+      String authority = endpoint.substring(authorityStart, authorityEnd);
+      if (authority.indexOf('=') >= 0 || hasUnsafePercentEscape(authority)) {
+        return null;
+      }
+      return authority;
+    }
+
+    private static boolean hasUnsafePercentEscape(String authority) {
+      int percent = authority.indexOf('%');
+      if (percent < 0) {
+        return false;
+      }
+      int bracketEnd = authority.indexOf(']');
+      return !authority.startsWith("[")
+          || bracketEnd < percent
+          || authority.indexOf('%', percent + 1) >= 0;
     }
 
     @Nullable

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -95,8 +95,6 @@ public class ClickHouseClientV2Singletons {
         return new ServerInfo(endpointAddress(endpoint), endpointPort(endpoint), null);
       }
 
-      String first = sanitizeEndpoint(endpoints.iterator().next());
-
       // Endpoint iteration order is unspecified, so canonicalize the configured target.
       List<String> sanitized = new ArrayList<>(endpoints.size());
       for (String endpoint : endpoints) {
@@ -111,7 +109,7 @@ public class ClickHouseClientV2Singletons {
         }
         addressGroup.append(endpoint);
       }
-      return new ServerInfo(endpointAddress(first), endpointPort(first), addressGroup.toString());
+      return new ServerInfo(null, null, addressGroup.toString());
     }
 
     public static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -148,7 +148,7 @@ public class ClickHouseClientV2Singletons {
       return new ServerInfo(null, null, addressGroup.toString());
     }
 
-    public static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
+    private static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
       if (endpoints.isEmpty()) {
         return EMPTY;
       }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -9,18 +9,21 @@ import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 public class ClickHouseClientV2Singletons {
 
   private static final String INSTRUMENTER_NAME = "io.opentelemetry.clickhouse-client-v2-0.8";
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
-  private static final VirtualField<Client, AddressAndPort> ADDRESS_AND_PORT =
-      VirtualField.find(Client.class, AddressAndPort.class);
+  private static final VirtualField<Client, ServerInfo> SERVER_INFO_FIELD =
+      VirtualField.find(Client.class, ServerInfo.class);
 
   static {
     instrumenter =
@@ -39,21 +42,124 @@ public class ClickHouseClientV2Singletons {
     return instrumenter;
   }
 
-  @Nullable
-  public static AddressAndPort getAddressAndPort(Client client) {
-    return ADDRESS_AND_PORT.get(client);
+  public static void captureServerInfo(Client client) {
+    SERVER_INFO_FIELD.set(client, ServerInfo.of(client.getEndpoints()));
   }
 
-  public static AddressAndPort setAddressAndPort(Client client, @Nullable String endpoint) {
-    AddressAndPort addressAndPort = new AddressAndPort();
+  @Nullable
+  public static ServerInfo serverInfo(Client client) {
+    return SERVER_INFO_FIELD.get(client);
+  }
 
-    if (endpoint != null) {
-      addressAndPort.setAddress(UrlParser.getHost(endpoint));
-      addressAndPort.setPort(UrlParser.getPort(endpoint));
+  public static class ServerInfo {
+
+    @Nullable private final String address;
+    @Nullable private final Integer port;
+    @Nullable private final String addressGroup;
+
+    private ServerInfo(
+        @Nullable String address, @Nullable Integer port, @Nullable String addressGroup) {
+      this.address = address;
+      this.port = port;
+      this.addressGroup = addressGroup;
     }
-    ADDRESS_AND_PORT.set(client, addressAndPort);
 
-    return addressAndPort;
+    static ServerInfo of(Set<String> endpoints) {
+      if (endpoints.isEmpty()) {
+        return new ServerInfo(null, null, null);
+      }
+      if (endpoints.size() == 1) {
+        String endpoint = endpoints.iterator().next();
+        return new ServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), null);
+      }
+
+      String first = sanitizeEndpoint(endpoints.iterator().next());
+
+      // Endpoint iteration order is unspecified, so canonicalize the configured target.
+      List<String> sanitized = new ArrayList<>(endpoints.size());
+      for (String endpoint : endpoints) {
+        sanitized.add(sanitizeEndpoint(endpoint));
+      }
+      Collections.sort(sanitized);
+
+      StringBuilder addressGroup = new StringBuilder();
+      for (String endpoint : sanitized) {
+        if (addressGroup.length() > 0) {
+          addressGroup.append(',');
+        }
+        addressGroup.append(endpoint);
+      }
+      return new ServerInfo(endpointAddress(first), endpointPort(first), addressGroup.toString());
+    }
+
+    private static String endpointAddress(String endpoint) {
+      if (endpoint.startsWith("[")) {
+        int bracketEnd = endpoint.indexOf(']');
+        if (bracketEnd > 0) {
+          return endpoint.substring(1, bracketEnd);
+        }
+      }
+      int colon = endpoint.lastIndexOf(':');
+      return colon >= 0 && colon == endpoint.indexOf(':') ? endpoint.substring(0, colon) : endpoint;
+    }
+
+    @Nullable
+    private static Integer endpointPort(String endpoint) {
+      int portStart;
+      if (endpoint.startsWith("[")) {
+        int bracketEnd = endpoint.indexOf(']');
+        portStart =
+            bracketEnd >= 0
+                    && bracketEnd + 1 < endpoint.length()
+                    && endpoint.charAt(bracketEnd + 1) == ':'
+                ? bracketEnd + 2
+                : -1;
+      } else {
+        int colon = endpoint.lastIndexOf(':');
+        portStart = colon >= 0 && colon == endpoint.indexOf(':') ? colon + 1 : -1;
+      }
+      if (portStart < 0 || portStart == endpoint.length()) {
+        return null;
+      }
+      try {
+        return Integer.valueOf(endpoint.substring(portStart));
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+
+    private static String sanitizeEndpoint(String endpoint) {
+      int authorityStart = endpoint.indexOf("://");
+      authorityStart = authorityStart < 0 ? 0 : authorityStart + 3;
+      int authorityEnd = endpoint.length();
+      for (int i = authorityStart; i < endpoint.length(); i++) {
+        char c = endpoint.charAt(i);
+        if (c == '/' || c == '?' || c == '#') {
+          authorityEnd = i;
+          break;
+        }
+      }
+      int userInfoEnd = endpoint.lastIndexOf('@', authorityEnd - 1);
+      if (userInfoEnd >= authorityStart) {
+        authorityStart = userInfoEnd + 1;
+      }
+      return endpoint.substring(authorityStart, authorityEnd);
+    }
+
+    @Nullable
+    public String getAddress() {
+      return address;
+    }
+
+    @Nullable
+    public Integer getPort() {
+      return port;
+    }
+
+    @Nullable
+    public String getAddressGroup() {
+      return addressGroup;
+    }
   }
 
   private ClickHouseClientV2Singletons() {}

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -111,7 +111,6 @@ public class ClickHouseClientV2Singletons {
 
     static ServerInfo of(Set<String> endpoints) {
       DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(true);
-      boolean inlinePorts = false;
       for (String endpoint : endpoints) {
         EndpointTarget extracted = extractEndpoint(endpoint);
         if (extracted == null) {
@@ -120,7 +119,6 @@ public class ClickHouseClientV2Singletons {
         int defaultPort = extracted.defaultPort();
         builder.addEndpoint(
             extracted.address, extracted.port == null ? -1 : extracted.port, defaultPort);
-        inlinePorts |= extracted.port != null && extracted.port != defaultPort;
       }
       DbServerTarget target = builder.build();
       if (target == null) {
@@ -128,10 +126,7 @@ public class ClickHouseClientV2Singletons {
       }
       return endpoints.size() == 1
           ? new ServerInfo(target.getAddress(), target.getPort(), null)
-          : new ServerInfo(
-              null,
-              null,
-              inlinePorts ? target.getAddress() : bracketIpv6Endpoints(target.getAddress()));
+          : new ServerInfo(null, null, target.getAddress());
     }
 
     private static ServerInfo ofCurrentEndpoint(Set<String> endpoints) {
@@ -223,21 +218,6 @@ public class ClickHouseClientV2Singletons {
         }
       }
       return port;
-    }
-
-    private static String bracketIpv6Endpoints(String addressGroup) {
-      StringBuilder result = new StringBuilder();
-      for (String endpoint : addressGroup.split(",", -1)) {
-        if (result.length() > 0) {
-          result.append(',');
-        }
-        if (endpoint.indexOf(':') >= 0) {
-          result.append('[').append(endpoint).append(']');
-        } else {
-          result.append(endpoint);
-        }
-      }
-      return result.toString();
     }
 
     private static boolean hasUnsafePercentEscape(String authority) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -26,6 +26,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -562,8 +564,9 @@ class ClickHouseClientV2Test {
     String firstEndpoint = client.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(firstEndpoint);
     Integer legacyPort = UrlParser.getPort(firstEndpoint);
-    String peerAddress = endpointHost(firstEndpoint);
-    int peerPort = URI.create(firstEndpoint).getPort();
+    Object selectedEndpoint = selectedEndpoint(client);
+    String peerAddress = endpointHost(selectedEndpoint);
+    int peerPort = endpointPort(selectedEndpoint);
 
     QueryResponse response = client.query("select * from " + TABLE_NAME).join();
     response.close();
@@ -590,6 +593,71 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv() ? (long) peerPort : null),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testRetryReportsSelectedEndpoint() throws Exception {
+    assumeTrue(isClassPresent("com.clickhouse.client.api.transport.ClientNodeSelector"));
+
+    int unavailablePort = 1;
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://127.0.0.1:" + unavailablePort)
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .setConnectTimeout(100)
+            .setMaxRetries(1)
+            .useAsyncRequests(true)
+            .build();
+    cleanup.deferCleanup(testClient);
+
+    List<String> configuredAddresses =
+        new ArrayList<>(asList("127.0.0.1:" + unavailablePort, host + ":" + port));
+    configuredAddresses.sort(String::compareTo);
+    putUnreachableEndpointFirst(testClient, unavailablePort);
+    String currentEndpoint = testClient.getEndpoints().iterator().next();
+    String legacyAddress = UrlParser.getHost(currentEndpoint);
+    Integer legacyPort = UrlParser.getPort(currentEndpoint);
+
+    QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "select test_table"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? String.join(",", configuredAddresses)
+                                    : legacyAddress),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -671,6 +739,9 @@ class ClickHouseClientV2Test {
     cleanup.deferCleanup(testClient);
     String currentHost = "127.0.0.1".equals(host) ? "localhost" : "127.0.0.1";
     replaceEndpoints(testClient, "http://" + currentHost + ":" + port);
+    Object selectedEndpoint = selectedEndpoint(testClient);
+    String peerAddress = endpointHost(selectedEndpoint);
+    int peerPort = endpointPort(selectedEndpoint);
 
     QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
     response.close();
@@ -692,10 +763,11 @@ class ClickHouseClientV2Test {
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? host : currentHost),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? peerAddress : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
-                                emitStableDatabaseSemconv() ? (long) port : null),
+                                emitStableDatabaseSemconv() ? (long) peerPort : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -748,7 +820,7 @@ class ClickHouseClientV2Test {
   }
 
   @Test
-  void testMultipleEndpointsExcludeCredentialsAndUrlComponents() {
+  void testMultipleEndpointsExcludeCredentialsAndUrlComponents() throws Exception {
     List<String> endpoints =
         new ArrayList<>(
             asList(
@@ -769,8 +841,9 @@ class ClickHouseClientV2Test {
     String currentEndpoint = testClient.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(currentEndpoint);
     Integer legacyPort = UrlParser.getPort(currentEndpoint);
-    String peerAddress = endpointHost(currentEndpoint);
-    int peerPort = URI.create(currentEndpoint).getPort();
+    Object selectedEndpoint = selectedEndpoint(testClient);
+    String peerAddress = endpointHost(selectedEndpoint);
+    int peerPort = endpointPort(selectedEndpoint);
 
     Throwable thrown = catchThrowable(() -> testClient.query("select 1").join());
     assertThat(thrown).isNotNull();
@@ -872,9 +945,7 @@ class ClickHouseClientV2Test {
     Integer legacyPort = UrlParser.getPort(currentEndpoint);
     String peerAddress = endpointHost(currentEndpoint);
     int peerPort = URI.create(currentEndpoint).getPort();
-    replaceRawEndpoint(testClient, "http://configured.example%3fpassword%3dsecret:8123");
-    captureServerInfo(testClient);
-    replaceRawEndpoint(testClient, currentEndpoint);
+    replaceServerInfo(testClient, "http://configured.example%3fpassword%3dsecret:8123");
 
     QueryResponse response = testClient.query("select 1").join();
     response.close();
@@ -921,14 +992,20 @@ class ClickHouseClientV2Test {
     }
   }
 
-  private static void replaceRawEndpoint(Client client, String endpoint) throws Exception {
-    Field endpointsField = Client.class.getDeclaredField("endpoints");
-    endpointsField.setAccessible(true);
-    endpointsField.set(client, singleton(endpoint));
-  }
+  private static void replaceServerInfo(Client client, String endpoint) throws Exception {
+    Class<?> singletons = singletons(client);
+    Class<?> serverInfoClass = serverInfo(client).getClass();
+    Method of = serverInfoClass.getDeclaredMethod("of", Set.class);
+    of.setAccessible(true);
+    Object replacement = of.invoke(null, singleton(endpoint));
 
-  private static void captureServerInfo(Client client) throws Exception {
-    singletons(client).getMethod("captureServerInfo", Client.class).invoke(null, client);
+    Field serverInfoField = singletons.getDeclaredField("SERVER_INFO_FIELD");
+    serverInfoField.setAccessible(true);
+    Object virtualField = serverInfoField.get(null);
+    virtualField
+        .getClass()
+        .getMethod("set", Object.class, Object.class)
+        .invoke(virtualField, client, replacement);
   }
 
   private static Object serverInfo(Client client) throws Exception {
@@ -956,6 +1033,72 @@ class ClickHouseClientV2Test {
   private static String endpointHost(String endpoint) {
     String host = URI.create(endpoint).getHost();
     return host.startsWith("[") ? host.substring(1, host.length() - 1) : host;
+  }
+
+  private static String endpointHost(Object endpoint) throws Exception {
+    String host = (String) endpoint.getClass().getMethod("getHost").invoke(endpoint);
+    return host.startsWith("[") ? host.substring(1, host.length() - 1) : host;
+  }
+
+  private static Object selectedEndpoint(Client client) throws Exception {
+    try {
+      Field selectorField = Client.class.getDeclaredField("nodeSelector");
+      selectorField.setAccessible(true);
+      Object selector = selectorField.get(client);
+      return selector.getClass().getMethod("getEndpoint").invoke(selector);
+    } catch (NoSuchFieldException ignored) {
+      Field endpointsField;
+      try {
+        endpointsField = Client.class.getDeclaredField("serverNodes");
+      } catch (NoSuchFieldException ignore) {
+        endpointsField = Client.class.getDeclaredField("endpoints");
+      }
+      endpointsField.setAccessible(true);
+      return ((List<?>) endpointsField.get(client)).get(0);
+    }
+  }
+
+  private static int endpointPort(Object endpoint) throws Exception {
+    return (Integer) endpoint.getClass().getMethod("getPort").invoke(endpoint);
+  }
+
+  private static boolean isClassPresent(String className) {
+    try {
+      Class.forName(className, false, Client.class.getClassLoader());
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  private static void putUnreachableEndpointFirst(Client client, int unavailablePort)
+      throws Exception {
+    Field endpointsField = Client.class.getDeclaredField("endpoints");
+    endpointsField.setAccessible(true);
+    List<?> endpoints = (List<?>) endpointsField.get(client);
+    List<Object> orderedEndpoints = new ArrayList<>(endpoints.size());
+    Object unavailableEndpoint = null;
+    for (Object endpoint : endpoints) {
+      int endpointPort = (Integer) endpoint.getClass().getMethod("getPort").invoke(endpoint);
+      if (endpointPort == unavailablePort) {
+        unavailableEndpoint = endpoint;
+      } else {
+        orderedEndpoints.add(endpoint);
+      }
+    }
+    assertThat(unavailableEndpoint).isNotNull();
+    orderedEndpoints.add(0, unavailableEndpoint);
+    endpointsField.set(client, orderedEndpoints);
+
+    Class<?> selectorClass =
+        Class.forName(
+            "com.clickhouse.client.api.transport.ClientNodeSelector",
+            true,
+            Client.class.getClassLoader());
+    Object selector = selectorClass.getConstructor(List.class).newInstance(orderedEndpoints);
+    Field selectorField = Client.class.getDeclaredField("nodeSelector");
+    selectorField.setAccessible(true);
+    selectorField.set(client, selector);
   }
 
   private static Class<?> singletons(Client client) throws Exception {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -39,6 +39,7 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -529,20 +531,19 @@ class ClickHouseClientV2Test {
   }
 
   @Test
-  void testBuilderReuseDoesNotChangeAnExistingClientTarget() throws Exception {
-    Client.Builder builder =
+  void testConfiguredAndCurrentEndpointsAreCapturedSeparately() throws Exception {
+    Client testClient =
         new Client.Builder()
             .addEndpoint(Protocol.HTTP, host, port, false)
             .setDefaultDatabase(DATABASE_NAME)
             .setUsername(USERNAME)
             .setPassword(PASSWORD)
-            .setOption("compress", "false");
-    Client firstClient = builder.build();
-    cleanup.deferCleanup(firstClient);
-    Client secondClient = builder.addEndpoint("http://unused.invalid:8123").build();
-    cleanup.deferCleanup(secondClient);
+            .setOption("compress", "false")
+            .build();
+    cleanup.deferCleanup(testClient);
+    replaceEndpoints(testClient, "http://current.example:8123");
 
-    QueryResponse response = firstClient.query("select * from " + TABLE_NAME).join();
+    QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
     response.close();
 
     testing.waitAndAssertTraces(
@@ -558,8 +559,10 @@ class ClickHouseClientV2Test {
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
-                            equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv() ? host : "current.example"),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? port : 8123),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -695,6 +698,15 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv()
                                     ? thrown.getClass().getName()
                                     : null))));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void replaceEndpoints(Client client, String endpoint) throws Exception {
+    Field endpointsField = Client.class.getDeclaredField("endpoints");
+    endpointsField.setAccessible(true);
+    Set<String> endpoints = (Set<String>) endpointsField.get(client);
+    endpoints.clear();
+    endpoints.add(endpoint);
   }
 
   private static Object clearServerInfo(Client client) throws Exception {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -772,7 +772,7 @@ class ClickHouseClientV2Test {
                 "http://host3.example:8123",
                 "http://host4.example:8123",
                 "http://host5.example:8123",
-                "http://host6.example=invalid:8123"));
+                "http://host6.example:not-a-port"));
 
     assertServerInfo(endpoints, null, null, null);
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -568,6 +568,44 @@ class ClickHouseClientV2Test {
   }
 
   @Test
+  void testMissingSnapshotRetainsOnlyLegacyEndpoint() throws Exception {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .build();
+    cleanup.deferCleanup(testClient);
+    ClickHouseClientV2Singletons.clearServerInfo(testClient);
+    assertThat(ClickHouseClientV2Singletons.serverInfo(testClient)).isNull();
+
+    QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
   void testMultipleEndpointsExcludeCredentialsAndUrlComponents() {
     List<String> endpoints =
         new ArrayList<>(

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -706,13 +705,12 @@ class ClickHouseClientV2Test {
                                     : null))));
   }
 
-  @SuppressWarnings("unchecked")
   private static void replaceEndpoints(Client client, String endpoint) throws Exception {
     Field endpointsField = Client.class.getDeclaredField("endpoints");
     endpointsField.setAccessible(true);
-    Set<String> endpoints = (Set<String>) endpointsField.get(client);
-    endpoints.clear();
-    endpoints.add(endpoint);
+    try (Client replacementClient = new Client.Builder().addEndpoint(endpoint).build()) {
+      endpointsField.set(client, endpointsField.get(replacementClient));
+    }
   }
 
   private static Object clearServerInfo(Client client) throws Exception {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -725,6 +725,20 @@ class ClickHouseClientV2Test {
   }
 
   @Test
+  void testConfiguredIpv6EndpointsOnDefaultPortsRemainUnbracketed() throws Exception {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://[2001:db8::2]:8123")
+            .addEndpoint("https://[2001:db8::1]:8443")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    cleanup.deferCleanup(testClient);
+
+    assertServerInfo(testClient, null, null, "2001:db8::1,2001:db8::2");
+  }
+
+  @Test
   void testConfiguredEndpointsIncludeAtMostFiveEndpoints() throws Exception {
     Set<String> fiveEndpoints =
         new HashSet<>(
@@ -911,7 +925,7 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? "[2001:db8::1],host.example"
+                                    ? "2001:db8::1,host.example"
                                     : legacyAddress),
                             equalTo(
                                 SERVER_PORT,

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -43,7 +43,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -483,7 +482,7 @@ class ClickHouseClientV2Test {
   }
 
   @Test
-  void testMultipleEndpointsReportTheWholeConfiguredTarget() throws Exception {
+  void testMultipleEndpointsReportCanonicalConfiguredTarget() throws Exception {
     String secondEndpoint = "http://127.0.0.1:" + port;
     Client client =
         new Client.Builder()
@@ -497,7 +496,7 @@ class ClickHouseClientV2Test {
     cleanup.deferCleanup(client);
 
     List<String> endpoints = new ArrayList<>(asList(host + ":" + port, "127.0.0.1:" + port));
-    Collections.sort(endpoints);
+    endpoints.sort(String::compareTo);
     String addressGroup = String.join(",", endpoints);
     String firstEndpoint = client.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(firstEndpoint);
@@ -708,7 +707,12 @@ class ClickHouseClientV2Test {
   private static void replaceEndpoints(Client client, String endpoint) throws Exception {
     Field endpointsField = Client.class.getDeclaredField("endpoints");
     endpointsField.setAccessible(true);
-    try (Client replacementClient = new Client.Builder().addEndpoint(endpoint).build()) {
+    try (Client replacementClient =
+        new Client.Builder()
+            .addEndpoint(endpoint)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build()) {
       endpointsField.set(client, endpointsField.get(replacementClient));
     }
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -542,7 +542,8 @@ class ClickHouseClientV2Test {
             .setOption("compress", "false")
             .build();
     cleanup.deferCleanup(testClient);
-    replaceEndpoints(testClient, "http://current.example:8123");
+    String currentHost = "127.0.0.1".equals(host) ? "localhost" : "127.0.0.1";
+    replaceEndpoints(testClient, "http://" + currentHost + ":" + port);
 
     QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
     response.close();
@@ -561,9 +562,8 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(
-                                SERVER_ADDRESS,
-                                emitStableDatabaseSemconv() ? host : "current.example"),
-                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? port : 8123),
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? host : currentHost),
+                            equalTo(SERVER_PORT, port),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -42,6 +44,7 @@ import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -127,6 +130,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -141,6 +149,8 @@ class ClickHouseClientV2Test {
         DB_SYSTEM_NAME,
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -175,6 +185,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -195,6 +210,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -233,6 +253,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -269,6 +294,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from non_existent_table"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -285,6 +315,8 @@ class ClickHouseClientV2Test {
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
         ERROR_TYPE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
     if (emitStableDatabaseSemconv()) {
@@ -328,6 +360,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
                             equalTo(
@@ -363,6 +400,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -406,6 +448,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)"),
                             equalTo(
@@ -426,6 +473,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -472,6 +524,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where value={param_s: String}"),
                             equalTo(
@@ -499,12 +556,14 @@ class ClickHouseClientV2Test {
             .build();
     cleanup.deferCleanup(client);
 
-    List<String> endpoints = new ArrayList<>(asList(host + ":" + port, secondHost + ":" + port));
+    List<String> endpoints = new ArrayList<>(asList(host, secondHost));
     endpoints.sort(String::compareTo);
     String addressGroup = String.join(",", endpoints);
     String firstEndpoint = client.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(firstEndpoint);
     Integer legacyPort = UrlParser.getPort(firstEndpoint);
+    String peerAddress = endpointHost(firstEndpoint);
+    int peerPort = URI.create(firstEndpoint).getPort();
 
     QueryResponse response = client.query("select * from " + TABLE_NAME).join();
     response.close();
@@ -522,7 +581,15 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv() ? addressGroup : legacyAddress),
                             equalTo(
                                 SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(port)
+                                    : Long.valueOf(legacyPort)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? peerAddress : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) peerPort : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -530,6 +597,64 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testConfiguredHttpAndHttpsDefaultPortsAreOmitted() throws Exception {
+    Client httpClient =
+        new Client.Builder()
+            .addEndpoint("http://http.example:8123")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    Client httpsClient =
+        new Client.Builder()
+            .addEndpoint("https://https.example:8443")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    Client multiClient =
+        new Client.Builder()
+            .addEndpoint("http://http.example:8123")
+            .addEndpoint("https://https.example:8443")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    cleanup.deferCleanup(httpClient);
+    cleanup.deferCleanup(httpsClient);
+    cleanup.deferCleanup(multiClient);
+
+    assertServerInfo(httpClient, "http.example", null, null);
+    assertServerInfo(httpsClient, "https.example", null, null);
+    assertServerInfo(multiClient, null, null, "http.example,https.example");
+  }
+
+  @Test
+  void testConfiguredEndpointsExtractCommonNonDefaultPort() throws Exception {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://host2.example:9123")
+            .addEndpoint("https://host1.example:9123")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    cleanup.deferCleanup(testClient);
+
+    assertServerInfo(testClient, null, 9123, "host1.example,host2.example");
+  }
+
+  @Test
+  void testConfiguredEndpointsInlineMixedPortsAndBracketIpv6() throws Exception {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://host.example:8123")
+            .addEndpoint("https://[2001:db8::1]:9443")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .build();
+    cleanup.deferCleanup(testClient);
+
+    assertServerInfo(testClient, null, null, "[2001:db8::1]:9443,host.example:8123");
   }
 
   @Test
@@ -541,6 +666,7 @@ class ClickHouseClientV2Test {
             .setUsername(USERNAME)
             .setPassword(PASSWORD)
             .setOption("compress", "false")
+            .useAsyncRequests(true)
             .build();
     cleanup.deferCleanup(testClient);
     String currentHost = "127.0.0.1".equals(host) ? "localhost" : "127.0.0.1";
@@ -565,6 +691,11 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 SERVER_ADDRESS, emitStableDatabaseSemconv() ? host : currentHost),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -602,6 +733,11 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -633,6 +769,8 @@ class ClickHouseClientV2Test {
     String currentEndpoint = testClient.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(currentEndpoint);
     Integer legacyPort = UrlParser.getPort(currentEndpoint);
+    String peerAddress = endpointHost(currentEndpoint);
+    int peerPort = URI.create(currentEndpoint).getPort();
 
     Throwable thrown = catchThrowable(() -> testClient.query("select 1").join());
     assertThat(thrown).isNotNull();
@@ -648,13 +786,19 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? "[2001:db8::1]:8443,host.example:8123"
+                                    ? "[2001:db8::1],host.example"
                                     : legacyAddress),
                             equalTo(
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() || legacyPort == null
                                     ? null
                                     : legacyPort.longValue()),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? peerAddress : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) peerPort : null),
                             equalTo(maybeStable(DB_STATEMENT), "select ?"),
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
@@ -695,6 +839,10 @@ class ClickHouseClientV2Test {
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv() ? "2001:db8::1" : "[2001"),
                             equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? 8443L : null),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? "2001:db8::1" : null),
+                            equalTo(NETWORK_PEER_PORT, emitStableDatabaseSemconv() ? 8443L : null),
                             equalTo(maybeStable(DB_STATEMENT), "select ?"),
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
@@ -722,6 +870,8 @@ class ClickHouseClientV2Test {
     String currentEndpoint = testClient.getEndpoints().iterator().next();
     String legacyAddress = UrlParser.getHost(currentEndpoint);
     Integer legacyPort = UrlParser.getPort(currentEndpoint);
+    String peerAddress = endpointHost(currentEndpoint);
+    int peerPort = URI.create(currentEndpoint).getPort();
     replaceRawEndpoint(testClient, "http://configured.example%3fpassword%3dsecret:8123");
     captureServerInfo(testClient);
     replaceRawEndpoint(testClient, currentEndpoint);
@@ -744,6 +894,12 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv() || legacyPort == null
                                     ? null
                                     : legacyPort.longValue()),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? peerAddress : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) peerPort : null),
                             equalTo(maybeStable(DB_STATEMENT), "select ?"),
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
@@ -775,12 +931,31 @@ class ClickHouseClientV2Test {
     singletons(client).getMethod("captureServerInfo", Client.class).invoke(null, client);
   }
 
+  private static Object serverInfo(Client client) throws Exception {
+    return singletons(client).getMethod("serverInfo", Client.class).invoke(null, client);
+  }
+
   private static Object clearServerInfo(Client client) throws Exception {
     Class<?> singletons = singletons(client);
     Method clearServerInfo = singletons.getDeclaredMethod("clearServerInfo", Client.class);
     clearServerInfo.setAccessible(true);
     clearServerInfo.invoke(null, client);
-    return singletons.getMethod("serverInfo", Client.class).invoke(null, client);
+    return serverInfo(client);
+  }
+
+  private static void assertServerInfo(
+      Client client, String address, Integer port, String addressGroup) throws Exception {
+    Object serverInfo = serverInfo(client);
+    Class<?> serverInfoClass = serverInfo.getClass();
+    assertThat(serverInfoClass.getMethod("getAddress").invoke(serverInfo)).isEqualTo(address);
+    assertThat(serverInfoClass.getMethod("getPort").invoke(serverInfo)).isEqualTo(port);
+    assertThat(serverInfoClass.getMethod("getAddressGroup").invoke(serverInfo))
+        .isEqualTo(addressGroup);
+  }
+
+  private static String endpointHost(String endpoint) {
+    String host = URI.create(endpoint).getHost();
+    return host.startsWith("[") ? host.substring(1, host.length() - 1) : host;
   }
 
   private static Class<?> singletons(Client client) throws Exception {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -585,7 +585,7 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv() ? addressGroup : legacyAddress),
                             equalTo(
                                 SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
+                                emitStableDatabaseSemconv() ? null : (long) legacyPort),
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv() ? peerAddress : null),
@@ -651,7 +651,7 @@ class ClickHouseClientV2Test {
                                     : legacyAddress),
                             equalTo(
                                 SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
+                                emitStableDatabaseSemconv() ? null : (long) legacyPort),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -868,9 +868,7 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : host),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : Long.valueOf(port)),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
                                 NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
                             equalTo(
@@ -931,7 +929,7 @@ class ClickHouseClientV2Test {
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() || legacyPort == null
                                     ? null
-                                    : legacyPort.longValue()),
+                                    : (long) legacyPort),
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv() ? peerAddress : null),
@@ -1030,7 +1028,7 @@ class ClickHouseClientV2Test {
                                 SERVER_PORT,
                                 emitStableDatabaseSemconv() || legacyPort == null
                                     ? null
-                                    : legacyPort.longValue()),
+                                    : (long) legacyPort),
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv() ? peerAddress : null),

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -37,7 +37,9 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlPa
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -578,8 +580,7 @@ class ClickHouseClientV2Test {
             .setOption("compress", "false")
             .build();
     cleanup.deferCleanup(testClient);
-    ClickHouseClientV2Singletons.clearServerInfo(testClient);
-    assertThat(ClickHouseClientV2Singletons.serverInfo(testClient)).isNull();
+    assertThat(clearServerInfo(testClient)).isNull();
 
     QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
     response.close();
@@ -694,5 +695,35 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv()
                                     ? thrown.getClass().getName()
                                     : null))));
+  }
+
+  private static Object clearServerInfo(Client client) throws Exception {
+    String singletonsName =
+        "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8."
+            + "ClickHouseClientV2Singletons";
+    ClassLoader clientClassLoader = client.getClass().getClassLoader();
+    Class<?> singletons;
+    try {
+      singletons = Class.forName(singletonsName, true, clientClassLoader);
+    } catch (ClassNotFoundException ignored) {
+      Class<?> registry =
+          AgentClassLoaderAccess.loadClass(
+              "io.opentelemetry.javaagent.tooling.instrumentation.indy.IndyModuleRegistry");
+      Method getInstrumentationClassLoader =
+          registry.getMethod("getInstrumentationClassLoader", String.class, ClassLoader.class);
+      ClassLoader instrumentationClassLoader =
+          (ClassLoader)
+              getInstrumentationClassLoader.invoke(
+                  null,
+                  "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8."
+                      + "ClickHouseClientV2InstrumentationModule",
+                  clientClassLoader);
+      singletons = Class.forName(singletonsName, true, instrumentationClassLoader);
+    }
+
+    Method clearServerInfo = singletons.getDeclaredMethod("clearServerInfo", Client.class);
+    clearServerInfo.setAccessible(true);
+    clearServerInfo.invoke(null, client);
+    return singletons.getMethod("serverInfo", Client.class).invoke(null, client);
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -483,7 +483,10 @@ class ClickHouseClientV2Test {
 
   @Test
   void testMultipleEndpointsReportCanonicalConfiguredTarget() throws Exception {
-    String secondEndpoint = "http://127.0.0.1:" + port;
+    // the two endpoints have to stay distinct, and the container host is 127.0.0.1 on some Docker
+    // configurations
+    String secondHost = "127.0.0.1".equals(host) ? "localhost" : "127.0.0.1";
+    String secondEndpoint = "http://" + secondHost + ":" + port;
     Client client =
         new Client.Builder()
             .addEndpoint(Protocol.HTTP, host, port, false)
@@ -495,7 +498,7 @@ class ClickHouseClientV2Test {
             .build();
     cleanup.deferCleanup(client);
 
-    List<String> endpoints = new ArrayList<>(asList(host + ":" + port, "127.0.0.1:" + port));
+    List<String> endpoints = new ArrayList<>(asList(host + ":" + port, secondHost + ":" + port));
     endpoints.sort(String::compareTo);
     String addressGroup = String.join(",", endpoints);
     String firstEndpoint = client.getEndpoints().iterator().next();

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -21,6 +21,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.CLICKHOUSE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -707,6 +708,50 @@ class ClickHouseClientV2Test {
                                     : null))));
   }
 
+  @Test
+  void testProgrammaticEndpointRejectsEncodedSensitiveOptions() throws Exception {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .build();
+    cleanup.deferCleanup(testClient);
+    String currentEndpoint = testClient.getEndpoints().iterator().next();
+    String legacyAddress = UrlParser.getHost(currentEndpoint);
+    Integer legacyPort = UrlParser.getPort(currentEndpoint);
+    replaceRawEndpoint(testClient, "http://configured.example%3fpassword%3dsecret:8123");
+    captureServerInfo(testClient);
+    replaceRawEndpoint(testClient, currentEndpoint);
+
+    QueryResponse response = testClient.query("select 1").join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS, emitStableDatabaseSemconv() ? null : legacyAddress),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() || legacyPort == null
+                                    ? null
+                                    : legacyPort.longValue()),
+                            equalTo(maybeStable(DB_STATEMENT), "select ?"),
+                            equalTo(
+                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
   private static void replaceEndpoints(Client client, String endpoint) throws Exception {
     Field endpointsField = Client.class.getDeclaredField("endpoints");
     endpointsField.setAccessible(true);
@@ -720,14 +765,31 @@ class ClickHouseClientV2Test {
     }
   }
 
+  private static void replaceRawEndpoint(Client client, String endpoint) throws Exception {
+    Field endpointsField = Client.class.getDeclaredField("endpoints");
+    endpointsField.setAccessible(true);
+    endpointsField.set(client, singleton(endpoint));
+  }
+
+  private static void captureServerInfo(Client client) throws Exception {
+    singletons(client).getMethod("captureServerInfo", Client.class).invoke(null, client);
+  }
+
   private static Object clearServerInfo(Client client) throws Exception {
+    Class<?> singletons = singletons(client);
+    Method clearServerInfo = singletons.getDeclaredMethod("clearServerInfo", Client.class);
+    clearServerInfo.setAccessible(true);
+    clearServerInfo.invoke(null, client);
+    return singletons.getMethod("serverInfo", Client.class).invoke(null, client);
+  }
+
+  private static Class<?> singletons(Client client) throws Exception {
     String singletonsName =
         "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8."
             + "ClickHouseClientV2Singletons";
     ClassLoader clientClassLoader = client.getClass().getClassLoader();
-    Class<?> singletons;
     try {
-      singletons = Class.forName(singletonsName, true, clientClassLoader);
+      return Class.forName(singletonsName, true, clientClassLoader);
     } catch (ClassNotFoundException ignored) {
       Class<?> registry =
           AgentClassLoaderAccess.loadClass(
@@ -741,12 +803,7 @@ class ClickHouseClientV2Test {
                   "io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8."
                       + "ClickHouseClientV2InstrumentationModule",
                   clientClassLoader);
-      singletons = Class.forName(singletonsName, true, instrumentationClassLoader);
+      return Class.forName(singletonsName, true, instrumentationClassLoader);
     }
-
-    Method clearServerInfo = singletons.getDeclaredMethod("clearServerInfo", Client.class);
-    clearServerInfo.setAccessible(true);
-    clearServerInfo.invoke(null, client);
-    return singletons.getMethod("serverInfo", Client.class).invoke(null, client);
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -628,9 +628,9 @@ class ClickHouseClientV2Test {
     }
     Client testClient = builder.build();
     cleanup.deferCleanup(testClient);
-    boolean ipv6First = testClient.getEndpoints().iterator().next().contains("[2001:db8::1]");
-    String legacyAddress = ipv6First ? "2001:db8::1" : "host.example";
-    long legacyPort = ipv6First ? 8443 : 8123;
+    String currentEndpoint = testClient.getEndpoints().iterator().next();
+    String legacyAddress = UrlParser.getHost(currentEndpoint);
+    Integer legacyPort = UrlParser.getPort(currentEndpoint);
 
     Throwable thrown = catchThrowable(() -> testClient.query("select 1").join());
     assertThat(thrown).isNotNull();
@@ -648,7 +648,11 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv()
                                     ? "[2001:db8::1]:8443,host.example:8123"
                                     : legacyAddress),
-                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : legacyPort),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() || legacyPort == null
+                                    ? null
+                                    : legacyPort.longValue()),
                             equalTo(maybeStable(DB_STATEMENT), "select ?"),
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
@@ -685,8 +689,10 @@ class ClickHouseClientV2Test {
                         .hasAttributesSatisfyingExactly(
                             equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
-                            equalTo(SERVER_ADDRESS, "2001:db8::1"),
-                            equalTo(SERVER_PORT, 8443),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv() ? "2001:db8::1" : "[2001"),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? 8443L : null),
                             equalTo(maybeStable(DB_STATEMENT), "select ?"),
                             equalTo(
                                 DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -49,6 +49,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -558,7 +559,7 @@ class ClickHouseClientV2Test {
             .build();
     cleanup.deferCleanup(client);
 
-    List<String> endpoints = new ArrayList<>(asList(host, secondHost));
+    List<String> endpoints = new ArrayList<>(asList(host + ":" + port, secondHost + ":" + port));
     endpoints.sort(String::compareTo);
     String addressGroup = String.join(",", endpoints);
     String firstEndpoint = client.getEndpoints().iterator().next();
@@ -584,9 +585,7 @@ class ClickHouseClientV2Test {
                                 emitStableDatabaseSemconv() ? addressGroup : legacyAddress),
                             equalTo(
                                 SERVER_PORT,
-                                emitStableDatabaseSemconv()
-                                    ? Long.valueOf(port)
-                                    : Long.valueOf(legacyPort)),
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv() ? peerAddress : null),
@@ -698,7 +697,7 @@ class ClickHouseClientV2Test {
   }
 
   @Test
-  void testConfiguredEndpointsExtractCommonNonDefaultPort() throws Exception {
+  void testConfiguredEndpointsInlineSharedNonDefaultPort() throws Exception {
     Client testClient =
         new Client.Builder()
             .addEndpoint("http://host2.example:9123")
@@ -708,7 +707,7 @@ class ClickHouseClientV2Test {
             .build();
     cleanup.deferCleanup(testClient);
 
-    assertServerInfo(testClient, null, 9123, "host1.example,host2.example");
+    assertServerInfo(testClient, null, null, "host1.example:9123,host2.example:9123");
   }
 
   @Test
@@ -723,6 +722,59 @@ class ClickHouseClientV2Test {
     cleanup.deferCleanup(testClient);
 
     assertServerInfo(testClient, null, null, "[2001:db8::1]:9443,host.example:8123");
+  }
+
+  @Test
+  void testConfiguredEndpointsIncludeAtMostFiveEndpoints() throws Exception {
+    Set<String> fiveEndpoints =
+        new HashSet<>(
+            asList(
+                "http://host5.example:8123",
+                "http://host3.example:8123",
+                "http://host1.example:8123",
+                "http://host4.example:8123",
+                "http://host2.example:8123"));
+    Set<String> sixEndpoints = new HashSet<>(fiveEndpoints);
+    sixEndpoints.add("http://host6.example:8123");
+    String expected = "host1.example,host2.example,host3.example,host4.example,host5.example";
+
+    assertServerInfo(fiveEndpoints, null, null, expected);
+    assertServerInfo(sixEndpoints, null, null, expected);
+  }
+
+  @Test
+  void testConfiguredEndpointsUsePortModeFromAllEndpoints() throws Exception {
+    Set<String> endpoints =
+        new HashSet<>(
+            asList(
+                "http://host1.example:8123",
+                "http://host2.example:8123",
+                "http://host3.example:8123",
+                "http://host4.example:8123",
+                "http://host5.example:8123",
+                "http://host6.example:9123"));
+
+    assertServerInfo(
+        endpoints,
+        null,
+        null,
+        "host1.example:8123,host2.example:8123,host3.example:8123,"
+            + "host4.example:8123,host5.example:8123");
+  }
+
+  @Test
+  void testConfiguredEndpointsValidateEndpointsAfterTheLimit() throws Exception {
+    Set<String> endpoints =
+        new HashSet<>(
+            asList(
+                "http://host1.example:8123",
+                "http://host2.example:8123",
+                "http://host3.example:8123",
+                "http://host4.example:8123",
+                "http://host5.example:8123",
+                "http://host6.example=invalid:8123"));
+
+    assertServerInfo(endpoints, null, null, null);
   }
 
   @Test
@@ -1022,7 +1074,19 @@ class ClickHouseClientV2Test {
 
   private static void assertServerInfo(
       Client client, String address, Integer port, String addressGroup) throws Exception {
-    Object serverInfo = serverInfo(client);
+    assertServerInfo(serverInfo(client), address, port, addressGroup);
+  }
+
+  private static void assertServerInfo(
+      Set<String> endpoints, String address, Integer port, String addressGroup) throws Exception {
+    Class<?> serverInfoClass = serverInfo(client).getClass();
+    Method of = serverInfoClass.getDeclaredMethod("of", Set.class);
+    of.setAccessible(true);
+    assertServerInfo(of.invoke(null, endpoints), address, port, addressGroup);
+  }
+
+  private static void assertServerInfo(
+      Object serverInfo, String address, Integer port, String addressGroup) throws Exception {
     Class<?> serverInfoClass = serverInfo.getClass();
     assertThat(serverInfoClass.getMethod("getAddress").invoke(serverInfo)).isEqualTo(address);
     assertThat(serverInfoClass.getMethod("getPort").invoke(serverInfo)).isEqualTo(port);

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -619,4 +619,42 @@ class ClickHouseClientV2Test {
                                     ? thrown.getClass().getName()
                                     : null))));
   }
+
+  @Test
+  void testSingleEndpointExcludesUrlComponents() {
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://[2001:db8::1]:8443/database?option=value#fragment")
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setConnectTimeout(100)
+            .setMaxRetries(0)
+            .build();
+    cleanup.deferCleanup(testClient);
+
+    Throwable thrown = catchThrowable(() -> testClient.query("select 1").join());
+    assertThat(thrown).isNotNull();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, "2001:db8::1"),
+                            equalTo(SERVER_PORT, 8443),
+                            equalTo(maybeStable(DB_STATEMENT), "select ?"),
+                            equalTo(
+                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? thrown.getClass().getName()
+                                    : null))));
+  }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.CLICKHOUSE;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -32,11 +33,14 @@ import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.client.api.query.Records;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -473,5 +477,146 @@ class ClickHouseClientV2Test {
                             equalTo(
                                 maybeStable(DB_OPERATION),
                                 emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testMultipleEndpointsReportTheWholeConfiguredTarget() throws Exception {
+    String secondEndpoint = "http://127.0.0.1:" + port;
+    Client client =
+        new Client.Builder()
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .addEndpoint(secondEndpoint)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .build();
+    cleanup.deferCleanup(client);
+
+    List<String> endpoints = new ArrayList<>(asList(host + ":" + port, "127.0.0.1:" + port));
+    Collections.sort(endpoints);
+    String addressGroup = String.join(",", endpoints);
+    String firstEndpoint = client.getEndpoints().iterator().next();
+    String legacyAddress = UrlParser.getHost(firstEndpoint);
+    Integer legacyPort = UrlParser.getPort(firstEndpoint);
+
+    QueryResponse response = client.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv() ? addressGroup : legacyAddress),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : Long.valueOf(legacyPort)),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testBuilderReuseDoesNotChangeAnExistingClientTarget() throws Exception {
+    Client.Builder builder =
+        new Client.Builder()
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false");
+    Client firstClient = builder.build();
+    cleanup.deferCleanup(firstClient);
+    Client secondClient = builder.addEndpoint("http://unused.invalid:8123").build();
+    cleanup.deferCleanup(secondClient);
+
+    QueryResponse response = firstClient.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "select test_table"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testMultipleEndpointsExcludeCredentialsAndUrlComponents() {
+    List<String> endpoints =
+        new ArrayList<>(
+            asList(
+                "https://user:secret@[2001:db8::1]:8443/database?option=value#fragment",
+                "http://host.example:8123"));
+
+    Client.Builder builder =
+        new Client.Builder()
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setConnectTimeout(100)
+            .setMaxRetries(0);
+    for (String endpoint : endpoints) {
+      builder.addEndpoint(endpoint);
+    }
+    Client testClient = builder.build();
+    cleanup.deferCleanup(testClient);
+    boolean ipv6First = testClient.getEndpoints().iterator().next().contains("[2001:db8::1]");
+    String legacyAddress = ipv6First ? "2001:db8::1" : "host.example";
+    long legacyPort = ipv6First ? 8443 : 8123;
+
+    Throwable thrown = catchThrowable(() -> testClient.query("select 1").join());
+    assertThat(thrown).isNotNull();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? "[2001:db8::1]:8443,host.example:8123"
+                                    : legacyAddress),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : legacyPort),
+                            equalTo(maybeStable(DB_STATEMENT), "select ?"),
+                            equalTo(
+                                DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? thrown.getClass().getName()
+                                    : null))));
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DbExecution {
+  private static final int MAX_ENDPOINTS = 5;
   // copied from DbAttributes.DbSystemNameValues
   private static final String POSTGRESQL = "postgresql";
   // copied from DbAttributes.DbSystemNameValues
@@ -217,9 +218,8 @@ public final class DbExecution {
     String hostList = stripUserInfo(serverAddress);
     String[] hosts = hostList.split(",", -1);
 
-    List<ServerTarget> targets = new ArrayList<>(hosts.length);
-    Integer commonPort = null;
-    boolean samePort = true;
+    List<ServerTarget> targets = new ArrayList<>(Math.min(hosts.length, MAX_ENDPOINTS));
+    boolean hasNonDefaultPort = false;
     for (String host : hosts) {
       String trimmed = host.trim();
       if (!isValidHostPort(trimmed)) {
@@ -230,14 +230,11 @@ public final class DbExecution {
         return ServerTarget.EMPTY;
       }
       Integer effectivePort = target.port != null ? target.port : defaultPort;
-      targets.add(new ServerTarget(target.address, effectivePort));
-      if (effectivePort == null) {
-        samePort = false;
-      } else if (commonPort == null) {
-        commonPort = effectivePort;
-      } else if (!commonPort.equals(effectivePort)) {
-        samePort = false;
+      if (targets.size() < MAX_ENDPOINTS) {
+        targets.add(new ServerTarget(target.address, effectivePort));
       }
+      hasNonDefaultPort |=
+          effectivePort != null && (defaultPort == null || !defaultPort.equals(effectivePort));
     }
 
     StringBuilder group = new StringBuilder();
@@ -245,10 +242,9 @@ public final class DbExecution {
       if (group.length() > 0) {
         group.append(',');
       }
-      appendAddress(group, target.address, samePort ? null : target.port);
+      appendAddress(group, target.address, hasNonDefaultPort ? target.port : null);
     }
-    Integer port = samePort && !commonPort.equals(defaultPort) ? commonPort : null;
-    return new ServerTarget(group.toString(), port);
+    return new ServerTarget(group.toString(), null);
   }
 
   private static String stripUserInfo(String serverAddress) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -18,9 +18,6 @@ import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -239,15 +236,46 @@ public final class DbExecution {
     return firstColon > 0 && isPort(value.substring(firstColon + 1));
   }
 
+  // Checks the syntax rather than resolving the value: InetAddress hands anything it cannot parse
+  // as a literal to the platform name service, and that lookup blocks until the resolver answers.
   private static boolean isIpv6Literal(String value) {
-    if (value.indexOf(':') < 0) {
+    String address = value;
+    int zone = value.indexOf('%');
+    if (zone >= 0) {
+      // a link-local address may carry a zone identifier, which is not part of the address
+      if (zone == 0 || zone == value.length() - 1) {
+        return false;
+      }
+      address = value.substring(0, zone);
+    }
+
+    int colons = 0;
+    boolean embeddedIpv4 = false;
+    for (int i = 0; i < address.length(); i++) {
+      char c = address.charAt(i);
+      if (c == ':') {
+        colons++;
+      } else if (c == '.') {
+        embeddedIpv4 = true;
+      } else if (!isHexDigit(c)) {
+        return false;
+      }
+    }
+    if (colons < 2 || colons > 7) {
       return false;
     }
-    try {
-      return InetAddress.getByName(value) instanceof Inet6Address;
-    } catch (UnknownHostException ignored) {
-      return false;
+
+    int compression = address.indexOf("::");
+    if (compression >= 0) {
+      // "::" stands for the omitted groups, so it may appear at most once
+      return compression == address.lastIndexOf("::");
     }
+    // an embedded IPv4 address spells out the last two groups
+    return colons == (embeddedIpv4 ? 6 : 7);
+  }
+
+  private static boolean isHexDigit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
   }
 
   private static boolean isPort(String value) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -178,6 +178,51 @@ public final class DbExecution {
     return configuredServerPort;
   }
 
+  public String getSystemName() {
+    return systemName;
+  }
+
+  @Deprecated // to be removed in 3.0
+  public String getSystem() {
+    return system;
+  }
+
+  @Nullable
+  public String getUser() {
+    return user;
+  }
+
+  @Nullable
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getConnectionString() {
+    return connectionString;
+  }
+
+  public List<String> getRawQueryTexts() {
+    return rawQueryTexts;
+  }
+
+  @Nullable
+  public Long getBatchSize() {
+    return batchSize;
+  }
+
+  public boolean isParameterizedQuery() {
+    return parameterizedQuery;
+  }
+
+  @Nullable
+  public Context getContext() {
+    return context;
+  }
+
+  public void setContext(Context context) {
+    this.context = context;
+  }
+
   private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
     return serverAddress != null && serverAddress.startsWith("/");
   }
@@ -343,51 +388,6 @@ public final class DbExecution {
 
   private static boolean isValidPort(int port) {
     return port >= 1 && port <= 65535;
-  }
-
-  public String getSystemName() {
-    return systemName;
-  }
-
-  @Deprecated // to be removed in 3.0
-  public String getSystem() {
-    return system;
-  }
-
-  @Nullable
-  public String getUser() {
-    return user;
-  }
-
-  @Nullable
-  public String getNamespace() {
-    return namespace;
-  }
-
-  public String getConnectionString() {
-    return connectionString;
-  }
-
-  public List<String> getRawQueryTexts() {
-    return rawQueryTexts;
-  }
-
-  @Nullable
-  public Long getBatchSize() {
-    return batchSize;
-  }
-
-  public boolean isParameterizedQuery() {
-    return parameterizedQuery;
-  }
-
-  @Nullable
-  public Context getContext() {
-    return context;
-  }
-
-  public void setContext(Context context) {
-    this.context = context;
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -117,19 +117,17 @@ public final class DbExecution {
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
+    Integer defaultPort =
+        resolveDefaultPort(
+            resolvedDriver,
+            resolvedProtocol,
+            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
     ServerTarget configuredServerTarget =
         isUnixDomainSocket(serverAddress)
             ? sanitizeUnixDomainSocket(serverAddress)
             : isServerAddressGroupCandidate(serverAddress)
-                ? sanitizeServerAddressGroup(
-                    serverAddress,
-                    serverPort,
-                    resolveDefaultPort(
-                        resolvedDriver,
-                        resolvedProtocol,
-                        factoryOptions.hasOption(SSL)
-                            && Boolean.TRUE.equals(factoryOptions.getValue(SSL))))
-                : sanitizeServerTarget(serverAddress, serverPort);
+                ? sanitizeServerAddressGroup(serverAddress, serverPort, defaultPort)
+                : sanitizeServerTarget(serverAddress, serverPort, defaultPort);
     this.configuredServerAddress = configuredServerTarget.address;
     this.configuredServerPort = configuredServerTarget.port;
     this.connectionString =
@@ -293,6 +291,14 @@ public final class DbExecution {
           host.substring(0, firstColon), Integer.valueOf(host.substring(firstColon + 1)));
     }
     return new ServerTarget(host, serverPort);
+  }
+
+  private static ServerTarget sanitizeServerTarget(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    ServerTarget target = sanitizeServerTarget(serverAddress, serverPort);
+    return defaultPort != null && defaultPort.equals(target.port)
+        ? new ServerTarget(target.address, null)
+        : target;
   }
 
   private static void appendAddress(

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -205,7 +205,7 @@ public final class DbExecution {
     }
     if (value.startsWith("[")) {
       int closingBracket = value.indexOf(']');
-      if (closingBracket < 0 || value.indexOf(']', closingBracket + 1) >= 0) {
+      if (closingBracket <= 1 || value.indexOf(']', closingBracket + 1) >= 0) {
         return false;
       }
       String rest = value.substring(closingBracket + 1);
@@ -215,7 +215,8 @@ public final class DbExecution {
       return false;
     }
     int colon = value.lastIndexOf(':');
-    return colon < 0 || value.indexOf(':') != colon || isPort(value.substring(colon + 1));
+    return colon < 0
+        || (colon > 0 && (value.indexOf(':') != colon || isPort(value.substring(colon + 1))));
   }
 
   private static boolean isPort(String value) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -72,6 +72,8 @@ public final class DbExecution {
   @Nullable private final Integer serverPort;
   private final boolean serverAddressGroupCandidate;
   @Nullable private final String serverAddressGroup;
+  @Nullable private final String configuredServerAddress;
+  @Nullable private final Integer configuredServerPort;
   private final String connectionString;
   private final List<String> rawQueryTexts;
   @Nullable private final Long batchSize;
@@ -101,9 +103,15 @@ public final class DbExecution {
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    this.serverAddressGroupCandidate = isServerAddressGroup(serverAddress);
+    this.serverAddressGroupCandidate = isServerAddressGroupCandidate(serverAddress);
     this.serverAddressGroup =
         serverAddressGroupCandidate ? sanitizeServerAddressGroup(serverAddress, serverPort) : null;
+    ServerTarget configuredServerTarget =
+        serverAddressGroupCandidate
+            ? new ServerTarget(serverAddressGroup, null)
+            : sanitizeServerTarget(serverAddress, serverPort);
+    this.configuredServerAddress = configuredServerTarget.address;
+    this.configuredServerPort = configuredServerTarget.port;
     this.connectionString =
         String.format(
             "%s%s:%s%s",
@@ -148,7 +156,17 @@ public final class DbExecution {
     return serverAddressGroupCandidate;
   }
 
-  private static boolean isServerAddressGroup(@Nullable String serverAddress) {
+  @Nullable
+  public String getConfiguredServerAddress() {
+    return configuredServerAddress;
+  }
+
+  @Nullable
+  public Integer getConfiguredServerPort() {
+    return configuredServerPort;
+  }
+
+  private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
     return serverAddress != null
         && serverAddress.indexOf(',') >= 0
         && !serverAddress.startsWith("/");
@@ -199,6 +217,43 @@ public final class DbExecution {
   private static String stripUserInfo(String serverAddress) {
     int at = serverAddress.lastIndexOf('@');
     return at < 0 ? serverAddress : serverAddress.substring(at + 1);
+  }
+
+  private static ServerTarget sanitizeServerTarget(
+      @Nullable String serverAddress, @Nullable Integer serverPort) {
+    if (serverAddress == null
+        || serverAddress.indexOf('/') >= 0
+        || serverAddress.indexOf('?') >= 0
+        || serverAddress.indexOf('#') >= 0
+        || (serverPort != null && !isPort(serverPort))) {
+      return ServerTarget.EMPTY;
+    }
+
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
+      return ServerTarget.EMPTY;
+    }
+
+    String host = stripUserInfo(serverAddress).trim();
+    if (!isValidHostPort(host)) {
+      return ServerTarget.EMPTY;
+    }
+
+    if (host.startsWith("[")) {
+      int closingBracket = host.indexOf(']');
+      String port = host.substring(closingBracket + 1);
+      return new ServerTarget(
+          host.substring(1, closingBracket),
+          port.isEmpty() ? serverPort : Integer.valueOf(port.substring(1)));
+    }
+
+    int firstColon = host.indexOf(':');
+    int lastColon = host.lastIndexOf(':');
+    if (firstColon >= 0 && firstColon == lastColon) {
+      return new ServerTarget(
+          host.substring(0, firstColon), Integer.valueOf(host.substring(firstColon + 1)));
+    }
+    return new ServerTarget(host, serverPort);
   }
 
   private static boolean isValidHostPort(String value) {
@@ -405,5 +460,17 @@ public final class DbExecution {
     // otherwise use DRIVER directly.
     String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
     return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
+  }
+
+  private static class ServerTarget {
+    private static final ServerTarget EMPTY = new ServerTarget(null, null);
+
+    @Nullable private final String address;
+    @Nullable private final Integer port;
+
+    private ServerTarget(@Nullable String address, @Nullable Integer port) {
+      this.address = address;
+      this.port = port;
+    }
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -218,16 +218,10 @@ public final class DbExecution {
     }
 
     DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort);
-    boolean inlinePorts = false;
     for (ParsedEndpoint endpoint : endpoints) {
       builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
-      inlinePorts |= endpoint.port != null && !defaultPort.equals(endpoint.port);
     }
-    ConfiguredServerTarget target = ConfiguredServerTarget.from(builder.build());
-    if (!inlinePorts && target.address != null) {
-      target = new ConfiguredServerTarget(bracketIpv6Endpoints(target.address), null);
-    }
-    return target;
+    return ConfiguredServerTarget.from(builder.build());
   }
 
   private static String stripUserInfo(String serverAddress) {
@@ -280,23 +274,8 @@ public final class DbExecution {
     return new ConfiguredServerTarget(addressGroup.toString(), null);
   }
 
-  private static String bracketIpv6Endpoints(String addressGroup) {
-    StringBuilder result = new StringBuilder();
-    for (String endpoint : addressGroup.split(",", -1)) {
-      if (result.length() > 0) {
-        result.append(',');
-      }
-      if (endpoint.indexOf(':') >= 0) {
-        result.append('[').append(endpoint).append(']');
-      } else {
-        result.append(endpoint);
-      }
-    }
-    return result.toString();
-  }
-
   private static void appendEndpoint(StringBuilder result, ParsedEndpoint endpoint) {
-    if (endpoint.host.indexOf(':') >= 0) {
+    if (endpoint.port != null && endpoint.host.indexOf(':') >= 0) {
       result.append('[').append(endpoint.host).append(']');
     } else {
       result.append(endpoint.host);

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -217,7 +217,7 @@ public final class DbExecution {
       return buildUnknownDefaultPortGroup(endpoints);
     }
 
-    DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort).setSorted(false);
+    DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort);
     boolean inlinePorts = false;
     for (ParsedEndpoint endpoint : endpoints) {
       builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
@@ -253,7 +253,6 @@ public final class DbExecution {
     int effectiveDefaultPort = defaultPort != null ? defaultPort : endpoint.port == null ? 1 : -1;
     return ConfiguredServerTarget.from(
         DbServerTarget.builder(effectiveDefaultPort)
-            .setSorted(false)
             .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
             .build());
   }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -70,6 +70,7 @@ public final class DbExecution {
   @Nullable private final String namespace;
   @Nullable private final String serverAddress;
   @Nullable private final Integer serverPort;
+  @Nullable private final String serverAddressGroup;
   private final String connectionString;
   private final List<String> rawQueryTexts;
   @Nullable private final Long batchSize;
@@ -99,6 +100,7 @@ public final class DbExecution {
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
+    this.serverAddressGroup = serverAddressGroup(serverAddress, serverPort);
     this.connectionString =
         String.format(
             "%s%s:%s%s",
@@ -132,6 +134,47 @@ public final class DbExecution {
   @Nullable
   public Integer getServerPort() {
     return serverPort;
+  }
+
+  @Nullable
+  public String getServerAddressGroup() {
+    return serverAddressGroup;
+  }
+
+  @Nullable
+  private static String serverAddressGroup(
+      @Nullable String serverAddress, @Nullable Integer serverPort) {
+    // Unix socket paths may contain commas but still identify one endpoint.
+    if (serverAddress == null || serverAddress.indexOf(',') < 0 || serverAddress.startsWith("/")) {
+      return null;
+    }
+    if (serverPort == null) {
+      return serverAddress;
+    }
+    StringBuilder group = new StringBuilder();
+    for (String host : serverAddress.split(",")) {
+      if (group.length() > 0) {
+        group.append(',');
+      }
+      String trimmed = host.trim();
+      if (isUnbracketedIpv6(trimmed)) {
+        group.append('[').append(trimmed).append("]:").append(serverPort);
+      } else {
+        group.append(trimmed);
+        if (!hasPort(trimmed)) {
+          group.append(':').append(serverPort);
+        }
+      }
+    }
+    return group.toString();
+  }
+
+  private static boolean isUnbracketedIpv6(String host) {
+    return !host.startsWith("[") && host.indexOf(':') != host.lastIndexOf(':');
+  }
+
+  private static boolean hasPort(String host) {
+    return host.startsWith("[") ? host.indexOf("]:") > 0 : host.indexOf(':') >= 0;
   }
 
   public String getSystemName() {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -163,7 +163,8 @@ public final class DbExecution {
     if (serverAddress == null
         || serverAddress.indexOf('/') >= 0
         || serverAddress.indexOf('?') >= 0
-        || serverAddress.indexOf('#') >= 0) {
+        || serverAddress.indexOf('#') >= 0
+        || (serverPort != null && !isPort(serverPort))) {
       return null;
     }
 
@@ -246,12 +247,22 @@ public final class DbExecution {
     if (value.isEmpty()) {
       return false;
     }
+    int port = 0;
     for (int i = 0; i < value.length(); i++) {
-      if (value.charAt(i) < '0' || value.charAt(i) > '9') {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9') {
+        return false;
+      }
+      port = port * 10 + c - '0';
+      if (!isPort(port)) {
         return false;
       }
     }
     return true;
+  }
+
+  private static boolean isPort(int value) {
+    return value >= 0 && value <= 65535;
   }
 
   private static boolean isUnbracketedIpv6(String host) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -172,9 +172,7 @@ public final class DbExecution {
   }
 
   private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
-    return serverAddress != null
-        && serverAddress.indexOf(',') >= 0
-        && !serverAddress.startsWith("/");
+    return serverAddress != null && serverAddress.indexOf(',') >= 0;
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -102,9 +102,11 @@ public final class DbExecution {
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
     ServerTarget configuredServerTarget =
-        isServerAddressGroupCandidate(serverAddress)
-            ? new ServerTarget(sanitizeServerAddressGroup(serverAddress, serverPort), null)
-            : sanitizeServerTarget(serverAddress, serverPort);
+        isUnixDomainSocket(serverAddress)
+            ? sanitizeUnixDomainSocket(serverAddress)
+            : isServerAddressGroupCandidate(serverAddress)
+                ? new ServerTarget(sanitizeServerAddressGroup(serverAddress, serverPort), null)
+                : sanitizeServerTarget(serverAddress, serverPort);
     this.configuredServerAddress = configuredServerTarget.address;
     this.configuredServerPort = configuredServerTarget.port;
     this.connectionString =
@@ -150,6 +152,23 @@ public final class DbExecution {
   @Nullable
   public Integer getConfiguredServerPort() {
     return configuredServerPort;
+  }
+
+  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.startsWith("/");
+  }
+
+  private static ServerTarget sanitizeUnixDomainSocket(@Nullable String serverAddress) {
+    if (serverAddress == null
+        || serverAddress.length() == 1
+        || serverAddress.indexOf(',') >= 0
+        || serverAddress.indexOf('=') >= 0
+        || serverAddress.indexOf('@') >= 0
+        || serverAddress.indexOf('?') >= 0
+        || serverAddress.indexOf('#') >= 0) {
+      return ServerTarget.EMPTY;
+    }
+    return new ServerTarget(serverAddress, null);
   }
 
   private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -157,7 +157,10 @@ public final class DbExecution {
   @Nullable
   private static String sanitizeServerAddressGroup(
       @Nullable String serverAddress, @Nullable Integer serverPort) {
-    if (serverAddress == null) {
+    if (serverAddress == null
+        || serverAddress.indexOf('/') >= 0
+        || serverAddress.indexOf('?') >= 0
+        || serverAddress.indexOf('#') >= 0) {
       return null;
     }
 

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -15,6 +15,8 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
@@ -123,12 +125,12 @@ public final class DbExecution {
             resolvedDriver,
             resolvedProtocol,
             factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
-    ServerTarget configuredServerTarget =
+    ConfiguredServerTarget configuredServerTarget =
         isUnixDomainSocket(serverAddress)
-            ? sanitizeUnixDomainSocket(serverAddress)
+            ? ConfiguredServerTarget.from(DbServerTarget.unixSocket(serverAddress))
             : isServerAddressGroupCandidate(serverAddress)
-                ? sanitizeServerAddressGroup(serverAddress, serverPort, defaultPort)
-                : sanitizeServerTarget(serverAddress, serverPort, defaultPort);
+                ? buildServerAddressGroup(serverAddress, serverPort, defaultPort)
+                : buildServerTarget(serverAddress, serverPort, defaultPort);
     this.configuredServerAddress = configuredServerTarget.address;
     this.configuredServerPort = configuredServerTarget.port;
     this.connectionString =
@@ -180,71 +182,52 @@ public final class DbExecution {
     return serverAddress != null && serverAddress.startsWith("/");
   }
 
-  private static ServerTarget sanitizeUnixDomainSocket(@Nullable String serverAddress) {
-    if (serverAddress == null
-        || serverAddress.length() == 1
-        || serverAddress.indexOf(',') >= 0
-        || serverAddress.indexOf('=') >= 0
-        || serverAddress.indexOf('%') >= 0
-        || serverAddress.indexOf('@') >= 0
-        || serverAddress.indexOf('?') >= 0
-        || serverAddress.indexOf('#') >= 0) {
-      return ServerTarget.EMPTY;
-    }
-    return new ServerTarget(serverAddress, null);
-  }
-
   private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
     return serverAddress != null && serverAddress.indexOf(',') >= 0;
   }
 
-  private static ServerTarget sanitizeServerAddressGroup(
+  private static ConfiguredServerTarget buildServerAddressGroup(
       @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
     if (serverAddress == null
         || serverAddress.indexOf('/') >= 0
         || serverAddress.indexOf('?') >= 0
         || serverAddress.indexOf('#') >= 0
-        || (serverPort != null && !isPort(serverPort))) {
-      return ServerTarget.EMPTY;
+        || (serverPort != null && !isValidPort(serverPort))) {
+      return ConfiguredServerTarget.EMPTY;
     }
 
     int firstComma = serverAddress.indexOf(',');
     int userInfoEnd = serverAddress.indexOf('@');
     if (userInfoEnd > firstComma
         || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
-      return ServerTarget.EMPTY;
+      return ConfiguredServerTarget.EMPTY;
     }
 
     String hostList = stripUserInfo(serverAddress);
     String[] hosts = hostList.split(",", -1);
-
-    List<ServerTarget> targets = new ArrayList<>(Math.min(hosts.length, MAX_ENDPOINTS));
-    boolean hasNonDefaultPort = false;
+    List<ParsedEndpoint> endpoints = new ArrayList<>(hosts.length);
     for (String host : hosts) {
-      String trimmed = host.trim();
-      if (!isValidHostPort(trimmed)) {
-        return ServerTarget.EMPTY;
+      ParsedEndpoint endpoint = parseEndpoint(host, serverPort);
+      if (endpoint == null) {
+        return ConfiguredServerTarget.EMPTY;
       }
-      ServerTarget target = sanitizeServerTarget(trimmed, serverPort);
-      if (target.address == null) {
-        return ServerTarget.EMPTY;
-      }
-      Integer effectivePort = target.port != null ? target.port : defaultPort;
-      if (targets.size() < MAX_ENDPOINTS) {
-        targets.add(new ServerTarget(target.address, effectivePort));
-      }
-      hasNonDefaultPort |=
-          effectivePort != null && (defaultPort == null || !defaultPort.equals(effectivePort));
+      endpoints.add(endpoint);
+    }
+    if (defaultPort == null) {
+      return buildUnknownDefaultPortGroup(endpoints);
     }
 
-    StringBuilder group = new StringBuilder();
-    for (ServerTarget target : targets) {
-      if (group.length() > 0) {
-        group.append(',');
-      }
-      appendAddress(group, target.address, hasNonDefaultPort ? target.port : null);
+    DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort).setSorted(false);
+    boolean inlinePorts = false;
+    for (ParsedEndpoint endpoint : endpoints) {
+      builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
+      inlinePorts |= endpoint.port != null && !defaultPort.equals(endpoint.port);
     }
-    return new ServerTarget(group.toString(), null);
+    ConfiguredServerTarget target = ConfiguredServerTarget.from(builder.build());
+    if (!inlinePorts && target.address != null) {
+      target = new ConfiguredServerTarget(bracketIpv6Endpoints(target.address), null);
+    }
+    return target;
   }
 
   private static String stripUserInfo(String serverAddress) {
@@ -252,216 +235,136 @@ public final class DbExecution {
     return at < 0 ? serverAddress : serverAddress.substring(at + 1);
   }
 
-  private static ServerTarget sanitizeServerTarget(
-      @Nullable String serverAddress, @Nullable Integer serverPort) {
-    if (serverAddress == null
-        || serverAddress.indexOf('/') >= 0
-        || serverAddress.indexOf('?') >= 0
-        || serverAddress.indexOf('#') >= 0
-        || (serverPort != null && !isPort(serverPort))) {
-      return ServerTarget.EMPTY;
+  private static ConfiguredServerTarget buildServerTarget(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (serverAddress != null
+        && (serverAddress.indexOf('/') >= 0
+            || serverAddress.indexOf('?') >= 0
+            || serverAddress.indexOf('#') >= 0)) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    if (serverPort != null && !isValidPort(serverPort)) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    ParsedEndpoint endpoint = parseEndpoint(serverAddress, serverPort);
+    if (endpoint == null) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    int effectiveDefaultPort = defaultPort != null ? defaultPort : endpoint.port == null ? 1 : -1;
+    return ConfiguredServerTarget.from(
+        DbServerTarget.builder(effectiveDefaultPort)
+            .setSorted(false)
+            .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
+            .build());
+  }
+
+  private static ConfiguredServerTarget buildUnknownDefaultPortGroup(
+      List<ParsedEndpoint> endpoints) {
+    for (ParsedEndpoint endpoint : endpoints) {
+      int validationDefaultPort = endpoint.port == null ? 1 : -1;
+      if (DbServerTarget.builder(validationDefaultPort)
+              .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
+              .build()
+          == null) {
+        return ConfiguredServerTarget.EMPTY;
+      }
     }
 
+    StringBuilder addressGroup = new StringBuilder();
+    for (int i = 0; i < Math.min(endpoints.size(), MAX_ENDPOINTS); i++) {
+      ParsedEndpoint endpoint = endpoints.get(i);
+      if (addressGroup.length() > 0) {
+        addressGroup.append(',');
+      }
+      appendEndpoint(addressGroup, endpoint);
+    }
+    return new ConfiguredServerTarget(addressGroup.toString(), null);
+  }
+
+  private static String bracketIpv6Endpoints(String addressGroup) {
+    StringBuilder result = new StringBuilder();
+    for (String endpoint : addressGroup.split(",", -1)) {
+      if (result.length() > 0) {
+        result.append(',');
+      }
+      if (endpoint.indexOf(':') >= 0) {
+        result.append('[').append(endpoint).append(']');
+      } else {
+        result.append(endpoint);
+      }
+    }
+    return result.toString();
+  }
+
+  private static void appendEndpoint(StringBuilder result, ParsedEndpoint endpoint) {
+    if (endpoint.host.indexOf(':') >= 0) {
+      result.append('[').append(endpoint.host).append(']');
+    } else {
+      result.append(endpoint.host);
+    }
+    if (endpoint.port != null) {
+      result.append(':').append(endpoint.port);
+    }
+  }
+
+  @Nullable
+  private static ParsedEndpoint parseEndpoint(
+      @Nullable String serverAddress, @Nullable Integer serverPort) {
+    if (serverAddress == null) {
+      return null;
+    }
     int userInfoEnd = serverAddress.indexOf('@');
     if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
-      return ServerTarget.EMPTY;
+      return null;
     }
 
     String host = stripUserInfo(serverAddress).trim();
-    if (!isValidHostPort(host)) {
-      return ServerTarget.EMPTY;
-    }
-
     if (host.startsWith("[")) {
       int closingBracket = host.indexOf(']');
-      String port = host.substring(closingBracket + 1);
-      return new ServerTarget(
-          host.substring(1, closingBracket),
-          port.isEmpty() ? serverPort : Integer.valueOf(port.substring(1)));
+      if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {
+        return null;
+      }
+      String rest = host.substring(closingBracket + 1);
+      Integer port =
+          rest.isEmpty() ? serverPort : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
+      return !rest.isEmpty() && port == null
+          ? null
+          : new ParsedEndpoint(host.substring(1, closingBracket), port);
+    }
+    if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
+      return null;
     }
 
     int firstColon = host.indexOf(':');
     int lastColon = host.lastIndexOf(':');
     if (firstColon >= 0 && firstColon == lastColon) {
-      return new ServerTarget(
-          host.substring(0, firstColon), Integer.valueOf(host.substring(firstColon + 1)));
+      Integer port = parsePort(host.substring(firstColon + 1));
+      return port == null ? null : new ParsedEndpoint(host.substring(0, firstColon), port);
     }
-    return new ServerTarget(host, serverPort);
+    return new ParsedEndpoint(host, serverPort);
   }
 
-  private static ServerTarget sanitizeServerTarget(
-      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
-    ServerTarget target = sanitizeServerTarget(serverAddress, serverPort);
-    return defaultPort != null && defaultPort.equals(target.port)
-        ? new ServerTarget(target.address, null)
-        : target;
-  }
-
-  private static void appendAddress(
-      StringBuilder addressGroup, String host, @Nullable Integer port) {
-    if (isUnbracketedIpv6(host)) {
-      addressGroup.append('[').append(host).append(']');
-    } else {
-      addressGroup.append(host);
-    }
-    if (port != null) {
-      addressGroup.append(':').append(port);
-    }
-  }
-
-  private static boolean isValidHostPort(String value) {
-    if (value.isEmpty()
-        || value.indexOf('=') >= 0
-        || value.indexOf('@') >= 0
-        || value.indexOf('[') > 0) {
-      return false;
-    }
-    for (int i = 0; i < value.length(); i++) {
-      if (Character.isWhitespace(value.charAt(i))) {
-        return false;
-      }
-    }
-    if (value.startsWith("[")) {
-      int closingBracket = value.indexOf(']');
-      if (closingBracket <= 1 || value.indexOf(']', closingBracket + 1) >= 0) {
-        return false;
-      }
-      if (!isIpv6Literal(value.substring(1, closingBracket))) {
-        return false;
-      }
-      String rest = value.substring(closingBracket + 1);
-      return rest.isEmpty() || (rest.startsWith(":") && isPort(rest.substring(1)));
-    }
-    if (value.indexOf(']') >= 0) {
-      return false;
-    }
-    int firstColon = value.indexOf(':');
-    if (firstColon < 0) {
-      return value.indexOf('%') < 0;
-    }
-    int lastColon = value.lastIndexOf(':');
-    if (firstColon != lastColon) {
-      return isIpv6Literal(value);
-    }
-    return value.indexOf('%') < 0 && firstColon > 0 && isPort(value.substring(firstColon + 1));
-  }
-
-  // Checks the syntax rather than resolving the value: InetAddress hands anything it cannot parse
-  // as a literal to the platform name service, and that lookup blocks until the resolver answers.
-  private static boolean isIpv6Literal(String value) {
-    String address = value;
-    int zone = value.indexOf('%');
-    if (zone >= 0) {
-      // a link-local address may carry a zone identifier, which is not part of the address
-      if (zone == 0 || zone == value.length() - 1 || value.indexOf('%', zone + 1) >= 0) {
-        return false;
-      }
-      address = value.substring(0, zone);
-    }
-
-    int firstDot = address.indexOf('.');
-    if (firstDot >= 0) {
-      int ipv4Start = address.lastIndexOf(':') + 1;
-      if (firstDot < ipv4Start || !isIpv4Literal(address.substring(ipv4Start))) {
-        return false;
-      }
-      // An embedded IPv4 address occupies the final two IPv6 groups.
-      address = address.substring(0, ipv4Start) + "0:0";
-    }
-
-    int compression = address.indexOf("::");
-    if (compression >= 0) {
-      // "::" stands for the omitted groups, so it may appear at most once
-      if (compression != address.lastIndexOf("::")) {
-        return false;
-      }
-      int leftGroups = countIpv6Groups(address.substring(0, compression));
-      int rightGroups = countIpv6Groups(address.substring(compression + 2));
-      return leftGroups >= 0 && rightGroups >= 0 && leftGroups + rightGroups < 8;
-    }
-    return countIpv6Groups(address) == 8;
-  }
-
-  private static int countIpv6Groups(String value) {
+  @Nullable
+  private static Integer parsePort(String value) {
     if (value.isEmpty()) {
-      return 0;
-    }
-
-    int groups = 0;
-    int groupStart = 0;
-    for (int i = 0; i <= value.length(); i++) {
-      if (i == value.length() || value.charAt(i) == ':') {
-        int length = i - groupStart;
-        if (length == 0 || length > 4) {
-          return -1;
-        }
-        for (int j = groupStart; j < i; j++) {
-          if (!isHexDigit(value.charAt(j))) {
-            return -1;
-          }
-        }
-        groups++;
-        groupStart = i + 1;
-      }
-    }
-    return groups;
-  }
-
-  private static boolean isIpv4Literal(String value) {
-    int octets = 0;
-    int octetStart = 0;
-    for (int i = 0; i <= value.length(); i++) {
-      if (i == value.length() || value.charAt(i) == '.') {
-        int length = i - octetStart;
-        if (length == 0 || length > 3) {
-          return false;
-        }
-        int octet = 0;
-        for (int j = octetStart; j < i; j++) {
-          char c = value.charAt(j);
-          if (c < '0' || c > '9') {
-            return false;
-          }
-          octet = octet * 10 + c - '0';
-        }
-        if (octet > 255) {
-          return false;
-        }
-        octets++;
-        octetStart = i + 1;
-      }
-    }
-    return octets == 4;
-  }
-
-  private static boolean isHexDigit(char c) {
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-  }
-
-  private static boolean isPort(String value) {
-    if (value.isEmpty()) {
-      return false;
+      return null;
     }
     int port = 0;
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
       if (c < '0' || c > '9') {
-        return false;
+        return null;
       }
       port = port * 10 + c - '0';
-      if (!isPort(port)) {
-        return false;
+      if (port > 65535) {
+        return null;
       }
     }
-    return true;
+    return port;
   }
 
-  private static boolean isPort(int value) {
-    return value >= 0 && value <= 65535;
-  }
-
-  private static boolean isUnbracketedIpv6(String host) {
-    return !host.startsWith("[") && host.indexOf(':') != host.lastIndexOf(':');
+  private static boolean isValidPort(int port) {
+    return port >= 1 && port <= 65535;
   }
 
   public String getSystemName() {
@@ -569,13 +472,29 @@ public final class DbExecution {
     return driver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(driver, OTHER_SQL) : OTHER_SQL;
   }
 
-  private static class ServerTarget {
-    private static final ServerTarget EMPTY = new ServerTarget(null, null);
+  private static class ParsedEndpoint {
+    private final String host;
+    @Nullable private final Integer port;
+
+    private ParsedEndpoint(String host, @Nullable Integer port) {
+      this.host = host;
+      this.port = port;
+    }
+  }
+
+  private static class ConfiguredServerTarget {
+    private static final ConfiguredServerTarget EMPTY = new ConfiguredServerTarget(null, null);
 
     @Nullable private final String address;
     @Nullable private final Integer port;
 
-    private ServerTarget(@Nullable String address, @Nullable Integer port) {
+    private static ConfiguredServerTarget from(@Nullable DbServerTarget target) {
+      return target == null
+          ? EMPTY
+          : new ConfiguredServerTarget(target.getAddress(), target.getPort());
+    }
+
+    private ConfiguredServerTarget(@Nullable String address, @Nullable Integer port) {
       this.address = address;
       this.port = port;
     }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -70,6 +70,7 @@ public final class DbExecution {
   @Nullable private final String namespace;
   @Nullable private final String serverAddress;
   @Nullable private final Integer serverPort;
+  private final boolean serverAddressGroupCandidate;
   @Nullable private final String serverAddressGroup;
   private final String connectionString;
   private final List<String> rawQueryTexts;
@@ -100,7 +101,9 @@ public final class DbExecution {
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    this.serverAddressGroup = serverAddressGroup(serverAddress, serverPort);
+    this.serverAddressGroupCandidate = isServerAddressGroup(serverAddress);
+    this.serverAddressGroup =
+        serverAddressGroupCandidate ? sanitizeServerAddressGroup(serverAddress, serverPort) : null;
     this.connectionString =
         String.format(
             "%s%s:%s%s",
@@ -141,32 +144,87 @@ public final class DbExecution {
     return serverAddressGroup;
   }
 
+  public boolean isServerAddressGroup() {
+    return serverAddressGroupCandidate;
+  }
+
+  private static boolean isServerAddressGroup(@Nullable String serverAddress) {
+    return serverAddress != null
+        && serverAddress.indexOf(',') >= 0
+        && !serverAddress.startsWith("/");
+  }
+
   @Nullable
-  private static String serverAddressGroup(
+  private static String sanitizeServerAddressGroup(
       @Nullable String serverAddress, @Nullable Integer serverPort) {
-    // Unix socket paths may contain commas but still identify one endpoint.
-    if (serverAddress == null || serverAddress.indexOf(',') < 0 || serverAddress.startsWith("/")) {
+    if (serverAddress == null) {
       return null;
     }
-    if (serverPort == null) {
-      return serverAddress;
+
+    String hostList = stripUserInfo(serverAddress);
+    String[] hosts = hostList.split(",", -1);
+    if (hosts.length < 2) {
+      return null;
     }
+
     StringBuilder group = new StringBuilder();
-    for (String host : serverAddress.split(",")) {
+    for (String host : hosts) {
+      String trimmed = host.trim();
+      if (!isValidHostPort(trimmed)) {
+        return null;
+      }
       if (group.length() > 0) {
         group.append(',');
       }
-      String trimmed = host.trim();
-      if (isUnbracketedIpv6(trimmed)) {
+      if (serverPort != null && isUnbracketedIpv6(trimmed)) {
         group.append('[').append(trimmed).append("]:").append(serverPort);
       } else {
         group.append(trimmed);
-        if (!hasPort(trimmed)) {
+        if (serverPort != null && !hasPort(trimmed)) {
           group.append(':').append(serverPort);
         }
       }
     }
     return group.toString();
+  }
+
+  private static String stripUserInfo(String serverAddress) {
+    int at = serverAddress.lastIndexOf('@');
+    return at < 0 ? serverAddress : serverAddress.substring(at + 1);
+  }
+
+  private static boolean isValidHostPort(String value) {
+    if (value.isEmpty()
+        || value.indexOf('=') >= 0
+        || value.indexOf('@') >= 0
+        || value.indexOf('[') > 0) {
+      return false;
+    }
+    if (value.startsWith("[")) {
+      int closingBracket = value.indexOf(']');
+      if (closingBracket < 0 || value.indexOf(']', closingBracket + 1) >= 0) {
+        return false;
+      }
+      String rest = value.substring(closingBracket + 1);
+      return rest.isEmpty() || (rest.startsWith(":") && isPort(rest.substring(1)));
+    }
+    if (value.indexOf(']') >= 0) {
+      return false;
+    }
+    int colon = value.lastIndexOf(':');
+    return colon < 0 || value.indexOf(':') != colon || isPort(value.substring(colon + 1));
+  }
+
+  private static boolean isPort(String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      if (value.charAt(i) < '0' || value.charAt(i) > '9') {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static boolean isUnbracketedIpv6(String host) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -271,6 +271,11 @@ public final class DbExecution {
         || value.indexOf('[') > 0) {
       return false;
     }
+    for (int i = 0; i < value.length(); i++) {
+      if (Character.isWhitespace(value.charAt(i))) {
+        return false;
+      }
+    }
     if (value.startsWith("[")) {
       int closingBracket = value.indexOf(']');
       if (closingBracket <= 1 || value.indexOf(']', closingBracket + 1) >= 0) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -188,8 +188,11 @@ public final class DbExecution {
       if (group.length() > 0) {
         group.append(',');
       }
-      if (serverPort != null && isUnbracketedIpv6(trimmed)) {
-        group.append('[').append(trimmed).append("]:").append(serverPort);
+      if (isUnbracketedIpv6(trimmed)) {
+        group.append('[').append(trimmed).append(']');
+        if (serverPort != null) {
+          group.append(':').append(serverPort);
+        }
       } else {
         group.append(trimmed);
         if (serverPort != null && !hasPort(trimmed)) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -163,6 +163,7 @@ public final class DbExecution {
         || serverAddress.length() == 1
         || serverAddress.indexOf(',') >= 0
         || serverAddress.indexOf('=') >= 0
+        || serverAddress.indexOf('%') >= 0
         || serverAddress.indexOf('@') >= 0
         || serverAddress.indexOf('?') >= 0
         || serverAddress.indexOf('#') >= 0) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -290,13 +290,13 @@ public final class DbExecution {
     }
     int firstColon = value.indexOf(':');
     if (firstColon < 0) {
-      return true;
+      return value.indexOf('%') < 0;
     }
     int lastColon = value.lastIndexOf(':');
     if (firstColon != lastColon) {
       return isIpv6Literal(value);
     }
-    return firstColon > 0 && isPort(value.substring(firstColon + 1));
+    return value.indexOf('%') < 0 && firstColon > 0 && isPort(value.substring(firstColon + 1));
   }
 
   // Checks the syntax rather than resolving the value: InetAddress hands anything it cannot parse

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -18,6 +18,9 @@ import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -208,15 +211,35 @@ public final class DbExecution {
       if (closingBracket <= 1 || value.indexOf(']', closingBracket + 1) >= 0) {
         return false;
       }
+      if (!isIpv6Literal(value.substring(1, closingBracket))) {
+        return false;
+      }
       String rest = value.substring(closingBracket + 1);
       return rest.isEmpty() || (rest.startsWith(":") && isPort(rest.substring(1)));
     }
     if (value.indexOf(']') >= 0) {
       return false;
     }
-    int colon = value.lastIndexOf(':');
-    return colon < 0
-        || (colon > 0 && (value.indexOf(':') != colon || isPort(value.substring(colon + 1))));
+    int firstColon = value.indexOf(':');
+    if (firstColon < 0) {
+      return true;
+    }
+    int lastColon = value.lastIndexOf(':');
+    if (firstColon != lastColon) {
+      return isIpv6Literal(value);
+    }
+    return firstColon > 0 && isPort(value.substring(firstColon + 1));
+  }
+
+  private static boolean isIpv6Literal(String value) {
+    if (value.indexOf(':') < 0) {
+      return false;
+    }
+    try {
+      return InetAddress.getByName(value) instanceof Inet6Address;
+    } catch (UnknownHostException ignored) {
+      return false;
+    }
   }
 
   private static boolean isPort(String value) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -240,35 +240,85 @@ public final class DbExecution {
     int zone = value.indexOf('%');
     if (zone >= 0) {
       // a link-local address may carry a zone identifier, which is not part of the address
-      if (zone == 0 || zone == value.length() - 1) {
+      if (zone == 0 || zone == value.length() - 1 || value.indexOf('%', zone + 1) >= 0) {
         return false;
       }
       address = value.substring(0, zone);
     }
 
-    int colons = 0;
-    boolean embeddedIpv4 = false;
-    for (int i = 0; i < address.length(); i++) {
-      char c = address.charAt(i);
-      if (c == ':') {
-        colons++;
-      } else if (c == '.') {
-        embeddedIpv4 = true;
-      } else if (!isHexDigit(c)) {
+    int firstDot = address.indexOf('.');
+    if (firstDot >= 0) {
+      int ipv4Start = address.lastIndexOf(':') + 1;
+      if (firstDot < ipv4Start || !isIpv4Literal(address.substring(ipv4Start))) {
         return false;
       }
-    }
-    if (colons < 2 || colons > 7) {
-      return false;
+      // An embedded IPv4 address occupies the final two IPv6 groups.
+      address = address.substring(0, ipv4Start) + "0:0";
     }
 
     int compression = address.indexOf("::");
     if (compression >= 0) {
       // "::" stands for the omitted groups, so it may appear at most once
-      return compression == address.lastIndexOf("::");
+      if (compression != address.lastIndexOf("::")) {
+        return false;
+      }
+      int leftGroups = countIpv6Groups(address.substring(0, compression));
+      int rightGroups = countIpv6Groups(address.substring(compression + 2));
+      return leftGroups >= 0 && rightGroups >= 0 && leftGroups + rightGroups < 8;
     }
-    // an embedded IPv4 address spells out the last two groups
-    return colons == (embeddedIpv4 ? 6 : 7);
+    return countIpv6Groups(address) == 8;
+  }
+
+  private static int countIpv6Groups(String value) {
+    if (value.isEmpty()) {
+      return 0;
+    }
+
+    int groups = 0;
+    int groupStart = 0;
+    for (int i = 0; i <= value.length(); i++) {
+      if (i == value.length() || value.charAt(i) == ':') {
+        int length = i - groupStart;
+        if (length == 0 || length > 4) {
+          return -1;
+        }
+        for (int j = groupStart; j < i; j++) {
+          if (!isHexDigit(value.charAt(j))) {
+            return -1;
+          }
+        }
+        groups++;
+        groupStart = i + 1;
+      }
+    }
+    return groups;
+  }
+
+  private static boolean isIpv4Literal(String value) {
+    int octets = 0;
+    int octetStart = 0;
+    for (int i = 0; i <= value.length(); i++) {
+      if (i == value.length() || value.charAt(i) == '.') {
+        int length = i - octetStart;
+        if (length == 0 || length > 3) {
+          return false;
+        }
+        int octet = 0;
+        for (int j = octetStart; j < i; j++) {
+          char c = value.charAt(j);
+          if (c < '0' || c > '9') {
+            return false;
+          }
+          octet = octet * 10 + c - '0';
+        }
+        if (octet > 255) {
+          return false;
+        }
+        octets++;
+        octetStart = i + 1;
+      }
+    }
+    return octets == 4;
   }
 
   private static boolean isHexDigit(char c) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -174,9 +174,6 @@ public final class DbExecution {
 
     String hostList = stripUserInfo(serverAddress);
     String[] hosts = hostList.split(",", -1);
-    if (hosts.length < 2) {
-      return null;
-    }
 
     StringBuilder group = new StringBuilder();
     for (String host : hosts) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -10,6 +10,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
@@ -18,6 +19,7 @@ import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -50,17 +52,29 @@ public final class DbExecution {
 
   // R2DBC driver identifier → stable semconv db.system.name value
   private static final Map<String, String> DRIVER_TO_SYSTEM_NAME = buildDriverToSystemName();
+  private static final Map<String, Integer> DRIVER_TO_DEFAULT_PORT = buildDriverToDefaultPort();
 
   private static Map<String, String> buildDriverToSystemName() {
     Map<String, String> map = new HashMap<>();
-    map.put("postgresql", POSTGRESQL);
-    map.put("mysql", MYSQL);
-    map.put("mariadb", MARIADB);
+    map.put(POSTGRESQL, POSTGRESQL);
+    map.put(MYSQL, MYSQL);
+    map.put(MARIADB, MARIADB);
     map.put("mssql", MICROSOFT_SQL_SERVER);
     map.put("oracle", ORACLE_DB);
     map.put("db2", IBM_DB2);
-    map.put("clickhouse", CLICKHOUSE);
+    map.put(CLICKHOUSE, CLICKHOUSE);
     map.put("h2", H2DATABASE);
+    return map;
+  }
+
+  private static Map<String, Integer> buildDriverToDefaultPort() {
+    Map<String, Integer> map = new HashMap<>();
+    map.put(POSTGRESQL, 5432);
+    map.put(MYSQL, 3306);
+    map.put(MARIADB, 3306);
+    map.put("mssql", 1433);
+    map.put("oracle", 1521);
+    map.put("db2", 50000);
     return map;
   }
 
@@ -96,7 +110,9 @@ public final class DbExecution {
         factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
     String protocol =
         factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
-    this.systemName = resolveDbSystemName(driver, protocol);
+    String resolvedDriver = resolveDriver(driver, protocol);
+    String resolvedProtocol = resolveProtocol(driver, protocol);
+    this.systemName = resolveDbSystemName(resolvedDriver);
     this.serverAddress =
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
@@ -105,7 +121,14 @@ public final class DbExecution {
         isUnixDomainSocket(serverAddress)
             ? sanitizeUnixDomainSocket(serverAddress)
             : isServerAddressGroupCandidate(serverAddress)
-                ? new ServerTarget(sanitizeServerAddressGroup(serverAddress, serverPort), null)
+                ? sanitizeServerAddressGroup(
+                    serverAddress,
+                    serverPort,
+                    resolveDefaultPort(
+                        resolvedDriver,
+                        resolvedProtocol,
+                        factoryOptions.hasOption(SSL)
+                            && Boolean.TRUE.equals(factoryOptions.getValue(SSL))))
                 : sanitizeServerTarget(serverAddress, serverPort);
     this.configuredServerAddress = configuredServerTarget.address;
     this.configuredServerPort = configuredServerTarget.port;
@@ -176,49 +199,58 @@ public final class DbExecution {
     return serverAddress != null && serverAddress.indexOf(',') >= 0;
   }
 
-  @Nullable
-  private static String sanitizeServerAddressGroup(
-      @Nullable String serverAddress, @Nullable Integer serverPort) {
+  private static ServerTarget sanitizeServerAddressGroup(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
     if (serverAddress == null
         || serverAddress.indexOf('/') >= 0
         || serverAddress.indexOf('?') >= 0
         || serverAddress.indexOf('#') >= 0
         || (serverPort != null && !isPort(serverPort))) {
-      return null;
+      return ServerTarget.EMPTY;
     }
 
     int firstComma = serverAddress.indexOf(',');
     int userInfoEnd = serverAddress.indexOf('@');
     if (userInfoEnd > firstComma
         || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
-      return null;
+      return ServerTarget.EMPTY;
     }
 
     String hostList = stripUserInfo(serverAddress);
     String[] hosts = hostList.split(",", -1);
 
-    StringBuilder group = new StringBuilder();
+    List<ServerTarget> targets = new ArrayList<>(hosts.length);
+    Integer commonPort = null;
+    boolean samePort = true;
     for (String host : hosts) {
       String trimmed = host.trim();
       if (!isValidHostPort(trimmed)) {
-        return null;
+        return ServerTarget.EMPTY;
       }
+      ServerTarget target = sanitizeServerTarget(trimmed, serverPort);
+      if (target.address == null) {
+        return ServerTarget.EMPTY;
+      }
+      Integer effectivePort = target.port != null ? target.port : defaultPort;
+      targets.add(new ServerTarget(target.address, effectivePort));
+      if (effectivePort == null) {
+        samePort = false;
+      } else if (commonPort == null) {
+        commonPort = effectivePort;
+      } else if (!commonPort.equals(effectivePort)) {
+        samePort = false;
+      }
+    }
+
+    StringBuilder group = new StringBuilder();
+    for (ServerTarget target : targets) {
       if (group.length() > 0) {
         group.append(',');
       }
-      if (isUnbracketedIpv6(trimmed)) {
-        group.append('[').append(trimmed).append(']');
-        if (serverPort != null) {
-          group.append(':').append(serverPort);
-        }
-      } else {
-        group.append(trimmed);
-        if (serverPort != null && !hasPort(trimmed)) {
-          group.append(':').append(serverPort);
-        }
-      }
+      appendAddress(group, target.address, samePort ? null : target.port);
     }
-    return group.toString();
+    Integer port = samePort && !commonPort.equals(defaultPort) ? commonPort : null;
+    return new ServerTarget(group.toString(), port);
   }
 
   private static String stripUserInfo(String serverAddress) {
@@ -261,6 +293,18 @@ public final class DbExecution {
           host.substring(0, firstColon), Integer.valueOf(host.substring(firstColon + 1)));
     }
     return new ServerTarget(host, serverPort);
+  }
+
+  private static void appendAddress(
+      StringBuilder addressGroup, String host, @Nullable Integer port) {
+    if (isUnbracketedIpv6(host)) {
+      addressGroup.append('[').append(host).append(']');
+    } else {
+      addressGroup.append(host);
+    }
+    if (port != null) {
+      addressGroup.append(':').append(port);
+    }
   }
 
   private static boolean isValidHostPort(String value) {
@@ -418,10 +462,6 @@ public final class DbExecution {
     return !host.startsWith("[") && host.indexOf(':') != host.lastIndexOf(':');
   }
 
-  private static boolean hasPort(String host) {
-    return host.startsWith("[") ? host.indexOf("]:") > 0 : host.indexOf(':') >= 0;
-  }
-
   public String getSystemName() {
     return systemName;
   }
@@ -467,11 +507,64 @@ public final class DbExecution {
     this.context = context;
   }
 
-  private static String resolveDbSystemName(@Nullable String driver, @Nullable String protocol) {
-    // Use PROTOCOL when DRIVER is "pool" (r2dbc-pool wraps the real driver in PROTOCOL),
-    // otherwise use DRIVER directly.
-    String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
-    return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
+  @Nullable
+  private static String resolveDriver(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return driver;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? protocol : protocol.substring(0, separator);
+  }
+
+  @Nullable
+  private static String resolveProtocol(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return protocol;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? null : protocol.substring(separator + 1);
+  }
+
+  @Nullable
+  private static Integer resolveDefaultPort(
+      @Nullable String driver, @Nullable String protocol, boolean ssl) {
+    if (CLICKHOUSE.equals(driver)) {
+      return resolveClickHouseDefaultPort(protocol, ssl);
+    }
+    if ("h2".equals(driver) && "tcp".equals(protocol)) {
+      return 9092;
+    }
+    return DRIVER_TO_DEFAULT_PORT.get(driver);
+  }
+
+  @Nullable
+  private static Integer resolveClickHouseDefaultPort(@Nullable String protocol, boolean ssl) {
+    if (protocol == null || "http".equals(protocol)) {
+      return ssl ? 8443 : 8123;
+    }
+    if ("https".equals(protocol)) {
+      return 8443;
+    }
+    if ("native".equals(protocol) || "tcp".equals(protocol)) {
+      return ssl ? 9440 : 9000;
+    }
+    if ("tcps".equals(protocol)) {
+      return 9440;
+    }
+    if ("mysql".equals(protocol)) {
+      return 9004;
+    }
+    if ("postgres".equals(protocol) || "postgresql".equals(protocol) || "pgsql".equals(protocol)) {
+      return 9005;
+    }
+    if ("grpc".equals(protocol) || "grpcs".equals(protocol)) {
+      return 9100;
+    }
+    return null;
+  }
+
+  private static String resolveDbSystemName(@Nullable String driver) {
+    return driver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(driver, OTHER_SQL) : OTHER_SQL;
   }
 
   private static class ServerTarget {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -168,6 +168,13 @@ public final class DbExecution {
       return null;
     }
 
+    int firstComma = serverAddress.indexOf(',');
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd > firstComma
+        || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
+      return null;
+    }
+
     String hostList = stripUserInfo(serverAddress);
     String[] hosts = hostList.split(",", -1);
     if (hosts.length < 2) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -70,8 +70,6 @@ public final class DbExecution {
   @Nullable private final String namespace;
   @Nullable private final String serverAddress;
   @Nullable private final Integer serverPort;
-  private final boolean serverAddressGroupCandidate;
-  @Nullable private final String serverAddressGroup;
   @Nullable private final String configuredServerAddress;
   @Nullable private final Integer configuredServerPort;
   private final String connectionString;
@@ -103,12 +101,9 @@ public final class DbExecution {
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    this.serverAddressGroupCandidate = isServerAddressGroupCandidate(serverAddress);
-    this.serverAddressGroup =
-        serverAddressGroupCandidate ? sanitizeServerAddressGroup(serverAddress, serverPort) : null;
     ServerTarget configuredServerTarget =
-        serverAddressGroupCandidate
-            ? new ServerTarget(serverAddressGroup, null)
+        isServerAddressGroupCandidate(serverAddress)
+            ? new ServerTarget(sanitizeServerAddressGroup(serverAddress, serverPort), null)
             : sanitizeServerTarget(serverAddress, serverPort);
     this.configuredServerAddress = configuredServerTarget.address;
     this.configuredServerPort = configuredServerTarget.port;
@@ -145,15 +140,6 @@ public final class DbExecution {
   @Nullable
   public Integer getServerPort() {
     return serverPort;
-  }
-
-  @Nullable
-  public String getServerAddressGroup() {
-    return serverAddressGroup;
-  }
-
-  public boolean isServerAddressGroup() {
-    return serverAddressGroupCandidate;
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.SqlDialectUtil.fromDbSystemName;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singleton;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
@@ -98,12 +99,19 @@ public final class R2dbcSqlAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DbExecution request) {
+    String addressGroup = request.getServerAddressGroup();
+    if (emitStableDatabaseSemconv() && addressGroup != null) {
+      return addressGroup;
+    }
     return request.getServerAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbExecution request) {
+    if (emitStableDatabaseSemconv() && request.getServerAddressGroup() != null) {
+      return null;
+    }
     return request.getServerPort();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -99,9 +99,8 @@ public final class R2dbcSqlAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DbExecution request) {
-    String addressGroup = request.getServerAddressGroup();
-    if (emitStableDatabaseSemconv() && addressGroup != null) {
-      return addressGroup;
+    if (emitStableDatabaseSemconv() && request.isServerAddressGroup()) {
+      return request.getServerAddressGroup();
     }
     return request.getServerAddress();
   }
@@ -109,7 +108,7 @@ public final class R2dbcSqlAttributesGetter
   @Nullable
   @Override
   public Integer getServerPort(DbExecution request) {
-    if (emitStableDatabaseSemconv() && request.getServerAddressGroup() != null) {
+    if (emitStableDatabaseSemconv() && request.isServerAddressGroup()) {
       return null;
     }
     return request.getServerPort();

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -99,19 +99,17 @@ public final class R2dbcSqlAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DbExecution request) {
-    if (emitStableDatabaseSemconv() && request.isServerAddressGroup()) {
-      return request.getServerAddressGroup();
-    }
-    return request.getServerAddress();
+    return emitStableDatabaseSemconv()
+        ? request.getConfiguredServerAddress()
+        : request.getServerAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbExecution request) {
-    if (emitStableDatabaseSemconv() && request.isServerAddressGroup()) {
-      return null;
-    }
-    return request.getServerPort();
+    return emitStableDatabaseSemconv()
+        ? request.getConfiguredServerPort()
+        : request.getServerPort();
   }
 
   @Override

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -162,7 +162,8 @@ class DbExecutionTest {
 
     assertThat(dbExecution.getServerAddress()).isEqualTo("host1:3306,host2:3307");
     assertThat(dbExecution.getServerPort()).isNull();
-    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1:3306,host2:3307");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3306,host2:3307");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @Test
@@ -178,7 +179,8 @@ class DbExecutionTest {
 
     assertThat(dbExecution.getServerAddress()).isEqualTo("host1,host2");
     assertThat(dbExecution.getServerPort()).isEqualTo(3306);
-    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1:3306,host2:3306");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3306,host2:3306");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @Test
@@ -193,7 +195,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getServerAddressGroup())
+    assertThat(dbExecution.getConfiguredServerAddress())
         .isEqualTo("host1:3307,[2001:db8::1]:3308,host3:3306,[2001:db8::2]:3306");
   }
 
@@ -208,7 +210,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getServerAddressGroup())
+    assertThat(dbExecution.getConfiguredServerAddress())
         .isEqualTo("[2001:db8::1]:5432,[2001:db8::2]:5432");
   }
 
@@ -222,8 +224,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.isServerAddressGroup()).isTrue();
-    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
   }
 
   @ParameterizedTest
@@ -254,8 +255,8 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.isServerAddressGroup()).isTrue();
-    assertThat(dbExecution.getServerAddressGroup()).isNull();
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest
@@ -270,13 +271,14 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.isServerAddressGroup()).isTrue();
-    assertThat(dbExecution.getServerAddressGroup()).isNull();
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"host1", "/var/run/postgresql", "[2001:db8::1]"})
-  void dbExecutionTreatsSingleHostAsSingular(String host) {
+  @CsvSource({"host1,host1,5432", "/var/run/postgresql,,", "[2001:db8::1],2001:db8::1,5432"})
+  void dbExecutionTreatsSingleHostAsSingular(
+      String host, String configuredAddress, Integer configuredPort) {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -287,8 +289,8 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
     assertThat(dbExecution.getServerAddress()).isEqualTo(host);
-    assertThat(dbExecution.isServerAddressGroup()).isFalse();
-    assertThat(dbExecution.getServerAddressGroup()).isNull();
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo(configuredAddress);
+    assertThat(dbExecution.getConfiguredServerPort()).isEqualTo(configuredPort);
   }
 
   private static QueryExecutionInfo queryExecutionInfo() {

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -206,6 +206,53 @@ class DbExecutionTest {
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
+  @ParameterizedTest
+  @CsvSource({
+    "postgresql, 5432",
+    "mysql, 3306",
+    "mariadb, 3306",
+    "mssql, 1433",
+    "oracle, 1521",
+    "db2, 50000",
+    "clickhouse, 8123"
+  })
+  void dbExecutionOmitsKnownDefaultPortForSingleHost(String driver, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, driver)
+            .option(ConnectionFactoryOptions.HOST, "host1")
+            .option(ConnectionFactoryOptions.PORT, defaultPort)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerPort()).isEqualTo(defaultPort);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionPreservesSingleNonDefaultAndUnknownDriverPorts() {
+    ConnectionFactoryOptions postgresqlOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1")
+            .option(ConnectionFactoryOptions.PORT, 15432)
+            .build();
+    ConnectionFactoryOptions unknownOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "unknown")
+            .option(ConnectionFactoryOptions.HOST, "host2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution postgresqlExecution = new DbExecution(queryExecutionInfo(), postgresqlOptions);
+    DbExecution unknownExecution = new DbExecution(queryExecutionInfo(), unknownOptions);
+
+    assertThat(postgresqlExecution.getConfiguredServerPort()).isEqualTo(15432);
+    assertThat(unknownExecution.getConfiguredServerPort()).isEqualTo(5432);
+  }
+
   @Test
   void dbExecutionUsesTheWrappedDriverProtocolDefaultPort() {
     ConnectionFactoryOptions factoryOptions =
@@ -472,13 +519,8 @@ class DbExecutionTest {
   }
 
   @ParameterizedTest
-  @CsvSource({
-    "host1,host1,5432",
-    "[2001:db8::1],2001:db8::1,5432",
-    "[fe80::1%eth0],fe80::1%eth0,5432"
-  })
-  void dbExecutionTreatsSingleHostAsSingular(
-      String host, String configuredAddress, Integer configuredPort) {
+  @CsvSource({"host1,host1", "[2001:db8::1],2001:db8::1", "[fe80::1%eth0],fe80::1%eth0"})
+  void dbExecutionTreatsSingleHostAsSingular(String host, String configuredAddress) {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -490,7 +532,7 @@ class DbExecutionTest {
 
     assertThat(dbExecution.getServerAddress()).isEqualTo(host);
     assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo(configuredAddress);
-    assertThat(dbExecution.getConfiguredServerPort()).isEqualTo(configuredPort);
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -229,6 +229,21 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionPreservesConfiguredHostOrderAndDuplicates() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host2,2001:db8::2,host1,host2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("host2:5432,[2001:db8::2]:5432,host1:5432,host2:5432");
+  }
+
+  @Test
   void dbExecutionSanitizesUserInfoFromMultiHostAddress() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -240,7 +240,8 @@ class DbExecutionTest {
         ":5432,host2",
         "host1,not:an:ipv6",
         "host1,[not:an:ipv6]",
-        "host1:65536,host2"
+        "host1:65536,host2",
+        "host1,user:secret@host2,host3"
       })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -215,6 +215,20 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionBracketsUnbracketedIpv6HostsThatHaveNoPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "2001:db8::1,2001:db8::2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("[2001:db8::1],[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
   void dbExecutionSanitizesUserInfoFromMultiHostAddress() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -167,7 +167,7 @@ class DbExecutionTest {
   }
 
   @Test
-  void dbExecutionExtractsACommonNonDefaultPort() {
+  void dbExecutionInlinesASharedNonDefaultPort() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "mariadb")
@@ -179,8 +179,8 @@ class DbExecutionTest {
 
     assertThat(dbExecution.getServerAddress()).isEqualTo("host1,host2");
     assertThat(dbExecution.getServerPort()).isEqualTo(3307);
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
-    assertThat(dbExecution.getConfiguredServerPort()).isEqualTo(3307);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3307,host2:3307");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @ParameterizedTest
@@ -412,6 +412,61 @@ class DbExecutionTest {
 
     assertThat(dbExecution.getConfiguredServerAddress())
         .isEqualTo("host2,[2001:db8::2],host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionIncludesAtMostFiveConfiguredHosts() {
+    ConnectionFactoryOptions fiveHostOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+    ConnectionFactoryOptions sixHostOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution fiveHostExecution = new DbExecution(queryExecutionInfo(), fiveHostOptions);
+    DbExecution sixHostExecution = new DbExecution(queryExecutionInfo(), sixHostOptions);
+
+    assertThat(fiveHostExecution.getConfiguredServerAddress())
+        .isEqualTo("host1,host2,host3,host4,host5");
+    assertThat(sixHostExecution.getConfiguredServerAddress())
+        .isEqualTo("host1,host2,host3,host4,host5");
+  }
+
+  @Test
+  void dbExecutionUsesPortModeFromAllConfiguredHosts() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6:15432")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("host1:5432,host2:5432,host3:5432,host4:5432,host5:5432");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionValidatesConfiguredHostsAfterTheLimit() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6:invalid")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -346,7 +346,11 @@ class DbExecutionTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"host1,host1,5432", "[2001:db8::1],2001:db8::1,5432"})
+  @CsvSource({
+    "host1,host1,5432",
+    "[2001:db8::1],2001:db8::1,5432",
+    "[fe80::1%eth0],fe80::1%eth0,5432"
+  })
   void dbExecutionTreatsSingleHostAsSingular(
       String host, String configuredAddress, Integer configuredPort) {
     ConnectionFactoryOptions factoryOptions =
@@ -361,6 +365,21 @@ class DbExecutionTest {
     assertThat(dbExecution.getServerAddress()).isEqualTo(host);
     assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo(configuredAddress);
     assertThat(dbExecution.getConfiguredServerPort()).isEqualTo(configuredPort);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"host%3Fpassword%3Dsecret", "host%3fpassword%3dsecret:5432"})
+  void dbExecutionRejectsPercentEscapesInNonIpv6Hosts(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   private static QueryExecutionInfo queryExecutionInfo() {

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -156,13 +156,13 @@ class DbExecutionTest {
   @Test
   void dbExecutionKeepsMultiHostAddressVerbatim() {
     ConnectionFactoryOptions factoryOptions =
-        ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host1:3306,host2:3307/db");
+        ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host2:3307,host1:3306/db");
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getServerAddress()).isEqualTo("host1:3306,host2:3307");
+    assertThat(dbExecution.getServerAddress()).isEqualTo("host2:3307,host1:3306");
     assertThat(dbExecution.getServerPort()).isNull();
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3306,host2:3307");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host2:3307,host1:3306");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -237,7 +237,9 @@ class DbExecutionTest {
         "host1?email=user@example.com,host2",
         "host1#fragment,host2",
         "[]:5432,host2",
-        ":5432,host2"
+        ":5432,host2",
+        "host1,not:an:ipv6",
+        "host1,[not:an:ipv6]"
       })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -228,7 +228,15 @@ class DbExecutionTest {
 
   @ParameterizedTest
   @ValueSource(
-      strings = {"host1:invalid,host2", "host1,,host2", "host1,host=value", "[2001:db8::1,host2"})
+      strings = {
+        "host1:invalid,host2",
+        "host1,,host2",
+        "host1,host=value",
+        "[2001:db8::1,host2",
+        "host1/path,host2",
+        "host1?email=user@example.com,host2",
+        "host1#fragment,host2"
+      })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -212,6 +212,36 @@ class DbExecutionTest {
         .isEqualTo("[2001:db8::1]:5432,[2001:db8::2]:5432");
   }
 
+  @Test
+  void dbExecutionSanitizesUserInfoFromMultiHostAddress() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "user:secret@host1,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.isServerAddressGroup()).isTrue();
+    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1,host2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"host1:invalid,host2", "host1,,host2", "host1,host=value", "[2001:db8::1,host2"})
+  void dbExecutionRejectsMalformedMultiHostAddress(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.isServerAddressGroup()).isTrue();
+    assertThat(dbExecution.getServerAddressGroup()).isNull();
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"host1", "/var/run/postgresql", "[2001:db8::1]"})
   void dbExecutionTreatsSingleHostAsSingular(String host) {
@@ -225,6 +255,7 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
     assertThat(dbExecution.getServerAddress()).isEqualTo(host);
+    assertThat(dbExecution.isServerAddressGroup()).isFalse();
     assertThat(dbExecution.getServerAddressGroup()).isNull();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -335,7 +335,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:1234,[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:1234,2001:db8::2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
@@ -371,7 +371,7 @@ class DbExecutionTest {
   }
 
   @Test
-  void dbExecutionBracketsUnbracketedIpv6HostsWhenOmittingDefaultPorts() {
+  void dbExecutionKeepsUnbracketedIpv6HostsWhenOmittingDefaultPorts() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -381,12 +381,12 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("[2001:db8::1],[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("2001:db8::1,2001:db8::2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @Test
-  void dbExecutionBracketsUnbracketedIpv6HostsThatHaveNoPort() {
+  void dbExecutionKeepsUnbracketedIpv6HostsThatHaveNoPort() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -395,7 +395,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("[2001:db8::1],[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("2001:db8::1,2001:db8::2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
@@ -410,8 +410,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getConfiguredServerAddress())
-        .isEqualTo("host2,[2001:db8::2],host1,host2");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host2,2001:db8::2,host1,host2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -167,19 +167,143 @@ class DbExecutionTest {
   }
 
   @Test
-  void dbExecutionGivesEveryHostOfAProgrammaticListThePort() {
+  void dbExecutionExtractsACommonNonDefaultPort() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "mariadb")
             .option(ConnectionFactoryOptions.HOST, "host1,host2")
-            .option(ConnectionFactoryOptions.PORT, 3306)
+            .option(ConnectionFactoryOptions.PORT, 3307)
             .build();
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
     assertThat(dbExecution.getServerAddress()).isEqualTo("host1,host2");
-    assertThat(dbExecution.getServerPort()).isEqualTo(3306);
-    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3306,host2:3306");
+    assertThat(dbExecution.getServerPort()).isEqualTo(3307);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isEqualTo(3307);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "postgresql, 5432",
+    "mysql, 3306",
+    "mariadb, 3306",
+    "mssql, 1433",
+    "oracle, 1521",
+    "db2, 50000",
+    "clickhouse, 8123"
+  })
+  void dbExecutionOmitsKnownDefaultPorts(String driver, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, driver)
+            .option(ConnectionFactoryOptions.HOST, "host1:" + defaultPort + ",host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionUsesTheWrappedDriverProtocolDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1:5432,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "http, false, 8123",
+    "http, true, 8443",
+    "tcp, false, 9000",
+    "tcp, true, 9440",
+    "mysql, false, 9004",
+    "postgresql, false, 9005",
+    "grpc, false, 9100"
+  })
+  void dbExecutionUsesClickHouseProtocolAndSslDefaultPorts(
+      String protocol, boolean ssl, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "clickhouse")
+            .option(ConnectionFactoryOptions.PROTOCOL, protocol)
+            .option(ConnectionFactoryOptions.SSL, ssl)
+            .option(ConnectionFactoryOptions.HOST, "host1:" + defaultPort + ",host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionUsesNestedPoolProtocolDefaults() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "clickhouse:http")
+            .option(ConnectionFactoryOptions.HOST, "host1:8123,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getSystemName()).isEqualTo("clickhouse");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionUsesH2TcpDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "h2")
+            .option(ConnectionFactoryOptions.PROTOCOL, "tcp")
+            .option(ConnectionFactoryOptions.HOST, "host1:9092,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionDoesNotGuessAnUnknownDriverDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "unknown")
+            .option(ConnectionFactoryOptions.HOST, "host1:1234,2001:db8::2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:1234,[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionDoesNotGuessAnUnknownClickHouseProtocolDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "clickhouse")
+            .option(ConnectionFactoryOptions.PROTOCOL, "custom")
+            .option(ConnectionFactoryOptions.HOST, "host1:8123,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:8123,host2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
@@ -200,7 +324,7 @@ class DbExecutionTest {
   }
 
   @Test
-  void dbExecutionBracketsUnbracketedIpv6HostsBeforeAddingThePort() {
+  void dbExecutionBracketsUnbracketedIpv6HostsWhenOmittingDefaultPorts() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -210,8 +334,8 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getConfiguredServerAddress())
-        .isEqualTo("[2001:db8::1]:5432,[2001:db8::2]:5432");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("[2001:db8::1],[2001:db8::2]");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @Test
@@ -240,7 +364,8 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
     assertThat(dbExecution.getConfiguredServerAddress())
-        .isEqualTo("host2:5432,[2001:db8::2]:5432,host1:5432,host2:5432");
+        .isEqualTo("host2,[2001:db8::2],host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -152,4 +152,86 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
     assertThat(dbExecution.getSystemName()).isEqualTo(expectedSystemName);
   }
+
+  @Test
+  void dbExecutionKeepsMultiHostAddressVerbatim() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host1:3306,host2:3307/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo("host1:3306,host2:3307");
+    assertThat(dbExecution.getServerPort()).isNull();
+    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1:3306,host2:3307");
+  }
+
+  @Test
+  void dbExecutionGivesEveryHostOfAProgrammaticListThePort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2")
+            .option(ConnectionFactoryOptions.PORT, 3306)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getServerPort()).isEqualTo(3306);
+    assertThat(dbExecution.getServerAddressGroup()).isEqualTo("host1:3306,host2:3306");
+  }
+
+  @Test
+  void dbExecutionKeepsTheHostsThatAlreadyCarryAPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+            .option(
+                ConnectionFactoryOptions.HOST, "host1:3307,[2001:db8::1]:3308,host3,[2001:db8::2]")
+            .option(ConnectionFactoryOptions.PORT, 3306)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddressGroup())
+        .isEqualTo("host1:3307,[2001:db8::1]:3308,host3:3306,[2001:db8::2]:3306");
+  }
+
+  @Test
+  void dbExecutionBracketsUnbracketedIpv6HostsBeforeAddingThePort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "2001:db8::1,2001:db8::2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddressGroup())
+        .isEqualTo("[2001:db8::1]:5432,[2001:db8::2]:5432");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"host1", "/var/run/postgresql", "[2001:db8::1]"})
+  void dbExecutionTreatsSingleHostAsSingular(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo(host);
+    assertThat(dbExecution.getServerAddressGroup()).isNull();
+  }
+
+  private static QueryExecutionInfo queryExecutionInfo() {
+    return MockQueryExecutionInfo.builder()
+        .queryInfo(new QueryInfo("SELECT 1"))
+        .connectionInfo(MockConnectionInfo.builder().build())
+        .build();
+  }
 }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -289,8 +289,47 @@ class DbExecutionTest {
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
 
+  @Test
+  void dbExecutionPreservesUnixDomainSocketWithoutPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "/var/run/postgresql/.s.PGSQL.5432")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("/var/run/postgresql/.s.PGSQL.5432");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
   @ParameterizedTest
-  @CsvSource({"host1,host1,5432", "/var/run/postgresql,,", "[2001:db8::1],2001:db8::1,5432"})
+  @ValueSource(
+      strings = {
+        "/",
+        "/var/run/postgresql,host2",
+        "/var/run/postgresql=secret",
+        "/var/run/user:secret@postgresql",
+        "/var/run/postgresql?password=secret",
+        "/var/run/postgresql#fragment"
+      })
+  void dbExecutionRejectsMalformedOrSensitiveUnixDomainSocket(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"host1,host1,5432", "[2001:db8::1],2001:db8::1,5432"})
   void dbExecutionTreatsSingleHostAsSingular(
       String host, String configuredAddress, Integer configuredPort) {
     ConnectionFactoryOptions factoryOptions =

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -273,7 +273,9 @@ class DbExecutionTest {
         "host1,12345::1",
         "host1,1::999.999.999.999",
         "host1:65536,host2",
-        "host1,user:secret@host2,host3"
+        "host1,user:secret@host2,host3",
+        "host1,host two",
+        "host1,[fe80::1%eth 0]"
       })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -239,13 +239,30 @@ class DbExecutionTest {
         "[]:5432,host2",
         ":5432,host2",
         "host1,not:an:ipv6",
-        "host1,[not:an:ipv6]"
+        "host1,[not:an:ipv6]",
+        "host1:65536,host2"
       })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
             .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.isServerAddressGroup()).isTrue();
+    assertThat(dbExecution.getServerAddressGroup()).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 65536, 70000})
+  void dbExecutionRejectsOutOfRangeSharedPort(int port) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2")
+            .option(ConnectionFactoryOptions.PORT, port)
             .build();
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -235,7 +235,9 @@ class DbExecutionTest {
         "[2001:db8::1,host2",
         "host1/path,host2",
         "host1?email=user@example.com,host2",
-        "host1#fragment,host2"
+        "host1#fragment,host2",
+        "[]:5432,host2",
+        ":5432,host2"
       })
   void dbExecutionRejectsMalformedMultiHostAddress(String host) {
     ConnectionFactoryOptions factoryOptions =

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -328,6 +328,7 @@ class DbExecutionTest {
         "/",
         "/var/run/postgresql,host2",
         "/var/run/postgresql=secret",
+        "/var/run/postgresql%3Fpassword%3Dsecret",
         "/var/run/user:secret@postgresql",
         "/var/run/postgresql?password=secret",
         "/var/run/postgresql#fragment"

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -240,6 +240,8 @@ class DbExecutionTest {
         ":5432,host2",
         "host1,not:an:ipv6",
         "host1,[not:an:ipv6]",
+        "host1,12345::1",
+        "host1,1::999.999.999.999",
         "host1:65536,host2",
         "host1,user:secret@host2,host3"
       })

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -200,6 +200,22 @@ class R2dbcSqlAttributesGetterTest {
     assertThat(getter.getServerPort(dbExecution)).isEqualTo(5432);
   }
 
+  @Test
+  void unixDomainSocketOmitsPortFromStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "/var/run/postgresql/.s.PGSQL.5432")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("/var/run/postgresql/.s.PGSQL.5432");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
   private static QueryExecutionInfo queryExecutionInfo() {
     return MockQueryExecutionInfo.builder()
         .queryInfo(new QueryInfo("SELECT 1"))

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.r2dbc.v1_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -94,5 +95,54 @@ class R2dbcSqlAttributesGetterTest {
         argumentSet("MySQL", "r2dbc:mysql://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS),
         argumentSet("SQL Server", "r2dbc:mssql://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS),
         argumentSet("unknown", "r2dbc:unknown://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS));
+  }
+
+  @Test
+  void multiHostUrlKeepsAddressAndHasNoPort() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host1:3306,host2:3307/db"));
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1:3306,host2:3307");
+    assertThat(getter.getServerPort(dbExecution)).isNull();
+  }
+
+  @Test
+  void multiHostOptionsKeepThePortInTheTargetInStableSemconv() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+                .option(ConnectionFactoryOptions.HOST, "host1,host2")
+                .option(ConnectionFactoryOptions.PORT, 3306)
+                .build());
+
+    if (emitStableDatabaseSemconv()) {
+      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1:3306,host2:3306");
+      assertThat(getter.getServerPort(dbExecution)).isNull();
+    } else {
+      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
+      assertThat(getter.getServerPort(dbExecution)).isEqualTo(3306);
+    }
+  }
+
+  @Test
+  void singleHostKeepsPortInEveryMode() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.parse("r2dbc:postgresql://host1:5432/db"));
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1");
+    assertThat(getter.getServerPort(dbExecution)).isEqualTo(5432);
+  }
+
+  private static QueryExecutionInfo queryExecutionInfo() {
+    return MockQueryExecutionInfo.builder()
+        .queryInfo(new QueryInfo("SELECT 1"))
+        .connectionInfo(MockConnectionInfo.builder().build())
+        .build();
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -119,13 +119,9 @@ class R2dbcSqlAttributesGetterTest {
                 .option(ConnectionFactoryOptions.PORT, 3306)
                 .build());
 
-    if (emitStableDatabaseSemconv()) {
-      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
-      assertThat(getter.getServerPort(dbExecution)).isNull();
-    } else {
-      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
-      assertThat(getter.getServerPort(dbExecution)).isEqualTo(3306);
-    }
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 3306);
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -129,6 +129,34 @@ class R2dbcSqlAttributesGetterTest {
   }
 
   @Test
+  void multiHostOptionsRemoveUserInfoFromTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "user:secret@host1,host2")
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1,host2" : "user:secret@host1,host2");
+  }
+
+  @Test
+  void malformedMultiHostOptionsOmitTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "host1:invalid,host2")
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : "host1:invalid,host2");
+  }
+
+  @Test
   void singleHostKeepsPortInEveryMode() {
     DbExecution dbExecution =
         new DbExecution(

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -129,7 +129,7 @@ class R2dbcSqlAttributesGetterTest {
   }
 
   @Test
-  void multiHostOptionsExtractACommonNonDefaultPortInStableSemconv() {
+  void multiHostOptionsInlineASharedNonDefaultPortInStableSemconv() {
     DbExecution dbExecution =
         new DbExecution(
             queryExecutionInfo(),
@@ -139,8 +139,10 @@ class R2dbcSqlAttributesGetterTest {
                 .option(ConnectionFactoryOptions.PORT, 3307)
                 .build());
 
-    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
-    assertThat(getter.getServerPort(dbExecution)).isEqualTo(3307);
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1:3307,host2:3307" : "host1,host2");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 3307);
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -184,7 +184,8 @@ class R2dbcSqlAttributesGetterTest {
 
     assertThat(getter.getServerAddress(dbExecution))
         .isEqualTo(emitStableDatabaseSemconv() ? "host1" : "user:secret@host1");
-    assertThat(getter.getServerPort(dbExecution)).isEqualTo(5432);
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
   }
 
   @Test
@@ -205,14 +206,15 @@ class R2dbcSqlAttributesGetterTest {
   }
 
   @Test
-  void singleHostKeepsPortInEveryMode() {
+  void singleHostOmitsKnownDefaultPortInStableMode() {
     DbExecution dbExecution =
         new DbExecution(
             queryExecutionInfo(),
             ConnectionFactoryOptions.parse("r2dbc:postgresql://host1:5432/db"));
 
     assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1");
-    assertThat(getter.getServerPort(dbExecution)).isEqualTo(5432);
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -157,6 +157,39 @@ class R2dbcSqlAttributesGetterTest {
   }
 
   @Test
+  void singleHostOptionsRemoveUserInfoFromTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "user:secret@host1")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1" : "user:secret@host1");
+    assertThat(getter.getServerPort(dbExecution)).isEqualTo(5432);
+  }
+
+  @Test
+  void malformedSingleHostOptionsOmitTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "host1:invalid")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : "host1:invalid");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
+  @Test
   void singleHostKeepsPortInEveryMode() {
     DbExecution dbExecution =
         new DbExecution(

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -109,7 +109,7 @@ class R2dbcSqlAttributesGetterTest {
   }
 
   @Test
-  void multiHostOptionsKeepThePortInTheTargetInStableSemconv() {
+  void multiHostOptionsOmitTheKnownDefaultPortInStableSemconv() {
     DbExecution dbExecution =
         new DbExecution(
             queryExecutionInfo(),
@@ -120,12 +120,27 @@ class R2dbcSqlAttributesGetterTest {
                 .build());
 
     if (emitStableDatabaseSemconv()) {
-      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1:3306,host2:3306");
+      assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
       assertThat(getter.getServerPort(dbExecution)).isNull();
     } else {
       assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
       assertThat(getter.getServerPort(dbExecution)).isEqualTo(3306);
     }
+  }
+
+  @Test
+  void multiHostOptionsExtractACommonNonDefaultPortInStableSemconv() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+                .option(ConnectionFactoryOptions.HOST, "host1,host2")
+                .option(ConnectionFactoryOptions.PORT, 3307)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
+    assertThat(getter.getServerPort(dbExecution)).isEqualTo(3307);
   }
 
   @Test


### PR DESCRIPTION
This PR is part of #19899 and applies the configured database target rules proposed in [open-telemetry/semantic-conventions#4058](https://github.com/open-telemetry/semantic-conventions/pull/4058) to ClickHouse and R2DBC, and the observed peer rules to ClickHouse only. R2DBC receives configured-target handling and gains no peer attributes. Stable ClickHouse spans distinguish the configured target in `server.*` from the endpoint contacted for each request in `network.peer.*`. Legacy database attributes and span names remain unchanged.

For PostgreSQL configured with `host1,host2` on shared port `6432`, stable telemetry reports `server.address=host1:6432,host2:6432` and omits `server.port`.

### Client coverage

- ClickHouse v1 uses each node's protocol and SSL metadata.
- ClickHouse v2 retains HTTP or HTTPS through normalization and reports the selected node as the stable peer across synchronous, asynchronous, and retried requests.
- R2DBC applies known driver and protocol defaults. Unknown drivers keep explicit ports, and Unix-domain socket targets stay portless.

### Multi-endpoint handling

Configured endpoint lists retain significant order where applicable and otherwise sort lexically, then report at most five endpoints. Lists using only default ports omit all ports, while a single non-default endpoint records its port in `server.port`.

### Omission rules

Configured targets exclude credentials, encoded secrets, and malformed values.