### PR TITLE
Report configured Elasticsearch transport addresses as server.address

### DIFF
--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/AbstractClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/AbstractClientInstrumentation.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.support.AbstractClient;
 
 class AbstractClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -62,7 +63,9 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
       }
 
       @Nullable
-      public static AdviceScope start(ElasticTransportRequest request) {
+      public static AdviceScope start(AbstractClient client, Object action, Object actionRequest) {
+        ElasticTransportRequest request =
+            Elasticsearch5TransportRequests.request(client, action, actionRequest);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
@@ -88,13 +91,13 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 2, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This AbstractClient client,
         @Advice.Argument(0) Action<?, ?, ?> action,
         @Advice.Argument(1) ActionRequest<?> actionRequest,
         @Advice.Argument(2) ActionListener<ActionResponse> originalActionListener) {
       ActionListener<ActionResponse> actionListener = originalActionListener;
 
-      ElasticTransportRequest request = ElasticTransportRequest.create(action, actionRequest);
-      AdviceScope adviceScope = AdviceScope.start(request);
+      AdviceScope adviceScope = AdviceScope.start(client, action, actionRequest);
       if (adviceScope == null) {
         return new Object[] {null, actionListener};
       }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentationModule.java
@@ -5,11 +5,12 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.FilterClientInstrumentation;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
@@ -20,6 +21,9 @@ public class Elasticsearch5TransportClientInstrumentationModule extends Instrume
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new AbstractClientInstrumentation());
+    return asList(
+        new AbstractClientInstrumentation(),
+        new FilterClientInstrumentation(),
+        new TransportClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportRequests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
+
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticTransportRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+
+public class Elasticsearch5TransportRequests {
+
+  static ElasticTransportRequest request(
+      AbstractClient client, Object action, Object actionRequest) {
+    return ElasticTransportRequest.create(
+        action, actionRequest, ElasticsearchTransportServerTargets.get(client));
+  }
+
+  public static void updateServerTarget(TransportClient client) {
+    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
+    if (updateLock == null) {
+      return;
+    }
+    synchronized (updateLock) {
+      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+      for (TransportAddress address : client.transportAddresses()) {
+        endpoints.add(
+            new ElasticsearchTransportServerTarget.Endpoint(host(address), address.getPort()));
+      }
+      ElasticsearchTransportServerTargets.update(client, endpoints);
+    }
+  }
+
+  private static String host(TransportAddress address) {
+    // TransportAddress.getHost() formats the resolved IP address before Elasticsearch 5.1, so read
+    // the configured host string from the wrapped socket address instead
+    return address instanceof InetSocketTransportAddress
+        ? ((InetSocketTransportAddress) address).address().getHostString()
+        : address.getHost();
+  }
+
+  private Elasticsearch5TransportRequests() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportRequests.java
@@ -24,18 +24,17 @@ public class Elasticsearch5TransportRequests {
   }
 
   public static void updateServerTarget(TransportClient client) {
-    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
-    if (updateLock == null) {
+    ElasticsearchTransportServerTargets.UpdateToken token =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+    if (token == null) {
       return;
     }
-    synchronized (updateLock) {
-      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
-      for (TransportAddress address : client.transportAddresses()) {
-        endpoints.add(
-            new ElasticsearchTransportServerTarget.Endpoint(host(address), address.getPort()));
-      }
-      ElasticsearchTransportServerTargets.update(client, endpoints);
+    List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+    for (TransportAddress address : client.transportAddresses()) {
+      endpoints.add(
+          new ElasticsearchTransportServerTarget.Endpoint(host(address), address.getPort()));
     }
+    ElasticsearchTransportServerTargets.update(client, token, endpoints);
   }
 
   private static String host(TransportAddress address) {

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/TransportClientInstrumentation.java
@@ -37,7 +37,7 @@ class TransportClientInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.This TransportClient client) {
-      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+      ElasticsearchTransportServerTargets.initializeUpdateState(client);
     }
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/TransportClientInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.elasticsearch.client.transport.TransportClient;
+
+class TransportClientInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.transport.TransportClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(isConstructor(), getClass().getName() + "$ConstructorAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("addTransportAddress", "addTransportAddresses", "removeTransportAddress"),
+        getClass().getName() + "$UpdateConfiguredAddressesAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.This TransportClient client) {
+      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class UpdateConfiguredAddressesAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This TransportClient client) {
+      Elasticsearch5TransportRequests.updateServerTarget(client);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientTest.java
@@ -5,14 +5,29 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.AbstractElasticsearchTransportClientTest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
 import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.FilterClient;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
@@ -21,6 +36,7 @@ import org.elasticsearch.transport.Netty3Plugin;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,12 +46,14 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
       LoggerFactory.getLogger(Elasticsearch5TransportClientTest.class);
 
   private static final String clusterName = UUID.randomUUID().toString();
+  private static final String DOWN_HOST = "es.example.com";
   private static Node testNode;
   private static TransportAddress tcpPublishAddress;
+  private static TransportAddress addressThatIsDown;
   private static TransportClient client;
 
   @BeforeAll
-  static void setUp(@TempDir File esWorkingDir) {
+  static void setUp(@TempDir File esWorkingDir) throws UnknownHostException {
     logger.info("ES work dir: {}", esWorkingDir);
 
     Settings settings =
@@ -54,6 +72,12 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
 
     tcpPublishAddress =
         testNode.injector().getInstance(TransportService.class).boundAddress().publishAddress();
+    // a configured endpoint that names a host nothing listens on, reachable only through the
+    // loopback bytes it carries
+    addressThatIsDown =
+        new InetSocketTransportAddress(
+            InetAddress.getByAddress(DOWN_HOST, InetAddress.getLoopbackAddress().getAddress()),
+            tcpPublishAddress.getPort() + 1);
 
     client =
         new PreBuiltTransportClient(
@@ -99,5 +123,183 @@ class Elasticsearch5TransportClientTest extends AbstractElasticsearchTransportCl
   @Override
   protected boolean hasWriteVersion() {
     return false;
+  }
+
+  @Test
+  void configuredAddressChangesBeforeFirstRequestAreSnapshotted() {
+    TransportClient addressListClient = newClient();
+    testing.runWithSpan(
+        "setup",
+        () -> {
+          addressListClient.addTransportAddress(tcpPublishAddress);
+          // nothing listens on this address; the configured target names it all the same
+          addressListClient.addTransportAddress(addressThatIsDown);
+          // adding an address makes the client reach out to it, which reports telemetry of its own
+          clusterHealth(addressListClient);
+        });
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    clusterHealth(addressListClient);
+
+    assertConfiguredTarget(configuredAddressListWithMixedPorts(), null);
+  }
+
+  @Test
+  void sharedDefaultPortIsOmitted() {
+    TransportClient addressListClient = connectedClient();
+    ElasticsearchTransportServerTargets.update(
+        addressListClient,
+        asList(
+            new ElasticsearchTransportServerTarget.Endpoint(getAddress(), 9300),
+            new ElasticsearchTransportServerTarget.Endpoint(DOWN_HOST, 9300)));
+
+    clusterHealth(addressListClient);
+
+    assertConfiguredTarget(configuredAddressListWithSharedPort(), null);
+  }
+
+  @Test
+  void sharedNonDefaultPortIsIncludedWithEachAddress() {
+    TransportClient addressListClient = connectedClient();
+    ElasticsearchTransportServerTargets.update(
+        addressListClient,
+        asList(
+            new ElasticsearchTransportServerTarget.Endpoint(getAddress(), 9400),
+            new ElasticsearchTransportServerTarget.Endpoint(DOWN_HOST, 9400)));
+
+    clusterHealth(addressListClient);
+
+    assertConfiguredTarget(configuredAddressListWithSharedNonDefaultPort(), null);
+  }
+
+  @Test
+  void concurrentAddressChangesPublishFinalSnapshot() {
+    TransportClient addressListClient = connectedClient();
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    cleanup.deferCleanup(executor::shutdownNow);
+    CompletableFuture<Void> start = new CompletableFuture<>();
+    CompletableFuture<Void> add =
+        start.thenRunAsync(
+            () -> addressListClient.addTransportAddress(addressThatIsDown), executor);
+    CompletableFuture<Void> remove =
+        start.thenRunAsync(
+            () -> addressListClient.removeTransportAddress(addressThatIsDown), executor);
+
+    testing.runWithSpan(
+        "setup",
+        () -> {
+          start.complete(null);
+          assertThat(add).succeedsWithin(Duration.ofSeconds(10));
+          assertThat(remove).succeedsWithin(Duration.ofSeconds(10));
+        });
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    boolean hasDownAddress = addressListClient.transportAddresses().contains(addressThatIsDown);
+    clusterHealth(addressListClient);
+    assertConfiguredTarget(hasDownAddress ? configuredAddressListWithMixedPorts() : null, null);
+  }
+
+  @Test
+  void threeArgumentFilterClientTracksExplicitAddressChanges() {
+    TransportClient singleAddressClient = newClient();
+    Client filteredClient = new TestFilterClient(singleAddressClient);
+    testing.runWithSpan(
+        "setup",
+        () -> {
+          singleAddressClient.addTransportAddress(tcpPublishAddress);
+          clusterHealth(filteredClient);
+        });
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    clusterHealth(filteredClient);
+    assertConfiguredTarget(null, null);
+    testing.clearData();
+
+    testing.runWithSpan("setup", () -> singleAddressClient.addTransportAddress(addressThatIsDown));
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    clusterHealth(filteredClient);
+    assertConfiguredTarget(configuredAddressListWithMixedPorts(), null);
+    testing.clearData();
+
+    testing.runWithSpan(
+        "setup", () -> singleAddressClient.removeTransportAddress(addressThatIsDown));
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    clusterHealth(filteredClient);
+    assertConfiguredTarget(null, null);
+  }
+
+  private static void clusterHealth(Client client) {
+    client.admin().cluster().prepareHealth().execute().actionGet(TIMEOUT);
+  }
+
+  private void assertConfiguredTarget(String addressList, Long sharedPort) {
+    String serverAddress = addressList == null ? getAddress() : addressList;
+    Long serverPort =
+        addressList == null ? (getPort() == 9300 ? null : Long.valueOf(getPort())) : sharedPort;
+    String stableSpanName =
+        "cluster:monitor/health " + serverAddress + (serverPort == null ? "" : ":" + serverPort);
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv() ? stableSpanName : "ClusterHealthAction")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            clusterHealthAttributes(
+                                emitStableDatabaseSemconv() ? serverAddress : null,
+                                emitStableDatabaseSemconv() ? serverPort : null))));
+  }
+
+  private String configuredAddressListWithMixedPorts() {
+    return getAddress() + ":" + getPort() + "," + DOWN_HOST + ":" + addressThatIsDown.getPort();
+  }
+
+  private String configuredAddressListWithSharedPort() {
+    return getAddress() + "," + DOWN_HOST;
+  }
+
+  private String configuredAddressListWithSharedNonDefaultPort() {
+    return getAddress() + ":9400," + DOWN_HOST + ":9400";
+  }
+
+  private static TransportClient connectedClient() {
+    TransportClient connectedClient = newClient();
+    testing.runWithSpan(
+        "setup",
+        () -> {
+          connectedClient.addTransportAddress(tcpPublishAddress);
+          clusterHealth(connectedClient);
+        });
+    testing.waitForTraces(1);
+    testing.clearData();
+    return connectedClient;
+  }
+
+  private static TransportClient newClient() {
+    TransportClient newClient =
+        new PreBuiltTransportClient(
+            Settings.builder()
+                .put("thread_pool.listener.size", 1)
+                // keep the background node sampler from reporting telemetry of its own
+                .put("client.transport.nodes_sampler_interval", "5m")
+                .put(CLUSTER_NAME_SETTING.getKey(), clusterName)
+                .build());
+    cleanup.deferCleanup(newClient);
+    return newClient;
+  }
+
+  private static class TestFilterClient extends FilterClient {
+
+    TestFilterClient(TransportClient delegate) {
+      super(Settings.EMPTY, delegate.threadPool(), delegate);
+    }
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/AbstractClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/AbstractClientInstrumentation.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.support.AbstractClient;
 
 class AbstractClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -62,7 +63,9 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
       }
 
       @Nullable
-      public static AdviceScope start(ElasticTransportRequest request) {
+      public static AdviceScope start(AbstractClient client, Object action, Object actionRequest) {
+        ElasticTransportRequest request =
+            Elasticsearch53TransportRequests.request(client, action, actionRequest);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
@@ -88,13 +91,13 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 2, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This AbstractClient client,
         @Advice.Argument(0) Action<?, ?, ?> action,
         @Advice.Argument(1) ActionRequest actionRequest,
         @Advice.Argument(2) ActionListener<ActionResponse> originalActionListener) {
       ActionListener<ActionResponse> actionListener = originalActionListener;
 
-      ElasticTransportRequest request = ElasticTransportRequest.create(action, actionRequest);
-      AdviceScope adviceScope = AdviceScope.start(request);
+      AdviceScope adviceScope = AdviceScope.start(client, action, actionRequest);
       if (adviceScope == null) {
         return new Object[] {null, actionListener};
       }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentationModule.java
@@ -6,11 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.FilterClientInstrumentation;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -29,6 +30,9 @@ public class Elasticsearch53TransportClientInstrumentationModule extends Instrum
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new AbstractClientInstrumentation());
+    return asList(
+        new AbstractClientInstrumentation(),
+        new FilterClientInstrumentation(),
+        new TransportClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportRequests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3;
+
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticTransportRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.TransportAddress;
+
+public class Elasticsearch53TransportRequests {
+
+  static ElasticTransportRequest request(
+      AbstractClient client, Object action, Object actionRequest) {
+    return ElasticTransportRequest.create(
+        action, actionRequest, ElasticsearchTransportServerTargets.get(client));
+  }
+
+  public static void updateServerTarget(TransportClient client) {
+    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
+    if (updateLock == null) {
+      return;
+    }
+    synchronized (updateLock) {
+      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+      for (TransportAddress address : client.transportAddresses()) {
+        endpoints.add(
+            new ElasticsearchTransportServerTarget.Endpoint(address.getHost(), address.getPort()));
+      }
+      ElasticsearchTransportServerTargets.update(client, endpoints);
+    }
+  }
+
+  private Elasticsearch53TransportRequests() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportRequests.java
@@ -23,18 +23,17 @@ public class Elasticsearch53TransportRequests {
   }
 
   public static void updateServerTarget(TransportClient client) {
-    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
-    if (updateLock == null) {
+    ElasticsearchTransportServerTargets.UpdateToken token =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+    if (token == null) {
       return;
     }
-    synchronized (updateLock) {
-      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
-      for (TransportAddress address : client.transportAddresses()) {
-        endpoints.add(
-            new ElasticsearchTransportServerTarget.Endpoint(address.getHost(), address.getPort()));
-      }
-      ElasticsearchTransportServerTargets.update(client, endpoints);
+    List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+    for (TransportAddress address : client.transportAddresses()) {
+      endpoints.add(
+          new ElasticsearchTransportServerTarget.Endpoint(address.getHost(), address.getPort()));
     }
+    ElasticsearchTransportServerTargets.update(client, token, endpoints);
   }
 
   private Elasticsearch53TransportRequests() {}

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportClientInstrumentation.java
@@ -37,7 +37,7 @@ class TransportClientInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.This TransportClient client) {
-      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+      ElasticsearchTransportServerTargets.initializeUpdateState(client);
     }
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v5_3/TransportClientInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v5_3;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.elasticsearch.client.transport.TransportClient;
+
+class TransportClientInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.transport.TransportClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(isConstructor(), getClass().getName() + "$ConstructorAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("addTransportAddress", "addTransportAddresses", "removeTransportAddress"),
+        getClass().getName() + "$UpdateConfiguredAddressesAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.This TransportClient client) {
+      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class UpdateConfiguredAddressesAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This TransportClient client) {
+      Elasticsearch53TransportRequests.updateServerTarget(client);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/AbstractClientInstrumentation.java
@@ -25,6 +25,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.support.AbstractClient;
 
 class AbstractClientInstrumentation implements TypeInstrumentation {
   @Override
@@ -66,7 +67,9 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
       }
 
       @Nullable
-      public static AdviceScope start(ElasticTransportRequest request) {
+      public static AdviceScope start(AbstractClient client, Object action, Object actionRequest) {
+        ElasticTransportRequest request =
+            Elasticsearch6TransportRequests.request(client, action, actionRequest);
         Context parentContext = Context.current();
         if (!instrumenter().shouldStart(parentContext, request)) {
           return null;
@@ -92,13 +95,13 @@ class AbstractClientInstrumentation implements TypeInstrumentation {
     @AssignReturned.ToArguments(@ToArgument(value = 2, index = 1))
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object[] onEnter(
+        @Advice.This AbstractClient client,
         @Advice.Argument(0) Object action,
         @Advice.Argument(1) ActionRequest actionRequest,
         @Advice.Argument(2) ActionListener<ActionResponse> originalActionListener) {
       ActionListener<ActionResponse> actionListener = originalActionListener;
 
-      ElasticTransportRequest request = ElasticTransportRequest.create(action, actionRequest);
-      AdviceScope adviceScope = AdviceScope.start(request);
+      AdviceScope adviceScope = AdviceScope.start(client, action, actionRequest);
       if (adviceScope == null) {
         return new Object[] {null, actionListener};
       }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentationModule.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentationModule.java
@@ -6,11 +6,12 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v6_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.FilterClientInstrumentation;
 import java.util.List;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -32,6 +33,9 @@ public class Elasticsearch6TransportClientInstrumentationModule extends Instrume
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new AbstractClientInstrumentation());
+    return asList(
+        new AbstractClientInstrumentation(),
+        new FilterClientInstrumentation(),
+        new TransportClientInstrumentation());
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportRequests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v6_0;
+
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticTransportRequest;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.client.support.AbstractClient;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.TransportAddress;
+
+public class Elasticsearch6TransportRequests {
+
+  static ElasticTransportRequest request(
+      AbstractClient client, Object action, Object actionRequest) {
+    return ElasticTransportRequest.create(
+        action, actionRequest, ElasticsearchTransportServerTargets.get(client));
+  }
+
+  public static void updateServerTarget(TransportClient client) {
+    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
+    if (updateLock == null) {
+      return;
+    }
+    synchronized (updateLock) {
+      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+      for (TransportAddress address : client.transportAddresses()) {
+        endpoints.add(
+            new ElasticsearchTransportServerTarget.Endpoint(
+                address.address().getHostString(), address.getPort()));
+      }
+      ElasticsearchTransportServerTargets.update(client, endpoints);
+    }
+  }
+
+  private Elasticsearch6TransportRequests() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportRequests.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportRequests.java
@@ -23,19 +23,18 @@ public class Elasticsearch6TransportRequests {
   }
 
   public static void updateServerTarget(TransportClient client) {
-    Object updateLock = ElasticsearchTransportServerTargets.getUpdateLock(client);
-    if (updateLock == null) {
+    ElasticsearchTransportServerTargets.UpdateToken token =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+    if (token == null) {
       return;
     }
-    synchronized (updateLock) {
-      List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
-      for (TransportAddress address : client.transportAddresses()) {
-        endpoints.add(
-            new ElasticsearchTransportServerTarget.Endpoint(
-                address.address().getHostString(), address.getPort()));
-      }
-      ElasticsearchTransportServerTargets.update(client, endpoints);
+    List<ElasticsearchTransportServerTarget.Endpoint> endpoints = new ArrayList<>();
+    for (TransportAddress address : client.transportAddresses()) {
+      endpoints.add(
+          new ElasticsearchTransportServerTarget.Endpoint(
+              address.address().getHostString(), address.getPort()));
     }
+    ElasticsearchTransportServerTargets.update(client, token, endpoints);
   }
 
   private Elasticsearch6TransportRequests() {}

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportClientInstrumentation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.v6_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTargets;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.elasticsearch.client.transport.TransportClient;
+
+class TransportClientInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.transport.TransportClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(isConstructor(), getClass().getName() + "$ConstructorAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("addTransportAddress", "addTransportAddresses", "removeTransportAddress"),
+        getClass().getName() + "$UpdateConfiguredAddressesAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.This TransportClient client) {
+      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class UpdateConfiguredAddressesAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This TransportClient client) {
+      Elasticsearch6TransportRequests.updateServerTarget(client);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/v6_0/TransportClientInstrumentation.java
@@ -37,7 +37,7 @@ class TransportClientInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.This TransportClient client) {
-      ElasticsearchTransportServerTargets.initializeUpdateLock(client);
+      ElasticsearchTransportServerTargets.initializeUpdateState(client);
     }
   }
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetterTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetterTest.java
@@ -90,7 +90,7 @@ class ElasticsearchTransportAttributesGetterTest {
     extractor.onEnd(
         attributes,
         Context.root(),
-        ElasticTransportRequest.create(new Object(), new Object()),
+        ElasticTransportRequest.create(new Object(), new Object(), null),
         null,
         error);
     return attributes.build();

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget.Endpoint;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchTransportServerTargetTest {
+
+  @Test
+  void noAddressHasNoTarget() {
+    assertThat(ElasticsearchTransportServerTarget.of(null)).isNull();
+    assertThat(ElasticsearchTransportServerTarget.of(emptyList())).isNull();
+  }
+
+  @Test
+  void oneAddressKeepsItsNonDefaultPort() {
+    DbServerTarget target =
+        ElasticsearchTransportServerTarget.of(singletonList(new Endpoint("10.0.0.1", 9301)));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.1");
+    assertThat(target.getPort()).isEqualTo(9301);
+  }
+
+  @Test
+  void oneAddressOmitsTheDefaultPort() {
+    DbServerTarget target =
+        ElasticsearchTransportServerTarget.of(singletonList(new Endpoint("10.0.0.1", 9300)));
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.1");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void configuredTransportAddressOrderDoesNotChangeTarget() {
+    DbServerTarget first =
+        ElasticsearchTransportServerTarget.of(
+            asList(new Endpoint("::1", 9301), new Endpoint("10.0.0.1", 9300)));
+    DbServerTarget second =
+        ElasticsearchTransportServerTarget.of(
+            asList(new Endpoint("10.0.0.1", 9300), new Endpoint("::1", 9301)));
+
+    assertThat(first).isNotNull();
+    assertThat(first.getAddress()).isEqualTo("10.0.0.1:9300,[::1]:9301");
+    assertThat(first.getPort()).isNull();
+    assertThat(second).isNotNull();
+    assertThat(second.getAddress()).isEqualTo(first.getAddress());
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0.ElasticsearchTransportServerTarget.Endpoint;
+import org.elasticsearch.client.support.AbstractClient;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchTransportServerTargetsTest {
+
+  @Test
+  void updateReplacesTarget() {
+    AbstractClient client = mock(AbstractClient.class);
+
+    ElasticsearchTransportServerTargets.update(
+        client, singletonList(new Endpoint("10.0.0.1", 9300)));
+    ElasticsearchTransportServerTargets.update(
+        client, singletonList(new Endpoint("10.0.0.2", 9301)));
+
+    DbServerTarget target = ElasticsearchTransportServerTargets.get(client);
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.2");
+    assertThat(target.getPort()).isEqualTo(9301);
+  }
+
+  @Test
+  void updateLockIsStableAndPerClient() {
+    AbstractClient firstClient = mock(AbstractClient.class);
+    AbstractClient secondClient = mock(AbstractClient.class);
+
+    ElasticsearchTransportServerTargets.initializeUpdateLock(firstClient);
+    Object firstLock = ElasticsearchTransportServerTargets.getUpdateLock(firstClient);
+    ElasticsearchTransportServerTargets.initializeUpdateLock(firstClient);
+    ElasticsearchTransportServerTargets.initializeUpdateLock(secondClient);
+
+    assertThat(firstLock).isNotNull();
+    assertThat(ElasticsearchTransportServerTargets.getUpdateLock(firstClient)).isSameAs(firstLock);
+    assertThat(ElasticsearchTransportServerTargets.getUpdateLock(secondClient))
+        .isNotSameAs(firstLock);
+  }
+
+  @Test
+  void updateClearsTarget() {
+    AbstractClient client = mock(AbstractClient.class);
+
+    ElasticsearchTransportServerTargets.update(
+        client, singletonList(new Endpoint("10.0.0.1", 9300)));
+    ElasticsearchTransportServerTargets.update(client, emptyList());
+
+    assertThat(ElasticsearchTransportServerTargets.get(client)).isNull();
+  }
+
+  @Test
+  void linkedClientUsesDelegateTarget() {
+    AbstractClient client = mock(AbstractClient.class);
+    AbstractClient delegate = mock(AbstractClient.class);
+    ElasticsearchTransportServerTargets.setDelegate(client, delegate);
+
+    assertThat(ElasticsearchTransportServerTargets.get(client)).isNull();
+
+    ElasticsearchTransportServerTargets.update(
+        delegate, singletonList(new Endpoint("10.0.0.1", 9301)));
+
+    DbServerTarget target = ElasticsearchTransportServerTargets.get(client);
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.1");
+    assertThat(target.getPort()).isEqualTo(9301);
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
@@ -19,7 +19,7 @@ class ElasticsearchTransportServerTargetsTest {
 
   @Test
   void updateReplacesTarget() {
-    AbstractClient client = mock(AbstractClient.class);
+    AbstractClient client = initializedClient();
 
     ElasticsearchTransportServerTargets.update(
         client, singletonList(new Endpoint("10.0.0.1", 9300)));
@@ -33,24 +33,46 @@ class ElasticsearchTransportServerTargetsTest {
   }
 
   @Test
-  void updateLockIsStableAndPerClient() {
-    AbstractClient firstClient = mock(AbstractClient.class);
-    AbstractClient secondClient = mock(AbstractClient.class);
+  void updateStateIsIndependentPerClient() {
+    AbstractClient firstClient = initializedClient();
+    AbstractClient secondClient = initializedClient();
 
-    ElasticsearchTransportServerTargets.initializeUpdateLock(firstClient);
-    Object firstLock = ElasticsearchTransportServerTargets.getUpdateLock(firstClient);
-    ElasticsearchTransportServerTargets.initializeUpdateLock(firstClient);
-    ElasticsearchTransportServerTargets.initializeUpdateLock(secondClient);
+    ElasticsearchTransportServerTargets.UpdateToken firstToken =
+        ElasticsearchTransportServerTargets.beginUpdate(firstClient);
+    ElasticsearchTransportServerTargets.UpdateToken secondToken =
+        ElasticsearchTransportServerTargets.beginUpdate(secondClient);
 
-    assertThat(firstLock).isNotNull();
-    assertThat(ElasticsearchTransportServerTargets.getUpdateLock(firstClient)).isSameAs(firstLock);
-    assertThat(ElasticsearchTransportServerTargets.getUpdateLock(secondClient))
-        .isNotSameAs(firstLock);
+    ElasticsearchTransportServerTargets.update(
+        firstClient, firstToken, singletonList(new Endpoint("10.0.0.1", 9300)));
+    ElasticsearchTransportServerTargets.update(
+        secondClient, secondToken, singletonList(new Endpoint("10.0.0.2", 9300)));
+
+    DbServerTarget firstTarget = ElasticsearchTransportServerTargets.get(firstClient);
+    DbServerTarget secondTarget = ElasticsearchTransportServerTargets.get(secondClient);
+    assertThat(firstTarget).isNotNull();
+    assertThat(secondTarget).isNotNull();
+    assertThat(firstTarget.getAddress()).isEqualTo("10.0.0.1");
+    assertThat(secondTarget.getAddress()).isEqualTo("10.0.0.2");
+  }
+
+  @Test
+  void initializingUpdateStatePreservesExistingState() {
+    AbstractClient client = initializedClient();
+    ElasticsearchTransportServerTargets.UpdateToken token =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+
+    ElasticsearchTransportServerTargets.initializeUpdateState(client);
+    ElasticsearchTransportServerTargets.update(
+        client, token, singletonList(new Endpoint("10.0.0.1", 9300)));
+
+    DbServerTarget target = ElasticsearchTransportServerTargets.get(client);
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.1");
   }
 
   @Test
   void updateClearsTarget() {
-    AbstractClient client = mock(AbstractClient.class);
+    AbstractClient client = initializedClient();
 
     ElasticsearchTransportServerTargets.update(
         client, singletonList(new Endpoint("10.0.0.1", 9300)));
@@ -60,9 +82,43 @@ class ElasticsearchTransportServerTargetsTest {
   }
 
   @Test
+  void staleUpdateCannotOverwriteNewerUpdate() {
+    AbstractClient client = initializedClient();
+    ElasticsearchTransportServerTargets.UpdateToken firstToken =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+    ElasticsearchTransportServerTargets.UpdateToken secondToken =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+
+    ElasticsearchTransportServerTargets.update(
+        client, secondToken, singletonList(new Endpoint("10.0.0.2", 9301)));
+    ElasticsearchTransportServerTargets.update(
+        client, firstToken, singletonList(new Endpoint("10.0.0.1", 9300)));
+
+    DbServerTarget target = ElasticsearchTransportServerTargets.get(client);
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.2");
+    assertThat(target.getPort()).isEqualTo(9301);
+  }
+
+  @Test
+  void staleUpdateCannotRestoreClearedTarget() {
+    AbstractClient client = initializedClient();
+    ElasticsearchTransportServerTargets.UpdateToken firstToken =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+    ElasticsearchTransportServerTargets.UpdateToken secondToken =
+        ElasticsearchTransportServerTargets.beginUpdate(client);
+
+    ElasticsearchTransportServerTargets.update(client, secondToken, emptyList());
+    ElasticsearchTransportServerTargets.update(
+        client, firstToken, singletonList(new Endpoint("10.0.0.1", 9300)));
+
+    assertThat(ElasticsearchTransportServerTargets.get(client)).isNull();
+  }
+
+  @Test
   void linkedClientUsesDelegateTarget() {
-    AbstractClient client = mock(AbstractClient.class);
-    AbstractClient delegate = mock(AbstractClient.class);
+    AbstractClient client = initializedClient();
+    AbstractClient delegate = initializedClient();
     ElasticsearchTransportServerTargets.setDelegate(client, delegate);
 
     assertThat(ElasticsearchTransportServerTargets.get(client)).isNull();
@@ -74,5 +130,11 @@ class ElasticsearchTransportServerTargetsTest {
     assertThat(target).isNotNull();
     assertThat(target.getAddress()).isEqualTo("10.0.0.1");
     assertThat(target.getPort()).isEqualTo(9301);
+  }
+
+  private static AbstractClient initializedClient() {
+    AbstractClient client = mock(AbstractClient.class);
+    ElasticsearchTransportServerTargets.initializeUpdateState(client);
+    return client;
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargetsTest.java
@@ -132,6 +132,23 @@ class ElasticsearchTransportServerTargetsTest {
     assertThat(target.getPort()).isEqualTo(9301);
   }
 
+  @Test
+  void linkedClientUsesNestedDelegateTarget() {
+    AbstractClient client = initializedClient();
+    AbstractClient delegate = initializedClient();
+    AbstractClient nestedDelegate = initializedClient();
+    ElasticsearchTransportServerTargets.setDelegate(client, delegate);
+    ElasticsearchTransportServerTargets.setDelegate(delegate, nestedDelegate);
+
+    ElasticsearchTransportServerTargets.update(
+        nestedDelegate, singletonList(new Endpoint("10.0.0.1", 9301)));
+
+    DbServerTarget target = ElasticsearchTransportServerTargets.get(client);
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("10.0.0.1");
+    assertThat(target.getPort()).isEqualTo(9301);
+  }
+
   private static AbstractClient initializedClient() {
     AbstractClient client = mock(AbstractClient.class);
     ElasticsearchTransportServerTargets.initializeUpdateState(client);

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticTransportRequest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticTransportRequest.java
@@ -6,15 +6,21 @@
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class ElasticTransportRequest {
 
-  public static ElasticTransportRequest create(Object action, Object request) {
-    return new AutoValue_ElasticTransportRequest(action, request);
+  public static ElasticTransportRequest create(
+      Object action, Object request, @Nullable DbServerTarget serverTarget) {
+    return new AutoValue_ElasticTransportRequest(action, request, serverTarget);
   }
 
   public abstract Object getAction();
 
   public abstract Object getRequest();
+
+  @Nullable
+  public abstract DbServerTarget getServerTarget();
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportAttributesGetter.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import javax.annotation.Nullable;
 import org.elasticsearch.ElasticsearchException;
@@ -58,5 +61,19 @@ public class ElasticsearchTransportAttributesGetter
     Throwable cause = ((ElasticsearchException) error).unwrapCause();
     // Returning null lets DbClientAttributesExtractor fall back to the exception class name.
     return cause != error ? cause.getClass().getName() : null;
+  }
+
+  @Override
+  @Nullable
+  public String getServerAddress(ElasticTransportRequest request) {
+    DbServerTarget target = request.getServerTarget();
+    return emitStableDatabaseSemconv() && target != null ? target.getAddress() : null;
+  }
+
+  @Override
+  @Nullable
+  public Integer getServerPort(ElasticTransportRequest request) {
+    DbServerTarget target = request.getServerTarget();
+    return emitStableDatabaseSemconv() && target != null ? target.getPort() : null;
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTarget.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTarget.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class ElasticsearchTransportServerTarget {
+
+  private static final int DEFAULT_PORT = 9300;
+
+  @Nullable
+  public static DbServerTarget of(@Nullable List<Endpoint> endpoints) {
+    if (endpoints == null || endpoints.isEmpty()) {
+      return null;
+    }
+
+    DbServerTargetBuilder builder = DbServerTarget.builder(DEFAULT_PORT).setSorted(true);
+    for (Endpoint endpoint : endpoints) {
+      builder.addEndpoint(endpoint.host, endpoint.port);
+    }
+    return builder.build();
+  }
+
+  public static class Endpoint {
+
+    @Nullable private final String host;
+    private final int port;
+
+    public Endpoint(@Nullable String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+  }
+
+  private ElasticsearchTransportServerTarget() {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargets.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargets.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.elasticsearch.client.support.AbstractClient;
+
+public class ElasticsearchTransportServerTargets {
+  private static final VirtualField<AbstractClient, DbServerTarget> SERVER_TARGET =
+      VirtualField.find(AbstractClient.class, DbServerTarget.class);
+  private static final VirtualField<AbstractClient, AbstractClient> DELEGATE =
+      VirtualField.find(AbstractClient.class, AbstractClient.class);
+  private static final VirtualField<AbstractClient, UpdateLock> UPDATE_LOCK =
+      VirtualField.find(AbstractClient.class, UpdateLock.class);
+
+  public static void initializeUpdateLock(AbstractClient client) {
+    if (UPDATE_LOCK.get(client) == null) {
+      UPDATE_LOCK.set(client, new UpdateLock());
+    }
+  }
+
+  @Nullable
+  public static Object getUpdateLock(AbstractClient client) {
+    return UPDATE_LOCK.get(client);
+  }
+
+  public static void update(
+      AbstractClient client,
+      @Nullable List<ElasticsearchTransportServerTarget.Endpoint> endpoints) {
+    SERVER_TARGET.set(client, ElasticsearchTransportServerTarget.of(endpoints));
+  }
+
+  public static void setDelegate(AbstractClient client, Object delegate) {
+    if (delegate instanceof AbstractClient) {
+      DELEGATE.set(client, (AbstractClient) delegate);
+    }
+  }
+
+  @Nullable
+  public static DbServerTarget get(AbstractClient client) {
+    DbServerTarget target = SERVER_TARGET.get(client);
+    if (target != null) {
+      return target;
+    }
+    AbstractClient delegate = DELEGATE.get(client);
+    return delegate == null ? null : get(delegate);
+  }
+
+  private ElasticsearchTransportServerTargets() {}
+
+  private static class UpdateLock {}
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargets.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/ElasticsearchTransportServerTargets.java
@@ -16,24 +16,49 @@ public class ElasticsearchTransportServerTargets {
       VirtualField.find(AbstractClient.class, DbServerTarget.class);
   private static final VirtualField<AbstractClient, AbstractClient> DELEGATE =
       VirtualField.find(AbstractClient.class, AbstractClient.class);
-  private static final VirtualField<AbstractClient, UpdateLock> UPDATE_LOCK =
-      VirtualField.find(AbstractClient.class, UpdateLock.class);
+  private static final VirtualField<AbstractClient, UpdateState> UPDATE_STATE =
+      VirtualField.find(AbstractClient.class, UpdateState.class);
 
-  public static void initializeUpdateLock(AbstractClient client) {
-    if (UPDATE_LOCK.get(client) == null) {
-      UPDATE_LOCK.set(client, new UpdateLock());
+  public static void initializeUpdateState(AbstractClient client) {
+    if (UPDATE_STATE.get(client) == null) {
+      UPDATE_STATE.set(client, new UpdateState());
     }
   }
 
   @Nullable
-  public static Object getUpdateLock(AbstractClient client) {
-    return UPDATE_LOCK.get(client);
+  public static UpdateToken beginUpdate(AbstractClient client) {
+    UpdateState state = UPDATE_STATE.get(client);
+    if (state == null) {
+      return null;
+    }
+    synchronized (state.lock) {
+      return new UpdateToken(state, ++state.generation);
+    }
   }
 
   public static void update(
       AbstractClient client,
       @Nullable List<ElasticsearchTransportServerTarget.Endpoint> endpoints) {
-    SERVER_TARGET.set(client, ElasticsearchTransportServerTarget.of(endpoints));
+    UpdateToken token = beginUpdate(client);
+    if (token != null) {
+      update(client, token, endpoints);
+    }
+  }
+
+  public static void update(
+      AbstractClient client,
+      @Nullable UpdateToken token,
+      @Nullable List<ElasticsearchTransportServerTarget.Endpoint> endpoints) {
+    DbServerTarget target = ElasticsearchTransportServerTarget.of(endpoints);
+    UpdateState state = UPDATE_STATE.get(client);
+    if (token == null || state != token.state) {
+      return;
+    }
+    synchronized (state.lock) {
+      if (token.generation == state.generation) {
+        SERVER_TARGET.set(client, target);
+      }
+    }
   }
 
   public static void setDelegate(AbstractClient client, Object delegate) {
@@ -54,5 +79,18 @@ public class ElasticsearchTransportServerTargets {
 
   private ElasticsearchTransportServerTargets() {}
 
-  private static class UpdateLock {}
+  public static final class UpdateToken {
+    private final UpdateState state;
+    private final long generation;
+
+    private UpdateToken(UpdateState state, long generation) {
+      this.state = state;
+      this.generation = generation;
+    }
+  }
+
+  private static class UpdateState {
+    private final Object lock = new Object();
+    private long generation;
+  }
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/FilterClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/FilterClientInstrumentation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.elasticsearch.transport.common.v5_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.elasticsearch.client.support.AbstractClient;
+
+public class FilterClientInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.elasticsearch.client.FilterClient");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    // FilterClient(Client) chains to this constructor, so it needs no advice of its own
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(2, named("org.elasticsearch.client.Client"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.This AbstractClient client, @Advice.Argument(2) Object delegate) {
+      ElasticsearchTransportServerTargets.setDelegate(client, delegate);
+    }
+  }
+}

--- a/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-common-5.0/testing/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/transport/common/v5_0/AbstractElasticsearchTransportClientTest.java
@@ -19,6 +19,8 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.ELASTICSEARCH;
@@ -32,14 +34,19 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.junit.jupiter.api.Test;
@@ -53,9 +60,27 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class AbstractElasticsearchTransportClientTest
     extends AbstractElasticsearchClientTest {
 
+  @Override
+  protected abstract TransportClient client();
+
   protected abstract String getAddress();
 
   protected abstract int getPort();
+
+  @Test
+  void transportAddressUpdatesDoNotUseClientMonitor() {
+    TransportClient client = client();
+    TransportAddress address = client.transportAddresses().get(0);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    cleanup.deferCleanup(executor::shutdownNow);
+    Object applicationMonitor = client;
+
+    synchronized (applicationMonitor) {
+      assertThat(CompletableFuture.supplyAsync(() -> client.addTransportAddress(address), executor))
+          .succeedsWithin(Duration.ofSeconds(5))
+          .isSameAs(client);
+    }
+  }
 
   private Stream<Arguments> healthArguments() {
     return Stream.of(
@@ -82,40 +107,67 @@ public abstract class AbstractElasticsearchTransportClientTest
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent(),
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "cluster:monitor/health"
-                                : "ClusterHealthAction")
+                    span.hasName(spanName("ClusterHealthAction", "cluster:monitor/health"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasAttributesSatisfyingExactly(
-                            addNetworkTypeAttribute(
-                                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
-                                equalTo(NETWORK_PEER_PORT, getPort()),
-                                equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                                equalTo(
-                                    maybeStable(DB_OPERATION),
-                                    emitStableDatabaseSemconv()
-                                        ? "cluster:monitor/health"
-                                        : "ClusterHealthAction"),
-                                equalTo(
-                                    stringKey("elasticsearch.action"),
-                                    experimental("ClusterHealthAction")),
-                                equalTo(
-                                    stringKey("elasticsearch.request"),
-                                    experimental("ClusterHealthRequest")))),
+                            clusterHealthAttributes(
+                                emitStableDatabaseSemconv() ? getAddress() : null,
+                                emitStableDatabaseSemconv() ? serverPort() : null)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
                         .hasParent(trace.getSpan(0))));
   }
 
-  private List<AttributeAssertion> addNetworkTypeAttribute(AttributeAssertion... assertions) {
-    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
+  protected List<AttributeAssertion> clusterHealthAttributes(
+      String serverAddress, Long serverPort) {
+    List<AttributeAssertion> result =
+        new ArrayList<>(
+            asList(
+                equalTo(NETWORK_PEER_ADDRESS, getAddress()),
+                equalTo(NETWORK_PEER_PORT, getPort()),
+                equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+                equalTo(
+                    maybeStable(DB_OPERATION),
+                    emitStableDatabaseSemconv() ? "cluster:monitor/health" : "ClusterHealthAction"),
+                equalTo(stringKey("elasticsearch.action"), experimental("ClusterHealthAction")),
+                equalTo(stringKey("elasticsearch.request"), experimental("ClusterHealthRequest")),
+                equalTo(SERVER_ADDRESS, serverAddress),
+                equalTo(SERVER_PORT, serverPort)));
     if (hasNetworkType()) {
       result.add(satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")));
     }
     return result;
+  }
+
+  private List<AttributeAssertion> addNetworkTypeAttribute(AttributeAssertion... assertions) {
+    List<AttributeAssertion> result = withServer(assertions);
+    if (hasNetworkType()) {
+      result.add(satisfies(NETWORK_TYPE, val -> val.isIn("ipv4", "ipv6")));
+    }
+    return result;
+  }
+
+  private List<AttributeAssertion> withServer(AttributeAssertion... assertions) {
+    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
+    if (emitStableDatabaseSemconv()) {
+      result.add(equalTo(SERVER_ADDRESS, getAddress()));
+      result.add(equalTo(SERVER_PORT, serverPort()));
+    }
+    return result;
+  }
+
+  private String spanName(String action, String wireAction) {
+    if (!emitStableDatabaseSemconv()) {
+      return action;
+    }
+    Long serverPort = serverPort();
+    return wireAction + " " + getAddress() + (serverPort == null ? "" : ":" + serverPort);
+  }
+
+  private Long serverPort() {
+    return getPort() == 9300 ? null : Long.valueOf(getPort());
   }
 
   private Stream<Arguments> errorArguments() {
@@ -140,16 +192,14 @@ public abstract class AbstractElasticsearchTransportClientTest
         .hasMessage(expectedException.getMessage());
 
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
-                equalTo(
-                    maybeStable(DB_OPERATION),
-                    emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction"),
-                equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
-                equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
-                equalTo(
-                    stringKey("elasticsearch.request.indices"), experimental("invalid-index"))));
+        withServer(
+            equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH),
+            equalTo(
+                maybeStable(DB_OPERATION),
+                emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction"),
+            equalTo(stringKey("elasticsearch.action"), experimental("GetAction")),
+            equalTo(stringKey("elasticsearch.request"), experimental("GetRequest")),
+            equalTo(stringKey("elasticsearch.request.indices"), experimental("invalid-index")));
 
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(ERROR_TYPE, "org.elasticsearch.index.IndexNotFoundException"));
@@ -165,8 +215,7 @@ public abstract class AbstractElasticsearchTransportClientTest
                         .hasStatus(StatusData.error())
                         .hasException(expectedException),
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction")
+                    span.hasName(spanName("GetAction", "indices:data/read/get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasParent(trace.getSpan(0))
                         .hasStatus(StatusData.error())
@@ -205,7 +254,7 @@ public abstract class AbstractElasticsearchTransportClientTest
     String indexType = "test-type";
     String id = "1";
 
-    Client client = client();
+    TransportClient client = client();
     CreateIndexResponse indexResult = client.admin().indices().prepareCreate(indexName).get();
     assertThat(indexResult.isAcknowledged()).isTrue();
 
@@ -232,17 +281,15 @@ public abstract class AbstractElasticsearchTransportClientTest
     // PutMappingAction and IndexAction run in separate threads so their order can vary
     testing.waitAndAssertSortedTraces(
         orderByRootSpanName(
-            emitStableDatabaseSemconv() ? "indices:admin/create" : "CreateIndexAction",
+            spanName("CreateIndexAction", "indices:admin/create"),
+            // the mapping update runs inside the node, on a client that has no remote target
             emitStableDatabaseSemconv() ? getPutMappingWireActionName() : getPutMappingActionName(),
-            emitStableDatabaseSemconv() ? "indices:data/write/index" : "IndexAction",
-            emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction"),
+            spanName("IndexAction", "indices:data/write/index"),
+            spanName("GetAction", "indices:data/read/get")),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "indices:admin/create"
-                                : "CreateIndexAction")
+                    span.hasName(spanName("CreateIndexAction", "indices:admin/create"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -289,10 +336,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "indices:data/write/index"
-                                : "IndexAction")
+                    span.hasName(spanName("IndexAction", "indices:data/write/index"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -334,8 +378,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction")
+                    span.hasName(spanName("GetAction", "indices:data/read/get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(
@@ -343,8 +386,7 @@ public abstract class AbstractElasticsearchTransportClientTest
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv() ? "indices:data/read/get" : "GetAction")
+                    span.hasName(spanName("GetAction", "indices:data/read/get"))
                         .hasKind(SpanKind.CLIENT)
                         .hasNoParent()
                         .hasAttributesSatisfyingExactly(


### PR DESCRIPTION
This PR is part of #19899 and applies the configured database target rules proposed in [open-telemetry/semantic-conventions#4058](https://github.com/open-telemetry/semantic-conventions/pull/4058) to the Elasticsearch 5.0, 5.3, and 6.0 through 7.x transport clients. Stable spans report the client's configured contact points as the logical server, so seed hostnames stay stable when Elasticsearch discovers or selects other nodes. Network peer attributes continue to identify the node selected for an operation, and legacy span naming and output are unchanged.

`es-a.example:9400,es-b.example:9400` reports `server.address=es-a.example:9400,es-b.example:9400` with no `server.port`.

### Multi-endpoint handling

The lexicographically sorted endpoint list includes at most its first five entries. A single non-default port is reported as `server.port`. Multiple endpoints omit ports when all use the default transport port `9300`; if any endpoint uses a non-default port, every endpoint keeps its effective port inline in `server.address` and `server.port` is unset.

### Compatibility

Credential stripping and IPv4 and IPv6 formatting keep their existing behavior, and stable span names append the configured target.

This PR is stacked on #19901.