### PR TITLE
Capture configured OpenSearch Java client targets

### DIFF
--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/build.gradle.kts
@@ -7,9 +7,8 @@ otelJava {
 }
 
 dependencies {
-  testImplementation(
-    project(":instrumentation:opensearch:opensearch-java-3.0:javaagent"),
-  )
-  testImplementation("org.opensearch.client:opensearch-java:3.0.0")
+  testImplementation(project(":instrumentation-api-incubator"))
+  testImplementation(project(":instrumentation:opensearch:opensearch-java-3.0:javaagent"))
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
+  testImplementation("org.opensearch.client:opensearch-java:3.0.0")
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHostTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHostTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OpenSearchConfiguredHostTest {
+
+  @Test
+  void nothingIsNoTarget() {
+    assertThat(OpenSearchConfiguredHost.parse(null)).isNull();
+    assertThat(OpenSearchConfiguredHost.parse("")).isNull();
+  }
+
+  @Test
+  void bareHostKeepsItsNameAndHasNoPort() {
+    DbServerTarget target =
+        OpenSearchConfiguredHost.parse("search-domain.us-east-1.es.amazonaws.com", "https");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("search-domain.us-east-1.es.amazonaws.com");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void schemeAndPortAreRead() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("https://os.example:9200");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isEqualTo(9200);
+  }
+
+  @Test
+  void defaultPortIsOmitted() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("https://os.example:443");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void credentialsPathQueryAndFragmentAreRemoved() {
+    DbServerTarget target =
+        OpenSearchConfiguredHost.parse("https://user:secret@os.example:9200/prefix?token=secret#f");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isEqualTo(9200);
+  }
+
+  @Test
+  void credentialsWithoutAPortAreRemoved() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("user:secret@os.example", "https");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void pathPrefixWithoutAPortIsRemoved() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("os.example/prefix", "https");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void urlInQueryDoesNotReplaceTarget() {
+    DbServerTarget target =
+        OpenSearchConfiguredHost.parse("os.example?token=https://secret.example", "https");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void userinfoAfterAuthorityHasNoTarget() {
+    assertThat(OpenSearchConfiguredHost.parse("os.example?token=user@secret")).isNull();
+    assertThat(OpenSearchConfiguredHost.parse("user:123/secret@os.example")).isNull();
+    assertThat(OpenSearchConfiguredHost.parse("os.example#user@secret")).isNull();
+  }
+
+  @Test
+  void literalIpv6AddressDropsItsBrackets() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("https://[::1]:9200");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("::1");
+    assertThat(target.getPort()).isEqualTo(9200);
+  }
+
+  @Test
+  void literalIpv6AddressWithoutAPortHasNoPort() {
+    DbServerTarget target = OpenSearchConfiguredHost.parse("https://[::1]");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("::1");
+    assertThat(target.getPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "os.example:not-a-port",
+        "os.example:+9200",
+        "os.example:-0",
+        "os.example:-1",
+        "os.example:65536",
+        "os.example:９２００",
+        "https://[::1]:not-a-port",
+        "https://[::1",
+        "https://[::1]suffix",
+        "https://::1"
+      })
+  void malformedAuthorityIsNoTarget(String host) {
+    assertThat(OpenSearchConfiguredHost.parse(host)).isNull();
+  }
+
+  @Test
+  void hostWithoutPortOrDefaultSchemeIsNoTarget() {
+    assertThat(OpenSearchConfiguredHost.parse("os.example")).isNull();
+  }
+
+  @Test
+  void hostThatIsOnlyCredentialsIsNoTarget() {
+    assertThat(OpenSearchConfiguredHost.parse("https://user:secret@")).isNull();
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHostTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHostTest.java
@@ -86,11 +86,19 @@ class OpenSearchConfiguredHostTest {
     assertThat(target.getPort()).isNull();
   }
 
-  @Test
-  void userinfoAfterAuthorityHasNoTarget() {
-    assertThat(OpenSearchConfiguredHost.parse("os.example?token=user@secret")).isNull();
-    assertThat(OpenSearchConfiguredHost.parse("user:123/secret@os.example")).isNull();
-    assertThat(OpenSearchConfiguredHost.parse("os.example#user@secret")).isNull();
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "os.example/path@secret",
+        "os.example?token=user@secret",
+        "os.example#user@secret"
+      })
+  void atSignsInEndpointSuffixAreIgnored(String host) {
+    DbServerTarget target = OpenSearchConfiguredHost.parse(host, "https");
+
+    assertThat(target).isNotNull();
+    assertThat(target.getAddress()).isEqualTo("os.example");
+    assertThat(target.getPort()).isNull();
   }
 
   @Test

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/build.gradle.kts
@@ -7,6 +7,8 @@ muzzle {
     group.set("org.opensearch.client")
     module.set("opensearch-java")
     versions.set("[3.0,)")
+    assertInverse.set(true)
+    extraDependency("org.opensearch.client:opensearch-rest-client:3.0.0")
   }
 }
 
@@ -16,13 +18,18 @@ otelJava {
 
 dependencies {
   library("org.opensearch.client:opensearch-java:3.0.0")
+
+  implementation(project(":instrumentation:opensearch:opensearch-rest-common-1.0:javaagent"))
+
   compileOnly("com.google.auto.value:auto-value-annotations")
+  compileOnly("org.opensearch.client:opensearch-rest-client:3.0.0")
   annotationProcessor("com.google.auto.value:auto-value")
   compileOnly("com.fasterxml.jackson.core:jackson-core")
 
   testImplementation("org.opensearch.client:opensearch-rest-client:3.0.0")
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
   testImplementation(project(":instrumentation:opensearch:opensearch-rest-common-1.0:testing"))
+  testInstrumentation(project(":instrumentation:opensearch:opensearch-rest-3.0:javaagent"))
   testInstrumentation(project(":instrumentation:apache-httpclient:apache-httpclient-5.0:javaagent"))
 
   // AwsSdk2Transport supports awssdk version 2.26.0

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/ApacheHttpClient5TransportInstrumentation.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/ApacheHttpClient5TransportInstrumentation.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0.OpenSearchServerTarget;
+import java.util.ArrayList;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.httpclient5.internal.Node;
+
+// capture the initial nodes before failure handling can replace the routing nodes
+class ApacheHttpClient5TransportInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(2, named("java.util.List"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This OpenSearchTransport transport,
+        @Advice.Argument(2) List<Node> configuredNodes) {
+      List<OpenSearchServerTarget.Endpoint> endpoints = new ArrayList<>(configuredNodes.size());
+      for (Node node : configuredNodes) {
+        HttpHost host = node.getHost();
+        endpoints.add(
+            new OpenSearchServerTarget.Endpoint(
+                host.getHostName(), host.getPort(), host.getSchemeName()));
+      }
+      OpenSearchServerTargets.capture(transport, endpoints);
+    }
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AwsSdk2TransportInstrumentation.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AwsSdk2TransportInstrumentation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.opensearch.client.transport.OpenSearchTransport;
+
+class AwsSdk2TransportInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.opensearch.client.transport.aws.AwsSdk2Transport");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(1, String.class)),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This OpenSearchTransport transport, @Advice.Argument(1) String host) {
+      OpenSearchServerTargets.capture(transport, OpenSearchConfiguredHost.parse(host, "https"));
+    }
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5InstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5InstrumentationModule.java
@@ -5,17 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class OpenSearchApacheHttpClient5InstrumentationModule extends InstrumentationModule {
   public OpenSearchApacheHttpClient5InstrumentationModule() {
     super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // added in 3.0.0
+    return hasClassesNamed("org.opensearch.client.opensearch.nodes.OpenSearchNodesClientBase");
   }
 
   @Override

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5InstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5InstrumentationModule.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+@AutoService(InstrumentationModule.class)
+public class OpenSearchApacheHttpClient5InstrumentationModule extends InstrumentationModule {
+  public OpenSearchApacheHttpClient5InstrumentationModule() {
+    super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new ApacheHttpClient5TransportInstrumentation());
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAttributesGetter.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAttributesGetter.java
@@ -5,7 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.DbClientAttributesGetter;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues;
 import java.util.concurrent.CompletionException;
 import javax.annotation.Nullable;
@@ -56,5 +59,25 @@ final class OpenSearchAttributesGetter
       }
     }
     return null;
+  }
+
+  @Override
+  @Nullable
+  public String getServerAddress(OpenSearchRequest request) {
+    if (!emitStableDatabaseSemconv()) {
+      return null;
+    }
+    DbServerTarget target = request.getServerTarget();
+    return target != null ? target.getAddress() : null;
+  }
+
+  @Override
+  @Nullable
+  public Integer getServerPort(OpenSearchRequest request) {
+    if (!emitStableDatabaseSemconv()) {
+      return null;
+    }
+    DbServerTarget target = request.getServerTarget();
+    return target != null ? target.getPort() : null;
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2InstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2InstrumentationModule.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+@AutoService(InstrumentationModule.class)
+public class OpenSearchAwsSdk2InstrumentationModule extends InstrumentationModule {
+  public OpenSearchAwsSdk2InstrumentationModule() {
+    super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new AwsSdk2TransportInstrumentation());
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2InstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2InstrumentationModule.java
@@ -5,17 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class OpenSearchAwsSdk2InstrumentationModule extends InstrumentationModule {
   public OpenSearchAwsSdk2InstrumentationModule() {
     super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // added in 3.0.0
+    return hasClassesNamed("org.opensearch.client.opensearch.nodes.OpenSearchNodesClientBase");
   }
 
   @Override

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
@@ -13,6 +13,9 @@ import javax.annotation.Nullable;
 
 public class OpenSearchConfiguredHost {
 
+  private static final int NO_PORT = -1;
+  private static final int INVALID = -2;
+
   @Nullable
   public static DbServerTarget parse(@Nullable String host) {
     return parse(host, "");
@@ -24,6 +27,12 @@ public class OpenSearchConfiguredHost {
       return null;
     }
 
+    OpenSearchServerTarget.Endpoint endpoint = parseEndpoint(host, defaultScheme);
+    return endpoint == null ? null : OpenSearchServerTarget.of(singletonList(endpoint));
+  }
+
+  @Nullable
+  private static OpenSearchServerTarget.Endpoint parseEndpoint(String host, String defaultScheme) {
     String rest = host;
     String scheme = defaultScheme;
     int schemeEnd = rest.indexOf("://");
@@ -32,64 +41,74 @@ public class OpenSearchConfiguredHost {
       rest = rest.substring(schemeEnd + 3);
     }
 
-    // the endpoint may carry a path prefix, a query string or a fragment, none of which belong to
-    // the target
-    for (int i = 0; i < rest.length(); i++) {
-      char c = rest.charAt(i);
-      if (c == '/' || c == '?' || c == '#') {
-        if (rest.indexOf('@', i) >= 0) {
-          return null;
-        }
-        rest = rest.substring(0, i);
-        break;
-      }
+    rest = stripEndpointSuffix(rest);
+    if (rest == null) {
+      return null;
     }
 
     int hostStart = rest.lastIndexOf('@') + 1;
-    int portStart;
-    if (hostStart < rest.length() && rest.charAt(hostStart) == '[') {
-      int closingBracket = rest.indexOf(']', hostStart);
+    int portStart = findPortStart(rest, hostStart);
+    if (portStart == INVALID) {
+      return null;
+    }
+
+    int port = parsePort(rest, portStart);
+    if (port == INVALID) {
+      return null;
+    }
+
+    String hostName =
+        portStart == NO_PORT ? rest.substring(hostStart) : rest.substring(hostStart, portStart);
+    return new OpenSearchServerTarget.Endpoint(hostName, port, scheme);
+  }
+
+  @Nullable
+  private static String stripEndpointSuffix(String value) {
+    // The endpoint may carry a path prefix, a query string or a fragment, none of which belong to
+    // the target.
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '/' || c == '?' || c == '#') {
+        return value.indexOf('@', i) >= 0 ? null : value.substring(0, i);
+      }
+    }
+    return value;
+  }
+
+  private static int findPortStart(String value, int hostStart) {
+    if (hostStart < value.length() && value.charAt(hostStart) == '[') {
+      int closingBracket = value.indexOf(']', hostStart);
       if (closingBracket < 0) {
-        return null;
+        return INVALID;
       }
-      if (closingBracket == rest.length() - 1) {
-        portStart = -1;
-      } else if (rest.charAt(closingBracket + 1) == ':') {
-        portStart = closingBracket + 1;
-      } else {
-        return null;
+      if (closingBracket == value.length() - 1) {
+        return NO_PORT;
       }
-    } else {
-      portStart = rest.indexOf(':', hostStart);
-      if (portStart >= 0 && portStart != rest.lastIndexOf(':')) {
-        return null;
-      }
+      return value.charAt(closingBracket + 1) == ':' ? closingBracket + 1 : INVALID;
     }
 
-    int port = -1;
-    String hostName;
-    if (portStart >= 0) {
-      if (portStart == rest.length() - 1) {
-        return null;
-      }
-      for (int i = portStart + 1; i < rest.length(); i++) {
-        char c = rest.charAt(i);
-        if (c < '0' || c > '9') {
-          return null;
-        }
-      }
-      try {
-        port = Integer.parseInt(rest.substring(portStart + 1));
-      } catch (NumberFormatException ignored) {
-        return null;
-      }
-      hostName = rest.substring(hostStart, portStart);
-    } else {
-      hostName = rest.substring(hostStart);
-    }
+    int portStart = value.indexOf(':', hostStart);
+    return portStart >= 0 && portStart != value.lastIndexOf(':') ? INVALID : portStart;
+  }
 
-    return OpenSearchServerTarget.of(
-        singletonList(new OpenSearchServerTarget.Endpoint(hostName, port, scheme)));
+  private static int parsePort(String value, int portStart) {
+    if (portStart == NO_PORT) {
+      return NO_PORT;
+    }
+    if (portStart == value.length() - 1) {
+      return INVALID;
+    }
+    for (int i = portStart + 1; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9') {
+        return INVALID;
+      }
+    }
+    try {
+      return Integer.parseInt(value.substring(portStart + 1));
+    } catch (NumberFormatException ignored) {
+      return INVALID;
+    }
   }
 
   private static boolean hasValidScheme(String value, int schemeEnd) {

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static java.util.Collections.singletonList;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0.OpenSearchServerTarget;
+import javax.annotation.Nullable;
+
+public class OpenSearchConfiguredHost {
+
+  @Nullable
+  public static DbServerTarget parse(@Nullable String host) {
+    return parse(host, "");
+  }
+
+  @Nullable
+  public static DbServerTarget parse(@Nullable String host, String defaultScheme) {
+    if (host == null) {
+      return null;
+    }
+
+    String rest = host;
+    String scheme = defaultScheme;
+    int schemeEnd = rest.indexOf("://");
+    if (hasValidScheme(rest, schemeEnd)) {
+      scheme = rest.substring(0, schemeEnd);
+      rest = rest.substring(schemeEnd + 3);
+    }
+
+    // the endpoint may carry a path prefix, a query string or a fragment, none of which belong to
+    // the target
+    for (int i = 0; i < rest.length(); i++) {
+      char c = rest.charAt(i);
+      if (c == '/' || c == '?' || c == '#') {
+        if (rest.indexOf('@', i) >= 0) {
+          return null;
+        }
+        rest = rest.substring(0, i);
+        break;
+      }
+    }
+
+    int hostStart = rest.lastIndexOf('@') + 1;
+    int portStart;
+    if (hostStart < rest.length() && rest.charAt(hostStart) == '[') {
+      int closingBracket = rest.indexOf(']', hostStart);
+      if (closingBracket < 0) {
+        return null;
+      }
+      if (closingBracket == rest.length() - 1) {
+        portStart = -1;
+      } else if (rest.charAt(closingBracket + 1) == ':') {
+        portStart = closingBracket + 1;
+      } else {
+        return null;
+      }
+    } else {
+      portStart = rest.indexOf(':', hostStart);
+      if (portStart >= 0 && portStart != rest.lastIndexOf(':')) {
+        return null;
+      }
+    }
+
+    int port = -1;
+    String hostName;
+    if (portStart >= 0) {
+      if (portStart == rest.length() - 1) {
+        return null;
+      }
+      for (int i = portStart + 1; i < rest.length(); i++) {
+        char c = rest.charAt(i);
+        if (c < '0' || c > '9') {
+          return null;
+        }
+      }
+      try {
+        port = Integer.parseInt(rest.substring(portStart + 1));
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+      hostName = rest.substring(hostStart, portStart);
+    } else {
+      hostName = rest.substring(hostStart);
+    }
+
+    return OpenSearchServerTarget.of(
+        singletonList(new OpenSearchServerTarget.Endpoint(hostName, port, scheme)));
+  }
+
+  private static boolean hasValidScheme(String value, int schemeEnd) {
+    if (schemeEnd <= 0 || !isAsciiLetter(value.charAt(0))) {
+      return false;
+    }
+    for (int i = 1; i < schemeEnd; i++) {
+      char c = value.charAt(i);
+      if (!isAsciiLetter(c) && (c < '0' || c > '9') && c != '+' && c != '-' && c != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isAsciiLetter(char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+  }
+
+  private OpenSearchConfiguredHost() {}
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchConfiguredHost.java
@@ -69,7 +69,7 @@ public class OpenSearchConfiguredHost {
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
       if (c == '/' || c == '?' || c == '#') {
-        return value.indexOf('@', i) >= 0 ? null : value.substring(0, i);
+        return value.substring(0, i);
       }
     }
     return value;

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchInstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchInstrumentationModule.java
@@ -5,17 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class OpenSearchInstrumentationModule extends InstrumentationModule {
   public OpenSearchInstrumentationModule() {
     super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // added in 3.0.0
+    return hasClassesNamed("org.opensearch.client.opensearch.nodes.OpenSearchNodesClientBase");
   }
 
   @Override

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRequest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRequest.java
@@ -6,13 +6,18 @@
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
 import com.google.auto.value.AutoValue;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class OpenSearchRequest {
 
-  public static OpenSearchRequest create(String method, String endpoint, @Nullable String body) {
-    return new AutoValue_OpenSearchRequest(method, endpoint, body);
+  public static OpenSearchRequest create(
+      String method,
+      String endpoint,
+      @Nullable String body,
+      @Nullable DbServerTarget serverTarget) {
+    return new AutoValue_OpenSearchRequest(method, endpoint, body, serverTarget);
   }
 
   public abstract String getMethod();
@@ -21,4 +26,7 @@ public abstract class OpenSearchRequest {
 
   @Nullable
   public abstract String getBody();
+
+  @Nullable
+  public abstract DbServerTarget getServerTarget();
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportInstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportInstrumentationModule.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static java.util.Collections.singletonList;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import java.util.List;
+
+@AutoService(InstrumentationModule.class)
+public class OpenSearchRestClientTransportInstrumentationModule extends InstrumentationModule {
+  public OpenSearchRestClientTransportInstrumentationModule() {
+    super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public List<TypeInstrumentation> typeInstrumentations() {
+    return singletonList(new RestClientTransportInstrumentation());
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportInstrumentationModule.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportInstrumentationModule.java
@@ -5,17 +5,25 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Collections.singletonList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.List;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
 public class OpenSearchRestClientTransportInstrumentationModule extends InstrumentationModule {
   public OpenSearchRestClientTransportInstrumentationModule() {
     super("opensearch-java", "opensearch-java-3.0", "opensearch");
+  }
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    // added in 3.0.0
+    return hasClassesNamed("org.opensearch.client.opensearch.nodes.OpenSearchNodesClientBase");
   }
 
   @Override

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchServerTargets.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchServerTargets.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0.OpenSearchServerTarget;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.opensearch.client.transport.OpenSearchTransport;
+
+public class OpenSearchServerTargets {
+
+  private static final VirtualField<OpenSearchTransport, DbServerTarget> SERVER_TARGET =
+      VirtualField.find(OpenSearchTransport.class, DbServerTarget.class);
+
+  public static void capture(
+      OpenSearchTransport transport, @Nullable List<OpenSearchServerTarget.Endpoint> endpoints) {
+    capture(transport, OpenSearchServerTarget.of(endpoints));
+  }
+
+  public static void capture(OpenSearchTransport transport, @Nullable DbServerTarget target) {
+    if (target == null) {
+      return;
+    }
+    SERVER_TARGET.set(transport, target);
+  }
+
+  @Nullable
+  public static DbServerTarget get(OpenSearchTransport transport) {
+    return SERVER_TARGET.get(transport);
+  }
+
+  private OpenSearchServerTargets() {}
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchTransportInstrumentation.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchTransportInstrumentation.java
@@ -73,7 +73,10 @@ class OpenSearchTransportInstrumentation implements TypeInstrumentation {
 
     @Nullable
     public static AdviceScope start(
-        Object request, Endpoint<Object, Object, Object> endpoint, JsonpMapper jsonpMapper) {
+        OpenSearchTransport transport,
+        Object request,
+        Endpoint<Object, Object, Object> endpoint,
+        JsonpMapper jsonpMapper) {
       Context parentContext = Context.current();
 
       String queryBody = null;
@@ -85,7 +88,10 @@ class OpenSearchTransportInstrumentation implements TypeInstrumentation {
 
       OpenSearchRequest otelRequest =
           OpenSearchRequest.create(
-              endpoint.method(request), endpoint.requestUrl(request), queryBody);
+              endpoint.method(request),
+              endpoint.requestUrl(request),
+              queryBody,
+              OpenSearchServerTargets.get(transport));
 
       if (!instrumenter().shouldStart(parentContext, otelRequest)) {
         return null;
@@ -139,7 +145,8 @@ class OpenSearchTransportInstrumentation implements TypeInstrumentation {
         @Advice.This OpenSearchTransport openSearchTransport,
         @Advice.Argument(0) Object request,
         @Advice.Argument(1) Endpoint<Object, Object, Object> endpoint) {
-      return AdviceScope.start(request, endpoint, openSearchTransport.jsonpMapper());
+      return AdviceScope.start(
+          openSearchTransport, request, endpoint, openSearchTransport.jsonpMapper());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
@@ -161,7 +168,8 @@ class OpenSearchTransportInstrumentation implements TypeInstrumentation {
         @Advice.This OpenSearchTransport openSearchTransport,
         @Advice.Argument(0) Object request,
         @Advice.Argument(1) Endpoint<Object, Object, Object> endpoint) {
-      return AdviceScope.start(request, endpoint, openSearchTransport.jsonpMapper());
+      return AdviceScope.start(
+          openSearchTransport, request, endpoint, openSearchTransport.jsonpMapper());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/RestClientTransportInstrumentation.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/RestClientTransportInstrumentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
+
+import static io.opentelemetry.javaagent.instrumentation.opensearch.rest.common.v1_0.OpenSearchServerTargets.get;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.transport.OpenSearchTransport;
+
+// capture the initial nodes before sniffing or setNodes can replace them
+class RestClientTransportInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("org.opensearch.client.transport.rest_client.RestClientTransport");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(0, named("org.opensearch.client.RestClient"))),
+        getClass().getName() + "$ConstructorAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This OpenSearchTransport transport, @Advice.Argument(0) RestClient restClient) {
+      OpenSearchServerTargets.capture(transport, get(restClient));
+    }
+  }
+}

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/RestClientTransportInstrumentation.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/RestClientTransportInstrumentation.java
@@ -18,7 +18,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 
-// capture the initial nodes before sniffing or setNodes can replace them
+// Preserve the nodes configured at construction for telemetry. Automatic node discovery or
+// setNodes() can later replace the client's active node list.
 class RestClientTransportInstrumentation implements TypeInstrumentation {
 
   @Override

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchQueryTest.java
@@ -5,19 +5,9 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
-import static java.util.Arrays.asList;
-
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -134,21 +124,5 @@ abstract class AbstractOpenSearchQueryTest {
   @AfterAll
   void tearDown() {
     opensearch.stop();
-  }
-
-  String openSearchSpanName(String method) {
-    return emitStableDatabaseSemconv()
-        ? method + " " + httpHost.getHost() + ":" + httpHost.getPort()
-        : method;
-  }
-
-  List<AttributeAssertion> withServer(AttributeAssertion... assertions) {
-    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
-    result.add(equalTo(NETWORK_TYPE, null));
-    if (emitStableDatabaseSemconv()) {
-      result.add(equalTo(SERVER_ADDRESS, httpHost.getHost()));
-      result.add(equalTo(SERVER_PORT, httpHost.getPort()));
-    }
-    return result;
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchQueryTest.java
@@ -5,9 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static java.util.Arrays.asList;
+
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -124,5 +134,21 @@ abstract class AbstractOpenSearchQueryTest {
   @AfterAll
   void tearDown() {
     opensearch.stop();
+  }
+
+  String openSearchSpanName(String method) {
+    return emitStableDatabaseSemconv()
+        ? method + " " + httpHost.getHost() + ":" + httpHost.getPort()
+        : method;
+  }
+
+  List<AttributeAssertion> withServer(AttributeAssertion... assertions) {
+    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
+    result.add(equalTo(NETWORK_TYPE, null));
+    if (emitStableDatabaseSemconv()) {
+      result.add(equalTo(SERVER_ADDRESS, httpHost.getHost()));
+      result.add(equalTo(SERVER_PORT, httpHost.getPort()));
+    }
+    return result;
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
@@ -5,14 +5,13 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
-import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
-import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
@@ -31,11 +30,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.AfterAll;
@@ -95,14 +91,6 @@ abstract class AbstractOpenSearchTest {
   void shouldGetStatusWithTraces() throws IOException {
     HealthResponse healthResponse = openSearchClient.cluster().health();
     assertThat(healthResponse).isNotNull();
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_TYPE, null));
-    assertions.add(
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
-    assertions.add(
-        equalTo(
-            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-
     getTesting()
         .waitAndAssertTraces(
             trace ->
@@ -113,7 +101,19 @@ abstract class AbstractOpenSearchTest {
                                     ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(assertions),
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -131,14 +131,6 @@ abstract class AbstractOpenSearchTest {
   @Test
   void shouldGetStatusAsyncWithTraces() throws Exception {
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_TYPE, null));
-    assertions.add(
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
-    assertions.add(
-        equalTo(
-            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-
     CompletableFuture<HealthResponse> responseCompletableFuture =
         getTesting()
             .runWithSpan(
@@ -167,7 +159,19 @@ abstract class AbstractOpenSearchTest {
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(assertions),
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -202,33 +206,19 @@ abstract class AbstractOpenSearchTest {
         SERVER_PORT);
   }
 
-  List<AttributeAssertion> databaseAttributes(String operation, String queryText) {
-    List<AttributeAssertion> result = new ArrayList<>();
-    if (emitOldDatabaseSemconv()) {
-      result.add(equalTo(DB_SYSTEM, OPENSEARCH));
-      result.add(equalTo(DB_OPERATION, operation));
-      result.add(equalTo(DB_STATEMENT, queryText));
-    }
-    if (emitStableDatabaseSemconv()) {
-      result.add(equalTo(DB_SYSTEM_NAME, OPENSEARCH));
-      result.add(equalTo(DB_OPERATION_NAME, operation));
-      result.add(equalTo(DB_QUERY_TEXT, queryText));
-    }
-    return result;
-  }
-
   void assertNodeListTarget(String nodeList) {
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_TYPE, null));
-    assertions.add(equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? nodeList : null));
-    assertions.add(equalTo(SERVER_PORT, null));
-
     getTesting()
         .waitAndAssertTraces(
             trace ->
                 assertThat(trace.getSpan(0))
                     .hasName(emitStableDatabaseSemconv() ? "GET " + nodeList : "GET")
                     .hasKind(SpanKind.CLIENT)
-                    .hasAttributesSatisfyingExactly(assertions));
+                    .hasAttributesSatisfyingExactly(
+                        equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                        equalTo(maybeStable(DB_OPERATION), "GET"),
+                        equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                        equalTo(NETWORK_TYPE, null),
+                        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? nodeList : null),
+                        equalTo(SERVER_PORT, null)));
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
@@ -25,7 +25,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
@@ -96,15 +95,25 @@ abstract class AbstractOpenSearchTest {
   void shouldGetStatusWithTraces() throws IOException {
     HealthResponse healthResponse = openSearchClient.cluster().health();
     assertThat(healthResponse).isNotNull();
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_TYPE, null));
+    assertions.add(
+        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
+    assertions.add(
+        equalTo(
+            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
 
     getTesting()
         .waitAndAssertTraces(
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("GET"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "GET")
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
+                            .hasAttributesSatisfyingExactly(assertions),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -122,6 +131,13 @@ abstract class AbstractOpenSearchTest {
   @Test
   void shouldGetStatusAsyncWithTraces() throws Exception {
     CountDownLatch countDownLatch = new CountDownLatch(1);
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_TYPE, null));
+    assertions.add(
+        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
+    assertions.add(
+        equalTo(
+            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
 
     CompletableFuture<HealthResponse> responseCompletableFuture =
         getTesting()
@@ -145,10 +161,13 @@ abstract class AbstractOpenSearchTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(openSearchSpanName("GET"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
+                            .hasAttributesSatisfyingExactly(assertions),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -183,31 +202,6 @@ abstract class AbstractOpenSearchTest {
         SERVER_PORT);
   }
 
-  String openSearchSpanName(String method) {
-    return openSearchSpanName(method, httpHost.getHost(), Long.valueOf(httpHost.getPort()));
-  }
-
-  String openSearchSpanName(String method, String serverAddress, Long serverPort) {
-    return emitStableDatabaseSemconv()
-        ? method + " " + serverAddress + (serverPort != null ? ":" + serverPort : "")
-        : method;
-  }
-
-  List<AttributeAssertion> withServer(AttributeAssertion... assertions) {
-    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
-    result.add(equalTo(NETWORK_TYPE, null));
-    if (emitStableDatabaseSemconv()) {
-      result.add(equalTo(SERVER_ADDRESS, httpHost.getHost()));
-      result.add(equalTo(SERVER_PORT, httpHost.getPort()));
-    }
-    return result;
-  }
-
-  List<AttributeAssertion> clusterHealthAttributes() {
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    return withServer(assertions.toArray(new AttributeAssertion[0]));
-  }
-
   List<AttributeAssertion> databaseAttributes(String operation, String queryText) {
     List<AttributeAssertion> result = new ArrayList<>();
     if (emitOldDatabaseSemconv()) {
@@ -233,7 +227,7 @@ abstract class AbstractOpenSearchTest {
         .waitAndAssertTraces(
             trace ->
                 assertThat(trace.getSpan(0))
-                    .hasName(openSearchSpanName("GET", nodeList, null))
+                    .hasName(emitStableDatabaseSemconv() ? "GET " + nodeList : "GET")
                     .hasKind(SpanKind.CLIENT)
                     .hasAttributesSatisfyingExactly(assertions));
   }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/AbstractOpenSearchTest.java
@@ -5,15 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
-import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
+import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -21,13 +25,18 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPER
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.AfterAll;
@@ -56,6 +65,8 @@ abstract class AbstractOpenSearchTest {
 
   @RegisterExtension
   static final AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
+
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
 
   protected InstrumentationExtension getTesting() {
     return testing;
@@ -91,12 +102,9 @@ abstract class AbstractOpenSearchTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("GET")
+                        span.hasName(openSearchSpanName("GET"))
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "GET"),
-                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health")),
+                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -137,13 +145,10 @@ abstract class AbstractOpenSearchTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("GET")
+                        span.hasName(openSearchSpanName("GET"))
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "GET"),
-                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health")),
+                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)
@@ -170,6 +175,66 @@ abstract class AbstractOpenSearchTest {
     getTesting().waitForTraces(1);
 
     assertDurationMetric(
-        getTesting(), "io.opentelemetry.opensearch-java-3.0", DB_OPERATION_NAME, DB_SYSTEM_NAME);
+        getTesting(),
+        "io.opentelemetry.opensearch-java-3.0",
+        DB_OPERATION_NAME,
+        DB_SYSTEM_NAME,
+        SERVER_ADDRESS,
+        SERVER_PORT);
+  }
+
+  String openSearchSpanName(String method) {
+    return openSearchSpanName(method, httpHost.getHost(), Long.valueOf(httpHost.getPort()));
+  }
+
+  String openSearchSpanName(String method, String serverAddress, Long serverPort) {
+    return emitStableDatabaseSemconv()
+        ? method + " " + serverAddress + (serverPort != null ? ":" + serverPort : "")
+        : method;
+  }
+
+  List<AttributeAssertion> withServer(AttributeAssertion... assertions) {
+    List<AttributeAssertion> result = new ArrayList<>(asList(assertions));
+    result.add(equalTo(NETWORK_TYPE, null));
+    if (emitStableDatabaseSemconv()) {
+      result.add(equalTo(SERVER_ADDRESS, httpHost.getHost()));
+      result.add(equalTo(SERVER_PORT, httpHost.getPort()));
+    }
+    return result;
+  }
+
+  List<AttributeAssertion> clusterHealthAttributes() {
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    return withServer(assertions.toArray(new AttributeAssertion[0]));
+  }
+
+  List<AttributeAssertion> databaseAttributes(String operation, String queryText) {
+    List<AttributeAssertion> result = new ArrayList<>();
+    if (emitOldDatabaseSemconv()) {
+      result.add(equalTo(DB_SYSTEM, OPENSEARCH));
+      result.add(equalTo(DB_OPERATION, operation));
+      result.add(equalTo(DB_STATEMENT, queryText));
+    }
+    if (emitStableDatabaseSemconv()) {
+      result.add(equalTo(DB_SYSTEM_NAME, OPENSEARCH));
+      result.add(equalTo(DB_OPERATION_NAME, operation));
+      result.add(equalTo(DB_QUERY_TEXT, queryText));
+    }
+    return result;
+  }
+
+  void assertNodeListTarget(String nodeList) {
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_TYPE, null));
+    assertions.add(equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? nodeList : null));
+    assertions.add(equalTo(SERVER_PORT, null));
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                assertThat(trace.getSpan(0))
+                    .hasName(openSearchSpanName("GET", nodeList, null))
+                    .hasKind(SpanKind.CLIENT)
+                    .hasAttributesSatisfyingExactly(assertions));
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
@@ -8,6 +8,9 @@ package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -224,8 +227,13 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
   private void assertErrorTypeSpan() {
     List<AttributeAssertion> databaseAssertions =
         databaseAttributes("GET", "GET /invalid-index/_doc/1");
-    List<AttributeAssertion> assertions =
-        withServer(databaseAssertions.toArray(new AttributeAssertion[0]));
+    databaseAssertions.add(equalTo(NETWORK_TYPE, null));
+    databaseAssertions.add(
+        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
+    databaseAssertions.add(
+        equalTo(
+            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
+    List<AttributeAssertion> assertions = databaseAssertions;
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(ERROR_TYPE, "404"));
     }
@@ -235,7 +243,10 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("GET"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(assertions),
                     span ->

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
@@ -6,30 +6,30 @@
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
-import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
-import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.util.ArrayList;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.stream.IntStream;
 import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.cluster.HealthResponse;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
@@ -55,50 +56,131 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
 
   @Override
   protected OpenSearchClient buildOpenSearchClient() throws Exception {
-    HttpHost host = new HttpHost("https", httpHost.getHost(), httpHost.getPort());
-
-    TrustStrategy acceptingTrustStrategy = (certificate, authType) -> true;
-    SSLContext sslContext =
-        SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
-    TlsStrategy tlsStrategy =
-        ClientTlsStrategyBuilder.create()
-            .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-            .setSslContext(sslContext)
-            .build();
-    PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
-
-    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-    credentialsProvider.setCredentials(
-        new AuthScope(null, -1),
-        new UsernamePasswordCredentials(
-            opensearch.getUsername(), opensearch.getPassword().toCharArray()));
-
-    OpenSearchTransport apacheHttpClient5Transport =
-        ApacheHttpClient5TransportBuilder.builder(host)
-            .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    httpClientBuilder
-                        .setConnectionManager(connectionManager)
-                        .setDefaultCredentialsProvider(credentialsProvider))
-            .build();
-    return new OpenSearchClient(apacheHttpClient5Transport);
+    return new OpenSearchClient(buildTransport(configuredHost()));
   }
 
   @Override
   protected OpenSearchAsyncClient buildOpenSearchAsyncClient() throws Exception {
-    HttpHost host = new HttpHost("https", httpHost.getHost(), httpHost.getPort());
+    return new OpenSearchAsyncClient(buildTransport(configuredHost()));
+  }
 
+  @Test
+  void configuredNodeListIsSortedAndPreservesDuplicates() throws Exception {
+    OpenSearchTransport transport =
+        buildTransport(hostThatIsDown(), configuredHost(), configuredHost());
+    cleanup.deferCleanup(transport);
+    OpenSearchClient nodeListClient = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = nodeListClient.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    assertNodeListTarget(
+        httpHost.getHost()
+            + ":"
+            + httpHost.getPort()
+            + ","
+            + httpHost.getHost()
+            + ":"
+            + httpHost.getPort()
+            + ","
+            + httpHost.getHost()
+            + ":61");
+  }
+
+  @Test
+  void configuredNodeListIsSortedWhenEffectivePortsDiffer() throws Exception {
+    OpenSearchTransport transport =
+        buildTransport(hostWithDefaultPortThatIsDown(), configuredHost());
+    cleanup.deferCleanup(transport);
+    OpenSearchClient nodeListClient = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = nodeListClient.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    assertNodeListTarget(
+        httpHost.getHost() + ":443," + httpHost.getHost() + ":" + httpHost.getPort());
+  }
+
+  @Test
+  void configuredNodeListIsSorted() throws Exception {
+    OpenSearchTransport transport = buildTransport(configuredHosts(5));
+    cleanup.deferCleanup(transport);
+    OpenSearchClient nodeListClient = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = nodeListClient.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    assertNodeListTarget(configuredTarget(5));
+  }
+
+  @Test
+  void configuredNodeListSortsBeforeCapping() throws Exception {
+    OpenSearchTransport transport = buildTransport(configuredHosts(6));
+    cleanup.deferCleanup(transport);
+    OpenSearchClient nodeListClient = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = nodeListClient.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    assertNodeListTarget(configuredTarget(6));
+  }
+
+  private HttpHost configuredHost() {
+    return new HttpHost("https", httpHost.getHost(), httpHost.getPort());
+  }
+
+  private HttpHost hostWithDefaultPortThatIsDown() {
+    return new HttpHost("https", httpHost.getHost(), -1);
+  }
+
+  private HttpHost hostThatIsDown() {
+    // nothing listens on this port, so the request is served by the running server after a retry
+    return new HttpHost("https", httpHost.getHost(), 61);
+  }
+
+  private HttpHost[] configuredHosts(int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(index -> new HttpHost("https", nodeName(index), httpHost.getPort()))
+        .toArray(HttpHost[]::new);
+  }
+
+  private String configuredTarget(int count) {
+    return IntStream.rangeClosed(1, Math.min(count, 5))
+        .mapToObj(index -> nodeName(count - index + 1) + ":" + httpHost.getPort())
+        .collect(joining(","));
+  }
+
+  private static String nodeName(int index) {
+    return "node-" + (char) ('z' - index + 1) + ".example";
+  }
+
+  private OpenSearchTransport buildTransport(HttpHost... hosts) throws Exception {
     TrustStrategy acceptingTrustStrategy = (certificate, authType) -> true;
     SSLContext sslContext =
         SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
-    TlsStrategy tlsStrategy =
+    ClientTlsStrategyBuilder tlsStrategyBuilder =
         ClientTlsStrategyBuilder.create()
             .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-            .setSslContext(sslContext)
-            .build();
+            .setSslContext(sslContext);
+    tlsStrategyBuilder.setHostnameVerificationPolicy(HostnameVerificationPolicy.CLIENT);
+    TlsStrategy tlsStrategy = tlsStrategyBuilder.build();
+    DnsResolver dnsResolver =
+        new DnsResolver() {
+          @Override
+          public InetAddress[] resolve(String host) throws UnknownHostException {
+            return InetAddress.getAllByName(httpHost.getHost());
+          }
+
+          @Override
+          public String resolveCanonicalHostname(String host) {
+            return host;
+          }
+        };
     PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setDnsResolver(dnsResolver)
+            .build();
 
     BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
@@ -106,15 +188,13 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
         new UsernamePasswordCredentials(
             opensearch.getUsername(), opensearch.getPassword().toCharArray()));
 
-    OpenSearchTransport apacheHttpClient5Transport =
-        ApacheHttpClient5TransportBuilder.builder(host)
-            .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    httpClientBuilder
-                        .setConnectionManager(connectionManager)
-                        .setDefaultCredentialsProvider(credentialsProvider))
-            .build();
-    return new OpenSearchAsyncClient(apacheHttpClient5Transport);
+    return ApacheHttpClient5TransportBuilder.builder(hosts)
+        .setHttpClientConfigCallback(
+            httpClientBuilder ->
+                httpClientBuilder
+                    .setConnectionManager(connectionManager)
+                    .setDefaultCredentialsProvider(credentialsProvider))
+        .build();
   }
 
   @Test
@@ -141,14 +221,11 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
     assertErrorTypeSpan();
   }
 
-  @SuppressWarnings("deprecation") // using deprecated semconv
   private void assertErrorTypeSpan() {
+    List<AttributeAssertion> databaseAssertions =
+        databaseAttributes("GET", "GET /invalid-index/_doc/1");
     List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                equalTo(maybeStable(DB_OPERATION), "GET"),
-                equalTo(maybeStable(DB_STATEMENT), "GET /invalid-index/_doc/1")));
+        withServer(databaseAssertions.toArray(new AttributeAssertion[0]));
     if (emitStableDatabaseSemconv()) {
       assertions.add(equalTo(ERROR_TYPE, "404"));
     }
@@ -158,7 +235,7 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("GET")
+                        span.hasName(openSearchSpanName("GET"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(assertions),
                     span ->

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
@@ -6,11 +6,16 @@
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,10 +23,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 import javax.net.ssl.SSLContext;
@@ -224,17 +227,8 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
     assertErrorTypeSpan();
   }
 
+  @SuppressWarnings("deprecation") // using deprecated semconv
   private void assertErrorTypeSpan() {
-    List<AttributeAssertion> databaseAssertions =
-        databaseAttributes("GET", "GET /invalid-index/_doc/1");
-    databaseAssertions.add(equalTo(NETWORK_TYPE, null));
-    databaseAssertions.add(
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
-    databaseAssertions.add(
-        equalTo(
-            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-    databaseAssertions.add(equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "404" : null));
-
     getTesting()
         .waitAndAssertTraces(
             trace ->
@@ -245,7 +239,20 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
                                     ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(databaseAssertions),
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_STATEMENT), "GET /invalid-index/_doc/1"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null),
+                                equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "404" : null)),
                     span ->
                         span.hasName("GET").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
@@ -233,10 +233,7 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
     databaseAssertions.add(
         equalTo(
             SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-    List<AttributeAssertion> assertions = databaseAssertions;
-    if (emitStableDatabaseSemconv()) {
-      assertions.add(equalTo(ERROR_TYPE, "404"));
-    }
+    databaseAssertions.add(equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "404" : null));
 
     getTesting()
         .waitAndAssertTraces(
@@ -248,7 +245,7 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
                                     ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(assertions),
+                            .hasAttributesSatisfyingExactly(databaseAssertions),
                     span ->
                         span.hasName("GET").hasKind(SpanKind.CLIENT).hasParent(trace.getSpan(0))));
   }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchApacheHttpClient5TransportTest.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -104,7 +105,9 @@ class OpenSearchApacheHttpClient5TransportTest extends AbstractOpenSearchTest {
     assertThat(healthResponse).isNotNull();
 
     assertNodeListTarget(
-        httpHost.getHost() + ":443," + httpHost.getHost() + ":" + httpHost.getPort());
+        Stream.of(httpHost.getHost() + ":443", httpHost.getHost() + ":" + httpHost.getPort())
+            .sorted()
+            .collect(joining(",")));
   }
 
   @Test

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -17,6 +18,10 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -24,14 +29,12 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
@@ -176,17 +179,6 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
     HealthResponse healthResponse = client.cluster().health();
     assertThat(healthResponse).isNotNull();
 
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_PEER_ADDRESS, null));
-    assertions.add(equalTo(NETWORK_PEER_PORT, null));
-    assertions.add(equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? "os.example" : null));
-    assertions.add(
-        equalTo(
-            SERVER_PORT,
-            emitStableDatabaseSemconv() && expectedPort != null
-                ? Long.valueOf(expectedPort)
-                : null));
-
     getTesting()
         .waitAndAssertTraces(
             trace ->
@@ -199,7 +191,20 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
                                         + (expectedPort == null ? "" : ":" + expectedPort)
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
-                            .hasAttributesSatisfyingExactly(assertions)));
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                                equalTo(NETWORK_PEER_ADDRESS, null),
+                                equalTo(NETWORK_PEER_PORT, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? "os.example" : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    (emitStableDatabaseSemconv() && expectedPort != null)
+                                        ? Long.valueOf(expectedPort)
+                                        : null))));
   }
 
   private static Stream<Arguments> bareAuthorityCases() {
@@ -257,14 +262,6 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
     countDownLatch.await();
     HealthResponse healthResponse = responseCompletableFuture.get();
     assertThat(healthResponse).isNotNull();
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_TYPE, null));
-    assertions.add(
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
-    assertions.add(
-        equalTo(
-            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-
     getTesting()
         .waitAndAssertTraces(
             trace ->
@@ -277,7 +274,19 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
                                     : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(assertions),
+                            .hasAttributesSatisfyingExactly(
+                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                                equalTo(maybeStable(DB_OPERATION), "GET"),
+                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
-import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
@@ -16,26 +16,32 @@ import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSIO
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.testing.internal.armeria.common.HttpResponse;
 import io.opentelemetry.testing.internal.armeria.common.HttpStatus;
 import io.opentelemetry.testing.internal.armeria.common.MediaType;
 import io.opentelemetry.testing.internal.armeria.testing.junit5.server.mock.MockWebServerExtension;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.cluster.HealthResponse;
@@ -43,8 +49,13 @@ import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
@@ -54,11 +65,29 @@ import software.amazon.awssdk.utils.AttributeMap;
 @SuppressWarnings("deprecation") // using deprecated semconv
 class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
 
-  protected static final MockWebServerExtension server = new MockWebServerExtension();
+  private static final MockWebServerExtension server = new MockWebServerExtension();
 
   private static final StaticCredentialsProvider CREDENTIALS_PROVIDER =
       StaticCredentialsProvider.create(
           AwsBasicCredentials.create("my-access-key", "my-secret-key"));
+  private static final String HEALTH_RESPONSE =
+      "{\n"
+          + "  \"cluster_name\": \"test-cluster\",\n"
+          + "  \"status\": \"green\",\n"
+          + "  \"timed_out\": false,\n"
+          + "  \"number_of_nodes\": 1,\n"
+          + "  \"number_of_data_nodes\": 1,\n"
+          + "  \"active_primary_shards\": 0,\n"
+          + "  \"active_shards\": 0,\n"
+          + "  \"relocating_shards\": 0,\n"
+          + "  \"initializing_shards\": 0,\n"
+          + "  \"unassigned_shards\": 0,\n"
+          + "  \"delayed_unassigned_shards\": 0,\n"
+          + "  \"number_of_pending_tasks\": 0,\n"
+          + "  \"number_of_in_flight_fetch\": 0,\n"
+          + "  \"task_max_waiting_in_queue_millis\": 0,\n"
+          + "  \"active_shards_percent_as_number\": 100.0\n"
+          + "}";
 
   @RegisterExtension
   static final AgentInstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -82,29 +111,9 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
   void setupForHealthResponse() {
     server.beforeTestExecution(null);
 
-    // Mock OpenSearch cluster health response
-    String healthResponse =
-        "{\n"
-            + "  \"cluster_name\": \"test-cluster\",\n"
-            + "  \"status\": \"green\",\n"
-            + "  \"timed_out\": false,\n"
-            + "  \"number_of_nodes\": 1,\n"
-            + "  \"number_of_data_nodes\": 1,\n"
-            + "  \"active_primary_shards\": 0,\n"
-            + "  \"active_shards\": 0,\n"
-            + "  \"relocating_shards\": 0,\n"
-            + "  \"initializing_shards\": 0,\n"
-            + "  \"unassigned_shards\": 0,\n"
-            + "  \"delayed_unassigned_shards\": 0,\n"
-            + "  \"number_of_pending_tasks\": 0,\n"
-            + "  \"number_of_in_flight_fetch\": 0,\n"
-            + "  \"task_max_waiting_in_queue_millis\": 0,\n"
-            + "  \"active_shards_percent_as_number\": 100.0\n"
-            + "}";
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, HEALTH_RESPONSE));
 
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, healthResponse));
-
-    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, healthResponse));
+    server.enqueue(HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, HEALTH_RESPONSE));
   }
 
   @Override
@@ -150,6 +159,82 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
     return new OpenSearchAsyncClient(transport);
   }
 
+  @ParameterizedTest
+  @MethodSource("bareAuthorityCases")
+  void bareAuthorityUsesHttpsPortDefaults(String authority, Integer expectedPort)
+      throws IOException {
+    AwsSdk2Transport transport =
+        new AwsSdk2Transport(
+            successfulHttpClient(),
+            authority,
+            Region.AP_NORTHEAST_1,
+            AwsSdk2TransportOptions.builder().setCredentials(CREDENTIALS_PROVIDER).build());
+    cleanup.deferCleanup(transport);
+    OpenSearchClient client = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = client.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_PEER_ADDRESS, null));
+    assertions.add(equalTo(NETWORK_PEER_PORT, null));
+    assertions.add(equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? "os.example" : null));
+    assertions.add(
+        equalTo(
+            SERVER_PORT,
+            emitStableDatabaseSemconv() && expectedPort != null
+                ? Long.valueOf(expectedPort)
+                : null));
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                trace.hasSpansSatisfyingExactly(
+                    span ->
+                        span.hasName(
+                                openSearchSpanName(
+                                    "GET",
+                                    "os.example",
+                                    expectedPort == null ? null : Long.valueOf(expectedPort)))
+                            .hasKind(SpanKind.CLIENT)
+                            .hasAttributesSatisfyingExactly(assertions)));
+  }
+
+  private static Stream<Arguments> bareAuthorityCases() {
+    return Stream.of(
+        argumentSet("HTTPS default port", "os.example:443", null),
+        argumentSet("non-default port", "os.example:9200", 9200));
+  }
+
+  private static SdkHttpClient successfulHttpClient() {
+    return new SdkHttpClient() {
+      @Override
+      public ExecutableHttpRequest prepareRequest(HttpExecuteRequest request) {
+        return new ExecutableHttpRequest() {
+          @Override
+          public HttpExecuteResponse call() {
+            return HttpExecuteResponse.builder()
+                .response(
+                    SdkHttpResponse.builder()
+                        .statusCode(200)
+                        .putHeader("Content-Type", "application/json")
+                        .build())
+                .responseBody(
+                    AbortableInputStream.create(
+                        new ByteArrayInputStream(HEALTH_RESPONSE.getBytes(UTF_8))))
+                .build();
+          }
+
+          @Override
+          public void abort() {}
+        };
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+
   @Test
   @Override
   void shouldGetStatusAsyncWithTraces() throws Exception {
@@ -177,13 +262,10 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName("GET")
+                        span.hasName(openSearchSpanName("GET"))
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
-                                equalTo(maybeStable(DB_OPERATION), "GET"),
-                                equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health")),
+                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchAwsSdk2TransportTest.java
@@ -13,6 +13,7 @@ import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -192,10 +193,11 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
                 trace.hasSpansSatisfyingExactly(
                     span ->
                         span.hasName(
-                                openSearchSpanName(
-                                    "GET",
-                                    "os.example",
-                                    expectedPort == null ? null : Long.valueOf(expectedPort)))
+                                emitStableDatabaseSemconv()
+                                    ? "GET "
+                                        + "os.example"
+                                        + (expectedPort == null ? "" : ":" + expectedPort)
+                                    : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(assertions)));
   }
@@ -255,6 +257,13 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
     countDownLatch.await();
     HealthResponse healthResponse = responseCompletableFuture.get();
     assertThat(healthResponse).isNotNull();
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_TYPE, null));
+    assertions.add(
+        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
+    assertions.add(
+        equalTo(
+            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
 
     getTesting()
         .waitAndAssertTraces(
@@ -262,10 +271,13 @@ class OpenSearchAwsSdk2TransportTest extends AbstractOpenSearchTest {
                 trace.hasSpansSatisfyingExactly(
                     span -> span.hasName("client").hasKind(SpanKind.INTERNAL),
                     span ->
-                        span.hasName(openSearchSpanName("GET"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "GET " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "GET")
                             .hasKind(SpanKind.CLIENT)
                             .hasParent(trace.getSpan(0))
-                            .hasAttributesSatisfyingExactly(clusterHealthAttributes()),
+                            .hasAttributesSatisfyingExactly(assertions),
                     span ->
                         span.hasName("GET")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -81,18 +81,19 @@ class OpenSearchBodyExtractorTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                satisfies(
-                                    maybeStable(DB_STATEMENT),
-                                    val ->
-                                        val.asString()
-                                            .doesNotContain(accentedCharacter)
-                                            .containsPattern("\\\\u00[eE]9")
-                                            .contains("\"?\""))),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    satisfies(
+                                        maybeStable(DB_STATEMENT),
+                                        val ->
+                                            val.asString()
+                                                .doesNotContain(accentedCharacter)
+                                                .containsPattern("\\\\u00[eE]9")
+                                                .contains("\"?\"")))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -81,19 +83,30 @@ class OpenSearchBodyExtractorTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    satisfies(
-                                        maybeStable(DB_STATEMENT),
-                                        val ->
-                                            val.asString()
-                                                .doesNotContain(accentedCharacter)
-                                                .containsPattern("\\\\u00[eE]9")
-                                                .contains("\"?\"")))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                satisfies(
+                                    maybeStable(DB_STATEMENT),
+                                    val ->
+                                        val.asString()
+                                            .doesNotContain(accentedCharacter)
+                                            .containsPattern("\\\\u00[eE]9")
+                                            .contains("\"?\"")),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryJsonbTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryJsonbTest.java
@@ -86,14 +86,15 @@ class OpenSearchCaptureSearchQueryJsonbTest extends AbstractOpenSearchQueryTest 
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -138,12 +139,13 @@ class OpenSearchCaptureSearchQueryJsonbTest extends AbstractOpenSearchQueryTest 
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(maybeStable(DB_STATEMENT), expected)),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(maybeStable(DB_STATEMENT), expected))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryJsonbTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryJsonbTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -86,15 +88,26 @@ class OpenSearchCaptureSearchQueryJsonbTest extends AbstractOpenSearchQueryTest 
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -139,13 +152,24 @@ class OpenSearchCaptureSearchQueryJsonbTest extends AbstractOpenSearchQueryTest 
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(maybeStable(DB_STATEMENT), expected))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(maybeStable(DB_STATEMENT), expected),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -59,15 +61,26 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -134,15 +147,26 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message2\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message3\":{\"value\":\"?\"}}}}"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    "{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message2\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message3\":{\"value\":\"?\"}}}}"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -218,15 +242,24 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "POST /test-search-index/_doc"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(maybeStable(DB_STATEMENT), "POST /test-search-index/_doc"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -251,13 +284,24 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(maybeStable(DB_STATEMENT), expected))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(maybeStable(DB_STATEMENT), expected),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchCaptureSearchQueryTest.java
@@ -59,14 +59,15 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"?\"}}}}"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -133,14 +134,15 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message2\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message3\":{\"value\":\"?\"}}}}")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message2\":{\"value\":\"?\"}}}};{\"index\":[\"?\"]};{\"query\":{\"term\":{\"message3\":{\"value\":\"?\"}}}}"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -216,12 +218,15 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(maybeStable(DB_STATEMENT), "POST /test-search-index/_doc")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "POST /test-search-index/_doc"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)
@@ -246,12 +251,13 @@ class OpenSearchCaptureSearchQueryTest extends AbstractOpenSearchQueryTest {
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(maybeStable(DB_STATEMENT), expected)),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(maybeStable(DB_STATEMENT), expected))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchDisabledCaptureSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchDisabledCaptureSearchQueryTest.java
@@ -59,16 +59,17 @@ class OpenSearchDisabledCaptureSearchQueryTest extends AbstractOpenSearchQueryTe
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                satisfies(
-                                    maybeStable(DB_STATEMENT),
-                                    val ->
-                                        val.asString()
-                                            .startsWith("POST /" + INDEX_NAME + "/_search"))),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    satisfies(
+                                        maybeStable(DB_STATEMENT),
+                                        val ->
+                                            val.asString()
+                                                .startsWith("POST /" + INDEX_NAME + "/_search")))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchDisabledCaptureSearchQueryTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchDisabledCaptureSearchQueryTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -59,17 +61,28 @@ class OpenSearchDisabledCaptureSearchQueryTest extends AbstractOpenSearchQueryTe
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    satisfies(
-                                        maybeStable(DB_STATEMENT),
-                                        val ->
-                                            val.asString()
-                                                .startsWith("POST /" + INDEX_NAME + "/_search")))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                satisfies(
+                                    maybeStable(DB_STATEMENT),
+                                    val ->
+                                        val.asString()
+                                            .startsWith("POST /" + INDEX_NAME + "/_search")),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledJsonbTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledJsonbTest.java
@@ -79,14 +79,15 @@ class OpenSearchQuerySanitizationDisabledJsonbTest extends AbstractOpenSearchQue
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledJsonbTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledJsonbTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -79,15 +81,26 @@ class OpenSearchQuerySanitizationDisabledJsonbTest extends AbstractOpenSearchQue
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledTest.java
@@ -51,14 +51,15 @@ class OpenSearchQuerySanitizationDisabledTest extends AbstractOpenSearchQueryTes
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName("POST")
+                        span.hasName(openSearchSpanName("POST"))
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                equalTo(maybeStable(DB_OPERATION), "POST"),
-                                equalTo(
-                                    maybeStable(DB_STATEMENT),
-                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}")),
+                                withServer(
+                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                    equalTo(maybeStable(DB_OPERATION), "POST"),
+                                    equalTo(
+                                        maybeStable(DB_STATEMENT),
+                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"))),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchQuerySanitizationDisabledTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -12,6 +13,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satis
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_METHOD;
 import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PROTOCOL_VERSION;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.UrlAttributes.URL_FULL;
@@ -51,15 +53,26 @@ class OpenSearchQuerySanitizationDisabledTest extends AbstractOpenSearchQueryTes
             trace ->
                 trace.hasSpansSatisfyingExactly(
                     span ->
-                        span.hasName(openSearchSpanName("POST"))
+                        span.hasName(
+                                emitStableDatabaseSemconv()
+                                    ? "POST " + httpHost.getHost() + ":" + httpHost.getPort()
+                                    : "POST")
                             .hasKind(SpanKind.CLIENT)
                             .hasAttributesSatisfyingExactly(
-                                withServer(
-                                    equalTo(maybeStable(DB_SYSTEM), "opensearch"),
-                                    equalTo(maybeStable(DB_OPERATION), "POST"),
-                                    equalTo(
-                                        maybeStable(DB_STATEMENT),
-                                        "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"))),
+                                equalTo(maybeStable(DB_SYSTEM), "opensearch"),
+                                equalTo(maybeStable(DB_OPERATION), "POST"),
+                                equalTo(
+                                    maybeStable(DB_STATEMENT),
+                                    "{\"query\":{\"match\":{\"message\":{\"query\":\"test\"}}}}"),
+                                equalTo(NETWORK_TYPE, null),
+                                equalTo(
+                                    SERVER_ADDRESS,
+                                    emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                                equalTo(
+                                    SERVER_PORT,
+                                    emitStableDatabaseSemconv()
+                                        ? Long.valueOf(httpHost.getPort())
+                                        : null)),
                     span ->
                         span.hasName("POST")
                             .hasKind(SpanKind.CLIENT)

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
@@ -5,12 +5,19 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -79,12 +86,17 @@ class OpenSearchRestClientTransportTest extends AbstractOpenSearchTest {
 
     HealthResponse healthResponse = client.cluster().health();
     assertThat(healthResponse).isNotNull();
+    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
+    assertions.add(equalTo(NETWORK_TYPE, null));
+    assertions.add(
+        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
+    assertions.add(
+        equalTo(
+            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
 
     getTesting()
         .waitAndAssertTraces(
-            trace ->
-                assertThat(trace.getSpan(0))
-                    .hasAttributesSatisfyingExactly(clusterHealthAttributes()));
+            trace -> assertThat(trace.getSpan(0)).hasAttributesSatisfyingExactly(assertions));
   }
 
   private HttpHost configuredHost() {

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
@@ -6,18 +6,21 @@
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_TYPE;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_STATEMENT;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.OPENSEARCH;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
-import java.util.List;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -86,17 +89,23 @@ class OpenSearchRestClientTransportTest extends AbstractOpenSearchTest {
 
     HealthResponse healthResponse = client.cluster().health();
     assertThat(healthResponse).isNotNull();
-    List<AttributeAssertion> assertions = databaseAttributes("GET", "GET /_cluster/health");
-    assertions.add(equalTo(NETWORK_TYPE, null));
-    assertions.add(
-        equalTo(SERVER_ADDRESS, emitStableDatabaseSemconv() ? httpHost.getHost() : null));
-    assertions.add(
-        equalTo(
-            SERVER_PORT, emitStableDatabaseSemconv() ? Long.valueOf(httpHost.getPort()) : null));
-
     getTesting()
         .waitAndAssertTraces(
-            trace -> assertThat(trace.getSpan(0)).hasAttributesSatisfyingExactly(assertions));
+            trace ->
+                assertThat(trace.getSpan(0))
+                    .hasAttributesSatisfyingExactly(
+                        equalTo(maybeStable(DB_SYSTEM), OPENSEARCH),
+                        equalTo(maybeStable(DB_OPERATION), "GET"),
+                        equalTo(maybeStable(DB_STATEMENT), "GET /_cluster/health"),
+                        equalTo(NETWORK_TYPE, null),
+                        equalTo(
+                            SERVER_ADDRESS,
+                            emitStableDatabaseSemconv() ? httpHost.getHost() : null),
+                        equalTo(
+                            SERVER_PORT,
+                            emitStableDatabaseSemconv()
+                                ? Long.valueOf(httpHost.getPort())
+                                : null)));
   }
 
   private HttpHost configuredHost() {

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchRestClientTransportTest.java
@@ -5,6 +5,10 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import javax.net.ssl.SSLContext;
@@ -19,11 +23,14 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.ssl.TrustStrategy;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.opensearch.client.Node;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.cluster.HealthResponse;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
 
@@ -41,39 +48,59 @@ class OpenSearchRestClientTransportTest extends AbstractOpenSearchTest {
 
   @Override
   protected OpenSearchClient buildOpenSearchClient() throws Exception {
-    TrustStrategy acceptingTrustStrategy = (certificate, authType) -> true;
-    SSLContext sslContext =
-        SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
-    TlsStrategy tlsStrategy =
-        ClientTlsStrategyBuilder.create()
-            .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-            .setSslContext(sslContext)
-            .build();
-    PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
-
-    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-    credentialsProvider.setCredentials(
-        new AuthScope(null, -1),
-        new UsernamePasswordCredentials(
-            opensearch.getUsername(), opensearch.getPassword().toCharArray()));
-
-    HttpHost httpHost = HttpHost.create(opensearch.getHttpHostAddress());
-    RestClient restClient =
-        RestClient.builder(httpHost)
-            .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    httpClientBuilder
-                        .setConnectionManager(connectionManager)
-                        .setDefaultCredentialsProvider(credentialsProvider))
-            .build();
-
-    OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
-    return new OpenSearchClient(transport);
+    return new OpenSearchClient(buildTransport(configuredHost()));
   }
 
   @Override
   protected OpenSearchAsyncClient buildOpenSearchAsyncClient() throws Exception {
+    return new OpenSearchAsyncClient(buildTransport(configuredHost()));
+  }
+
+  @Test
+  void configuredNodeListIsSorted() throws Exception {
+    OpenSearchTransport transport = buildTransport(hostThatIsDown(), configuredHost());
+    cleanup.deferCleanup(transport);
+    OpenSearchClient nodeListClient = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = nodeListClient.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    assertNodeListTarget(
+        httpHost.getHost() + ":" + httpHost.getPort() + "," + httpHost.getHost() + ":61");
+  }
+
+  @Test
+  void targetDoesNotFollowNodeChangesBeforeTransportConstruction() throws Exception {
+    RestClient restClient = buildRestClient(configuredHost());
+    restClient.setNodes(asList(new Node(configuredHost()), new Node(hostThatIsDown())));
+    OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+    cleanup.deferCleanup(transport);
+    OpenSearchClient client = new OpenSearchClient(transport);
+
+    HealthResponse healthResponse = client.cluster().health();
+    assertThat(healthResponse).isNotNull();
+
+    getTesting()
+        .waitAndAssertTraces(
+            trace ->
+                assertThat(trace.getSpan(0))
+                    .hasAttributesSatisfyingExactly(clusterHealthAttributes()));
+  }
+
+  private HttpHost configuredHost() {
+    return new HttpHost("https", httpHost.getHost(), httpHost.getPort());
+  }
+
+  private HttpHost hostThatIsDown() {
+    // nothing listens on this port, so the request is served by the running server after a retry
+    return new HttpHost("https", httpHost.getHost(), 61);
+  }
+
+  private OpenSearchTransport buildTransport(HttpHost... hosts) throws Exception {
+    return new RestClientTransport(buildRestClient(hosts), new JacksonJsonpMapper());
+  }
+
+  private RestClient buildRestClient(HttpHost... hosts) throws Exception {
     TrustStrategy acceptingTrustStrategy = (certificate, authType) -> true;
     SSLContext sslContext =
         SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
@@ -91,17 +118,12 @@ class OpenSearchRestClientTransportTest extends AbstractOpenSearchTest {
         new UsernamePasswordCredentials(
             opensearch.getUsername(), opensearch.getPassword().toCharArray()));
 
-    HttpHost httpHost = HttpHost.create(opensearch.getHttpHostAddress());
-    RestClient restClient =
-        RestClient.builder(httpHost)
-            .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    httpClientBuilder
-                        .setConnectionManager(connectionManager)
-                        .setDefaultCredentialsProvider(credentialsProvider))
-            .build();
-
-    OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
-    return new OpenSearchAsyncClient(transport);
+    return RestClient.builder(hosts)
+        .setHttpClientConfigCallback(
+            httpClientBuilder ->
+                httpClientBuilder
+                    .setConnectionManager(connectionManager)
+                    .setDefaultCredentialsProvider(credentialsProvider))
+        .build();
   }
 }


### PR DESCRIPTION
Captures configured server targets for OpenSearch Java clients and emits `server.address` and `server.port` in stable and `database/dup` telemetry. Stable span names include the target, so `GET` becomes `GET os.example:9200`.

Supports `RestClientTransport`, `ApacheHttpClient5Transport`, and `AwsSdk2Transport`. Each transport captures its configuration at construction time instead of following mutable routing state. Multi-endpoint targets are sorted, capped at five, omit default ports, and include every effective port when any endpoint uses a non-default port. Bare AWS SDK authorities default to HTTPS.

Legacy telemetry remains unchanged and emits no `server.*` attributes. This PR is stacked on #19903 and is part of #19899.