### PR TITLE
Switch smoke tests to http

### DIFF
--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -33,8 +33,6 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
             // java.util.zip.ZipException: Invalid CEN header (invalid zip64 extra data field size)
             + " -Djdk.util.zip.disableZip64ExtraFieldValidation=true");
 
-    environment.put("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
-
     environment.put("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1");
     environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");
     environment.put("OTEL_METRIC_EXPORT_INTERVAL", "1000");

--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/AbstractTestContainerManager.java
@@ -33,9 +33,7 @@ public abstract class AbstractTestContainerManager implements TestContainerManag
             // java.util.zip.ZipException: Invalid CEN header (invalid zip64 extra data field size)
             + " -Djdk.util.zip.disableZip64ExtraFieldValidation=true");
 
-    // TODO (heya) update smoke tests to run using http/protobuf
-    // in the meantime, force smoke tests to use grpc protocol for all exporters
-    environment.put("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+    environment.put("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
 
     environment.put("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "1");
     environment.put("OTEL_BSP_SCHEDULE_DELAY", "10ms");

--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/ImageVersions.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/ImageVersions.java
@@ -9,10 +9,10 @@ package io.opentelemetry.smoketest;
 public class ImageVersions {
 
   // smoke-test-fake-backend
-  public static final String FAKE_BACKEND_VERSION = "20251117.19421579342";
+  public static final String FAKE_BACKEND_VERSION = "20260825.32803070924";
 
   // smoke-test-fake-backend-windows
-  public static final String FAKE_BACKEND_WINDOWS_VERSION = "20251117.19421579342";
+  public static final String FAKE_BACKEND_WINDOWS_VERSION = "20260825.32803070924";
 
   private ImageVersions() {}
 }

--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/ImageVersions.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/ImageVersions.java
@@ -12,7 +12,7 @@ public class ImageVersions {
   public static final String FAKE_BACKEND_VERSION = "20260825.32803070924";
 
   // smoke-test-fake-backend-windows
-  public static final String FAKE_BACKEND_WINDOWS_VERSION = "20260825.32803070924";
+  public static final String FAKE_BACKEND_WINDOWS_VERSION = FAKE_BACKEND_VERSION;
 
   private ImageVersions() {}
 }

--- a/smoke-tests/src/test/resources/declarative-config.yaml
+++ b/smoke-tests/src/test/resources/declarative-config.yaml
@@ -6,8 +6,8 @@ tracer_provider:
         schedule_delay: 10
         max_export_batch_size: 1
         exporter:
-          otlp_grpc:
-            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          otlp_http:
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces
 
 # add extra resource attributes to verify that declarative config is picked up
 resource:

--- a/smoke-tests/src/test/resources/ibmhttpsurlconnection/test.sh
+++ b/smoke-tests/src/test/resources/ibmhttpsurlconnection/test.sh
@@ -4,7 +4,7 @@ echo "compiling"
 javac IbmHttpsUrlConnectionTest.java
 echo "finish compiling"
 echo "executing"
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://backend:8080
 export OTEL_JAVAAGENT_DEBUG=true
 java -javaagent:opentelemetry-javaagent.jar IbmHttpsUrlConnectionTest


### PR DESCRIPTION
After #19733 was merged, a new package was published and we can now leverage http (instead of gRPC) in the smoke tests. 