### PR TITLE
Report configured Elasticsearch REST addresses as server.address

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/api/client/v7_16/ElasticsearchClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-api-client-7.16/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/api/client/v7_16/ElasticsearchClientTest.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.api.client.v7_16;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
@@ -111,7 +113,10 @@ class ElasticsearchClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("info")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "info " + httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "info")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -148,7 +153,10 @@ class ElasticsearchClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("index")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "index " + httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "index")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -162,10 +170,10 @@ class ElasticsearchClientTest {
                                 httpHost.toURI() + "/test-index/_doc/test-id?timeout=10s"),
                             equalTo(
                                 DB_ELASTICSEARCH_PATH_PARTS.getAttributeKey("index"),
-                                emitStableDatabaseSemconv() ? null : "test-index"),
+                                emitOldDatabaseSemconv() ? "test-index" : null),
                             equalTo(
                                 DB_ELASTICSEARCH_PATH_PARTS.getAttributeKey("id"),
-                                emitStableDatabaseSemconv() ? null : "test-id"),
+                                emitOldDatabaseSemconv() ? "test-id" : null),
                             equalTo(
                                 DB_OPERATION_PARAMETER.getAttributeKey("index"),
                                 emitStableDatabaseSemconv() ? "test-index" : null),
@@ -206,7 +214,10 @@ class ElasticsearchClientTest {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("search")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "search " + httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "search")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(searchAttributes()),
@@ -269,7 +280,10 @@ class ElasticsearchClientTest {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("info")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "info " + httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "info")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -295,6 +309,53 @@ class ElasticsearchClientTest {
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void configuredNodeListIsTheWholeTarget() throws IOException {
+    HttpHost alternateHost = alternateHost();
+    RestClient nodeListRestClient = RestClient.builder(httpHost, alternateHost).build();
+    cleanup.deferCleanup(nodeListRestClient);
+    ElasticsearchClient nodeListClient =
+        new ElasticsearchClient(
+            new RestClientTransport(nodeListRestClient, new JacksonJsonpMapper()));
+
+    nodeListClient.info();
+
+    assertConfiguredTarget(hostList(alternateHost));
+  }
+
+  private static HttpHost alternateHost() {
+    return new HttpHost("127.0.0.1", httpHost.getPort(), httpHost.getSchemeName());
+  }
+
+  private static String hostList(HttpHost alternateHost) {
+    return alternateHost.getHostName()
+        + ":"
+        + alternateHost.getPort()
+        + ","
+        + httpHost.getHostName()
+        + ":"
+        + httpHost.getPort();
+  }
+
+  private static void assertConfiguredTarget(String hostList) {
+    testing.waitAndAssertTraces(
+        trace ->
+            assertThat(trace.getSpan(0))
+                .hasName(emitStableDatabaseSemconv() ? "info " + hostList : "info")
+                .hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                    equalTo(maybeStable(DB_OPERATION), "info"),
+                    equalTo(HTTP_REQUEST_METHOD, "GET"),
+                    equalTo(URL_FULL, httpHost.toURI() + "/"),
+                    equalTo(
+                        SERVER_ADDRESS,
+                        emitStableDatabaseSemconv() ? hostList : httpHost.getHostName()),
+                    equalTo(
+                        SERVER_PORT,
+                        emitStableDatabaseSemconv() ? null : Long.valueOf(httpHost.getPort()))));
   }
 
   private static class AsyncRequest {

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5InstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5InstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
@@ -29,6 +29,6 @@ public class ElasticsearchRest5InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new RestClientInstrumentation());
+    return asList(new RestClientConstructorInstrumentation(), new RestClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientConstructorInstrumentation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
+
+import static java.util.Arrays.asList;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+
+// capture the initial hosts before RestClient.setHosts can replace them
+class RestClientConstructorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.RestClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(3, named("org.apache.http.HttpHost[]"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This RestClient restClient, @Advice.Argument(3) HttpHost[] configuredHosts) {
+      ElasticsearchServerTargets.capture(restClient, asList(configuredHosts));
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientConstructorInstrumentation.java
@@ -19,7 +19,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 
-// capture the initial hosts before RestClient.setHosts can replace them
+// Preserve the hosts configured at construction for telemetry. setHosts() can later replace
+// the client's active host list.
 class RestClientConstructorInstrumentation implements TypeInstrumentation {
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/RestClientInstrumentation.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchRestRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.RestResponseListener;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -25,6 +26,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpEntity;
 import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.client.RestClient;
 
 class RestClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -86,6 +88,7 @@ class RestClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 5, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This RestClient restClient,
         @Advice.Argument(0) String method,
         @Advice.Argument(1) String endpoint,
         @Advice.Argument(3) @Nullable HttpEntity httpEntity,
@@ -93,7 +96,8 @@ class RestClientInstrumentation implements TypeInstrumentation {
       ResponseListener responseListener = originalResponseListener;
 
       ElasticsearchRestRequest request =
-          ElasticsearchRestRequest.create(method, endpoint, null, httpEntity);
+          ElasticsearchRestRequest.create(
+              method, endpoint, null, httpEntity, ElasticsearchServerTargets.get(restClient));
       AdviceScope adviceScope = AdviceScope.start(request);
       if (adviceScope == null) {
         return new Object[] {null, responseListener};

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -273,8 +273,8 @@ class ElasticsearchRest5Test {
   void theTargetDoesNotFollowLaterHostChanges() throws IOException {
     RestClient hostListClient = hostListClient();
     cleanup.deferCleanup(hostListClient);
-    // a client is given new hosts when it is sniffed; the configured target must not shrink to the
-    // single host this one is left with
+    // Simulate automatic node discovery replacing the active host list. The configured target must
+    // continue to reflect the hosts supplied when the client was built.
     hostListClient.setHosts(httpHost);
 
     hostListClient.performRequest("GET", "_cluster/health");

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v5_0/ElasticsearchRest5Test.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.v3Preview;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
@@ -104,7 +106,10 @@ class ElasticsearchRest5Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -150,7 +155,10 @@ class ElasticsearchRest5Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("POST")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "POST")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -221,7 +229,10 @@ class ElasticsearchRest5Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -246,5 +257,62 @@ class ElasticsearchRest5Test {
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void configuredHostListIsTheWholeTarget() throws IOException {
+    RestClient hostListClient = hostListClient();
+    cleanup.deferCleanup(hostListClient);
+
+    hostListClient.performRequest("GET", "_cluster/health");
+
+    assertConfiguredTarget(hostList());
+  }
+
+  @Test
+  void theTargetDoesNotFollowLaterHostChanges() throws IOException {
+    RestClient hostListClient = hostListClient();
+    cleanup.deferCleanup(hostListClient);
+    // a client is given new hosts when it is sniffed; the configured target must not shrink to the
+    // single host this one is left with
+    hostListClient.setHosts(httpHost);
+
+    hostListClient.performRequest("GET", "_cluster/health");
+
+    assertConfiguredTarget(hostList());
+  }
+
+  private static RestClient hostListClient() {
+    return RestClient.builder(httpHost, httpHost)
+        .setMaxRetryTimeoutMillis(Integer.MAX_VALUE)
+        .build();
+  }
+
+  private static String hostList() {
+    return httpHost.getHostName()
+        + ":"
+        + httpHost.getPort()
+        + ","
+        + httpHost.getHostName()
+        + ":"
+        + httpHost.getPort();
+  }
+
+  private static void assertConfiguredTarget(String hostList) {
+    testing.waitAndAssertTraces(
+        trace ->
+            assertThat(trace.getSpan(0))
+                .hasName(emitStableDatabaseSemconv() ? hostList : "GET")
+                .hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                    equalTo(HTTP_REQUEST_METHOD, "GET"),
+                    equalTo(
+                        SERVER_ADDRESS,
+                        emitStableDatabaseSemconv() ? hostList : httpHost.getHostName()),
+                    equalTo(
+                        SERVER_PORT,
+                        emitStableDatabaseSemconv() ? null : Long.valueOf(httpHost.getPort())),
+                    equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")));
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6InstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6InstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
@@ -31,6 +31,6 @@ public class ElasticsearchRest6InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new RestClientInstrumentation());
+    return asList(new RestClientConstructorInstrumentation(), new RestClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientConstructorInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
+import java.util.ArrayList;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestClient;
+
+// capture the initial nodes before sniffing or RestClient.setNodes can replace them
+class RestClientConstructorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.RestClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(3, named("java.util.List"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This RestClient restClient, @Advice.Argument(3) List<Node> configuredNodes) {
+      List<HttpHost> configuredHosts = new ArrayList<>(configuredNodes.size());
+      for (Node node : configuredNodes) {
+        configuredHosts.add(node.getHost());
+      }
+      ElasticsearchServerTargets.capture(restClient, configuredHosts);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientConstructorInstrumentation.java
@@ -21,7 +21,8 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.RestClient;
 
-// capture the initial nodes before sniffing or RestClient.setNodes can replace them
+// Preserve the nodes configured at construction for telemetry. Automatic node discovery or
+// setNodes() can later replace the client's active node list.
 class RestClientConstructorInstrumentation implements TypeInstrumentation {
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/RestClientInstrumentation.java
@@ -15,6 +15,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchRestRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.RestResponseListener;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -24,6 +25,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.client.RestClient;
 
 class RestClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -84,13 +86,18 @@ class RestClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 1, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This RestClient restClient,
         @Advice.Argument(0) Request request,
         @Advice.Argument(1) ResponseListener originalResponseListener) {
       ResponseListener responseListener = originalResponseListener;
 
       ElasticsearchRestRequest otelRequest =
           ElasticsearchRestRequest.create(
-              request.getMethod(), request.getEndpoint(), null, request.getEntity());
+              request.getMethod(),
+              request.getEndpoint(),
+              null,
+              request.getEntity(),
+              ElasticsearchServerTargets.get(restClient));
       AdviceScope adviceScope = AdviceScope.start(otelRequest);
       if (adviceScope == null) {
         return new Object[] {null, responseListener};

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v6_4;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.v3Preview;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
@@ -20,6 +22,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STAT
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +39,8 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
@@ -98,7 +103,10 @@ class ElasticsearchRest6Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -144,7 +152,10 @@ class ElasticsearchRest6Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("POST")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "POST")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -215,7 +226,10 @@ class ElasticsearchRest6Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -240,5 +254,64 @@ class ElasticsearchRest6Test {
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
+  }
+
+  @Test
+  void configuredNodeListIsTheWholeTarget() throws IOException {
+    HttpHost deadHost = deadHost();
+    RestClient nodeListClient =
+        RestClient.builder(httpHost, deadHost).setMaxRetryTimeoutMillis(Integer.MAX_VALUE).build();
+    cleanup.deferCleanup(nodeListClient);
+
+    nodeListClient.performRequest(new Request("GET", "_cluster/health"));
+
+    assertConfiguredTarget(hostList(deadHost));
+  }
+
+  @Test
+  void theTargetDoesNotFollowLaterNodeChanges() throws IOException {
+    RestClient singleNodeClient = RestClient.builder(httpHost).build();
+    cleanup.deferCleanup(singleNodeClient);
+    // a client is given new nodes when it is sniffed; the configured target must not follow them
+    singleNodeClient.setNodes(asList(new Node(httpHost), new Node(deadHost())));
+
+    singleNodeClient.performRequest(new Request("GET", "_cluster/health"));
+
+    assertConfiguredTarget(null);
+  }
+
+  private static HttpHost deadHost() {
+    // nothing listens on this port, so a request is served by the running server after a retry
+    return new HttpHost(httpHost.getHostName(), httpHost.getPort() + 1, httpHost.getSchemeName());
+  }
+
+  private static String hostList(HttpHost deadHost) {
+    return httpHost.getHostName()
+        + ":"
+        + httpHost.getPort()
+        + ","
+        + deadHost.getHostName()
+        + ":"
+        + deadHost.getPort();
+  }
+
+  private static void assertConfiguredTarget(String hostList) {
+    boolean stableHostList = emitStableDatabaseSemconv() && hostList != null;
+    testing.waitAndAssertTraces(
+        trace ->
+            assertThat(trace.getSpan(0))
+                .hasName(
+                    emitStableDatabaseSemconv()
+                        ? (hostList != null
+                            ? hostList
+                            : httpHost.getHostName() + ":" + httpHost.getPort())
+                        : "GET")
+                .hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                    equalTo(HTTP_REQUEST_METHOD, "GET"),
+                    equalTo(SERVER_ADDRESS, stableHostList ? hostList : httpHost.getHostName()),
+                    equalTo(SERVER_PORT, stableHostList ? null : Long.valueOf(httpHost.getPort())),
+                    equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")));
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v6_4/ElasticsearchRest6Test.java
@@ -272,7 +272,8 @@ class ElasticsearchRest6Test {
   void theTargetDoesNotFollowLaterNodeChanges() throws IOException {
     RestClient singleNodeClient = RestClient.builder(httpHost).build();
     cleanup.deferCleanup(singleNodeClient);
-    // a client is given new nodes when it is sniffed; the configured target must not follow them
+    // Simulate automatic node discovery replacing the active node list. The configured target must
+    // continue to reflect the nodes supplied when the client was built.
     singleNodeClient.setNodes(asList(new Node(httpHost), new Node(deadHost())));
 
     singleNodeClient.performRequest(new Request("GET", "_cluster/health"));

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7InstrumentationModule.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
@@ -32,6 +32,6 @@ public class ElasticsearchRest7InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new RestClientInstrumentation());
+    return asList(new RestClientConstructorInstrumentation(), new RestClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientConstructorInstrumentation.java
@@ -21,7 +21,8 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.RestClient;
 
-// capture the initial nodes before sniffing or RestClient.setNodes can replace them
+// Preserve the nodes configured at construction for telemetry. Automatic node discovery or
+// setNodes() can later replace the client's active node list.
 class RestClientConstructorInstrumentation implements TypeInstrumentation {
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientConstructorInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientConstructorInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
+import java.util.ArrayList;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.RestClient;
+
+// capture the initial nodes before sniffing or RestClient.setNodes can replace them
+class RestClientConstructorInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.RestClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(2, named("java.util.List"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This RestClient restClient, @Advice.Argument(2) List<Node> configuredNodes) {
+      List<HttpHost> configuredHosts = new ArrayList<>(configuredNodes.size());
+      for (Node node : configuredNodes) {
+        configuredHosts.add(node.getHost());
+      }
+      ElasticsearchServerTargets.capture(restClient, configuredHosts);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/RestClientInstrumentation.java
@@ -16,6 +16,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchRestRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.ElasticsearchServerTargets;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0.RestResponseListener;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
@@ -26,6 +27,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.client.RestClient;
 
 class RestClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -96,14 +98,16 @@ class RestClientInstrumentation implements TypeInstrumentation {
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static AdviceScope onEnter(@Advice.Argument(0) Request request) {
+    public static AdviceScope onEnter(
+        @Advice.This RestClient restClient, @Advice.Argument(0) Request request) {
       ElasticsearchRestRequest otelRequest =
           ElasticsearchRestRequest.create(
               request.getMethod(),
               request.getEndpoint(),
               // set by elasticsearch-api-client instrumentation
               ENDPOINT_DEFINITION.get(request),
-              request.getEntity());
+              request.getEntity(),
+              ElasticsearchServerTargets.get(restClient));
       return AdviceScope.start(otelRequest);
     }
 
@@ -124,6 +128,7 @@ class RestClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 1, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This RestClient restClient,
         @Advice.Argument(0) Request request,
         @Advice.Argument(1) ResponseListener originalResponseListener) {
       ResponseListener responseListener = originalResponseListener;
@@ -133,7 +138,8 @@ class RestClientInstrumentation implements TypeInstrumentation {
               request.getEndpoint(),
               // set by elasticsearch-api-client instrumentation
               ENDPOINT_DEFINITION.get(request),
-              request.getEntity());
+              request.getEntity(),
+              ElasticsearchServerTargets.get(restClient));
       AdviceScope adviceScope = AdviceScope.start(otelRequest);
       if (adviceScope == null) {
         return new Object[] {null, responseListener};

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -239,7 +239,8 @@ class ElasticsearchRest7Test {
   void theTargetDoesNotFollowLaterNodeChanges() throws IOException {
     RestClient singleNodeClient = RestClient.builder(httpHost).build();
     cleanup.deferCleanup(singleNodeClient);
-    // a client is given new nodes when it is sniffed; the configured target must not follow them
+    // Simulate automatic node discovery replacing the active node list. The configured target must
+    // continue to reflect the nodes supplied when the client was built.
     singleNodeClient.setNodes(asList(new Node(httpHost), new Node(deadHost())));
 
     singleNodeClient.performRequest(new Request("GET", "_cluster/health"));

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/v7_0/ElasticsearchRest7Test.java
@@ -5,10 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.GlobalTraceUtil.runWithSpan;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
@@ -19,6 +21,7 @@ import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +34,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.apache.http.HttpHost;
+import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseListener;
@@ -90,7 +94,10 @@ class ElasticsearchRest7Test {
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -166,7 +173,10 @@ class ElasticsearchRest7Test {
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName("GET")
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? httpHost.getHostName() + ":" + httpHost.getPort()
+                                : "GET")
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
@@ -212,5 +222,63 @@ class ElasticsearchRest7Test {
     void setException(Exception exception) {
       this.exception = exception;
     }
+  }
+
+  @Test
+  void configuredNodeListIsTheWholeTarget() throws IOException {
+    HttpHost deadHost = deadHost();
+    RestClient nodeListClient = RestClient.builder(deadHost, httpHost).build();
+    cleanup.deferCleanup(nodeListClient);
+
+    nodeListClient.performRequest(new Request("GET", "_cluster/health"));
+
+    assertConfiguredTarget(hostList(deadHost));
+  }
+
+  @Test
+  void theTargetDoesNotFollowLaterNodeChanges() throws IOException {
+    RestClient singleNodeClient = RestClient.builder(httpHost).build();
+    cleanup.deferCleanup(singleNodeClient);
+    // a client is given new nodes when it is sniffed; the configured target must not follow them
+    singleNodeClient.setNodes(asList(new Node(httpHost), new Node(deadHost())));
+
+    singleNodeClient.performRequest(new Request("GET", "_cluster/health"));
+
+    assertConfiguredTarget(null);
+  }
+
+  private static HttpHost deadHost() {
+    // nothing listens on this port, so a request is served by the running server after a retry
+    return new HttpHost(httpHost.getHostName(), httpHost.getPort() + 1, httpHost.getSchemeName());
+  }
+
+  private static String hostList(HttpHost deadHost) {
+    return httpHost.getHostName()
+        + ":"
+        + httpHost.getPort()
+        + ","
+        + deadHost.getHostName()
+        + ":"
+        + deadHost.getPort();
+  }
+
+  private static void assertConfiguredTarget(String hostList) {
+    boolean stableHostList = emitStableDatabaseSemconv() && hostList != null;
+    testing.waitAndAssertTraces(
+        trace ->
+            assertThat(trace.getSpan(0))
+                .hasName(
+                    emitStableDatabaseSemconv()
+                        ? (hostList != null
+                            ? hostList
+                            : httpHost.getHostName() + ":" + httpHost.getPort())
+                        : "GET")
+                .hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                    equalTo(HTTP_REQUEST_METHOD, "GET"),
+                    equalTo(SERVER_ADDRESS, stableHostList ? hostList : httpHost.getHostName()),
+                    equalTo(SERVER_PORT, stableHostList ? null : Long.valueOf(httpHost.getPort())),
+                    equalTo(URL_FULL, httpHost.toURI() + "/_cluster/health")));
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTargetTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTargetTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import java.util.stream.Stream;
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ElasticsearchServerTargetTest {
+
+  @Test
+  void noHostsHasNoTarget() {
+    assertThat(ElasticsearchServerTarget.of(null)).isNull();
+    assertThat(ElasticsearchServerTarget.of(emptyList())).isNull();
+  }
+
+  @Test
+  void singleHostKeepsItsHostAndPort() {
+    DbServerTarget target =
+        ElasticsearchServerTarget.of(singletonList(new HttpHost("es.example", 9200, "https")));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("es.example");
+    assertThat(target.getPort()).isEqualTo(9200);
+  }
+
+  @ParameterizedTest
+  @MethodSource("defaultPortCases")
+  void singleHostOmitsItsDefaultPort(String scheme, int port) {
+    DbServerTarget target =
+        ElasticsearchServerTarget.of(singletonList(new HttpHost("es.example", port, scheme)));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("es.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void singleHostWithoutPortHasNoPort() {
+    DbServerTarget target = ElasticsearchServerTarget.of(singletonList(new HttpHost("es.example")));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("es.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void mixedHttpAndHttpsDefaultPortsAreOmitted() {
+    DbServerTarget target =
+        ElasticsearchServerTarget.of(
+            asList(
+                new HttpHost("secure.example", 443, "https"),
+                new HttpHost("plain.example", 80, "http")));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("plain.example,secure.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void configuredNodeOrderDoesNotChangeTarget() {
+    DbServerTarget first =
+        ElasticsearchServerTarget.of(
+            asList(new HttpHost("h3", 9202), new HttpHost("h1", 9200), new HttpHost("h2", 9201)));
+    DbServerTarget second =
+        ElasticsearchServerTarget.of(
+            asList(new HttpHost("h2", 9201), new HttpHost("h3", 9202), new HttpHost("h1", 9200)));
+
+    assertThat(first).isNotNull();
+    assertThat(second).isNotNull();
+    assertThat(first.getAddress()).isEqualTo("h1:9200,h2:9201,h3:9202");
+    assertThat(second.getAddress()).isEqualTo(first.getAddress());
+  }
+
+  private static Stream<Arguments> defaultPortCases() {
+    return Stream.of(
+        argumentSet("HTTP", "http", 80),
+        argumentSet("case-insensitive HTTP", "HTTP", 80),
+        argumentSet("HTTPS", "https", 443),
+        argumentSet("case-insensitive HTTPS", "HTTPS", 443));
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchClientAttributeExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchClientAttributeExtractor.java
@@ -50,6 +50,9 @@ final class ElasticsearchClientAttributeExtractor
   }
 
   private static void setServerAttributes(AttributesBuilder attributes, Response response) {
+    if (emitStableDatabaseSemconv()) {
+      return;
+    }
     HttpHost host = response.getHost();
     if (host != null) {
       attributes.put(SERVER_ADDRESS, host.getHostName());

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchDbAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchDbAttributesGetter.java
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
 import static java.util.stream.Collectors.joining;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -150,5 +152,25 @@ final class ElasticsearchDbAttributesGetter
       }
     }
     return null;
+  }
+
+  @Override
+  @Nullable
+  public String getServerAddress(ElasticsearchRestRequest request) {
+    if (!emitStableDatabaseSemconv()) {
+      return null;
+    }
+    DbServerTarget target = request.getServerTarget();
+    return target != null ? target.getAddress() : null;
+  }
+
+  @Override
+  @Nullable
+  public Integer getServerPort(ElasticsearchRestRequest request) {
+    if (!emitStableDatabaseSemconv()) {
+      return null;
+    }
+    DbServerTarget target = request.getServerTarget();
+    return target != null ? target.getPort() : null;
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchRestRequest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchRestRequest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import javax.annotation.Nullable;
 import org.apache.http.HttpEntity;
 
@@ -25,7 +26,17 @@ public abstract class ElasticsearchRestRequest {
       String endpoint,
       @Nullable ElasticsearchEndpointDefinition endpointDefinition,
       @Nullable HttpEntity httpEntity) {
-    return new AutoValue_ElasticsearchRestRequest(method, endpoint, endpointDefinition, httpEntity);
+    return create(method, endpoint, endpointDefinition, httpEntity, null);
+  }
+
+  public static ElasticsearchRestRequest create(
+      String method,
+      String endpoint,
+      @Nullable ElasticsearchEndpointDefinition endpointDefinition,
+      @Nullable HttpEntity httpEntity,
+      @Nullable DbServerTarget serverTarget) {
+    return new AutoValue_ElasticsearchRestRequest(
+        method, endpoint, endpointDefinition, httpEntity, serverTarget);
   }
 
   public abstract String getMethod();
@@ -37,4 +48,7 @@ public abstract class ElasticsearchRestRequest {
 
   @Nullable
   public abstract HttpEntity getHttpEntity();
+
+  @Nullable
+  public abstract DbServerTarget getServerTarget();
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTarget.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTarget.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.http.HttpHost;
+
+public final class ElasticsearchServerTarget {
+
+  @Nullable
+  public static DbServerTarget of(@Nullable List<HttpHost> hosts) {
+    if (hosts == null || hosts.isEmpty()) {
+      return null;
+    }
+
+    DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(true);
+    for (HttpHost httpHost : hosts) {
+      builder.addEndpoint(httpHost.getHostName(), httpHost.getPort(), defaultPort(httpHost));
+    }
+    return builder.build();
+  }
+
+  private static int defaultPort(HttpHost httpHost) {
+    if (httpHost.getSchemeName().equalsIgnoreCase("http")) {
+      return 80;
+    }
+    if (httpHost.getSchemeName().equalsIgnoreCase("https")) {
+      return 443;
+    }
+    return -1;
+  }
+
+  private ElasticsearchServerTarget() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTargets.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchServerTargets.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+
+// keep the initial target separate from the mutable routing hosts
+public class ElasticsearchServerTargets {
+
+  private static final VirtualField<RestClient, DbServerTarget> SERVER_TARGET =
+      VirtualField.find(RestClient.class, DbServerTarget.class);
+
+  public static void capture(RestClient restClient, @Nullable List<HttpHost> configuredHosts) {
+    DbServerTarget target = ElasticsearchServerTarget.of(configuredHosts);
+    if (target != null) {
+      SERVER_TARGET.set(restClient, target);
+    }
+  }
+
+  @Nullable
+  public static DbServerTarget get(RestClient restClient) {
+    return SERVER_TARGET.get(restClient);
+  }
+
+  private ElasticsearchServerTargets() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchSpanNameExtractor.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/ElasticsearchSpanNameExtractor.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientSpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 
 /**
@@ -14,13 +17,18 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 final class ElasticsearchSpanNameExtractor implements SpanNameExtractor<ElasticsearchRestRequest> {
 
   private final ElasticsearchDbAttributesGetter dbAttributesGetter;
+  private final SpanNameExtractor<ElasticsearchRestRequest> stableDelegate;
 
   ElasticsearchSpanNameExtractor(ElasticsearchDbAttributesGetter dbAttributesGetter) {
     this.dbAttributesGetter = dbAttributesGetter;
+    stableDelegate = DbClientSpanNameExtractor.create(dbAttributesGetter);
   }
 
   @Override
   public String extract(ElasticsearchRestRequest elasticsearchRestRequest) {
+    if (emitStableDatabaseSemconv()) {
+      return stableDelegate.extract(elasticsearchRestRequest);
+    }
     String name = dbAttributesGetter.getDbOperationName(elasticsearchRestRequest);
     return name != null ? name : elasticsearchRestRequest.getMethod();
   }


### PR DESCRIPTION
Capture configured Elasticsearch REST nodes at client construction and use that immutable target for stable database server attributes and span names, so sniffing and setNodes changes do not alter telemetry identity.

This PR is part of #19899 and applies the configured database target rules proposed in [open-telemetry/semantic-conventions#4058](https://github.com/open-telemetry/semantic-conventions/pull/4058) to the Elasticsearch REST client.

### Configured target

A single configured host reports `server.address=es.example`, plus `server.port=9200` when the port is not the scheme default. Host lists preserve duplicates, use deterministic lexical ordering, and report at most the first five endpoints. When every endpoint uses its scheme default, ports and `server.port` are omitted. If any endpoint in a multi-host target uses a non-default port, every endpoint keeps its effective port in `server.address`, including default-port members, and `server.port` is omitted.