### PR TITLE
Capture Jedis 2.x socket peer attributes

### DIFF
--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
@@ -7,3 +7,23 @@ dependencies {
   testImplementation(project(":instrumentation:jedis:jedis-2.0:javaagent"))
   testImplementation("redis.clients:jedis:2.0.0")
 }
+
+tasks {
+  val testStableSemconv = register<Test>("testStableSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.semconv-stability.opt-in=database")
+  }
+
+  val testDupSemconv = register<Test>("testDupSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+
+    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup")
+  }
+
+  check {
+    dependsOn(testDupSemconv, testStableSemconv)
+  }
+}

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+  testImplementation(project(":javaagent-extension-api"))
   testImplementation(project(":instrumentation-api-incubator"))
   testImplementation(project(":instrumentation:jedis:jedis-2.0:javaagent"))
   testImplementation("redis.clients:jedis:2.0.0")

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/build.gradle.kts
@@ -16,14 +16,7 @@ tasks {
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 
-  val testDupSemconv = register<Test>("testDupSemconv") {
-    testClassesDirs = sourceSets.test.get().output.classesDirs
-    classpath = sourceSets.test.get().runtimeClasspath
-
-    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup")
-  }
-
   check {
-    dependsOn(testDupSemconv, testStableSemconv)
+    dependsOn(testStableSemconv)
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -15,11 +15,13 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import redis.clients.jedis.Connection;
+import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Transaction;
 
@@ -168,6 +170,58 @@ class JedisNetworkAttributesGetterTest {
   }
 
   @Test
+  void failedPipelineSendUsesConnectedPeerAddress() {
+    InetSocketAddress first = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    InetSocketAddress second = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
+    MutableConnection connection = new MutableConnection(connectedSocket(first));
+    Pipeline pipeline = new Pipeline();
+
+    JedisPipelineContext.enter(pipeline);
+    try {
+      JedisConnectionInstrumentation.AdviceScope firstScope =
+          JedisConnectionInstrumentation.SendCommandNoArgsAdvice.onEnter(
+              connection, Protocol.Command.GET);
+      JedisConnectionInstrumentation.SendCommandNoArgsAdvice.stopSpan(null, firstScope);
+
+      connection.setSocket(connectedSocket(second));
+      JedisConnectionInstrumentation.AdviceScope failedScope =
+          JedisConnectionInstrumentation.SendCommandNoArgsAdvice.onEnter(
+              connection, Protocol.Command.GET);
+      JedisConnectionInstrumentation.SendCommandNoArgsAdvice.stopSpan(
+          new RuntimeException("send failed"), failedScope);
+    } finally {
+      JedisPipelineContext.exit();
+    }
+
+    List<JedisRequest> requests = JedisPipelineContext.getAndClearCapturedRequests(pipeline);
+    assertThat(JedisRequest.createPipeline(requests).getPeerAddress()).isEqualTo(second);
+  }
+
+  @ParameterizedTest
+  @MethodSource("unreliableSockets")
+  void failedTransactionSendKeepsEarlierPeerAddress(Socket unreliableSocket) {
+    InetSocketAddress first = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    JedisRequest queuedRequest = requestWithPeer(first);
+    queuedRequest.capturePeerAddress();
+    JedisRequest transactionRequest =
+        JedisRequest.createTransaction(singletonList(queuedRequest), null);
+    MutableConnection connection = new MutableConnection(unreliableSocket);
+
+    JedisPipelineContext.enterTransactionFraming(transactionRequest);
+    try {
+      JedisConnectionInstrumentation.AdviceScope failedScope =
+          JedisConnectionInstrumentation.SendCommandNoArgsAdvice.onEnter(
+              connection, Protocol.Command.EXEC);
+      JedisConnectionInstrumentation.SendCommandNoArgsAdvice.stopSpan(
+          new RuntimeException("send failed"), failedScope);
+    } finally {
+      JedisPipelineContext.exitTransactionFraming();
+    }
+
+    assertThat(transactionRequest.getPeerAddress()).isEqualTo(first);
+  }
+
+  @Test
   void ordinaryCommandDoesNotBecomeTransactionFramingRequest() {
     JedisRequest request =
         requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379));
@@ -270,31 +324,55 @@ class JedisNetworkAttributesGetterTest {
   }
 
   private static JedisRequest requestWithPeer(InetSocketAddress peerAddress) {
-    Socket socket =
+    return JedisRequest.create(
+        new MutableConnection(connectedSocket(peerAddress)), Protocol.Command.GET);
+  }
+
+  private static Socket connectedSocket(InetSocketAddress peerAddress) {
+    return new Socket() {
+      @Override
+      public SocketAddress getRemoteSocketAddress() {
+        return peerAddress;
+      }
+
+      @Override
+      public boolean isConnected() {
+        return true;
+      }
+    };
+  }
+
+  private static Stream<Socket> unreliableSockets() {
+    Socket unconnectedSocket =
         new Socket() {
           @Override
           public SocketAddress getRemoteSocketAddress() {
-            return peerAddress;
-          }
-
-          @Override
-          public boolean isConnected() {
-            return true;
+            return new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
           }
         };
-    Connection connection =
-        new Connection() {
-          @Override
-          public Socket getSocket() {
-            return socket;
-          }
-        };
-    return JedisRequest.create(connection, Protocol.Command.GET);
+    return Stream.of(null, unconnectedSocket);
   }
 
   private static Stream<InetAddress> resolvedAddresses() throws UnknownHostException {
     return Stream.of(
         InetAddress.getByAddress(new byte[] {127, 0, 0, 1}),
         InetAddress.getByAddress(new byte[16]));
+  }
+
+  private static class MutableConnection extends Connection {
+    private Socket socket;
+
+    private MutableConnection(Socket socket) {
+      this.socket = socket;
+    }
+
+    @Override
+    public Socket getSocket() {
+      return socket;
+    }
+
+    private void setSocket(Socket socket) {
+      this.socket = socket;
+    }
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -177,6 +177,27 @@ class JedisNetworkAttributesGetterTest {
         .isNull();
   }
 
+  @Test
+  void transactionDropsPeerWhenExecFails() {
+    InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    JedisRequest queuedRequest = requestWithPeer(queuedPeer);
+    queuedRequest.capturePeerAddress();
+    JedisRequest transactionRequest = JedisRequest.createTransaction(singletonList(queuedRequest));
+
+    JedisRequest execRequest = requestWithPeer(queuedPeer);
+
+    JedisPipelineContext.enterTransactionFraming(transactionRequest);
+    try {
+      JedisPipelineContext.captureTransactionFramingPeer(execRequest);
+    } finally {
+      JedisPipelineContext.exitTransactionFraming();
+    }
+
+    assertThat(
+            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
+        .isNull();
+  }
+
   private static JedisRequest requestWithPeer(InetSocketAddress peerAddress) {
     Socket socket =
         new Socket() {

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -159,7 +159,10 @@ class JedisNetworkAttributesGetterTest {
     InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     JedisRequest queuedRequest = requestWithPeer(queuedPeer);
     queuedRequest.capturePeerAddress();
-    JedisRequest transactionRequest = JedisRequest.createTransaction(singletonList(queuedRequest));
+    JedisRequest multiRequest = requestWithPeer(queuedPeer);
+    multiRequest.capturePeerAddress();
+    JedisRequest transactionRequest =
+        JedisRequest.createTransaction(singletonList(queuedRequest), multiRequest);
 
     InetSocketAddress execPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
     JedisRequest execRequest = requestWithPeer(execPeer);
@@ -182,7 +185,10 @@ class JedisNetworkAttributesGetterTest {
     InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     JedisRequest queuedRequest = requestWithPeer(queuedPeer);
     queuedRequest.capturePeerAddress();
-    JedisRequest transactionRequest = JedisRequest.createTransaction(singletonList(queuedRequest));
+    JedisRequest multiRequest = requestWithPeer(queuedPeer);
+    multiRequest.capturePeerAddress();
+    JedisRequest transactionRequest =
+        JedisRequest.createTransaction(singletonList(queuedRequest), multiRequest);
 
     JedisRequest execRequest = requestWithPeer(queuedPeer);
 
@@ -192,6 +198,24 @@ class JedisNetworkAttributesGetterTest {
     } finally {
       JedisPipelineContext.exitTransactionFraming();
     }
+
+    assertThat(
+            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
+        .isNull();
+  }
+
+  @Test
+  void transactionDropsPeerWhenMultiUsesDifferentSocket() {
+    InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    JedisRequest queuedRequest = requestWithPeer(queuedPeer);
+    queuedRequest.capturePeerAddress();
+
+    InetSocketAddress multiPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
+    JedisRequest multiRequest = requestWithPeer(multiPeer);
+    multiRequest.capturePeerAddress();
+
+    JedisRequest transactionRequest =
+        JedisRequest.createTransaction(singletonList(queuedRequest), multiRequest);
 
     assertThat(
             new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -15,6 +15,7 @@ import java.net.SocketAddress;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Transaction;
 
 class JedisNetworkAttributesGetterTest {
 
@@ -152,6 +153,19 @@ class JedisNetworkAttributesGetterTest {
 
     assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
         .isEqualTo(first);
+  }
+
+  @Test
+  void ordinaryCommandDoesNotBecomeTransactionFramingRequest() {
+    JedisRequest request =
+        requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379));
+    request.capturePeerAddress();
+    Transaction transaction = new Transaction();
+
+    JedisPipelineContext.captureTransactionFramingPeer(request);
+    JedisPipelineContext.exitTransactionFraming(transaction);
+
+    assertThat(JedisPipelineContext.getAndClearTransactionFramingRequest(transaction)).isNull();
   }
 
   @Test

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,8 +45,17 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
     request.capturePeerAddress();
 
+    assertThat(request.getPeerAddress()).isEqualTo(peerAddress);
+  }
+
+  @Test
+  void emitsConnectedSocketAddressOnlyForStableSemconv() {
+    InetSocketAddress peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    JedisRequest request = requestWithPeer(peerAddress);
+    request.capturePeerAddress();
+
     assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
-        .isEqualTo(peerAddress);
+        .isEqualTo(emitStableDatabaseSemconv() ? peerAddress : null);
   }
 
   @Test
@@ -53,8 +63,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest request = JedisRequest.create(new Connection(), Protocol.Command.GET);
     request.capturePeerAddress();
 
-    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
-        .isNull();
+    assertThat(request.getPeerAddress()).isNull();
   }
 
   @Test
@@ -82,9 +91,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
     request.capturePeerAddress();
 
-    JedisDbAttributesGetter getter = new JedisDbAttributesGetter();
-    assertThat(getter.getNetworkPeerAddress(request, null)).isNull();
-    assertThat(getter.getNetworkPeerPort(request, null)).isNull();
+    assertThat(request.getPeerAddress()).isNull();
   }
 
   @Test
@@ -117,8 +124,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
     request.capturePeerAddress();
 
-    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
-        .isNull();
+    assertThat(request.getPeerAddress()).isNull();
   }
 
   @Test
@@ -151,8 +157,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
     request.capturePeerAddress();
 
-    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
-        .isEqualTo(first);
+    assertThat(request.getPeerAddress()).isEqualTo(first);
   }
 
   @Test
@@ -189,9 +194,7 @@ class JedisNetworkAttributesGetterTest {
       JedisPipelineContext.exitTransactionFraming();
     }
 
-    assertThat(
-            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
-        .isNull();
+    assertThat(transactionRequest.getPeerAddress()).isNull();
   }
 
   @Test
@@ -213,9 +216,7 @@ class JedisNetworkAttributesGetterTest {
       JedisPipelineContext.exitTransactionFraming();
     }
 
-    assertThat(
-            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
-        .isNull();
+    assertThat(transactionRequest.getPeerAddress()).isNull();
   }
 
   @Test
@@ -231,9 +232,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest transactionRequest =
         JedisRequest.createTransaction(singletonList(queuedRequest), multiRequest);
 
-    assertThat(
-            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
-        .isNull();
+    assertThat(transactionRequest.getPeerAddress()).isNull();
   }
 
   private static JedisRequest requestWithPeer(InetSocketAddress peerAddress) {

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.Protocol;
+
+class JedisNetworkAttributesGetterTest {
+
+  @Test
+  void usesConnectedSocketAddress() {
+    InetSocketAddress peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    Socket socket =
+        new Socket() {
+          @Override
+          public SocketAddress getRemoteSocketAddress() {
+            return peerAddress;
+          }
+
+          @Override
+          public boolean isConnected() {
+            return true;
+          }
+        };
+    Connection connection =
+        new Connection() {
+          @Override
+          public Socket getSocket() {
+            return socket;
+          }
+        };
+    JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
+    request.capturePeerAddress();
+
+    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
+        .isEqualTo(peerAddress);
+  }
+
+  @Test
+  void dropsMissingSocketAddress() {
+    JedisRequest request = JedisRequest.create(new Connection(), Protocol.Command.GET);
+
+    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
+        .isNull();
+  }
+
+  @Test
+  void dropsUnresolvedSocketAddress() {
+    InetSocketAddress peerAddress = InetSocketAddress.createUnresolved("redis.example", 6379);
+    Socket socket =
+        new Socket() {
+          @Override
+          public SocketAddress getRemoteSocketAddress() {
+            return peerAddress;
+          }
+
+          @Override
+          public boolean isConnected() {
+            return true;
+          }
+        };
+    Connection connection =
+        new Connection() {
+          @Override
+          public Socket getSocket() {
+            return socket;
+          }
+        };
+    JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
+    request.capturePeerAddress();
+
+    JedisDbAttributesGetter getter = new JedisDbAttributesGetter();
+    assertThat(getter.getNetworkPeerAddress(request, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(request, null)).isNull();
+  }
+
+  @Test
+  void dropsClosedSocketAddress() {
+    InetSocketAddress peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    Socket socket =
+        new Socket() {
+          @Override
+          public SocketAddress getRemoteSocketAddress() {
+            return peerAddress;
+          }
+
+          @Override
+          public boolean isConnected() {
+            return true;
+          }
+
+          @Override
+          public boolean isClosed() {
+            return true;
+          }
+        };
+    Connection connection =
+        new Connection() {
+          @Override
+          public Socket getSocket() {
+            return socket;
+          }
+        };
+    JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
+    request.capturePeerAddress();
+
+    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
+        .isNull();
+  }
+
+  @Test
+  void peerAddressIsSnapshot() {
+    InetSocketAddress first = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    InetSocketAddress second = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
+    Socket socket =
+        new Socket() {
+          private SocketAddress address = first;
+
+          @Override
+          public SocketAddress getRemoteSocketAddress() {
+            SocketAddress current = address;
+            address = second;
+            return current;
+          }
+
+          @Override
+          public boolean isConnected() {
+            return true;
+          }
+        };
+    Connection connection =
+        new Connection() {
+          @Override
+          public Socket getSocket() {
+            return socket;
+          }
+        };
+    JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
+    request.capturePeerAddress();
+
+    assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
+        .isEqualTo(first);
+  }
+
+  @Test
+  void transactionDropsPeerWhenExecUsesDifferentSocket() {
+    InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+    JedisRequest queuedRequest = requestWithPeer(queuedPeer);
+    queuedRequest.capturePeerAddress();
+    JedisRequest transactionRequest = JedisRequest.createTransaction(singletonList(queuedRequest));
+
+    InetSocketAddress execPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
+    JedisRequest execRequest = requestWithPeer(execPeer);
+
+    JedisPipelineContext.enterTransactionFraming(transactionRequest);
+    try {
+      execRequest.capturePeerAddress();
+      JedisPipelineContext.captureTransactionFramingPeer(execRequest);
+    } finally {
+      JedisPipelineContext.exitTransactionFraming();
+    }
+
+    assertThat(
+            new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(transactionRequest, null))
+        .isNull();
+  }
+
+  private static JedisRequest requestWithPeer(InetSocketAddress peerAddress) {
+    Socket socket =
+        new Socket() {
+          @Override
+          public SocketAddress getRemoteSocketAddress() {
+            return peerAddress;
+          }
+
+          @Override
+          public boolean isConnected() {
+            return true;
+          }
+        };
+    Connection connection =
+        new Connection() {
+          @Override
+          public Socket getSocket() {
+            return socket;
+          }
+        };
+    return JedisRequest.create(connection, Protocol.Command.GET);
+  }
+}

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -171,6 +172,20 @@ class JedisNetworkAttributesGetterTest {
     JedisPipelineContext.exitTransactionFraming(transaction);
 
     assertThat(JedisPipelineContext.getAndClearTransactionFramingRequest(transaction)).isNull();
+  }
+
+  @Test
+  void pipelineDropsPeerWhenCommandsUseDifferentPeerAddresses() {
+    JedisRequest first =
+        requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379));
+    first.capturePeerAddress();
+    JedisRequest second =
+        requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380));
+    second.capturePeerAddress();
+
+    JedisRequest pipelineRequest = JedisRequest.createPipeline(asList(first, second));
+
+    assertThat(pipelineRequest.getPeerAddress()).isNull();
   }
 
   @Test

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -50,6 +50,7 @@ class JedisNetworkAttributesGetterTest {
   @Test
   void dropsMissingSocketAddress() {
     JedisRequest request = JedisRequest.create(new Connection(), Protocol.Command.GET);
+    request.capturePeerAddress();
 
     assertThat(new JedisDbAttributesGetter().getNetworkPeerInetSocketAddress(request, null))
         .isNull();

--- a/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisNetworkAttributesGetterTest.java
@@ -14,16 +14,21 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Transaction;
 
 class JedisNetworkAttributesGetterTest {
 
-  @Test
-  void usesConnectedSocketAddress() {
-    InetSocketAddress peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
+  @ParameterizedTest
+  @MethodSource("resolvedAddresses")
+  void usesConnectedInetSocketAddress(InetAddress address) {
+    InetSocketAddress peerAddress = new InetSocketAddress(address, 6379);
     Socket socket =
         new Socket() {
           @Override
@@ -129,7 +134,7 @@ class JedisNetworkAttributesGetterTest {
   }
 
   @Test
-  void peerAddressIsSnapshot() {
+  void laterCaptureReplacesEarlierPeerAddress() {
     InetSocketAddress first = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     InetSocketAddress second = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380);
     Socket socket =
@@ -157,8 +162,9 @@ class JedisNetworkAttributesGetterTest {
         };
     JedisRequest request = JedisRequest.create(connection, Protocol.Command.GET);
     request.capturePeerAddress();
+    request.capturePeerAddress();
 
-    assertThat(request.getPeerAddress()).isEqualTo(first);
+    assertThat(request.getPeerAddress()).isEqualTo(second);
   }
 
   @Test
@@ -175,7 +181,7 @@ class JedisNetworkAttributesGetterTest {
   }
 
   @Test
-  void pipelineDropsPeerWhenCommandsUseDifferentPeerAddresses() {
+  void pipelineUsesLastSuccessfullyObservedPeerAddress() {
     JedisRequest first =
         requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379));
     first.capturePeerAddress();
@@ -185,11 +191,24 @@ class JedisNetworkAttributesGetterTest {
 
     JedisRequest pipelineRequest = JedisRequest.createPipeline(asList(first, second));
 
-    assertThat(pipelineRequest.getPeerAddress()).isNull();
+    assertThat(pipelineRequest.getPeerAddress()).isEqualTo(second.getPeerAddress());
   }
 
   @Test
-  void transactionDropsPeerWhenExecUsesDifferentSocket() {
+  void pipelineKeepsEarlierPeerWhenLaterSendHasNoReliableAddress() {
+    JedisRequest first =
+        requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379));
+    first.capturePeerAddress();
+    JedisRequest failed =
+        requestWithPeer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 6380));
+
+    JedisRequest pipelineRequest = JedisRequest.createPipeline(asList(first, failed));
+
+    assertThat(pipelineRequest.getPeerAddress()).isEqualTo(first.getPeerAddress());
+  }
+
+  @Test
+  void transactionUsesExecPeerAddress() {
     InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     JedisRequest queuedRequest = requestWithPeer(queuedPeer);
     queuedRequest.capturePeerAddress();
@@ -209,11 +228,11 @@ class JedisNetworkAttributesGetterTest {
       JedisPipelineContext.exitTransactionFraming();
     }
 
-    assertThat(transactionRequest.getPeerAddress()).isNull();
+    assertThat(transactionRequest.getPeerAddress()).isEqualTo(execPeer);
   }
 
   @Test
-  void transactionDropsPeerWhenExecFails() {
+  void transactionKeepsLastSuccessfulPeerWhenExecFails() {
     InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     JedisRequest queuedRequest = requestWithPeer(queuedPeer);
     queuedRequest.capturePeerAddress();
@@ -231,11 +250,11 @@ class JedisNetworkAttributesGetterTest {
       JedisPipelineContext.exitTransactionFraming();
     }
 
-    assertThat(transactionRequest.getPeerAddress()).isNull();
+    assertThat(transactionRequest.getPeerAddress()).isEqualTo(queuedPeer);
   }
 
   @Test
-  void transactionDropsPeerWhenMultiUsesDifferentSocket() {
+  void transactionUsesLastQueuedPeerAfterMulti() {
     InetSocketAddress queuedPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 6379);
     JedisRequest queuedRequest = requestWithPeer(queuedPeer);
     queuedRequest.capturePeerAddress();
@@ -247,7 +266,7 @@ class JedisNetworkAttributesGetterTest {
     JedisRequest transactionRequest =
         JedisRequest.createTransaction(singletonList(queuedRequest), multiRequest);
 
-    assertThat(transactionRequest.getPeerAddress()).isNull();
+    assertThat(transactionRequest.getPeerAddress()).isEqualTo(queuedPeer);
   }
 
   private static JedisRequest requestWithPeer(InetSocketAddress peerAddress) {
@@ -271,5 +290,11 @@ class JedisNetworkAttributesGetterTest {
           }
         };
     return JedisRequest.create(connection, Protocol.Command.GET);
+  }
+
+  private static Stream<InetAddress> resolvedAddresses() throws UnknownHostException {
+    return Stream.of(
+        InetAddress.getByAddress(new byte[] {127, 0, 0, 1}),
+        InetAddress.getByAddress(new byte[16]));
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/jedis/jedis-2.0/javaagent/build.gradle.kts
@@ -41,7 +41,24 @@ tasks {
     systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database,service.peer")
   }
 
+  val testBothSemconv = register<Test>("testBothSemconv") {
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    filter {
+      includeTestsMatching("*JedisClientTest.setCommand")
+      includeTestsMatching("*JedisClientTest.pooledCommand")
+      includeTestsMatching("*JedisClientTest.reconnectUsesNewlyConnectedSocket")
+      includeTestsMatching("*JedisClientTest.pipelineCommand*")
+      includeTestsMatching("*JedisClientTest.transactionCommand*")
+      includeTestsMatching("*ShardedJedisClientTest.*")
+    }
+
+    jvmArgs("-Dotel.semconv-stability.opt-in=database/dup,service.peer")
+    systemProperty("metadataConfig", "otel.semconv-stability.opt-in=database/dup,service.peer")
+  }
+
   check {
     dependsOn(testStableSemconv)
+    dependsOn(testBothSemconv)
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClusterCommandContext.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClusterCommandContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
+
+import static io.opentelemetry.javaagent.instrumentation.jedis.v2_0.JedisSingletons.instrumenter;
+
+import io.opentelemetry.context.Context;
+import javax.annotation.Nullable;
+
+public final class JedisClusterCommandContext {
+  private static final ThreadLocal<JedisClusterCommandContext> current = new ThreadLocal<>();
+
+  @Nullable private Context context;
+  @Nullable private JedisRequest request;
+
+  @Nullable
+  public static JedisClusterCommandContext start() {
+    if (current.get() != null) {
+      return null;
+    }
+    JedisClusterCommandContext commandContext = new JedisClusterCommandContext();
+    current.set(commandContext);
+    return commandContext;
+  }
+
+  @Nullable
+  public static JedisClusterCommandContext current() {
+    return current.get();
+  }
+
+  public boolean hasRequest() {
+    return request != null;
+  }
+
+  public void capture(@Nullable Context context, JedisRequest request) {
+    if (this.request == null) {
+      if (context != null) {
+        this.context = context;
+        this.request = request;
+      }
+    } else if (this.request.getOperationName().equals(request.getOperationName())
+        && this.request.getQueryText().equals(request.getQueryText())) {
+      this.request.useLaterPeerAddress(request);
+    }
+  }
+
+  public void end(@Nullable Throwable throwable) {
+    current.remove();
+    if (context != null && request != null) {
+      instrumenter().end(context, request, null, throwable);
+    }
+  }
+
+  private JedisClusterCommandContext() {}
+}

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClusterCommandInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClusterCommandInstrumentation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class JedisClusterCommandInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("redis.clients.jedis.JedisClusterCommand");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isPublic().and(namedOneOf("run", "runBinary", "runWithAnyNode")),
+        getClass().getName() + "$CommandAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class CommandAdvice {
+
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static JedisClusterCommandContext onEnter() {
+      return JedisClusterCommandContext.start();
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Enter @Nullable JedisClusterCommandContext commandContext) {
+      if (commandContext != null) {
+        commandContext.end(throwable);
+      }
+    }
+  }
+}

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
@@ -95,7 +95,7 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
       if (JedisPipelineContext.inTransactionFraming()) {
         // MULTI/EXEC/DISCARD frame a batched transaction; they are represented by the MULTI batch
         // span rather than getting their own spans. Keep the request until method exit so a
-        // successful EXEC socket can become the transaction's last observed peer.
+        // connected EXEC socket observed at method exit can become the transaction's last peer.
         return new AdviceScope(null, null, request, null);
       }
       Context parentContext = Context.current();
@@ -117,9 +117,7 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
 
     public void end(@Nullable Throwable throwable) {
       try {
-        if (throwable == null) {
-          request.capturePeerAddress();
-        }
+        request.capturePeerAddress();
         JedisPipelineContext.captureTransactionFramingPeer(request);
       } finally {
         Context context = this.context;

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
@@ -74,11 +74,11 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
   }
 
   public static class AdviceScope {
-    private final Context context;
-    private final Scope scope;
+    @Nullable private final Context context;
+    @Nullable private final Scope scope;
     private final JedisRequest request;
 
-    private AdviceScope(Context context, Scope scope, JedisRequest request) {
+    private AdviceScope(@Nullable Context context, @Nullable Scope scope, JedisRequest request) {
       this.context = context;
       this.scope = scope;
       this.request = request;
@@ -88,14 +88,15 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     public static AdviceScope start(JedisRequest request) {
       if (JedisPipelineContext.inTransactionFraming()) {
         // MULTI/EXEC/DISCARD frame a batched transaction; they are represented by the MULTI batch
-        // span rather than getting their own spans.
-        return null;
+        // span rather than getting their own spans. Keep the request until method exit so the EXEC
+        // socket can be compared with the queued commands' sockets.
+        return new AdviceScope(null, null, request);
       }
       Context parentContext = Context.current();
       if (JedisPipelineContext.capture(request)) {
-        // A pipeline or transaction is active, so this command is captured and aggregated into the
-        // batch span created at sync()/exec() rather than getting its own span.
-        return null;
+        // Keep the request until method exit so its post-send peer snapshot is available to the
+        // batch span created at sync()/exec().
+        return new AdviceScope(null, null, request);
       }
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
@@ -105,8 +106,18 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     }
 
     public void end(@Nullable Throwable throwable) {
-      scope.close();
-      JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
+      try {
+        if (throwable == null) {
+          request.capturePeerAddress();
+          JedisPipelineContext.captureTransactionFramingPeer(request);
+        }
+      } finally {
+        Context context = this.context;
+        if (scope != null && context != null) {
+          scope.close();
+          JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
+        }
+      }
     }
   }
 

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
@@ -109,8 +109,8 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
       try {
         if (throwable == null) {
           request.capturePeerAddress();
-          JedisPipelineContext.captureTransactionFramingPeer(request);
         }
+        JedisPipelineContext.captureTransactionFramingPeer(request);
       } finally {
         Context context = this.context;
         if (scope != null && context != null) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
@@ -77,11 +77,17 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     @Nullable private final Context context;
     @Nullable private final Scope scope;
     private final JedisRequest request;
+    @Nullable private final JedisClusterCommandContext clusterCommandContext;
 
-    private AdviceScope(@Nullable Context context, @Nullable Scope scope, JedisRequest request) {
+    private AdviceScope(
+        @Nullable Context context,
+        @Nullable Scope scope,
+        JedisRequest request,
+        @Nullable JedisClusterCommandContext clusterCommandContext) {
       this.context = context;
       this.scope = scope;
       this.request = request;
+      this.clusterCommandContext = clusterCommandContext;
     }
 
     @Nullable
@@ -90,19 +96,23 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
         // MULTI/EXEC/DISCARD frame a batched transaction; they are represented by the MULTI batch
         // span rather than getting their own spans. Keep the request until method exit so a
         // successful EXEC socket can become the transaction's last observed peer.
-        return new AdviceScope(null, null, request);
+        return new AdviceScope(null, null, request, null);
       }
       Context parentContext = Context.current();
       if (JedisPipelineContext.capture(request)) {
         // Keep the request until method exit so its post-send peer snapshot is available to the
         // batch span created at sync()/exec().
-        return new AdviceScope(null, null, request);
+        return new AdviceScope(null, null, request, null);
+      }
+      JedisClusterCommandContext clusterCommandContext = JedisClusterCommandContext.current();
+      if (clusterCommandContext != null && clusterCommandContext.hasRequest()) {
+        return new AdviceScope(null, null, request, clusterCommandContext);
       }
       if (!instrumenter().shouldStart(parentContext, request)) {
         return null;
       }
       Context context = instrumenter().start(parentContext, request);
-      return new AdviceScope(context, context.makeCurrent(), request);
+      return new AdviceScope(context, context.makeCurrent(), request, clusterCommandContext);
     }
 
     public void end(@Nullable Throwable throwable) {
@@ -113,8 +123,12 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
         JedisPipelineContext.captureTransactionFramingPeer(request);
       } finally {
         Context context = this.context;
-        if (scope != null && context != null) {
+        if (scope != null) {
           scope.close();
+        }
+        if (clusterCommandContext != null) {
+          clusterCommandContext.capture(context, request);
+        } else if (context != null) {
           JedisRequestContext.endIfNotAttached(instrumenter(), context, request, throwable);
         }
       }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisConnectionInstrumentation.java
@@ -88,8 +88,8 @@ class JedisConnectionInstrumentation implements TypeInstrumentation {
     public static AdviceScope start(JedisRequest request) {
       if (JedisPipelineContext.inTransactionFraming()) {
         // MULTI/EXEC/DISCARD frame a batched transaction; they are represented by the MULTI batch
-        // span rather than getting their own spans. Keep the request until method exit so the EXEC
-        // socket can be compared with the queued commands' sockets.
+        // span rather than getting their own spans. Keep the request until method exit so a
+        // successful EXEC socket can become the transaction's last observed peer.
         return new AdviceScope(null, null, request);
       }
       Context parentContext = Context.current();

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisDbAttributesGetter.java
@@ -73,6 +73,6 @@ class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, 
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       JedisRequest request, @Nullable Void unused) {
-    return request.getPeerAddress();
+    return emitStableDatabaseSemconv() ? request.getPeerAddress() : null;
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisDbAttributesGetter.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisDbAttributesGetter.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.RedisServerTarget;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
+import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
 
 class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, Void> {
@@ -66,5 +67,12 @@ class JedisDbAttributesGetter implements DbClientAttributesGetter<JedisRequest, 
     }
     RedisServerTarget target = JedisSingletons.connectionTarget(request.getConnection());
     return target != null ? target.getPort() : null;
+  }
+
+  @Override
+  @Nullable
+  public InetSocketAddress getNetworkPeerInetSocketAddress(
+      JedisRequest request, @Nullable Void unused) {
+    return request.getPeerAddress();
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisInstrumentation.java
@@ -19,6 +19,7 @@ import io.opentelemetry.javaagent.instrumentation.jedis.common.v1_4.JedisRequest
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class JedisInstrumentation implements TypeInstrumentation {
@@ -79,8 +80,9 @@ class JedisInstrumentation implements TypeInstrumentation {
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
-    public static void onExit() {
-      JedisPipelineContext.exitTransactionFraming();
+    public static void onExit(
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable Object transaction) {
+      JedisPipelineContext.exitTransactionFraming(transaction);
     }
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisInstrumentationModule.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisInstrumentationModule.java
@@ -49,6 +49,7 @@ public class JedisInstrumentationModule extends InstrumentationModule
         new JedisSentinelPoolInstrumentation(),
         new PoolResourceInstrumentation(),
         new JedisClusterInstrumentation(),
+        new JedisClusterCommandInstrumentation(),
         new JedisInstrumentation(),
         new JedisPipelineInstrumentation(),
         new JedisTransactionInstrumentation());

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
@@ -10,6 +10,7 @@ import static java.util.Collections.emptyList;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Queable;
 import redis.clients.jedis.Transaction;
@@ -18,8 +19,12 @@ public final class JedisPipelineContext {
   private static final ThreadLocal<Queable> currentBatch = new ThreadLocal<>();
   private static final ThreadLocal<Boolean> inTransactionFraming = new ThreadLocal<>();
   private static final ThreadLocal<JedisRequest> currentTransactionRequest = new ThreadLocal<>();
+  private static final ThreadLocal<JedisRequest> currentTransactionFramingRequest =
+      new ThreadLocal<>();
   private static final VirtualField<Queable, List<JedisRequest>> CAPTURED_REQUESTS =
       VirtualField.find(Queable.class, List.class);
+  private static final VirtualField<Queable, JedisRequest> TRANSACTION_FRAMING_REQUEST =
+      VirtualField.find(Queable.class, JedisRequest.class);
 
   public static void enter(Object batch) {
     // Pipeline aggregates at sync() and Transaction at exec(); both capture their queued commands
@@ -43,9 +48,25 @@ public final class JedisPipelineContext {
     currentTransactionRequest.set(request);
   }
 
+  public static void exitTransactionFraming(@Nullable Object transaction) {
+    try {
+      JedisRequest request = currentTransactionFramingRequest.get();
+      if (request != null && transaction instanceof Queable) {
+        TRANSACTION_FRAMING_REQUEST.set((Queable) transaction, request);
+      }
+    } finally {
+      clearTransactionFraming();
+    }
+  }
+
   public static void exitTransactionFraming() {
+    clearTransactionFraming();
+  }
+
+  private static void clearTransactionFraming() {
     inTransactionFraming.remove();
     currentTransactionRequest.remove();
+    currentTransactionFramingRequest.remove();
   }
 
   public static boolean inTransactionFraming() {
@@ -56,7 +77,20 @@ public final class JedisPipelineContext {
     JedisRequest transactionRequest = currentTransactionRequest.get();
     if (transactionRequest != null) {
       transactionRequest.retainCommonPeerAddress(request);
+    } else {
+      currentTransactionFramingRequest.set(request);
     }
+  }
+
+  @Nullable
+  public static JedisRequest getAndClearTransactionFramingRequest(Object transaction) {
+    if (!(transaction instanceof Queable)) {
+      return null;
+    }
+    Queable queable = (Queable) transaction;
+    JedisRequest request = TRANSACTION_FRAMING_REQUEST.get(queable);
+    TRANSACTION_FRAMING_REQUEST.set(queable, null);
+    return request;
   }
 
   public static boolean capture(JedisRequest request) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
@@ -77,7 +77,7 @@ public final class JedisPipelineContext {
     JedisRequest transactionRequest = currentTransactionRequest.get();
     if (transactionRequest != null) {
       transactionRequest.retainCommonPeerAddress(request);
-    } else {
+    } else if (inTransactionFraming()) {
       currentTransactionFramingRequest.set(request);
     }
   }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
@@ -17,6 +17,7 @@ import redis.clients.jedis.Transaction;
 public final class JedisPipelineContext {
   private static final ThreadLocal<Queable> currentBatch = new ThreadLocal<>();
   private static final ThreadLocal<Boolean> inTransactionFraming = new ThreadLocal<>();
+  private static final ThreadLocal<JedisRequest> currentTransactionRequest = new ThreadLocal<>();
   private static final VirtualField<Queable, List<JedisRequest>> CAPTURED_REQUESTS =
       VirtualField.find(Queable.class, List.class);
 
@@ -37,12 +38,25 @@ public final class JedisPipelineContext {
     inTransactionFraming.set(Boolean.TRUE);
   }
 
+  public static void enterTransactionFraming(JedisRequest request) {
+    enterTransactionFraming();
+    currentTransactionRequest.set(request);
+  }
+
   public static void exitTransactionFraming() {
     inTransactionFraming.remove();
+    currentTransactionRequest.remove();
   }
 
   public static boolean inTransactionFraming() {
     return Boolean.TRUE.equals(inTransactionFraming.get());
+  }
+
+  public static void captureTransactionFramingPeer(JedisRequest request) {
+    JedisRequest transactionRequest = currentTransactionRequest.get();
+    if (transactionRequest != null) {
+      transactionRequest.retainCommonPeerAddress(request);
+    }
   }
 
   public static boolean capture(JedisRequest request) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisPipelineContext.java
@@ -76,7 +76,7 @@ public final class JedisPipelineContext {
   public static void captureTransactionFramingPeer(JedisRequest request) {
     JedisRequest transactionRequest = currentTransactionRequest.get();
     if (transactionRequest != null) {
-      transactionRequest.retainCommonPeerAddress(request);
+      transactionRequest.useLaterPeerAddress(request);
     } else if (inTransactionFraming()) {
       currentTransactionFramingRequest.set(request);
     }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
@@ -44,8 +44,11 @@ public abstract class JedisRequest {
     return createBatch(requests, "PIPELINE");
   }
 
-  public static JedisRequest createTransaction(List<JedisRequest> requests) {
-    return createBatch(requests, "MULTI");
+  public static JedisRequest createTransaction(
+      List<JedisRequest> requests, @Nullable JedisRequest multiRequest) {
+    JedisRequest request = createBatch(requests, "MULTI");
+    request.retainCommonPeerAddress(multiRequest);
+    return request;
   }
 
   private static JedisRequest createBatch(List<JedisRequest> requests, String prefix) {
@@ -95,8 +98,8 @@ public abstract class JedisRequest {
     return peerAddress;
   }
 
-  public void retainCommonPeerAddress(JedisRequest request) {
-    if (peerAddress == null || !peerAddress.equals(request.peerAddress)) {
+  public void retainCommonPeerAddress(@Nullable JedisRequest request) {
+    if (request == null || peerAddress == null || !peerAddress.equals(request.peerAddress)) {
       peerAddress = null;
     }
   }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
@@ -47,7 +47,9 @@ public abstract class JedisRequest {
   public static JedisRequest createTransaction(
       List<JedisRequest> requests, @Nullable JedisRequest multiRequest) {
     JedisRequest request = createBatch(requests, "MULTI");
-    request.retainCommonPeerAddress(multiRequest);
+    if (request.peerAddress == null && multiRequest != null) {
+      request.peerAddress = multiRequest.peerAddress;
+    }
     return request;
   }
 
@@ -59,7 +61,7 @@ public abstract class JedisRequest {
             batchOperationName(requests, prefix),
             pipelineQueryText(requests),
             requests.size() != 1 ? (long) requests.size() : null);
-    request.peerAddress = commonPeerAddress(requests);
+    request.peerAddress = lastPeerAddress(requests);
     return request;
   }
 
@@ -98,24 +100,21 @@ public abstract class JedisRequest {
     return peerAddress;
   }
 
-  public void retainCommonPeerAddress(@Nullable JedisRequest request) {
-    if (request == null || peerAddress == null || !peerAddress.equals(request.peerAddress)) {
-      peerAddress = null;
+  public void useLaterPeerAddress(JedisRequest request) {
+    if (request.peerAddress != null) {
+      peerAddress = request.peerAddress;
     }
   }
 
   @Nullable
-  private static InetSocketAddress commonPeerAddress(List<JedisRequest> requests) {
-    InetSocketAddress peerAddress = requests.get(0).getPeerAddress();
-    if (peerAddress == null) {
-      return null;
-    }
-    for (int i = 1; i < requests.size(); i++) {
-      if (!peerAddress.equals(requests.get(i).getPeerAddress())) {
-        return null;
+  private static InetSocketAddress lastPeerAddress(List<JedisRequest> requests) {
+    for (int i = requests.size() - 1; i >= 0; i--) {
+      InetSocketAddress peerAddress = requests.get(i).getPeerAddress();
+      if (peerAddress != null) {
+        return peerAddress;
       }
     }
-    return peerAddress;
+    return null;
   }
 
   private static String batchOperationName(List<JedisRequest> requests, String prefix) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisRequest.java
@@ -12,6 +12,9 @@ import com.google.auto.value.AutoValue;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.config.internal.DbConfig;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.RedisCommandSanitizer;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
 import redis.clients.jedis.BinaryClient;
@@ -24,6 +27,7 @@ public abstract class JedisRequest {
       RedisCommandSanitizer.create(
           DbConfig.isQuerySanitizationEnabled(GlobalOpenTelemetry.get(), "jedis"));
   private static final int LIMIT = 32 * 1024;
+  @Nullable private InetSocketAddress peerAddress;
 
   public static JedisRequest create(Connection connection, Protocol.Command command) {
     return create(connection, command, emptyList());
@@ -46,11 +50,14 @@ public abstract class JedisRequest {
 
   private static JedisRequest createBatch(List<JedisRequest> requests, String prefix) {
     JedisRequest first = requests.get(0);
-    return new AutoValue_JedisRequest(
-        first.getConnection(),
-        batchOperationName(requests, prefix),
-        pipelineQueryText(requests),
-        requests.size() != 1 ? (long) requests.size() : null);
+    JedisRequest request =
+        new AutoValue_JedisRequest(
+            first.getConnection(),
+            batchOperationName(requests, prefix),
+            pipelineQueryText(requests),
+            requests.size() != 1 ? (long) requests.size() : null);
+    request.peerAddress = commonPeerAddress(requests);
+    return request;
   }
 
   public abstract Connection getConnection();
@@ -71,6 +78,42 @@ public abstract class JedisRequest {
 
   @Nullable
   public abstract Long getBatchSize();
+
+  public void capturePeerAddress() {
+    Socket socket = getConnection().getSocket();
+    if (socket == null || !socket.isConnected() || socket.isClosed()) {
+      return;
+    }
+    SocketAddress address = socket.getRemoteSocketAddress();
+    if (address instanceof InetSocketAddress && !((InetSocketAddress) address).isUnresolved()) {
+      peerAddress = (InetSocketAddress) address;
+    }
+  }
+
+  @Nullable
+  public InetSocketAddress getPeerAddress() {
+    return peerAddress;
+  }
+
+  public void retainCommonPeerAddress(JedisRequest request) {
+    if (peerAddress == null || !peerAddress.equals(request.peerAddress)) {
+      peerAddress = null;
+    }
+  }
+
+  @Nullable
+  private static InetSocketAddress commonPeerAddress(List<JedisRequest> requests) {
+    InetSocketAddress peerAddress = requests.get(0).getPeerAddress();
+    if (peerAddress == null) {
+      return null;
+    }
+    for (int i = 1; i < requests.size(); i++) {
+      if (!peerAddress.equals(requests.get(i).getPeerAddress())) {
+        return null;
+      }
+    }
+    return peerAddress;
+  }
 
   private static String batchOperationName(List<JedisRequest> requests, String prefix) {
     if (requests.size() == 1) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisTransactionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisTransactionInstrumentation.java
@@ -52,14 +52,15 @@ class JedisTransactionInstrumentation implements TypeInstrumentation {
         List<JedisRequest> requests = JedisPipelineContext.getAndClearCapturedRequests(transaction);
         // Suppress the EXEC framing command's own span; the transaction is reported as a single
         // batch span here.
-        JedisPipelineContext.enterTransactionFraming();
         if (requests.isEmpty()) {
           // An empty transaction sends nothing for the batch, and with no captured request there
           // is no connection to derive server attributes from, so it is not reported as a batch
           // span.
+          JedisPipelineContext.enterTransactionFraming();
           return new AdviceScope(null, null, null);
         }
         JedisRequest request = JedisRequest.createTransaction(requests);
+        JedisPipelineContext.enterTransactionFraming(request);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return new AdviceScope(null, null, null);

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisTransactionInstrumentation.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisTransactionInstrumentation.java
@@ -50,6 +50,8 @@ class JedisTransactionInstrumentation implements TypeInstrumentation {
 
       public static AdviceScope start(Object transaction) {
         List<JedisRequest> requests = JedisPipelineContext.getAndClearCapturedRequests(transaction);
+        JedisRequest multiRequest =
+            JedisPipelineContext.getAndClearTransactionFramingRequest(transaction);
         // Suppress the EXEC framing command's own span; the transaction is reported as a single
         // batch span here.
         if (requests.isEmpty()) {
@@ -59,7 +61,7 @@ class JedisTransactionInstrumentation implements TypeInstrumentation {
           JedisPipelineContext.enterTransactionFraming();
           return new AdviceScope(null, null, null);
         }
-        JedisRequest request = JedisRequest.createTransaction(requests);
+        JedisRequest request = JedisRequest.createTransaction(requests, multiRequest);
         JedisPipelineContext.enterTransactionFraming(request);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisAggregateTargetTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisAggregateTargetTest.java
@@ -6,8 +6,11 @@
 package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -19,8 +22,12 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,8 +53,11 @@ class JedisAggregateTargetTest {
 
   private static GenericContainer<?> clusterServer;
   private static Object cluster;
+  private static Object clusterHandler;
+  private static Object clusterNode;
   private static String clusterTarget;
   private static String clusterHost;
+  private static int clusterPort;
 
   @BeforeAll
   static void setup() throws Exception {
@@ -115,6 +125,54 @@ class JedisAggregateTargetTest {
                     .allSatisfy(span -> assertTarget(span, clusterTarget)));
   }
 
+  @Test
+  void clusterRerouteUsesLastPeer() throws Exception {
+    String key = "rerouted";
+    int slot =
+        (int)
+            Class.forName("redis.clients.util.JedisClusterCRC16")
+                .getMethod("getSlot", String.class)
+                .invoke(null, key);
+    Class<?> hostAndPortClass = Class.forName("redis.clients.jedis.HostAndPort");
+
+    try (AskingServer askingServer = new AskingServer(slot, clusterPort)) {
+      Object askingNode =
+          hostAndPortClass
+              .getConstructor(String.class, int.class)
+              .newInstance("127.0.0.1", askingServer.getPort());
+      assignSlotToNode(clusterHandler, slot, askingNode);
+      try {
+        cluster
+            .getClass()
+            .getMethod("set", String.class, String.class)
+            .invoke(cluster, key, "value");
+        askingServer.awaitRequest();
+      } finally {
+        assignSlotToNode(clusterHandler, slot, clusterNode);
+      }
+    }
+
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(testing.spans())
+                    .filteredOn(span -> span.getName().startsWith("SET"))
+                    .singleElement()
+                    .satisfies(
+                        span -> {
+                          assertTarget(span, clusterTarget);
+                          if (emitStableDatabaseSemconv()) {
+                            assertThat(span.getAttributes().get(NETWORK_PEER_ADDRESS))
+                                .isEqualTo("127.0.0.1");
+                            assertThat(span.getAttributes().get(NETWORK_PEER_PORT))
+                                .isEqualTo((long) clusterPort);
+                          } else {
+                            assertThat(span.getAttributes().get(NETWORK_PEER_ADDRESS)).isNull();
+                            assertThat(span.getAttributes().get(NETWORK_PEER_PORT)).isNull();
+                          }
+                        }));
+  }
+
   private static void startSentinelServer() throws Exception {
     int masterPort = availablePort();
     int sentinelPort = availablePort();
@@ -146,7 +204,7 @@ class JedisAggregateTargetTest {
   }
 
   private static void startClusterServer() throws Exception {
-    int clusterPort = availablePort();
+    clusterPort = availablePort();
     clusterServer = new GenericContainer<>("redis:6.2.3-alpine").withExposedPorts(6379);
     clusterServer.setPortBindings(singletonList(clusterPort + ":6379"));
     clusterServer.withCommand(
@@ -168,16 +226,22 @@ class JedisAggregateTargetTest {
     if (result.getExitCode() != 0) {
       throw new IllegalStateException(result.getStderr());
     }
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        clusterServer.execInContainer("redis-cli", "cluster", "info").getStdout())
+                    .contains("cluster_state:ok"));
 
     clusterHost = clusterServer.getHost();
     Class<?> hostAndPortClass = Class.forName("redis.clients.jedis.HostAndPort");
-    Object selected =
+    clusterNode =
         hostAndPortClass
             .getConstructor(String.class, int.class)
             .newInstance(clusterHost, clusterPort);
     Object unavailable =
         hostAndPortClass.getConstructor(String.class, int.class).newInstance(clusterHost, 1);
-    Set<Object> nodes = new LinkedHashSet<>(asList(selected, unavailable));
+    Set<Object> nodes = new LinkedHashSet<>(asList(clusterNode, unavailable));
     clusterTarget = clusterHost + ":1," + clusterHost + ":" + clusterPort;
 
     cluster =
@@ -185,6 +249,31 @@ class JedisAggregateTargetTest {
             .getConstructor(Set.class)
             .newInstance(nodes);
     cleanup.deferAfterAll(() -> cluster.getClass().getMethod("close").invoke(cluster));
+
+    Field handlerField =
+        Class.forName("redis.clients.jedis.BinaryJedisCluster")
+            .getDeclaredField("connectionHandler");
+    handlerField.setAccessible(true);
+    clusterHandler = handlerField.get(cluster);
+  }
+
+  private static void assignSlotToNode(Object handler, int slot, Object node) throws Exception {
+    try {
+      handler
+          .getClass()
+          .getMethod("assignSlotToNode", int.class, node.getClass())
+          .invoke(handler, slot, node);
+    } catch (NoSuchMethodException ignored) {
+      Field cacheField =
+          Class.forName("redis.clients.jedis.JedisClusterConnectionHandler")
+              .getDeclaredField("cache");
+      cacheField.setAccessible(true);
+      Object cache = cacheField.get(handler);
+      cache
+          .getClass()
+          .getMethod("assignSlotToNode", int.class, node.getClass())
+          .invoke(cache, slot, node);
+    }
   }
 
   private static void assertTarget(SpanData span, String configuredTarget) {
@@ -209,6 +298,85 @@ class JedisAggregateTargetTest {
       return true;
     } catch (ClassNotFoundException ignored) {
       return false;
+    }
+  }
+
+  private static final class AskingServer implements AutoCloseable {
+    private final ServerSocket serverSocket;
+    private final Thread thread;
+    private final int slot;
+    private final int targetPort;
+    private Socket socket;
+    private Throwable failure;
+
+    private AskingServer(int slot, int targetPort) throws IOException {
+      this.slot = slot;
+      this.targetPort = targetPort;
+      serverSocket = new ServerSocket(0);
+      thread = new Thread(this::serve, "jedis-asking-server");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    private int getPort() {
+      return serverSocket.getLocalPort();
+    }
+
+    private void awaitRequest() throws InterruptedException {
+      thread.join(5_000);
+      assertThat(thread.isAlive()).isFalse();
+      assertThat(failure).isNull();
+    }
+
+    private void serve() {
+      try {
+        socket = serverSocket.accept();
+        readCommand(socket.getInputStream());
+        OutputStream output = socket.getOutputStream();
+        output.write(("-ASK " + slot + " 127.0.0.1:" + targetPort + "\r\n").getBytes(US_ASCII));
+        output.flush();
+      } catch (Throwable t) {
+        if (!serverSocket.isClosed()) {
+          failure = t;
+        }
+      }
+    }
+
+    private static void readCommand(InputStream input) throws IOException {
+      String arrayHeader = readLine(input);
+      int count = Integer.parseInt(arrayHeader.substring(1));
+      for (int i = 0; i < count; i++) {
+        String bulkHeader = readLine(input);
+        int length = Integer.parseInt(bulkHeader.substring(1));
+        for (int j = 0; j < length + 2; j++) {
+          if (input.read() == -1) {
+            throw new IOException("Unexpected end of Redis command");
+          }
+        }
+      }
+    }
+
+    private static String readLine(InputStream input) throws IOException {
+      StringBuilder line = new StringBuilder();
+      int previous = -1;
+      int current;
+      while ((current = input.read()) != -1) {
+        if (previous == '\r' && current == '\n') {
+          line.setLength(line.length() - 1);
+          return line.toString();
+        }
+        line.append((char) current);
+        previous = current;
+      }
+      throw new IOException("Unexpected end of Redis command");
+    }
+
+    @Override
+    public void close() throws IOException {
+      serverSocket.close();
+      if (socket != null) {
+        socket.close();
+      }
     }
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
@@ -20,6 +20,7 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
+import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV6;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -33,8 +34,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,18 +63,16 @@ class JedisClientTest {
       new GenericContainer<>("redis:6.2.3-alpine").withExposedPorts(6379);
 
   private static String host;
-  private static String ip;
 
   private static int port;
 
   private static Jedis jedis;
 
   @BeforeAll
-  static void setup() throws UnknownHostException {
+  static void setup() {
     redisServer.start();
     cleanup.deferAfterAll(redisServer::stop);
     host = redisServer.getHost();
-    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     jedis = new Jedis(host, port);
     cleanup.deferAfterAll(jedis::disconnect);
@@ -104,9 +103,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
 
     assertDurationMetric(
         testing,
@@ -139,9 +141,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @Test
@@ -192,9 +197,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -208,9 +216,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @Test
@@ -234,9 +245,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -253,9 +267,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @Test
@@ -283,9 +300,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @ParameterizedTest
@@ -320,9 +340,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @ParameterizedTest
@@ -360,9 +383,12 @@ class JedisClientTest {
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, ip),
-                            equalTo(NETWORK_PEER_PORT, port),
-                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
+                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
   }
 
   @Test
@@ -375,6 +401,14 @@ class JedisClientTest {
     transaction.discard();
 
     assertThat(testing.spans()).isEmpty();
+  }
+
+  private static String peerNetworkType() {
+    return peerAddress().getAddress() instanceof Inet4Address ? IPV4 : IPV6;
+  }
+
+  private static InetSocketAddress peerAddress() {
+    return (InetSocketAddress) jedis.getClient().getSocket().getRemoteSocketAddress();
   }
 
   private static Stream<Arguments> batchScenarios() {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
@@ -88,6 +88,7 @@ class JedisClientTest {
   @Test
   void setCommand() {
     jedis.set("foo", "bar");
+    InetSocketAddress peerAddress = peerAddress();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -121,17 +122,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
 
     if (emitStableDatabaseSemconv()) {
@@ -161,6 +162,7 @@ class JedisClientTest {
   void reconnectUsesNewlyConnectedSocket() {
     jedis.disconnect();
     jedis.set("foo", "bar");
+    InetSocketAddress peerAddress = peerAddress();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -194,17 +196,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -271,6 +273,7 @@ class JedisClientTest {
   void getCommand() {
     jedis.set("foo", "bar");
     String value = jedis.get("foo");
+    InetSocketAddress peerAddress = peerAddress();
 
     assertThat(value).isEqualTo("bar");
 
@@ -306,17 +309,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -349,17 +352,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -367,6 +370,7 @@ class JedisClientTest {
   void commandWithNoArguments() {
     jedis.set("foo", "bar");
     String value = jedis.randomKey();
+    InetSocketAddress peerAddress = peerAddress();
 
     assertThat(value).isEqualTo("foo");
 
@@ -402,17 +406,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -448,17 +452,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -472,6 +476,7 @@ class JedisClientTest {
     testing.clearData();
 
     jedis.set("foo", "bar");
+    InetSocketAddress peerAddress = peerAddress();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -505,17 +510,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -530,6 +535,7 @@ class JedisClientTest {
       assertThat(testing.spans()).isEmpty();
       return;
     }
+    InetSocketAddress peerAddress = peerAddress();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -569,17 +575,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -597,6 +603,7 @@ class JedisClientTest {
       assertThat(testing.spans()).isEmpty();
       return;
     }
+    InetSocketAddress peerAddress = peerAddress();
 
     testing.waitAndAssertTraces(
         trace ->
@@ -636,17 +643,17 @@ class JedisClientTest {
                             equalTo(
                                 NETWORK_PEER_ADDRESS,
                                 emitStableDatabaseSemconv()
-                                    ? peerAddress().getAddress().getHostAddress()
+                                    ? peerAddress.getAddress().getHostAddress()
                                     : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv()
-                                    ? Long.valueOf(peerAddress().getPort())
+                                    ? Long.valueOf(peerAddress.getPort())
                                     : null),
                             equalTo(
                                 NETWORK_TYPE,
                                 emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
-                                    ? peerNetworkType()
+                                    ? peerNetworkType(peerAddress)
                                     : null))));
   }
 
@@ -660,10 +667,6 @@ class JedisClientTest {
     transaction.discard();
 
     assertThat(testing.spans()).isEmpty();
-  }
-
-  private static String peerNetworkType() {
-    return peerNetworkType(peerAddress());
   }
 
   private static String peerNetworkType(InetSocketAddress peerAddress) {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
@@ -13,7 +14,12 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -27,6 +33,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,16 +62,18 @@ class JedisClientTest {
       new GenericContainer<>("redis:6.2.3-alpine").withExposedPorts(6379);
 
   private static String host;
+  private static String ip;
 
   private static int port;
 
   private static Jedis jedis;
 
   @BeforeAll
-  static void setup() {
+  static void setup() throws UnknownHostException {
     redisServer.start();
     cleanup.deferAfterAll(redisServer::stop);
     host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     jedis = new Jedis(host, port);
     cleanup.deferAfterAll(jedis::disconnect);
@@ -93,7 +103,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
 
     assertDurationMetric(
         testing,
@@ -102,7 +115,33 @@ class JedisClientTest {
         DB_OPERATION_NAME,
         DB_NAMESPACE,
         SERVER_ADDRESS,
-        SERVER_PORT);
+        SERVER_PORT,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT);
+  }
+
+  @Test
+  void reconnectUsesNewlyConnectedSocket() {
+    jedis.disconnect();
+    jedis.set("foo", "bar");
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + host + ":" + port : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
+                            equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(maybeStablePeerService(), "test-peer-service"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @Test
@@ -152,7 +191,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -165,7 +207,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @Test
@@ -188,7 +233,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -204,7 +252,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @Test
@@ -231,7 +282,10 @@ class JedisClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "1" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @ParameterizedTest
@@ -265,7 +319,10 @@ class JedisClientTest {
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @ParameterizedTest
@@ -302,7 +359,10 @@ class JedisClientTest {
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, ip),
+                            equalTo(NETWORK_PEER_PORT, port),
+                            equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null))));
   }
 
   @Test

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/JedisClientTest.java
@@ -99,27 +99,62 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET foo ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
 
-    assertDurationMetric(
-        testing,
-        "io.opentelemetry.jedis-2.0",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_NAMESPACE,
-        SERVER_ADDRESS,
-        SERVER_PORT,
-        NETWORK_PEER_ADDRESS,
-        NETWORK_PEER_PORT);
+    if (emitStableDatabaseSemconv()) {
+      assertDurationMetric(
+          testing,
+          "io.opentelemetry.jedis-2.0",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_NAMESPACE,
+          SERVER_ADDRESS,
+          SERVER_PORT,
+          NETWORK_PEER_ADDRESS,
+          NETWORK_PEER_PORT);
+    } else {
+      assertDurationMetric(
+          testing,
+          "io.opentelemetry.jedis-2.0",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_NAMESPACE,
+          SERVER_ADDRESS,
+          SERVER_PORT);
+    }
   }
 
   @Test
@@ -137,16 +172,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET foo ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @Test
@@ -154,8 +213,10 @@ class JedisClientTest {
     JedisPool pool = new JedisPool(host, port);
     cleanup.deferAfterAll(pool::destroy);
     Jedis pooled = pool.getResource();
+    InetSocketAddress pooledPeerAddress;
     try {
       pooled.set("pooled", "value");
+      pooledPeerAddress = peerAddress(pooled);
     } finally {
       pool.returnResource(pooled);
     }
@@ -170,10 +231,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET pooled ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET pooled ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? pooledPeerAddress.getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(pooledPeerAddress.getPort())
+                                    : null),
+                            equalTo(
+                                NETWORK_TYPE,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType(pooledPeerAddress)
+                                    : null))));
   }
 
   @Test
@@ -193,16 +284,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET foo ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))),
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -212,16 +327,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "GET foo"),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "GET foo"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "GET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @Test
@@ -241,16 +380,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET foo ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))),
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -263,16 +426,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "RANDOMKEY"),
                             equalTo(maybeStable(DB_OPERATION), "RANDOMKEY"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "RANDOMKEY"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "RANDOMKEY"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @Test
@@ -296,16 +483,40 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), "SET foo ?"),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET foo ?"
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? "SET"
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "1" : null),
                             equalTo(maybeStablePeerService(), "test-peer-service"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @ParameterizedTest
@@ -333,6 +544,21 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), scenario.queryText),
                             equalTo(maybeStable(DB_OPERATION), scenario.operationName),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? scenario.queryText
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? scenario.operationName
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
@@ -341,11 +567,20 @@ class JedisClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @ParameterizedTest
@@ -376,6 +611,21 @@ class JedisClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(maybeStable(DB_STATEMENT), scenario.queryText),
                             equalTo(maybeStable(DB_OPERATION), scenario.operationName),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_SYSTEM : DB_SYSTEM_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? REDIS
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_STATEMENT : DB_QUERY_TEXT,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? scenario.queryText
+                                    : null),
+                            equalTo(
+                                emitStableDatabaseSemconv() ? DB_OPERATION : DB_OPERATION_NAME,
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? scenario.operationName
+                                    : null),
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
@@ -384,11 +634,20 @@ class JedisClientTest {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
-                                NETWORK_PEER_ADDRESS, peerAddress().getAddress().getHostAddress()),
-                            equalTo(NETWORK_PEER_PORT, peerAddress().getPort()),
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerAddress().getAddress().getHostAddress()
+                                    : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(peerAddress().getPort())
+                                    : null),
                             equalTo(
                                 NETWORK_TYPE,
-                                emitOldDatabaseSemconv() ? peerNetworkType() : null))));
+                                emitStableDatabaseSemconv() && emitOldDatabaseSemconv()
+                                    ? peerNetworkType()
+                                    : null))));
   }
 
   @Test
@@ -404,11 +663,19 @@ class JedisClientTest {
   }
 
   private static String peerNetworkType() {
-    return peerAddress().getAddress() instanceof Inet4Address ? IPV4 : IPV6;
+    return peerNetworkType(peerAddress());
+  }
+
+  private static String peerNetworkType(InetSocketAddress peerAddress) {
+    return peerAddress.getAddress() instanceof Inet4Address ? IPV4 : IPV6;
   }
 
   private static InetSocketAddress peerAddress() {
-    return (InetSocketAddress) jedis.getClient().getSocket().getRemoteSocketAddress();
+    return peerAddress(jedis);
+  }
+
+  private static InetSocketAddress peerAddress(Jedis client) {
+    return (InetSocketAddress) client.getClient().getSocket().getRemoteSocketAddress();
   }
 
   private static Stream<Arguments> batchScenarios() {

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
@@ -41,6 +41,7 @@ import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.ShardedJedis;
+import redis.clients.jedis.ShardedJedisPipeline;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class ShardedJedisClientTest {
@@ -125,6 +126,93 @@ class ShardedJedisClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
                             attributes("SET", "SET all-shards ?", shard))));
+  }
+
+  @Test
+  void shardedPipelineFanOutWithinOneScopeKeepsPerCommandPeers() {
+    List<Jedis> shards = new ArrayList<>(sharded.getAllShards());
+    Jedis firstShard = shards.get(0);
+    Jedis secondShard = shards.get(1);
+    String firstKey = keyForShard(firstShard, "same-scope-first");
+    String secondKey = keyForShard(secondShard, "same-scope-second");
+
+    testing.runWithSpan(
+        "parent",
+        () -> {
+          sharded.pipelined(
+              new ShardedJedisPipeline() {
+                @Override
+                public void execute() {
+                  set(firstKey, "first");
+                  set(secondKey, "second");
+                }
+              });
+        });
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasNoParent().hasTotalAttributeCount(0),
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            attributes("SET", "SET " + firstKey + " ?", firstShard)),
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            attributes("SET", "SET " + secondKey + " ?", secondShard))));
+  }
+
+  @Test
+  void shardedPipelineFanOutAcrossScopesKeepsPerCommandPeers() {
+    List<Jedis> shards = new ArrayList<>(sharded.getAllShards());
+    Jedis firstShard = shards.get(0);
+    Jedis secondShard = shards.get(1);
+    String firstKey = keyForShard(firstShard, "cross-scope-first");
+    String secondKey = keyForShard(secondShard, "cross-scope-second");
+
+    sharded.pipelined(
+        new ShardedJedisPipeline() {
+          @Override
+          public void execute() {
+            testing.runWithSpan("first parent", () -> set(firstKey, "first"));
+            testing.runWithSpan("second parent", () -> set(secondKey, "second"));
+          }
+        });
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("first parent").hasNoParent().hasTotalAttributeCount(0),
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            attributes("SET", "SET " + firstKey + " ?", firstShard))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("second parent").hasNoParent().hasTotalAttributeCount(0),
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasParent(trace.getSpan(0))
+                        .hasAttributesSatisfyingExactly(
+                            attributes("SET", "SET " + secondKey + " ?", secondShard))));
+  }
+
+  private static String keyForShard(Jedis selectedShard, String prefix) {
+    for (int i = 0; i < 1000; i++) {
+      String key = prefix + "-" + i;
+      if (sharded.getShard(key) == selectedShard) {
+        return key;
+      }
+    }
+    throw new AssertionError("Could not find a key for selected shard");
   }
 
   private static List<AttributeAssertion> attributes(

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
@@ -32,6 +32,7 @@ import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -128,24 +129,35 @@ class ShardedJedisClientTest {
 
   private static List<AttributeAssertion> attributes(
       String operation, String queryText, Jedis selectedShard) {
-    String selectedHost = selectedShard.getClient().getHost();
-    int selectedPort = selectedShard.getClient().getPort();
-    InetSocketAddress peerAddress =
-        (InetSocketAddress) selectedShard.getClient().getSocket().getRemoteSocketAddress();
-    return asList(
-        equalTo(maybeStable(DB_SYSTEM), REDIS),
-        equalTo(maybeStable(DB_STATEMENT), queryText),
-        equalTo(maybeStable(DB_OPERATION), operation),
-        equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
-        equalTo(maybeStablePeerService(), emitStableDatabaseSemconv() ? null : "test-peer-service"),
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? configuredTarget : selectedHost),
-        equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) selectedPort),
-        equalTo(NETWORK_PEER_ADDRESS, peerAddress.getAddress().getHostAddress()),
-        equalTo(NETWORK_PEER_PORT, (long) peerAddress.getPort()),
-        equalTo(
-            NETWORK_TYPE,
-            emitOldDatabaseSemconv()
-                ? (peerAddress.getAddress() instanceof Inet4Address ? IPV4 : IPV6)
-                : null));
+    String serverAddress = selectedShard.getClient().getHost();
+    int serverPort = selectedShard.getClient().getPort();
+    List<AttributeAssertion> assertions =
+        new ArrayList<>(
+            asList(
+                equalTo(maybeStable(DB_SYSTEM), REDIS),
+                equalTo(maybeStable(DB_STATEMENT), queryText),
+                equalTo(maybeStable(DB_OPERATION), operation),
+                equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null)));
+    if (emitStableDatabaseSemconv() && emitOldDatabaseSemconv()) {
+      assertions.add(equalTo(DB_SYSTEM, REDIS));
+      assertions.add(equalTo(DB_STATEMENT, queryText));
+      assertions.add(equalTo(DB_OPERATION, operation));
+    }
+    if (emitStableDatabaseSemconv()) {
+      InetSocketAddress peerAddress =
+          (InetSocketAddress) selectedShard.getClient().getSocket().getRemoteSocketAddress();
+      assertions.add(equalTo(SERVER_ADDRESS, configuredTarget));
+      assertions.add(equalTo(NETWORK_PEER_ADDRESS, peerAddress.getAddress().getHostAddress()));
+      assertions.add(equalTo(NETWORK_PEER_PORT, peerAddress.getPort()));
+      if (emitOldDatabaseSemconv()) {
+        assertions.add(
+            equalTo(NETWORK_TYPE, peerAddress.getAddress() instanceof Inet4Address ? IPV4 : IPV6));
+      }
+    } else {
+      assertions.add(equalTo(maybeStablePeerService(), "test-peer-service"));
+      assertions.add(equalTo(SERVER_ADDRESS, serverAddress));
+      assertions.add(equalTo(SERVER_PORT, serverPort));
+    }
+    return assertions;
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.javaagent.instrumentation.jedis.v2_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -24,6 +29,8 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -53,10 +60,11 @@ class ShardedJedisClientTest {
   private static String configuredTarget;
 
   private static String shardHost;
+  private static String shardIp;
   private static int shardPort;
 
   @BeforeAll
-  static void setup() {
+  static void setup() throws UnknownHostException {
     firstServer.start();
     cleanup.deferAfterAll(firstServer::stop);
     secondServer.start();
@@ -81,6 +89,7 @@ class ShardedJedisClientTest {
 
     Jedis shard = sharded.getShard("foo");
     shardHost = shard.getClient().getHost();
+    shardIp = InetAddress.getByName(shardHost).getHostAddress();
     shardPort = shard.getClient().getPort();
   }
 
@@ -135,6 +144,9 @@ class ShardedJedisClientTest {
         equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
         equalTo(maybeStablePeerService(), emitStableDatabaseSemconv() ? null : "test-peer-service"),
         equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? configuredTarget : selectedHost),
-        equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) selectedPort));
+        equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) selectedPort),
+        equalTo(NETWORK_PEER_ADDRESS, shardIp),
+        equalTo(NETWORK_PEER_PORT, (long) shardPort),
+        equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null));
   }
 }

--- a/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
+++ b/instrumentation/jedis/jedis-2.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jedis/v2_0/ShardedJedisClientTest.java
@@ -15,6 +15,7 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV4;
+import static io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues.IPV6;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -29,8 +30,8 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,15 +57,12 @@ class ShardedJedisClientTest {
       new GenericContainer<>("redis:6.2.3-alpine").withExposedPorts(6379);
 
   private static ShardedJedis sharded;
+  private static Jedis shard;
 
   private static String configuredTarget;
 
-  private static String shardHost;
-  private static String shardIp;
-  private static int shardPort;
-
   @BeforeAll
-  static void setup() throws UnknownHostException {
+  static void setup() {
     firstServer.start();
     cleanup.deferAfterAll(firstServer::stop);
     secondServer.start();
@@ -87,10 +85,7 @@ class ShardedJedisClientTest {
     sharded = new ShardedJedis(shards);
     cleanup.deferAfterAll(sharded::disconnect);
 
-    Jedis shard = sharded.getShard("foo");
-    shardHost = shard.getClient().getHost();
-    shardIp = InetAddress.getByName(shardHost).getHostAddress();
-    shardPort = shard.getClient().getPort();
+    shard = sharded.getShard("foo");
   }
 
   @Test
@@ -106,22 +101,18 @@ class ShardedJedisClientTest {
                 span ->
                     span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            attributes("SET", "SET foo ?", shardHost, shardPort))),
+                        .hasAttributesSatisfyingExactly(attributes("SET", "SET foo ?", shard))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
                     span.hasName(emitStableDatabaseSemconv() ? "GET " + configuredTarget : "GET")
                         .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            attributes("GET", "GET foo", shardHost, shardPort))));
+                        .hasAttributesSatisfyingExactly(attributes("GET", "GET foo", shard))));
   }
 
   @Test
   void commandFromAllShardsUsesConfiguredTarget() {
     Jedis shard = sharded.getAllShards().iterator().next();
-    String selectedHost = shard.getClient().getHost();
-    int selectedPort = shard.getClient().getPort();
 
     shard.set("all-shards", "bar");
 
@@ -132,11 +123,15 @@ class ShardedJedisClientTest {
                     span.hasName(emitStableDatabaseSemconv() ? "SET " + configuredTarget : "SET")
                         .hasKind(SpanKind.CLIENT)
                         .hasAttributesSatisfyingExactly(
-                            attributes("SET", "SET all-shards ?", selectedHost, selectedPort))));
+                            attributes("SET", "SET all-shards ?", shard))));
   }
 
   private static List<AttributeAssertion> attributes(
-      String operation, String queryText, String selectedHost, int selectedPort) {
+      String operation, String queryText, Jedis selectedShard) {
+    String selectedHost = selectedShard.getClient().getHost();
+    int selectedPort = selectedShard.getClient().getPort();
+    InetSocketAddress peerAddress =
+        (InetSocketAddress) selectedShard.getClient().getSocket().getRemoteSocketAddress();
     return asList(
         equalTo(maybeStable(DB_SYSTEM), REDIS),
         equalTo(maybeStable(DB_STATEMENT), queryText),
@@ -145,8 +140,12 @@ class ShardedJedisClientTest {
         equalTo(maybeStablePeerService(), emitStableDatabaseSemconv() ? null : "test-peer-service"),
         equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? configuredTarget : selectedHost),
         equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) selectedPort),
-        equalTo(NETWORK_PEER_ADDRESS, shardIp),
-        equalTo(NETWORK_PEER_PORT, (long) shardPort),
-        equalTo(NETWORK_TYPE, emitOldDatabaseSemconv() ? IPV4 : null));
+        equalTo(NETWORK_PEER_ADDRESS, peerAddress.getAddress().getHostAddress()),
+        equalTo(NETWORK_PEER_PORT, (long) peerAddress.getPort()),
+        equalTo(
+            NETWORK_TYPE,
+            emitOldDatabaseSemconv()
+                ? (peerAddress.getAddress() instanceof Inet4Address ? IPV4 : IPV6)
+                : null));
   }
 }


### PR DESCRIPTION
This PR is part of #19899 and applies the observed peer rules proposed in [open-telemetry/semantic-conventions#4058](https://github.com/open-telemetry/semantic-conventions/pull/4058) to Jedis 2.x. Spans report `network.peer.address` and `network.peer.port` from the operation socket when stable database semantic conventions are enabled, while `server.address`, `server.port`, and stable span names continue to describe the normalized configured target from #19871.

### Peer capture

Ordered retries, pipelines, and transactions keep the last reliably captured socket, including a reroute to a later connection. If a later send does not expose a reliable socket, aggregation retains the most recent reliable peer. Independent sharded operations stay separate spans instead of collapsing multiple sockets into one peer, and peer attributes are omitted when no single reliable socket can be identified.

### Semantic convention modes

Legacy mode is unchanged, and `database/dup` retains the legacy `network.type` attribute.

This PR is stacked on #19871.