### PR TITLE
Add HTTP server socket peer fallback test

### DIFF
--- a/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/v10_0/AbstractHttpServerInstrumentationTest.scala
+++ b/instrumentation/akka/akka-http-10.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/akkahttp/v10_0/AbstractHttpServerInstrumentationTest.scala
@@ -23,6 +23,8 @@ abstract class AbstractHttpServerInstrumentationTest
       options: HttpServerTestOptions
   ): Unit = {
     options.setTestCaptureHttpHeaders(false)
+    // TODO: client.address is missing socket-peer fallback: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19840
+    options.setTestClientAddressFromSocketPeer(false)
     options.setHttpAttributes(
       new Function[ServerEndpoint, util.Set[AttributeKey[_]]] {
         override def apply(v1: ServerEndpoint): util.Set[AttributeKey[_]] = {

--- a/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-1.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v1_0/KtorHttpServerTest.kt
@@ -123,6 +123,7 @@ class KtorHttpServerTest : AbstractHttpServerTest<ApplicationEngine>() {
 
   override fun configure(options: HttpServerTestOptions) {
     options.setTestPathParam(true)
+    options.setTestClientAddressFromSocketPeer(false)
 
     options.setHttpAttributes {
       HttpServerTestOptions.DEFAULT_HTTP_ATTRIBUTES - ServerAttributes.SERVER_PORT

--- a/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerTest.kt
+++ b/instrumentation/ktor/ktor-2.0/library/src/test/kotlin/io/opentelemetry/instrumentation/ktor/v2_0/KtorHttpServerTest.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.ktor.v2_0
 import io.ktor.server.application.*
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension
 import io.opentelemetry.instrumentation.testing.junit.http.HttpServerInstrumentationExtension
+import io.opentelemetry.instrumentation.testing.junit.http.HttpServerTestOptions
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class KtorHttpServerTest : AbstractKtorHttpServerTest() {
@@ -22,5 +23,10 @@ class KtorHttpServerTest : AbstractKtorHttpServerTest() {
 
   override fun installOpenTelemetry(application: Application) {
     KtorTestUtil.installOpenTelemetry(application, testing.openTelemetry)
+  }
+
+  override fun configure(options: HttpServerTestOptions) {
+    super.configure(options)
+    options.setTestClientAddressFromSocketPeer(false)
   }
 }

--- a/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/AbstractHttpServerInstrumentationTest.scala
+++ b/instrumentation/pekko/pekko-http-1.0/javaagent/src/test/scala/io/opentelemetry/javaagent/instrumentation/pekkohttp/v1_0/AbstractHttpServerInstrumentationTest.scala
@@ -39,6 +39,8 @@ abstract class AbstractHttpServerInstrumentationTest
       options: HttpServerTestOptions
   ): Unit = {
     options.setTestCaptureHttpHeaders(false)
+    // TODO: client.address is missing socket-peer fallback: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19841
+    options.setTestClientAddressFromSocketPeer(false)
     options.setHttpAttributes(
       new Function[ServerEndpoint, util.Set[AttributeKey[_]]] {
         override def apply(v1: ServerEndpoint): util.Set[AttributeKey[_]] = {

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/play28Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_8/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/play28Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_8/PlayServerTest.java
@@ -108,6 +108,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     options.setHttpAttributes(endpoint -> emptySet());
 
     options.setExpectedException(new IllegalArgumentException(EXCEPTION.getBody()));
+    options.setTestClientAddressFromSocketPeer(false);
     options.disableTestNonStandardHttpMethod();
   }
 

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/play3Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v3_0/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/play3Test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v3_0/PlayServerTest.java
@@ -108,6 +108,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     options.setHttpAttributes(endpoint -> emptySet());
 
     options.setExpectedException(new IllegalArgumentException(EXCEPTION.getBody()));
+    options.setTestClientAddressFromSocketPeer(false);
     options.disableTestNonStandardHttpMethod();
   }
 

--- a/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_6/PlayServerTest.java
+++ b/instrumentation/play/play-mvc/play-mvc-2.6/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/playmvc/v2_6/PlayServerTest.java
@@ -106,6 +106,7 @@ class PlayServerTest extends AbstractHttpServerTest<Server> {
     options.setHasHandlerSpan(unused -> true);
     options.setHttpAttributes(endpoint -> emptySet());
     options.setExpectedException(new IllegalArgumentException(EXCEPTION.getBody()));
+    options.setTestClientAddressFromSocketPeer(false);
     options.disableTestNonStandardHttpMethod();
   }
 

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackAsyncHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackAsyncHttpServerTest.java
@@ -35,5 +35,6 @@ class RatpackAsyncHttpServerTest extends AbstractRatpackAsyncHttpServerTest {
     super.configure(options);
 
     options.setHasHandlerSpan(endpoint -> false);
+    options.setTestClientAddressFromSocketPeer(false);
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackForkedHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackForkedHttpServerTest.java
@@ -35,5 +35,6 @@ class RatpackForkedHttpServerTest extends AbstractRatpackForkedHttpServerTest {
     super.configure(options);
 
     options.setHasHandlerSpan(endpoint -> false);
+    options.setTestClientAddressFromSocketPeer(false);
   }
 }

--- a/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackHttpServerTest.java
+++ b/instrumentation/ratpack/ratpack-1.7/library/src/test/java/io/opentelemetry/instrumentation/ratpack/v1_7/server/RatpackHttpServerTest.java
@@ -35,5 +35,6 @@ class RatpackHttpServerTest extends AbstractRatpackHttpServerTest {
     super.configure(options);
 
     options.setHasHandlerSpan(endpoint -> false);
+    options.setTestClientAddressFromSocketPeer(false);
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -230,6 +230,21 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
   }
 
   @Test
+  void clientAddressFromSocketPeer() {
+    assumeTrue(options.testClientAddressFromSocketPeer);
+
+    String method = "GET";
+    AggregatedHttpRequest request = request(SUCCESS, method);
+    AggregatedHttpResponse response = clientWithoutForwardedFor.execute(request).aggregate().join();
+
+    assertThat(response.status().code()).isEqualTo(SUCCESS.getStatus());
+    assertThat(response.contentUtf8()).isEqualTo(SUCCESS.getBody());
+
+    String spanId = assertResponseHasCustomizedHeaders(response, SUCCESS, null);
+    assertTheTraces(1, null, null, spanId, method, SUCCESS, "127.0.0.1", "127.0.0.1");
+  }
+
+  @Test
   void successfulGetRequestWithParent() {
     String method = "GET";
     String traceId = "00000000000000000000000000000123";
@@ -951,6 +966,50 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
       String spanId,
       String method,
       ServerEndpoint endpoint) {
+    assertTheTraces(
+        size,
+        traceId,
+        parentId,
+        spanId,
+        method,
+        endpoint,
+        span -> assertServerSpan(span, method, endpoint, endpoint.status));
+  }
+
+  private void assertTheTraces(
+      int size,
+      String traceId,
+      String parentId,
+      String spanId,
+      String method,
+      ServerEndpoint endpoint,
+      String expectedNetworkPeerAddress,
+      String expectedClientAddress) {
+    assertTheTraces(
+        size,
+        traceId,
+        parentId,
+        spanId,
+        method,
+        endpoint,
+        span ->
+            assertServerSpan(
+                span,
+                method,
+                endpoint,
+                endpoint.status,
+                expectedNetworkPeerAddress,
+                expectedClientAddress));
+  }
+
+  private void assertTheTraces(
+      int size,
+      String traceId,
+      String parentId,
+      String spanId,
+      String method,
+      ServerEndpoint endpoint,
+      Consumer<SpanDataAssert> serverSpanAssertion) {
     List<Consumer<TraceAssert>> assertions = new ArrayList<>();
     for (int i = 0; i < size; i++) {
       assertions.add(
@@ -958,7 +1017,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
             List<Consumer<SpanDataAssert>> spanAssertions = new ArrayList<>();
             spanAssertions.add(
                 span -> {
-                  assertServerSpan(span, method, endpoint, endpoint.status);
+                  serverSpanAssertion.accept(span);
                   if (traceId != null) {
                     span.hasTraceId(traceId);
                   }
@@ -1122,7 +1181,18 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
   @CanIgnoreReturnValue
   protected SpanDataAssert assertServerSpan(
       SpanDataAssert span, String method, ServerEndpoint endpoint, int statusCode) {
+    return assertServerSpan(
+        span, method, endpoint, statusCode, options.sockPeerAddr.apply(endpoint), TEST_CLIENT_IP);
+  }
 
+  @CanIgnoreReturnValue
+  private SpanDataAssert assertServerSpan(
+      SpanDataAssert span,
+      String method,
+      ServerEndpoint endpoint,
+      int statusCode,
+      String expectedNetworkPeerAddress,
+      String expectedClientAddress) {
     Set<AttributeKey<?>> httpAttributes = options.httpAttributes.apply(endpoint);
     String expectedRoute = options.expectedHttpRoute.apply(endpoint, method);
     String name = options.expectedServerSpanNameMapper.apply(endpoint, method, expectedRoute);
@@ -1162,8 +1232,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
           }
 
           if (attrs.get(NETWORK_PEER_ADDRESS) != null) {
-            assertThat(attrs)
-                .containsEntry(NETWORK_PEER_ADDRESS, options.sockPeerAddr.apply(endpoint));
+            assertThat(attrs).containsEntry(NETWORK_PEER_ADDRESS, expectedNetworkPeerAddress);
           }
           if (attrs.get(NETWORK_PEER_PORT) != null) {
             assertThat(attrs)
@@ -1175,7 +1244,7 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
                             .isNotEqualTo(Long.valueOf(port)));
           }
 
-          assertThat(attrs).containsEntry(CLIENT_ADDRESS, TEST_CLIENT_IP);
+          assertThat(attrs).containsEntry(CLIENT_ADDRESS, expectedClientAddress);
           // client.port is opt-in
           assertThat(attrs).doesNotContainKey(CLIENT_PORT);
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerTest.java
@@ -241,7 +241,14 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
     assertThat(response.contentUtf8()).isEqualTo(SUCCESS.getBody());
 
     String spanId = assertResponseHasCustomizedHeaders(response, SUCCESS, null);
-    assertTheTraces(1, null, null, spanId, method, SUCCESS, "127.0.0.1", "127.0.0.1");
+    assertTheTraces(
+        1,
+        null,
+        null,
+        spanId,
+        method,
+        SUCCESS,
+        span -> assertServerSpan(span, method, SUCCESS, SUCCESS.status, "127.0.0.1", "127.0.0.1"));
   }
 
   @Test
@@ -974,32 +981,6 @@ public abstract class AbstractHttpServerTest<SERVER> extends AbstractHttpServerU
         method,
         endpoint,
         span -> assertServerSpan(span, method, endpoint, endpoint.status));
-  }
-
-  private void assertTheTraces(
-      int size,
-      String traceId,
-      String parentId,
-      String spanId,
-      String method,
-      ServerEndpoint endpoint,
-      String expectedNetworkPeerAddress,
-      String expectedClientAddress) {
-    assertTheTraces(
-        size,
-        traceId,
-        parentId,
-        spanId,
-        method,
-        endpoint,
-        span ->
-            assertServerSpan(
-                span,
-                method,
-                endpoint,
-                endpoint.status,
-                expectedNetworkPeerAddress,
-                expectedClientAddress));
   }
 
   private void assertTheTraces(

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/AbstractHttpServerUsingTest.java
@@ -24,6 +24,7 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
   InstrumentationTestRunner testing;
   private SERVER server;
   public WebClient client;
+  WebClient clientWithoutForwardedFor;
   public int port;
   public URI address;
   public URI h1Address;
@@ -106,13 +107,23 @@ public abstract class AbstractHttpServerUsingTest<SERVER> {
     return url;
   }
 
-  void setTesting(InstrumentationTestRunner testing, WebClient client, int port) {
-    setTesting(testing, client, port, null);
+  void setTesting(
+      InstrumentationTestRunner testing,
+      WebClient client,
+      WebClient clientWithoutForwardedFor,
+      int port) {
+    setTesting(testing, client, clientWithoutForwardedFor, port, null);
   }
 
-  void setTesting(InstrumentationTestRunner testing, WebClient client, int port, URI address) {
+  void setTesting(
+      InstrumentationTestRunner testing,
+      WebClient client,
+      WebClient clientWithoutForwardedFor,
+      int port,
+      URI address) {
     this.testing = testing;
     this.client = client;
+    this.clientWithoutForwardedFor = clientWithoutForwardedFor;
     this.port = port;
     this.address = address;
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerInstrumentationExtension.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerInstrumentationExtension.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.testing.LibraryTestRunner;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.testing.internal.armeria.client.ClientFactory;
 import io.opentelemetry.testing.internal.armeria.client.WebClient;
+import io.opentelemetry.testing.internal.armeria.client.WebClientBuilder;
 import io.opentelemetry.testing.internal.armeria.client.logging.LoggingClient;
 import io.opentelemetry.testing.internal.armeria.common.HttpHeaderNames;
 import java.time.Duration;
@@ -43,21 +44,26 @@ public class HttpServerInstrumentationExtension extends InstrumentationExtension
   }
 
   private final int port;
+  private final ClientFactory clientFactory;
   private final WebClient client;
+  private final WebClient clientWithoutForwardedFor;
 
   private HttpServerInstrumentationExtension(InstrumentationTestRunner runner) {
     super(runner);
 
     port = PortUtils.findOpenPort();
-    client =
-        WebClient.builder()
-            .responseTimeout(Duration.ofMinutes(1))
-            .writeTimeout(Duration.ofMinutes(1))
-            .factory(ClientFactory.builder().connectTimeout(Duration.ofMinutes(1)).build())
-            .setHeader(HttpHeaderNames.USER_AGENT, TEST_USER_AGENT)
-            .setHeader(HttpHeaderNames.X_FORWARDED_FOR, TEST_CLIENT_IP)
-            .decorator(LoggingClient.newDecorator())
-            .build();
+    clientFactory = ClientFactory.builder().connectTimeout(Duration.ofMinutes(1)).build();
+    client = clientBuilder().setHeader(HttpHeaderNames.X_FORWARDED_FOR, TEST_CLIENT_IP).build();
+    clientWithoutForwardedFor = clientBuilder().build();
+  }
+
+  private WebClientBuilder clientBuilder() {
+    return WebClient.builder()
+        .responseTimeout(Duration.ofMinutes(1))
+        .writeTimeout(Duration.ofMinutes(1))
+        .factory(clientFactory)
+        .setHeader(HttpHeaderNames.USER_AGENT, TEST_USER_AGENT)
+        .decorator(LoggingClient.newDecorator());
   }
 
   @Override
@@ -71,6 +77,7 @@ public class HttpServerInstrumentationExtension extends InstrumentationExtension
               + "AbstractHttpServerUsingTest");
     }
 
-    ((AbstractHttpServerUsingTest) testInstance).setTesting(getTestRunner(), client, port);
+    ((AbstractHttpServerUsingTest) testInstance)
+        .setTesting(getTestRunner(), client, clientWithoutForwardedFor, port);
   }
 }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/http/HttpServerTestOptions.java
@@ -61,6 +61,7 @@ public class HttpServerTestOptions {
   boolean testPathParam = false;
   boolean testCaptureHttpHeaders = true;
   boolean testCaptureRequestParameters = false;
+  boolean testClientAddressFromSocketPeer = true;
   boolean testHttpPipelining = true;
   boolean testHttpBodyPipelining = false;
   boolean testNonStandardHttpMethod = true;
@@ -199,6 +200,13 @@ public class HttpServerTestOptions {
   public HttpServerTestOptions setTestCaptureRequestParameters(
       boolean testCaptureRequestParameters) {
     this.testCaptureRequestParameters = testCaptureRequestParameters;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public HttpServerTestOptions setTestClientAddressFromSocketPeer(
+      boolean testClientAddressFromSocketPeer) {
+    this.testClientAddressFromSocketPeer = testClientAddressFromSocketPeer;
     return this;
   }
 


### PR DESCRIPTION
Adds shared HTTP server coverage that sends a success request without `X-Forwarded-For` and verifies `client.address` falls back to the socket peer.

The shared extension reuses one client factory for forwarded and unforwarded clients. A focused test option exempts integrations that do not currently expose the socket peer: Akka HTTP (#19840), Pekko HTTP (#19841), Play 2.6, 2.8, and 3.0, and the Ktor 1.x/2.x and Ratpack 1.7 libraries.