### PR TITLE
Give a batched pekko task a context of its own

### DIFF
--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/build.gradle.kts
@@ -34,6 +34,34 @@ dependencies {
   testImplementation(project(":instrumentation:executors:testing"))
 }
 
+testing {
+  suites {
+    // the agent matches methods of pekko classes by name, some of them are private and scala
+    // mangles their names, run the tests against the scala 3 artifacts to catch a name that only
+    // holds for scala 2
+    register<JvmTestSuite>("scala3Test") {
+      dependencies {
+        implementation("org.scala-lang:scala3-library_3:3.3.6")
+        implementation("org.apache.pekko:pekko-actor_3:${baseVersion("1.0.1").orLatest()}")
+        implementation(project(":instrumentation:executors:testing"))
+      }
+    }
+  }
+}
+
+// the scala 3 suite runs the same tests as the scala 2 suite, against the _3 artifacts
+sourceSets.named("scala3Test") {
+  java.srcDir("src/test/java")
+  resources.srcDir("src/test/resources")
+  extensions.getByType(org.gradle.api.tasks.ScalaSourceDirectorySet::class.java).srcDir("src/test/scala")
+}
+
+tasks {
+  check {
+    dependsOn(testing.suites)
+  }
+}
+
 if (otelProps.testLatestDeps) {
   configurations {
     // pekko artifact name is different for regular and latest tests

--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoActorInstrumentationModule.java
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoActorInstrumentationModule.java
@@ -22,6 +22,7 @@ public class PekkoActorInstrumentationModule extends InstrumentationModule {
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
         new PekkoDispatcherInstrumentation(),
+        new PekkoBatchingExecutorInstrumentation(),
         new PekkoActorCellInstrumentation(),
         new PekkoDefaultSystemMessageQueueInstrumentation(),
         new PekkoScheduleInstrumentation());

--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoBatchingExecutorInstrumentation.java
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoBatchingExecutorInstrumentation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pekkoactor.v1_0;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasSuperType;
+import static io.opentelemetry.javaagent.instrumentation.pekkoactor.v1_0.VirtualFields.RUNNABLE_PROPAGATED_CONTEXT;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.bootstrap.executors.ExecutorAdviceHelper;
+import io.opentelemetry.javaagent.bootstrap.executors.PropagatedContext;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * A pekko dispatcher batches the tasks that scala marks as {@code Batchable}, which since scala
+ * 2.13 includes the task that runs the body of a {@code Future}. Rather than being submitted to the
+ * underlying pool, such a task is appended to a batch that is already running on the current thread
+ * and is run when that batch is drained. The context that the executor instrumentation captures
+ * when the batch itself is submitted is the only context those tasks can inherit, so a task that is
+ * added to a batch that started before the current context became current runs without it.
+ *
+ * <p>Attaching the current context to the task when it is handed to the dispatcher gives it a
+ * context of its own, which the runnable instrumentation makes current while it runs. The task is
+ * not wrapped, so it stays batchable and is batched as before.
+ */
+class PekkoBatchingExecutorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    // scala 2 gives the implementing class a forwarder for the method declared on the trait, scala
+    // 3 leaves it on the interface, so both need to be matched
+    return hasSuperType(named("org.apache.pekko.dispatch.BatchingExecutor"));
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("execute").and(takesArguments(1)).and(takesArgument(0, Runnable.class)),
+        getClass().getName() + "$ExecuteAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ExecuteAdvice {
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static PropagatedContext enterExecute(@Advice.Argument(0) Runnable task) {
+      Context context = Java8BytecodeBridge.currentContext();
+      if (ExecutorAdviceHelper.shouldPropagateContext(context, task)) {
+        return ExecutorAdviceHelper.attachContextToTask(context, RUNNABLE_PROPAGATED_CONTEXT, task);
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void exitExecute(
+        @Advice.Argument(0) Runnable task,
+        @Advice.Enter @Nullable PropagatedContext propagatedContext,
+        @Advice.Thrown @Nullable Throwable throwable) {
+      ExecutorAdviceHelper.cleanUpAfterSubmit(
+          propagatedContext, throwable, RUNNABLE_PROPAGATED_CONTEXT, task);
+    }
+  }
+}

--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/VirtualFields.java
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/VirtualFields.java
@@ -12,6 +12,9 @@ import org.apache.pekko.dispatch.sysmsg.SystemMessage;
 
 public class VirtualFields {
 
+  public static final VirtualField<Runnable, PropagatedContext> RUNNABLE_PROPAGATED_CONTEXT =
+      VirtualField.find(Runnable.class, PropagatedContext.class);
+
   public static final VirtualField<Envelope, PropagatedContext> ENVELOPE_PROPAGATED_CONTEXT =
       VirtualField.find(Envelope.class, PropagatedContext.class);
 

--- a/instrumentation/pekko/pekko-actor-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoBatchedTaskTest.scala
+++ b/instrumentation/pekko/pekko-actor-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkoactor/v1_0/PekkoBatchedTaskTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.pekkoactor.v1_0
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.testing.junit.{
+  AgentInstrumentationExtension,
+  InstrumentationExtension
+}
+import io.opentelemetry.sdk.testing.assertj.{SpanDataAssert, TraceAssert}
+import io.opentelemetry.sdk.trace.data.SpanData
+import org.apache.pekko.actor.ActorSystem
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier
+
+import java.util.function.Consumer
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+/** Since scala 2.13 the task that runs the body of a Future is batchable, and a
+  * pekko dispatcher appends such a task to a batch that is already running on
+  * the current thread rather than submitting it to the pool. A future that is
+  * created inside an already running task therefore needs a context of its own,
+  * the one captured when the enclosing batch was submitted predates the span
+  * that is current when the future is created.
+  */
+class PekkoBatchedTaskTest {
+
+  @RegisterExtension val testing: InstrumentationExtension =
+    AgentInstrumentationExtension.create()
+
+  @Test def futureCreatedInsideRunningTaskKeepsContext(): Unit = {
+    val system = ActorSystem("batched-task-test")
+    implicit val executionContext: ExecutionContext = system.dispatcher
+    try {
+      // the outer future is the task that the batch is created for, the inner one is appended to
+      // that batch and only runs once the outer task has returned
+      val outer = Future {
+        testing.runWithSpan(
+          "parent",
+          new ThrowingSupplier[Future[Unit], RuntimeException] {
+            override def get(): Future[Unit] =
+              Future {
+                testing.runWithSpan(
+                  "child",
+                  new ThrowingSupplier[Unit, RuntimeException] {
+                    override def get(): Unit = ()
+                  }
+                )
+              }
+          }
+        )
+      }
+
+      Await.result(Await.result(outer, 10.seconds), 10.seconds)
+
+      testing.waitAndAssertTraces(new Consumer[TraceAssert] {
+        override def accept(trace: TraceAssert): Unit =
+          trace.hasSpansSatisfyingExactly(
+            new Consumer[SpanDataAssert] {
+              override def accept(span: SpanDataAssert): Unit = {
+                span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent()
+                ()
+              }
+            },
+            new Consumer[SpanDataAssert] {
+              override def accept(span: SpanDataAssert): Unit = {
+                span
+                  .hasName("child")
+                  .hasKind(SpanKind.INTERNAL)
+                  .hasParent(trace.getSpan(0).asInstanceOf[SpanData])
+                ()
+              }
+            }
+          )
+      })
+    } finally Await.result(system.terminate(), 10.seconds)
+  }
+}


### PR DESCRIPTION
## Problem

A future created inside an already running pekko dispatcher task loses the current context, so spans that user code starts inside it begin a new trace instead of continuing the current one.

## Why

A pekko dispatcher batches the tasks that scala marks as `Batchable`, and the task that runs the body of a `Future` is one of them. Instead of being submitted to the underlying pool, such a task is appended to a batch that is already running on the current thread and is run when that batch is drained. The context that the executor instrumentation captures when the batch itself is submitted is therefore the only one those tasks can inherit, and a task added to a batch that started before the current context became current runs without it.

## Change

Attach the current context to the task when it is handed to the dispatcher, using the same `VirtualField<Runnable, PropagatedContext>` the executor instrumentation already reads, so the runnable instrumentation makes it current while the task runs.

The task is deliberately **not** wrapped. Wrapping would strip its `Batchable` type and silently move pekko onto the unbatched path, changing scheduling for every dispatcher task; attaching through the virtual field leaves batching behaviour untouched.

The type matcher uses `hasSuperType` so that it covers both the interface and the implementing classes.

## Only the scala 3 artifacts are affected

The new test was run against both pekko 1.0.1 and 1.2.1, with the instrumentation unregistered:

| scala | pekko 1.0.1 | pekko 1.2.1 |
|---|---|---|
| 2.12 | passes | — |
| 2.13 | passes | passes |
| 3 | **fails** | **fails** |

So this follows the scala version rather than the pekko version. I have not established what in the scala 3 build makes the difference; the behaviour is reproducible and the fix addresses it, but I would not want the description to claim a cause I have not shown.

## Testing

`PekkoBatchedTaskTest` creates a future inside an already running dispatcher task and asserts that a span started in the inner future is a child of the outer one. It fails without the change (`Expected size: 1 but was: 2`, the child span having started its own trace) and passes with it.

The pekko-actor tests are now also run against the scala 3 artifacts, the same way the pekko-http tests already are after #19824, so this class of difference is covered here too.

Verified locally: `test` and `scala3Test` both 8 tests / 0 failures, plus `muzzle` and `spotlessCheck`.

## Related

This was found while investigating a CI failure on #19817, where the http/2 handler is invoked from inside such a batch and user code consequently lost the server context. That PR currently carries an equivalent fix scoped to the pekko-http module; if this one is accepted, that copy should be dropped in favour of it. akka has the same structure and would need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)