### PR TITLE
Add gen_ai.request.stream to OpenAI and AWS Bedrock spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ⚠️ Breaking changes to non-stable APIs
 
+- Add the required `isRequestStreaming(REQUEST)` method to `GenAiAttributesGetter`.
+  ([#19879](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19879))
 - Elasticsearch REST javaagent and 7.x library instrumentation now capture sanitized search query
   bodies by default under v3-preview; outside v3-preview, capture defaults remain unchanged. The
   javaagent also sanitizes explicitly enabled capture by default, replacing literal values with `?`

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.genai;
 
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.doubleKey;
 import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
@@ -41,6 +42,8 @@ public final class GenAiAttributesExtractor<REQUEST, RESPONSE>
   private static final AttributeKey<Long> GEN_AI_REQUEST_SEED = longKey("gen_ai.request.seed");
   private static final AttributeKey<List<String>> GEN_AI_REQUEST_STOP_SEQUENCES =
       stringArrayKey("gen_ai.request.stop_sequences");
+  private static final AttributeKey<Boolean> GEN_AI_REQUEST_STREAM =
+      booleanKey("gen_ai.request.stream");
   private static final AttributeKey<Double> GEN_AI_REQUEST_TEMPERATURE =
       doubleKey("gen_ai.request.temperature");
   private static final AttributeKey<Double> GEN_AI_REQUEST_TOP_K =
@@ -73,6 +76,9 @@ public final class GenAiAttributesExtractor<REQUEST, RESPONSE>
     attributes.put(GEN_AI_OPERATION_NAME, getter.getOperationName(request));
     attributes.put(GEN_AI_PROVIDER_NAME, getter.getSystem(request));
     attributes.put(GEN_AI_REQUEST_MODEL, getter.getRequestModel(request));
+    if (getter.isRequestStreaming(request)) {
+      attributes.put(GEN_AI_REQUEST_STREAM, true);
+    }
     attributes.put(GEN_AI_REQUEST_SEED, getter.getRequestSeed(request));
     attributes.put(GEN_AI_REQUEST_ENCODING_FORMATS, getter.getRequestEncodingFormats(request));
     attributes.put(GEN_AI_REQUEST_FREQUENCY_PENALTY, getter.getRequestFrequencyPenalty(request));

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesGetter.java
@@ -23,6 +23,8 @@ public interface GenAiAttributesGetter<REQUEST, RESPONSE> {
   @Nullable
   String getRequestModel(REQUEST request);
 
+  boolean isRequestStreaming(REQUEST request);
+
   @Nullable
   Long getRequestSeed(REQUEST request);
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.genai;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_OPERATION_NAME;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_PROVIDER_NAME;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_REQUEST_MODEL;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Collections.emptyList;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class GenAiAttributesExtractorTest {
+
+  private static final AttributeKey<Boolean> GEN_AI_REQUEST_STREAM =
+      booleanKey("gen_ai.request.stream");
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void extractsStreamingOnStart(boolean streaming) {
+    AttributesExtractor<Request, Void> extractor =
+        GenAiAttributesExtractor.create(new TestGetter());
+    Request request = new Request(streaming);
+
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, Context.root(), request);
+
+    AttributesBuilder expected =
+        Attributes.builder()
+            .put(GEN_AI_OPERATION_NAME, "chat")
+            .put(GEN_AI_PROVIDER_NAME, "test")
+            .put(GEN_AI_REQUEST_MODEL, "test-model");
+    if (streaming) {
+      expected.put(GEN_AI_REQUEST_STREAM, true);
+    }
+    assertThat(attributes.build()).isEqualTo(expected.build());
+  }
+
+  private static final class Request {
+    private final boolean streaming;
+
+    private Request(boolean streaming) {
+      this.streaming = streaming;
+    }
+  }
+
+  private static final class TestGetter implements GenAiAttributesGetter<Request, Void> {
+
+    @Override
+    public String getOperationName(Request request) {
+      return "chat";
+    }
+
+    @Override
+    public String getSystem(Request request) {
+      return "test";
+    }
+
+    @Override
+    public String getRequestModel(Request request) {
+      return "test-model";
+    }
+
+    @Override
+    public boolean isRequestStreaming(Request request) {
+      return request.streaming;
+    }
+
+    @Nullable
+    @Override
+    public Long getRequestSeed(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getRequestEncodingFormats(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Double getRequestFrequencyPenalty(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Long getRequestMaxTokens(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Double getRequestPresencePenalty(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getRequestStopSequences(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Double getRequestTemperature(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Double getRequestTopK(Request request) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Double getRequestTopP(Request request) {
+      return null;
+    }
+
+    @Override
+    public List<String> getResponseFinishReasons(Request request, @Nullable Void response) {
+      return emptyList();
+    }
+
+    @Nullable
+    @Override
+    public String getResponseId(Request request, @Nullable Void response) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public String getResponseModel(Request request, @Nullable Void response) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Long getUsageInputTokens(Request request, @Nullable Void response) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Long getUsageOutputTokens(Request request, @Nullable Void response) {
+      return null;
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
@@ -73,6 +73,11 @@ final class BedrockRuntimeAccess {
     return enabled ? BedrockRuntimeImpl.getOperationName(executionAttributes) : null;
   }
 
+  @NoMuzzle
+  static boolean isRequestStreaming(ExecutionAttributes executionAttributes) {
+    return enabled && BedrockRuntimeImpl.isRequestStreaming(executionAttributes);
+  }
+
   @Nullable
   @NoMuzzle
   static Long getMaxTokens(ExecutionAttributes executionAttributes) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesGetter.java
@@ -37,6 +37,11 @@ class BedrockRuntimeAttributesGetter
     return BedrockRuntimeAccess.getModelId(executionAttributes);
   }
 
+  @Override
+  public boolean isRequestStreaming(ExecutionAttributes executionAttributes) {
+    return BedrockRuntimeAccess.isRequestStreaming(executionAttributes);
+  }
+
   @Nullable
   @Override
   public Long getRequestSeed(ExecutionAttributes executionAttributes) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
@@ -202,6 +202,12 @@ public final class BedrockRuntimeImpl {
     return null;
   }
 
+  static boolean isRequestStreaming(ExecutionAttributes executionAttributes) {
+    SdkRequest request = executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE);
+    return request instanceof ConverseStreamRequest
+        || request instanceof InvokeModelWithResponseStreamRequest;
+  }
+
   @Nullable
   private static String getOperationNameInvokeModel(@Nullable String modelId) {
     if (modelId == null) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/Aws2BedrockRuntimeTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVEN
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_MODEL;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STREAM;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_TOKEN_TYPE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_INPUT_TOKENS;
@@ -670,6 +671,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));
@@ -1369,6 +1371,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 165),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("tool_use")))));
@@ -1576,6 +1579,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 558),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 58),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));
@@ -2207,6 +2211,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 144),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("tool_use")))));
@@ -2389,6 +2394,7 @@ class Aws2BedrockRuntimeTest extends AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 601),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 145),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_MAX_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_MODEL;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STOP_SEQUENCES;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STREAM;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_TEMPERATURE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_TOP_P;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
@@ -999,6 +1000,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 554),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 59),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));
@@ -1230,6 +1232,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 8),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 10),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));
@@ -1356,6 +1359,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 5),
                                 satisfies(
                                     GEN_AI_REQUEST_TEMPERATURE,
@@ -1582,6 +1586,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 100),
                                 satisfies(
                                     GEN_AI_REQUEST_TEMPERATURE,
@@ -1898,6 +1903,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 100),
                                 satisfies(
                                     GEN_AI_REQUEST_TEMPERATURE,
@@ -2432,6 +2438,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
                                     GEN_AI_REQUEST_TEMPERATURE,
@@ -3106,6 +3113,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 416),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 165),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("tool_use")))));
@@ -3327,6 +3335,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 558),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 58),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));
@@ -4018,6 +4027,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 380),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 144),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("tool_use")))));
@@ -4214,6 +4224,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 601),
                                 equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 145),
                                 equalTo(GEN_AI_RESPONSE_FINISH_REASONS, asList("end_turn")))));

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetter.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetter.java
@@ -10,66 +10,71 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.completions.CompletionUsage;
 import io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesGetter;
 import java.util.List;
 import javax.annotation.Nullable;
 
 final class ChatAttributesGetter
-    implements GenAiAttributesGetter<ChatCompletionCreateParams, ChatCompletion> {
+    implements GenAiAttributesGetter<ChatCompletionRequest, ChatCompletion> {
 
   ChatAttributesGetter() {}
 
   @Override
-  public String getOperationName(ChatCompletionCreateParams request) {
+  public String getOperationName(ChatCompletionRequest request) {
     return GenAiAttributes.GenAiOperationNameIncubatingValues.CHAT;
   }
 
   @Override
-  public String getSystem(ChatCompletionCreateParams request) {
+  public String getSystem(ChatCompletionRequest request) {
     return GenAiAttributes.GenAiProviderNameIncubatingValues.OPENAI;
   }
 
   @Override
-  public String getRequestModel(ChatCompletionCreateParams request) {
-    return request.model().asString();
+  public String getRequestModel(ChatCompletionRequest request) {
+    return request.getRequest().model().asString();
+  }
+
+  @Override
+  public boolean isRequestStreaming(ChatCompletionRequest request) {
+    return request.isStreaming();
   }
 
   @Nullable
   @Override
-  public Long getRequestSeed(ChatCompletionCreateParams request) {
-    return request.seed().orElse(null);
+  public Long getRequestSeed(ChatCompletionRequest request) {
+    return request.getRequest().seed().orElse(null);
   }
 
   @Nullable
   @Override
-  public List<String> getRequestEncodingFormats(ChatCompletionCreateParams request) {
+  public List<String> getRequestEncodingFormats(ChatCompletionRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Double getRequestFrequencyPenalty(ChatCompletionCreateParams request) {
-    return request.frequencyPenalty().orElse(null);
+  public Double getRequestFrequencyPenalty(ChatCompletionRequest request) {
+    return request.getRequest().frequencyPenalty().orElse(null);
   }
 
   @Nullable
   @Override
-  public Long getRequestMaxTokens(ChatCompletionCreateParams request) {
-    return request.maxCompletionTokens().orElse(null);
+  public Long getRequestMaxTokens(ChatCompletionRequest request) {
+    return request.getRequest().maxCompletionTokens().orElse(null);
   }
 
   @Nullable
   @Override
-  public Double getRequestPresencePenalty(ChatCompletionCreateParams request) {
-    return request.presencePenalty().orElse(null);
+  public Double getRequestPresencePenalty(ChatCompletionRequest request) {
+    return request.getRequest().presencePenalty().orElse(null);
   }
 
   @Nullable
   @Override
-  public List<String> getRequestStopSequences(ChatCompletionCreateParams request) {
+  public List<String> getRequestStopSequences(ChatCompletionRequest request) {
     return request
+        .getRequest()
         .stop()
         .map(
             s -> {
@@ -86,25 +91,25 @@ final class ChatAttributesGetter
 
   @Nullable
   @Override
-  public Double getRequestTemperature(ChatCompletionCreateParams request) {
-    return request.temperature().orElse(null);
+  public Double getRequestTemperature(ChatCompletionRequest request) {
+    return request.getRequest().temperature().orElse(null);
   }
 
   @Nullable
   @Override
-  public Double getRequestTopK(ChatCompletionCreateParams request) {
+  public Double getRequestTopK(ChatCompletionRequest request) {
     return null;
   }
 
   @Nullable
   @Override
-  public Double getRequestTopP(ChatCompletionCreateParams request) {
-    return request.topP().orElse(null);
+  public Double getRequestTopP(ChatCompletionRequest request) {
+    return request.getRequest().topP().orElse(null);
   }
 
   @Override
   public List<String> getResponseFinishReasons(
-      ChatCompletionCreateParams request, @Nullable ChatCompletion response) {
+      ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return emptyList();
     }
@@ -115,8 +120,7 @@ final class ChatAttributesGetter
 
   @Override
   @Nullable
-  public String getResponseId(
-      ChatCompletionCreateParams request, @Nullable ChatCompletion response) {
+  public String getResponseId(ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return null;
     }
@@ -125,8 +129,7 @@ final class ChatAttributesGetter
 
   @Override
   @Nullable
-  public String getResponseModel(
-      ChatCompletionCreateParams request, @Nullable ChatCompletion response) {
+  public String getResponseModel(ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return null;
     }
@@ -136,7 +139,7 @@ final class ChatAttributesGetter
   @Override
   @Nullable
   public Long getUsageInputTokens(
-      ChatCompletionCreateParams request, @Nullable ChatCompletion response) {
+      ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return null;
     }
@@ -146,7 +149,7 @@ final class ChatAttributesGetter
   @Override
   @Nullable
   public Long getUsageOutputTokens(
-      ChatCompletionCreateParams request, @Nullable ChatCompletion response) {
+      ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return null;
     }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionRequest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+
+final class ChatCompletionRequest {
+
+  private final ChatCompletionCreateParams request;
+  private final boolean streaming;
+
+  static ChatCompletionRequest create(ChatCompletionCreateParams request) {
+    return new ChatCompletionRequest(request, false);
+  }
+
+  static ChatCompletionRequest createStreaming(ChatCompletionCreateParams request) {
+    return new ChatCompletionRequest(request, true);
+  }
+
+  private ChatCompletionRequest(ChatCompletionCreateParams request, boolean streaming) {
+    this.request = request;
+    this.streaming = streaming;
+  }
+
+  ChatCompletionCreateParams getRequest() {
+    return request;
+  }
+
+  boolean isStreaming() {
+    return streaming;
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/EmbeddingAttributesGetter.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/EmbeddingAttributesGetter.java
@@ -34,6 +34,11 @@ final class EmbeddingAttributesGetter
     return request.model().asString();
   }
 
+  @Override
+  public boolean isRequestStreaming(EmbeddingCreateParams request) {
+    return false;
+  }
+
   @Nullable
   @Override
   public Long getRequestSeed(EmbeddingCreateParams request) {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionService.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionService.java
@@ -20,13 +20,13 @@ import java.lang.reflect.Method;
 final class InstrumentedChatCompletionService
     extends DelegatingInvocationHandler<ChatCompletionService> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedChatCompletionService(
       ChatCompletionService delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
     super(delegate);
@@ -73,21 +73,22 @@ final class InstrumentedChatCompletionService
 
   private ChatCompletion create(
       ChatCompletionCreateParams chatCompletionCreateParams, RequestOptions requestOptions) {
+    ChatCompletionRequest request = ChatCompletionRequest.create(chatCompletionCreateParams);
     Context parentContext = Context.current();
-    if (!instrumenter.shouldStart(parentContext, chatCompletionCreateParams)) {
+    if (!instrumenter.shouldStart(parentContext, request)) {
       return createWithLogs(parentContext, chatCompletionCreateParams, requestOptions);
     }
 
-    Context context = instrumenter.start(parentContext, chatCompletionCreateParams);
+    Context context = instrumenter.start(parentContext, request);
     ChatCompletion completion;
     try (Scope ignored = context.makeCurrent()) {
       completion = createWithLogs(context, chatCompletionCreateParams, requestOptions);
     } catch (Throwable t) {
-      instrumenter.end(context, chatCompletionCreateParams, null, t);
+      instrumenter.end(context, request, null, t);
       throw t;
     }
 
-    instrumenter.end(context, chatCompletionCreateParams, completion, null);
+    instrumenter.end(context, request, completion, null);
     return completion;
   }
 
@@ -105,26 +106,28 @@ final class InstrumentedChatCompletionService
 
   private StreamResponse<ChatCompletionChunk> createStreaming(
       ChatCompletionCreateParams chatCompletionCreateParams, RequestOptions requestOptions) {
+    ChatCompletionRequest request =
+        ChatCompletionRequest.createStreaming(chatCompletionCreateParams);
     Context parentContext = Context.current();
-    if (!instrumenter.shouldStart(parentContext, chatCompletionCreateParams)) {
-      return createStreamingWithLogs(
-          parentContext, chatCompletionCreateParams, requestOptions, false);
+    if (!instrumenter.shouldStart(parentContext, request)) {
+      return createStreamingWithLogs(parentContext, request, requestOptions, false);
     }
 
-    Context context = instrumenter.start(parentContext, chatCompletionCreateParams);
+    Context context = instrumenter.start(parentContext, request);
     try (Scope ignored = context.makeCurrent()) {
-      return createStreamingWithLogs(context, chatCompletionCreateParams, requestOptions, true);
+      return createStreamingWithLogs(context, request, requestOptions, true);
     } catch (Throwable t) {
-      instrumenter.end(context, chatCompletionCreateParams, null, t);
+      instrumenter.end(context, request, null, t);
       throw t;
     }
   }
 
   private StreamResponse<ChatCompletionChunk> createStreamingWithLogs(
       Context context,
-      ChatCompletionCreateParams chatCompletionCreateParams,
+      ChatCompletionRequest request,
       RequestOptions requestOptions,
       boolean newSpan) {
+    ChatCompletionCreateParams chatCompletionCreateParams = request.getRequest();
     ChatCompletionEventsHelper.emitPromptLogEvents(
         context, eventLogger, chatCompletionCreateParams, captureMessageContent);
     StreamResponse<ChatCompletionChunk> result =
@@ -132,11 +135,6 @@ final class InstrumentedChatCompletionService
     return new TracingStreamedResponse(
         result,
         new StreamListener(
-            context,
-            chatCompletionCreateParams,
-            instrumenter,
-            eventLogger,
-            captureMessageContent,
-            newSpan));
+            context, request, instrumenter, eventLogger, captureMessageContent, newSpan));
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionServiceAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatCompletionServiceAsync.java
@@ -21,13 +21,13 @@ import java.util.concurrent.CompletableFuture;
 final class InstrumentedChatCompletionServiceAsync
     extends DelegatingInvocationHandler<ChatCompletionServiceAsync> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedChatCompletionServiceAsync(
       ChatCompletionServiceAsync delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
     super(delegate);
@@ -74,23 +74,22 @@ final class InstrumentedChatCompletionServiceAsync
 
   private CompletableFuture<ChatCompletion> create(
       ChatCompletionCreateParams chatCompletionCreateParams, RequestOptions requestOptions) {
+    ChatCompletionRequest request = ChatCompletionRequest.create(chatCompletionCreateParams);
     Context parentContext = Context.current();
-    if (!instrumenter.shouldStart(parentContext, chatCompletionCreateParams)) {
+    if (!instrumenter.shouldStart(parentContext, request)) {
       return createWithLogs(parentContext, chatCompletionCreateParams, requestOptions);
     }
 
-    Context context = instrumenter.start(parentContext, chatCompletionCreateParams);
+    Context context = instrumenter.start(parentContext, request);
     CompletableFuture<ChatCompletion> future;
     try (Scope ignored = context.makeCurrent()) {
       future = createWithLogs(context, chatCompletionCreateParams, requestOptions);
     } catch (Throwable t) {
-      instrumenter.end(context, chatCompletionCreateParams, null, t);
+      instrumenter.end(context, request, null, t);
       throw t;
     }
 
-    future =
-        future.whenComplete(
-            (res, t) -> instrumenter.end(context, chatCompletionCreateParams, res, t));
+    future = future.whenComplete((res, t) -> instrumenter.end(context, request, res, t));
     return CompletableFutureWrapper.wrap(future, parentContext);
   }
 
@@ -111,26 +110,28 @@ final class InstrumentedChatCompletionServiceAsync
 
   private AsyncStreamResponse<ChatCompletionChunk> createStreaming(
       ChatCompletionCreateParams chatCompletionCreateParams, RequestOptions requestOptions) {
+    ChatCompletionRequest request =
+        ChatCompletionRequest.createStreaming(chatCompletionCreateParams);
     Context parentContext = Context.current();
-    if (!instrumenter.shouldStart(parentContext, chatCompletionCreateParams)) {
-      return createStreamingWithLogs(
-          parentContext, chatCompletionCreateParams, requestOptions, false);
+    if (!instrumenter.shouldStart(parentContext, request)) {
+      return createStreamingWithLogs(parentContext, request, requestOptions, false);
     }
 
-    Context context = instrumenter.start(parentContext, chatCompletionCreateParams);
+    Context context = instrumenter.start(parentContext, request);
     try (Scope ignored = context.makeCurrent()) {
-      return createStreamingWithLogs(context, chatCompletionCreateParams, requestOptions, true);
+      return createStreamingWithLogs(context, request, requestOptions, true);
     } catch (Throwable t) {
-      instrumenter.end(context, chatCompletionCreateParams, null, t);
+      instrumenter.end(context, request, null, t);
       throw t;
     }
   }
 
   private AsyncStreamResponse<ChatCompletionChunk> createStreamingWithLogs(
       Context context,
-      ChatCompletionCreateParams chatCompletionCreateParams,
+      ChatCompletionRequest request,
       RequestOptions requestOptions,
       boolean newSpan) {
+    ChatCompletionCreateParams chatCompletionCreateParams = request.getRequest();
     ChatCompletionEventsHelper.emitPromptLogEvents(
         context, eventLogger, chatCompletionCreateParams, captureMessageContent);
     AsyncStreamResponse<ChatCompletionChunk> result =
@@ -138,11 +139,6 @@ final class InstrumentedChatCompletionServiceAsync
     return new TracingAsyncStreamedResponse(
         result,
         new StreamListener(
-            context,
-            chatCompletionCreateParams,
-            instrumenter,
-            eventLogger,
-            captureMessageContent,
-            newSpan));
+            context, request, instrumenter, eventLogger, captureMessageContent, newSpan));
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatService.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatService.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.openai.v1_1;
 
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.services.blocking.ChatService;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -14,13 +13,13 @@ import java.lang.reflect.Method;
 
 final class InstrumentedChatService extends DelegatingInvocationHandler<ChatService> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedChatService(
       ChatService delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
     super(delegate);

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedChatServiceAsync.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.openai.v1_1;
 
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.services.async.ChatServiceAsync;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
@@ -14,13 +13,13 @@ import java.lang.reflect.Method;
 
 final class InstrumentedChatServiceAsync extends DelegatingInvocationHandler<ChatServiceAsync> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedChatServiceAsync(
       ChatServiceAsync delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {
     super(delegate);

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClient.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClient.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.openai.v1_1;
 
 import com.openai.client.OpenAIClient;
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import io.opentelemetry.api.logs.Logger;
@@ -16,14 +15,14 @@ import java.lang.reflect.Method;
 
 final class InstrumentedOpenAiClient extends DelegatingInvocationHandler<OpenAIClient> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter;
   private final Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingInstrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedOpenAiClient(
       OpenAIClient delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter,
       Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingInstrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClientAsync.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/InstrumentedOpenAiClientAsync.java
@@ -7,7 +7,6 @@ package io.opentelemetry.instrumentation.openai.v1_1;
 
 import com.openai.client.OpenAIClientAsync;
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import io.opentelemetry.api.logs.Logger;
@@ -16,14 +15,14 @@ import java.lang.reflect.Method;
 
 final class InstrumentedOpenAiClientAsync extends DelegatingInvocationHandler<OpenAIClientAsync> {
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter;
   private final Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingInstrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
 
   InstrumentedOpenAiClientAsync(
       OpenAIClientAsync delegate,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter,
       Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingInstrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetry.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetry.java
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.openai.v1_1;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import io.opentelemetry.api.OpenTelemetry;
@@ -18,7 +17,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 /** Entrypoint for instrumenting OpenAI clients. */
 @SuppressWarnings("IdentifierName") // Want to match library's convention
 public final class OpenAITelemetry {
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter;
   private final Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingsInstrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
@@ -36,7 +35,7 @@ public final class OpenAITelemetry {
   }
 
   OpenAITelemetry(
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter,
       Instrumenter<EmbeddingCreateParams, CreateEmbeddingResponse> embeddingsInstrumenter,
       Logger eventLogger,
       boolean captureMessageContent) {

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/OpenAITelemetryBuilder.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.inter
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.openai.models.chat.completions.ChatCompletion;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import io.opentelemetry.api.OpenTelemetry;
@@ -51,15 +50,15 @@ public final class OpenAITelemetryBuilder {
    */
   public OpenAITelemetry build() {
     ChatAttributesGetter chatAttributesGetter = new ChatAttributesGetter();
-    InstrumenterBuilder<ChatCompletionCreateParams, ChatCompletion> chatBuilder =
-        Instrumenter.<ChatCompletionCreateParams, ChatCompletion>builder(
+    InstrumenterBuilder<ChatCompletionRequest, ChatCompletion> chatBuilder =
+        Instrumenter.<ChatCompletionRequest, ChatCompletion>builder(
                 openTelemetry,
                 INSTRUMENTATION_NAME,
                 GenAiSpanNameExtractor.create(chatAttributesGetter))
             .addAttributesExtractor(GenAiAttributesExtractor.create(chatAttributesGetter))
             .addOperationMetrics(GenAiClientMetrics.get());
     setGenAiClientExceptionEventExtractor(chatBuilder);
-    Instrumenter<ChatCompletionCreateParams, ChatCompletion> chatInstrumenter =
+    Instrumenter<ChatCompletionRequest, ChatCompletion> chatInstrumenter =
         chatBuilder.buildInstrumenter(SpanKindExtractor.alwaysClient());
 
     EmbeddingAttributesGetter embeddingAttributesGetter = new EmbeddingAttributesGetter();

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/StreamListener.java
@@ -9,7 +9,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionChunk;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.completions.CompletionUsage;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.context.Context;
@@ -22,10 +21,10 @@ import javax.annotation.Nullable;
 final class StreamListener {
 
   private final Context context;
-  private final ChatCompletionCreateParams request;
+  private final ChatCompletionRequest request;
   private final Map<Long, StreamedMessageBuffer> choiceBuffers;
 
-  private final Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter;
+  private final Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter;
   private final Logger eventLogger;
   private final boolean captureMessageContent;
   private final boolean newSpan;
@@ -37,8 +36,8 @@ final class StreamListener {
 
   StreamListener(
       Context context,
-      ChatCompletionCreateParams request,
-      Instrumenter<ChatCompletionCreateParams, ChatCompletion> instrumenter,
+      ChatCompletionRequest request,
+      Instrumenter<ChatCompletionRequest, ChatCompletion> instrumenter,
       Logger eventLogger,
       boolean captureMessageContent,
       boolean newSpan) {

--- a/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionRequestTest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatCompletionRequestTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import org.junit.jupiter.api.Test;
+
+class ChatCompletionRequestTest {
+
+  private static final ChatCompletionCreateParams REQUEST =
+      ChatCompletionCreateParams.builder().messages(emptyList()).model("test-model").build();
+
+  @Test
+  void createsStreamingRequest() {
+    ChatCompletionRequest request = ChatCompletionRequest.createStreaming(REQUEST);
+
+    assertThat(request.getRequest()).isSameAs(REQUEST);
+    assertThat(request.isStreaming()).isTrue();
+  }
+
+  @Test
+  void createsNonStreamingRequest() {
+    ChatCompletionRequest request = ChatCompletionRequest.create(REQUEST);
+
+    assertThat(request.getRequest()).isSameAs(REQUEST);
+    assertThat(request.isStreaming()).isFalse();
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVEN
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_MODEL;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STREAM;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_ID;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_MODEL;
@@ -622,6 +623,7 @@ class ChatTest extends AbstractChatTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -718,6 +720,7 @@ class ChatTest extends AbstractChatTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -820,6 +823,7 @@ class ChatTest extends AbstractChatTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -922,6 +926,7 @@ class ChatTest extends AbstractChatTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -17,6 +17,7 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_PRESENCE_PENALTY;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_SEED;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STOP_SEQUENCES;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_STREAM;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_TEMPERATURE;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_REQUEST_TOP_P;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_FINISH_REASONS;
@@ -986,6 +987,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1061,6 +1063,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                 equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                 equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                equalTo(GEN_AI_REQUEST_STREAM, true),
                                 equalTo(GEN_AI_REQUEST_SEED, 19746),
                                 satisfies(GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                 equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1107,6 +1110,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1230,6 +1234,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1384,6 +1389,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1516,6 +1522,7 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
                                     equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true),
                                     satisfies(
                                         GEN_AI_RESPONSE_ID, val -> val.startsWith("chatcmpl-")),
                                     equalTo(GEN_AI_RESPONSE_MODEL, TEST_CHAT_RESPONSE_MODEL),
@@ -1669,7 +1676,8 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                 .hasAttributesSatisfyingExactly(
                                     equalTo(GEN_AI_PROVIDER_NAME, OPENAI),
                                     equalTo(GEN_AI_OPERATION_NAME, CHAT),
-                                    equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL)))));
+                                    equalTo(GEN_AI_REQUEST_MODEL, TEST_CHAT_MODEL),
+                                    equalTo(GEN_AI_REQUEST_STREAM, true)))));
 
     getTesting()
         .waitAndAssertMetrics(


### PR DESCRIPTION
## Why

Java GenAI spans currently omit `gen_ai.request.stream` for OpenAI and AWS Bedrock streaming calls. The semantic convention requires `true` for streaming requests and treats an absent attribute as non-streaming.

Specification: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-spans.md#inference

## What

- Add streaming state to the shared GenAI getter/extractor and emit `gen_ai.request.stream=true` at span start.
- Carry OpenAI's method-level streaming state in an internal request wrapper using `create(...)` and `createStreaming(...)` factories.
- Detect AWS Bedrock `ConverseStreamRequest` and `InvokeModelWithResponseStreamRequest` calls and cover them in the existing Bedrock tests.

## Why the approach

OpenAI selects streaming through the invoked service method, while AWS Bedrock exposes it through the SDK request type. Both signals are available before span creation, so the attribute is available to samplers and on setup failures. The extractor emits only `true`; non-streaming calls omit the attribute.

`isRequestStreaming(REQUEST)` is required so each instrumentation reports its actual behavior instead of silently inheriting `false`. This is an intentional change to the incubating getter API and is documented in the non-stable API changelog.

## Validation

- **Unit:** `./gradlew :instrumentation-api-incubator:check` passed, including direct `onStart(...)` coverage for streaming `true` and non-streaming omission; `ChatCompletionRequestTest` passed through the OpenAI library check.
- **Integration:** `./gradlew :instrumentation:openai:openai-java-1.1:library:check` and `./gradlew :instrumentation:aws-sdk:aws-sdk-2.2:library:testBedrockRuntime` passed; the affected AWS checkstyle tasks also passed.
- **End to end:** `./gradlew :instrumentation:openai:openai-java-1.1:javaagent:check` and `./gradlew :instrumentation:aws-sdk:aws-sdk-2.2:javaagent:testBedrockRuntime` passed against the instrumented SDK paths.

<!--
CHANGELOG.md is generated from merged pull requests. Do not add an entry unless this PR introduces
a deprecation or breaking change.
-->
