### PR TITLE
Add detailed OpenAI token usage attributes

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractor.java
@@ -56,8 +56,12 @@ public final class GenAiAttributesExtractor<REQUEST, RESPONSE>
   static final AttributeKey<String> GEN_AI_RESPONSE_MODEL = stringKey("gen_ai.response.model");
   static final AttributeKey<String> GEN_AI_PROVIDER_NAME = stringKey("gen_ai.provider.name");
   static final AttributeKey<Long> GEN_AI_USAGE_INPUT_TOKENS = longKey("gen_ai.usage.input_tokens");
+  static final AttributeKey<Long> GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS =
+      longKey("gen_ai.usage.cache_read.input_tokens");
   static final AttributeKey<Long> GEN_AI_USAGE_OUTPUT_TOKENS =
       longKey("gen_ai.usage.output_tokens");
+  static final AttributeKey<Long> GEN_AI_USAGE_REASONING_OUTPUT_TOKENS =
+      longKey("gen_ai.usage.reasoning.output_tokens");
 
   /** Creates the GenAI attributes extractor. */
   public static <REQUEST, RESPONSE> AttributesExtractor<REQUEST, RESPONSE> create(
@@ -104,6 +108,12 @@ public final class GenAiAttributesExtractor<REQUEST, RESPONSE>
     attributes.put(GEN_AI_RESPONSE_ID, getter.getResponseId(request, response));
     attributes.put(GEN_AI_RESPONSE_MODEL, getter.getResponseModel(request, response));
     attributes.put(GEN_AI_USAGE_INPUT_TOKENS, getter.getUsageInputTokens(request, response));
+    attributes.put(
+        GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        getter.getUsageCacheReadInputTokens(request, response));
     attributes.put(GEN_AI_USAGE_OUTPUT_TOKENS, getter.getUsageOutputTokens(request, response));
+    attributes.put(
+        GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+        getter.getUsageReasoningOutputTokens(request, response));
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesGetter.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesGetter.java
@@ -64,5 +64,15 @@ public interface GenAiAttributesGetter<REQUEST, RESPONSE> {
   Long getUsageInputTokens(REQUEST request, @Nullable RESPONSE response);
 
   @Nullable
+  default Long getUsageCacheReadInputTokens(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
+
+  @Nullable
   Long getUsageOutputTokens(REQUEST request, @Nullable RESPONSE response);
+
+  @Nullable
+  default Long getUsageReasoningOutputTokens(REQUEST request, @Nullable RESPONSE response) {
+    return null;
+  }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/genai/GenAiAttributesExtractorTest.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_PROVIDER_NAME;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_REQUEST_MODEL;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS;
+import static io.opentelemetry.instrumentation.api.incubator.semconv.genai.GenAiAttributesExtractor.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static java.util.Collections.emptyList;
 
@@ -19,6 +21,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -30,7 +33,7 @@ class GenAiAttributesExtractorTest {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   void extractsStreamingOnStart(boolean streaming) {
-    AttributesExtractor<Request, Void> extractor =
+    AttributesExtractor<Request, Response> extractor =
         GenAiAttributesExtractor.create(new TestGetter());
     Request request = new Request(streaming);
 
@@ -48,6 +51,49 @@ class GenAiAttributesExtractorTest {
     assertThat(attributes.build()).isEqualTo(expected.build());
   }
 
+  @Test
+  void extractsDetailedTokenUsageOnEnd() {
+    AttributesExtractor<Request, Response> extractor =
+        GenAiAttributesExtractor.create(new TestGetter());
+    AttributesBuilder attributes = Attributes.builder();
+
+    extractor.onEnd(attributes, Context.root(), new Request(false), new Response(12L, 4L), null);
+
+    assertThat(attributes.build())
+        .isEqualTo(
+            Attributes.builder()
+                .put(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 12L)
+                .put(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 4L)
+                .build());
+  }
+
+  @Test
+  void preservesExplicitZeroDetailedTokenUsageOnEnd() {
+    AttributesExtractor<Request, Response> extractor =
+        GenAiAttributesExtractor.create(new TestGetter());
+    AttributesBuilder attributes = Attributes.builder();
+
+    extractor.onEnd(attributes, Context.root(), new Request(false), new Response(0L, 0L), null);
+
+    assertThat(attributes.build())
+        .isEqualTo(
+            Attributes.builder()
+                .put(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L)
+                .put(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)
+                .build());
+  }
+
+  @Test
+  void omitsDetailedTokenUsageWhenResponseIsUnavailable() {
+    AttributesExtractor<Request, Response> extractor =
+        GenAiAttributesExtractor.create(new TestGetter());
+    AttributesBuilder attributes = Attributes.builder();
+
+    extractor.onEnd(attributes, Context.root(), new Request(false), null, null);
+
+    assertThat(attributes.build()).isEmpty();
+  }
+
   private static final class Request {
     private final boolean streaming;
 
@@ -56,7 +102,17 @@ class GenAiAttributesExtractorTest {
     }
   }
 
-  private static final class TestGetter implements GenAiAttributesGetter<Request, Void> {
+  private static final class Response {
+    private final Long cacheReadInputTokens;
+    private final Long reasoningOutputTokens;
+
+    private Response(Long cacheReadInputTokens, Long reasoningOutputTokens) {
+      this.cacheReadInputTokens = cacheReadInputTokens;
+      this.reasoningOutputTokens = reasoningOutputTokens;
+    }
+  }
+
+  private static final class TestGetter implements GenAiAttributesGetter<Request, Response> {
 
     @Override
     public String getOperationName(Request request) {
@@ -133,32 +189,44 @@ class GenAiAttributesExtractorTest {
     }
 
     @Override
-    public List<String> getResponseFinishReasons(Request request, @Nullable Void response) {
+    public List<String> getResponseFinishReasons(Request request, @Nullable Response response) {
       return emptyList();
     }
 
     @Nullable
     @Override
-    public String getResponseId(Request request, @Nullable Void response) {
+    public String getResponseId(Request request, @Nullable Response response) {
       return null;
     }
 
     @Nullable
     @Override
-    public String getResponseModel(Request request, @Nullable Void response) {
+    public String getResponseModel(Request request, @Nullable Response response) {
       return null;
     }
 
     @Nullable
     @Override
-    public Long getUsageInputTokens(Request request, @Nullable Void response) {
+    public Long getUsageInputTokens(Request request, @Nullable Response response) {
       return null;
     }
 
     @Nullable
     @Override
-    public Long getUsageOutputTokens(Request request, @Nullable Void response) {
+    public Long getUsageCacheReadInputTokens(Request request, @Nullable Response response) {
+      return response == null ? null : response.cacheReadInputTokens;
+    }
+
+    @Nullable
+    @Override
+    public Long getUsageOutputTokens(Request request, @Nullable Response response) {
       return null;
+    }
+
+    @Nullable
+    @Override
+    public Long getUsageReasoningOutputTokens(Request request, @Nullable Response response) {
+      return response == null ? null : response.reasoningOutputTokens;
     }
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetter.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetter.java
@@ -148,11 +148,39 @@ final class ChatAttributesGetter
 
   @Override
   @Nullable
+  public Long getUsageCacheReadInputTokens(
+      ChatCompletionRequest request, @Nullable ChatCompletion response) {
+    if (response == null) {
+      return null;
+    }
+    return response
+        .usage()
+        .flatMap(CompletionUsage::promptTokensDetails)
+        .flatMap(CompletionUsage.PromptTokensDetails::cachedTokens)
+        .orElse(null);
+  }
+
+  @Override
+  @Nullable
   public Long getUsageOutputTokens(
       ChatCompletionRequest request, @Nullable ChatCompletion response) {
     if (response == null) {
       return null;
     }
     return response.usage().map(CompletionUsage::completionTokens).orElse(null);
+  }
+
+  @Override
+  @Nullable
+  public Long getUsageReasoningOutputTokens(
+      ChatCompletionRequest request, @Nullable ChatCompletion response) {
+    if (response == null) {
+      return null;
+    }
+    return response
+        .usage()
+        .flatMap(CompletionUsage::completionTokensDetails)
+        .flatMap(CompletionUsage.CompletionTokensDetails::reasoningTokens)
+        .orElse(null);
   }
 }

--- a/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetterTest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatAttributesGetterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.openai.v1_1;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.completions.CompletionUsage;
+import org.junit.jupiter.api.Test;
+
+class ChatAttributesGetterTest {
+
+  private static final ChatCompletionRequest REQUEST =
+      ChatCompletionRequest.create(
+          ChatCompletionCreateParams.builder().messages(emptyList()).model("test-model").build());
+
+  private final ChatAttributesGetter getter = new ChatAttributesGetter();
+
+  @Test
+  void extractsDetailedTokenUsage() {
+    CompletionUsage usage =
+        CompletionUsage.builder()
+            .promptTokens(20)
+            .completionTokens(10)
+            .totalTokens(30)
+            .promptTokensDetails(
+                CompletionUsage.PromptTokensDetails.builder().cachedTokens(12).build())
+            .completionTokensDetails(
+                CompletionUsage.CompletionTokensDetails.builder().reasoningTokens(4).build())
+            .build();
+    ChatCompletion response =
+        ChatCompletion.builder()
+            .id("test-id")
+            .choices(emptyList())
+            .created(0)
+            .model("test-model")
+            .usage(usage)
+            .build();
+
+    assertThat(getter.getUsageCacheReadInputTokens(REQUEST, response)).isEqualTo(12L);
+    assertThat(getter.getUsageReasoningOutputTokens(REQUEST, response)).isEqualTo(4L);
+  }
+
+  @Test
+  void omitsDetailedTokenUsageWhenDetailsAreUnavailable() {
+    CompletionUsage usage =
+        CompletionUsage.builder().promptTokens(20).completionTokens(10).totalTokens(30).build();
+    ChatCompletion response =
+        ChatCompletion.builder()
+            .id("test-id")
+            .choices(emptyList())
+            .created(0)
+            .model("test-model")
+            .usage(usage)
+            .build();
+
+    assertThat(getter.getUsageCacheReadInputTokens(REQUEST, response)).isNull();
+    assertThat(getter.getUsageReasoningOutputTokens(REQUEST, response)).isNull();
+  }
+
+  @Test
+  void omitsDetailedTokenUsageWhenResponseIsUnavailable() {
+    assertThat(getter.getUsageCacheReadInputTokens(REQUEST, null)).isNull();
+    assertThat(getter.getUsageReasoningOutputTokens(REQUEST, null)).isNull();
+  }
+}

--- a/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/library/src/test/java/io/opentelemetry/instrumentation/openai/v1_1/ChatTest.java
@@ -16,8 +16,10 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_ID;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_MODEL;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_TOKEN_TYPE;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.CHAT;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.OPENAI;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
@@ -224,7 +226,9 @@ class ChatTest extends AbstractChatTest {
                                     GEN_AI_RESPONSE_FINISH_REASONS,
                                     val -> val.containsExactly("stop", "stop")),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 22L),
-                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 7L))));
+                                equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 7L),
+                                equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -354,7 +358,9 @@ class ChatTest extends AbstractChatTest {
                                     GEN_AI_RESPONSE_FINISH_REASONS,
                                     val -> val.containsExactly("tool_calls")),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 67L),
-                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 46L))));
+                                equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 46L),
+                                equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -477,7 +483,9 @@ class ChatTest extends AbstractChatTest {
                                     GEN_AI_RESPONSE_FINISH_REASONS,
                                     val -> val.containsExactly("stop")),
                                 equalTo(GEN_AI_USAGE_INPUT_TOKENS, 99L),
-                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 25L))));
+                                equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 25L),
+                                equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L))));
 
     getTesting()
         .waitAndAssertMetrics(

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/java/io/opentelemetry/instrumentation/openai/v1_1/AbstractChatTest.java
@@ -24,8 +24,10 @@ import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_ID;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_RESPONSE_MODEL;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_TOKEN_TYPE;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_INPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_OUTPUT_TOKENS;
+import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.CHAT;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiProviderNameIncubatingValues.OPENAI;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GenAiTokenTypeIncubatingValues.INPUT;
@@ -367,7 +369,9 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                         GEN_AI_RESPONSE_FINISH_REASONS,
                                         val -> val.containsExactly("stop")),
                                     equalTo(GEN_AI_USAGE_INPUT_TOKENS, 22L),
-                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 3L)))));
+                                    equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 3L),
+                                    equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -470,7 +474,9 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                         GEN_AI_RESPONSE_FINISH_REASONS,
                                         val -> val.containsExactly("stop", "stop")),
                                     equalTo(GEN_AI_USAGE_INPUT_TOKENS, 22L),
-                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 7L)))));
+                                    equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 7L),
+                                    equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -603,7 +609,9 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                         GEN_AI_RESPONSE_FINISH_REASONS,
                                         val -> val.containsExactly("tool_calls")),
                                     equalTo(GEN_AI_USAGE_INPUT_TOKENS, 67L),
-                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 46L)))));
+                                    equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 46L),
+                                    equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -753,7 +761,9 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                         GEN_AI_RESPONSE_FINISH_REASONS,
                                         val -> val.containsExactly("stop")),
                                     equalTo(GEN_AI_USAGE_INPUT_TOKENS, 99L),
-                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 25L)))));
+                                    equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 25L),
+                                    equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)))));
 
     getTesting()
         .waitAndAssertMetrics(
@@ -1118,7 +1128,9 @@ public abstract class AbstractChatTest extends AbstractOpenAiTest {
                                         GEN_AI_RESPONSE_FINISH_REASONS,
                                         val -> val.containsExactly("stop")),
                                     equalTo(GEN_AI_USAGE_INPUT_TOKENS, 22L),
-                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 3L)))));
+                                    equalTo(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0L),
+                                    equalTo(GEN_AI_USAGE_OUTPUT_TOKENS, 3L),
+                                    equalTo(GEN_AI_USAGE_REASONING_OUTPUT_TOKENS, 0L)))));
 
     getTesting()
         .waitAndAssertMetrics(

--- a/instrumentation/openai/openai-java-1.1/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.openai.v1_1.abstractchattest.basic.yaml
+++ b/instrumentation/openai/openai-java-1.1/testing/src/main/resources/mappings/io.opentelemetry.instrumentation.openai.v1_1.abstractchattest.basic.yaml
@@ -39,17 +39,7 @@ response:
       "usage": {
         "prompt_tokens": 22,
         "completion_tokens": 2,
-        "total_tokens": 24,
-        "prompt_tokens_details": {
-          "cached_tokens": 0,
-          "audio_tokens": 0
-        },
-        "completion_tokens_details": {
-          "reasoning_tokens": 0,
-          "audio_tokens": 0,
-          "accepted_prediction_tokens": 0,
-          "rejected_prediction_tokens": 0
-        }
+        "total_tokens": 24
       },
       "service_tier": "default",
       "system_fingerprint": "fp_34a54ae93c"


### PR DESCRIPTION
## Why

This PR is another one to catch Java instrumentation up to GenAI semantics.

The OpenAI GenAI semantic conventions recommend `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.reasoning.output_tokens` when the provider reports them. The OpenAI Java SDK exposes both values, but the instrumentation currently emits only total input and output token counts.

Related to #19857.

## What

- Add optional detailed-token getters to the shared GenAI attributes extractor.
- Map OpenAI cached prompt tokens and reasoning completion tokens from `CompletionUsage`.
- Cover non-zero, explicit-zero, unavailable, synchronous, asynchronous, and streaming responses.

## Why the approach

* The new getter methods default to `null`, preserving existing provider implementations and omitting attributes when the source does not supply a value
* Explicit zero values are still emitted. 
* Bedrock related changes will be another PR because its cache fields require provider specific normalization and AWS SDK compatibility handling.

## Validation

- Unit tests: `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :instrumentation-api-incubator:test --tests '*GenAiAttributesExtractorTest' --no-configuration-cache --console=plain` and `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :instrumentation:openai:openai-java-1.1:library:test --tests '*ChatAttributesGetterTest' --console=plain` — passed.
- Integration tests: the OpenAI library `check` task exercised synchronous, asynchronous, and streaming fixtures, including explicit-zero and unavailable detail values — passed.
- End-to-end: `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :instrumentation-api-incubator:check :instrumentation:openai:openai-java-1.1:library:check :instrumentation:openai:openai-java-1.1:javaagent:check --console=plain` — passed (`288 actionable tasks: 185 executed, 103 up-to-date`).
