### PR TITLE
Use shared util for parsing http version

### DIFF
--- a/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
+++ b/instrumentation/jodd-http-4.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/joddhttp/v4_2/JoddHttpHttpAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.joddhttp.v4_2;
 
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
+import io.opentelemetry.instrumentation.api.internal.HttpProtocolUtil;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesGetter;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -54,12 +55,7 @@ final class JoddHttpHttpAttributesGetter
     if (httpVersion == null && response != null) {
       httpVersion = response.httpVersion();
     }
-    if (httpVersion != null) {
-      if (httpVersion.contains("/")) {
-        httpVersion = httpVersion.substring(httpVersion.lastIndexOf("/") + 1);
-      }
-    }
-    return httpVersion;
+    return HttpProtocolUtil.getVersion(httpVersion);
   }
 
   @Override


### PR DESCRIPTION
Although the util isn't quite equivalent to the existing code as far as I understand the http version can't really be anything else besides `HTTP/1.0` or `HTTP/1.1`. I think it can be set to a different value but that probably won't result in a successful request.