### PR TITLE
Improve automated flaky test remediation

### DIFF
--- a/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
+++ b/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
@@ -111,6 +111,14 @@ def flaky_result_count(history):
     return total
 
 
+def visible_flaky_result_count(history):
+    return sum(
+        1
+        for result in (history.get("testResults") or [])
+        if result.get("outcome") in FLAKY_OUTCOMES
+    )
+
+
 def _all_source_files():
     """Tracked .java/.groovy/.kt files, posix-relative to WORKSPACE_ROOT."""
     out = subprocess.check_output(
@@ -198,7 +206,8 @@ def collect_flaky_scans_by_time(fetch_history, *, base, since_ms, until_ms,
     history = fetch_history(since_ms, until_ms)
     sample_build, sample_failure = best_failure_sample(history)
     scans = collect_flaky_scans(history, base=base, limit=limit, seen=seen)
-    if scans or flaky_result_count(history) == 0:
+    if (len(scans) >= limit
+            or flaky_result_count(history) <= visible_flaky_result_count(history)):
         return sample_build, sample_failure, scans
 
     if (depth >= MAX_HISTORY_SPLIT_DEPTH
@@ -208,7 +217,7 @@ def collect_flaky_scans_by_time(fetch_history, *, base, since_ms, until_ms,
     mid_ms = (since_ms + until_ms) // 2
     right_build, right_failure, right_scans = collect_flaky_scans_by_time(
         fetch_history, base=base, since_ms=mid_ms + 1, until_ms=until_ms,
-        limit=limit, seen=seen, depth=depth + 1,
+        limit=limit - len(scans), seen=seen, depth=depth + 1,
     )
     scans.extend(right_scans)
     if not sample_failure:

--- a/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
+++ b/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
@@ -323,7 +323,7 @@ def main():
         # narrowed to each day-bucket that had a flaky execution. Busy
         # tests can still return only passed rows for an entire day, so
         # recursively split those windows until the flaky rows are visible.
-        if not sample_failure or not recent_scans:
+        if not sample_failure or len(recent_scans) < 5:
             def fetch_history_window(since_ms, until_ms):
                 return fetch_test_history(
                     base, container=cname, test_name=chosen["name"],

--- a/.github/scripts/flaky-test-remediation/2-fix-flaky-test.py
+++ b/.github/scripts/flaky-test-remediation/2-fix-flaky-test.py
@@ -43,24 +43,24 @@ Sample failure captured from Develocity (truncated):
 
 {recent_section}{per_day_section}
 Goals:
-1. Diagnose the root cause of flakiness from the sample failure(s) and the
-   test source. Common causes include unbounded waits, fixed-duration sleeps,
-   shared mutable state across tests, executor/IO-reactor reuse, missing
-   cleanup, and gRPC `Context` cancellation propagating into deferred work.
-   Look at related helper files referenced from the test (such as
-   `AbstractGrpcTest.java` for gRPC tests).
+1. Diagnose the root cause of flakiness from the sample failure(s), the test
+   source, related implementation and helper files, and recent commits. Do not
+   assume the test is faulty. If the flakiness began after an instrumentation
+   change, inspect that change and fix the implementation when it caused the
+   failure.
 2. If multiple scan links are listed above, open at least two of them via
    their build-scan URLs to confirm the failure mode is consistent before
    committing to a fix.
-3. Apply a minimal, surgical fix to the test or its helper. Do NOT rewrite
-   unrelated code. Do NOT add new dependencies.
+3. Apply a minimal, surgical fix to the test, its helper, or the instrumentation
+   implementation. Do NOT rewrite unrelated code. Do NOT add new dependencies.
 4. Preserve the test's original intent and assertions. If the test was
    regression-tracking a specific issue, keep that coverage.
 5. If the fix needs `await` calls, prefer assertions on the boolean return
    value of `CountDownLatch.await(...)` over ignoring it; prefer Awaitility
    helpers already used elsewhere in the test for polling.
 6. Do not disable the test, do not add `@Disabled`, and do not lower coverage
-   by deleting assertions.
+   by deleting assertions, accepting missing telemetry, or serializing a
+   concurrency test.
 
 Output protocol:
 - Apply the fix to the working tree (do not produce JSON output).

--- a/.github/scripts/flaky-test-remediation/3-open-pr.py
+++ b/.github/scripts/flaky-test-remediation/3-open-pr.py
@@ -41,10 +41,12 @@ def failure_scans(selected):
         sample_scan = next(
             (scan for scan in recent_scans
              if scan.get("scan_url") == sample_url),
+            # selected.json records no outcome or work unit for the sample
+            # scan, so leave both blank instead of guessing.
             {
                 "build_id": selected.get("sample_build_id", ""),
                 "scan_url": sample_url,
-                "outcome": "failed",
+                "outcome": "",
                 "work_unit": "",
             },
         )

--- a/.github/scripts/flaky-test-remediation/3-open-pr.py
+++ b/.github/scripts/flaky-test-remediation/3-open-pr.py
@@ -31,11 +31,38 @@ def pr_title_target(selected):
     return f"{class_name}.{method_name}"
 
 
+def failure_scans(selected):
+    recent_scans = selected.get("recent_flaky_scans", [])[:5]
+    sample_url = selected.get("sample_scan_url", "")
+
+    scans = []
+    seen_urls = set()
+    if sample_url:
+        sample_scan = next(
+            (scan for scan in recent_scans
+             if scan.get("scan_url") == sample_url),
+            {
+                "build_id": selected.get("sample_build_id", ""),
+                "scan_url": sample_url,
+                "outcome": "failed",
+                "work_unit": "",
+            },
+        )
+        scans.append(sample_scan)
+        seen_urls.add(sample_url)
+
+    for scan in recent_scans:
+        scan_url = scan.get("scan_url", "")
+        if scan_url and scan_url not in seen_urls:
+            scans.append(scan)
+            seen_urls.add(scan_url)
+    return scans
+
+
 def render(selected):
     fq = selected["fully_qualified"]
     source_file = selected["source_file"]
     window_days = selected["window_days"]
-    sample_url = selected["sample_scan_url"]
     sample_failure = selected["sample_failure"].rstrip()
 
     lines = [
@@ -45,18 +72,20 @@ def render(selected):
         f"- Exact test invocation: **{selected['flaky_count']}** "
         f"flaky executions in last {window_days}d",
     ]
-    if sample_url:
-        lines.append(f"- Primary failed scan: {sample_url}")
     lines.append("")
 
-    scans = selected["recent_flaky_scans"]
+    scans = failure_scans(selected)
     if scans:
-        lines += ["### Recent failed/flaky scans", ""]
-        for s in scans[:5]:
-            bullet = f"- [{s['build_id'][:13]}]({s['scan_url']}) ({s['outcome']}"
-            if s["work_unit"]:
-                bullet += f", `{s['work_unit']}`"
-            bullet += ")"
+        lines += ["### Gradle Build Scans for the flaky failures", ""]
+        for scan in scans:
+            label = scan.get("build_id", "")[:13] or "Build Scan"
+            bullet = f"- [{label}]({scan['scan_url']})"
+            details = [scan.get("outcome", "")]
+            if scan.get("work_unit"):
+                details.append(f"`{scan['work_unit']}`")
+            details = [detail for detail in details if detail]
+            if details:
+                bullet += f" ({', '.join(details)})"
             lines.append(bullet)
         lines.append("")
 

--- a/.github/scripts/flaky-test-remediation/3-open-pr.py
+++ b/.github/scripts/flaky-test-remediation/3-open-pr.py
@@ -58,7 +58,7 @@ def failure_scans(selected):
         if scan_url and scan_url not in seen_urls:
             scans.append(scan)
             seen_urls.add(scan_url)
-    return scans
+    return scans[:5]
 
 
 def render(selected):

--- a/.github/scripts/flaky-test-remediation/3-open-pr.py
+++ b/.github/scripts/flaky-test-remediation/3-open-pr.py
@@ -32,7 +32,7 @@ def pr_title_target(selected):
 
 
 def failure_scans(selected):
-    recent_scans = selected.get("recent_flaky_scans", [])[:5]
+    recent_scans = selected.get("recent_flaky_scans", [])
     sample_url = selected.get("sample_scan_url", "")
 
     scans = []

--- a/.github/scripts/flaky-test-remediation/README.md
+++ b/.github/scripts/flaky-test-remediation/README.md
@@ -32,7 +32,7 @@ centralized in [`_paths.py`](_paths.py).
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `1-select-flaky-test.py` | Hits Develocity dashboard endpoints, picks one flaky test, writes `selected.json`.                                                                                                    |
 | `2-fix-flaky-test.py`    | Renders `prompt.txt` and invokes the Copilot CLI agent to fix the test (writes `copilot-output.jsonl`, `copilot-stderr.log`, and — if Copilot follows the protocol — `diagnosis.md`). |
-| `3-open-pr.py`           | Renders `pr-body.md` (incorporates `diagnosis.md` if Copilot wrote one) and opens the PR via `gh pr create`.                                                                          |
+| `3-open-pr.py`           | Renders `pr-body.md` with the failure's Gradle Build Scan links (and `diagnosis.md` if Copilot wrote one), then opens the PR via `gh pr create`.                                      |
 | `_paths.py`              | Single source of truth for every file under `build/flaky-test-remediation/`.                                                                                                          |
 | `_render.py`             | Tiny formatting helpers shared by the renderers.                                                                                                                                      |
 

--- a/.github/scripts/flaky-test-remediation/README.md
+++ b/.github/scripts/flaky-test-remediation/README.md
@@ -1,13 +1,12 @@
 # Flaky-test fix toolkit
 
 A small pipeline that picks the most-flaky JUnit test from Develocity and asks
-the Copilot CLI agent to fix it. Drives both the
-[`flaky-test-remediation.yml`](../../workflows/flaky-test-remediation.yml) workflow and a
-local equivalent.
+the Copilot CLI agent to fix it. It is run by the
+[`flaky-test-remediation.yml`](../../workflows/flaky-test-remediation.yml) workflow.
 
 ## Pipeline
 
-```
+```text
    skip.txt (from progress branch)
         |
         v
@@ -36,29 +35,20 @@ centralized in [`_paths.py`](_paths.py).
 | `3-open-pr.py`           | Renders `pr-body.md` (incorporates `diagnosis.md` if Copilot wrote one) and opens the PR via `gh pr create`.                                                                          |
 | `_paths.py`              | Single source of truth for every file under `build/flaky-test-remediation/`.                                                                                                          |
 | `_render.py`             | Tiny formatting helpers shared by the renderers.                                                                                                                                      |
-| `run-local.py`           | Local driver: runs the same pipeline as CI, pushes to `origin`, opens the PR against `upstream/main`.                                                                                 |
 
 ## Skip list / progress tracking
 
-The orphan branch `otelbot/flaky-test-remediation-progress` carries a single
-`attempted.txt` file (one Develocity test container/class name per line). Both the CI
-workflow and `run-local.py` read it as a skip list so we don't keep retrying
-related flaky methods in the same class, and append the selected class after each
-successful attempt.
+The orphan branch `otelbot/flaky-test-remediation-progress` carries an
+`attempted.txt` file with one Develocity test container/class name per line.
+The workflow reads it as a skip list so it doesn't keep retrying related flaky
+methods in the same class. It appends the selected class after each successful
+attempt.
 
-## Local usage
+## Workflow usage
 
-```bash
-python .github/scripts/flaky-test-remediation/run-local.py            # opens a PR
-python .github/scripts/flaky-test-remediation/run-local.py --draft    # opens a draft
-```
-
-Requires:
-
-- `git` remotes `origin` (your fork) and `upstream`
-  (`open-telemetry/opentelemetry-java-instrumentation`)
-- `gh` authenticated for the upstream repo
-- `copilot` CLI on PATH
+Run `Flaky Test Remediation` manually from GitHub Actions. Each run analyzes
+one test class, uploads the analysis and fix diagnostics as workflow artifacts,
+and opens an automated draft PR when Copilot produces a change.
 
 ## Environment
 

--- a/.github/scripts/flaky-test-remediation/_paths.py
+++ b/.github/scripts/flaky-test-remediation/_paths.py
@@ -1,8 +1,7 @@
 """Shared paths for the flaky-test-remediation toolkit.
 
-All intermediate files live under ``build/flaky-test-remediation/`` (gitignored). The
-workflow and ``run-local.py`` both rely on this layout; do not change a path
-here without also updating both.
+All intermediate files live under ``build/flaky-test-remediation/`` (gitignored).
+The workflow relies on this layout; keep its artifact paths in sync with changes here.
 """
 
 from pathlib import Path

--- a/.github/scripts/flaky-test-remediation/test_open_pr.py
+++ b/.github/scripts/flaky-test-remediation/test_open_pr.py
@@ -98,6 +98,8 @@ class RenderTest(unittest.TestCase):
             [scan["build_id"] for scan in scans],
             ["build-6", "build-1", "build-2", "build-3", "build-4"],
         )
+        self.assertEqual(scans[0]["outcome"], "flaky")
+        self.assertEqual(scans[0]["work_unit"], "test")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/flaky-test-remediation/test_open_pr.py
+++ b/.github/scripts/flaky-test-remediation/test_open_pr.py
@@ -74,7 +74,7 @@ class RenderTest(unittest.TestCase):
         body = render_without_diagnosis(selected)
 
         self.assertIn(
-            "- [primary-build](https://develocity.example/s/primary-build-id) (failed)",
+            "- [primary-build](https://develocity.example/s/primary-build-id)\n",
             body,
         )
 

--- a/.github/scripts/flaky-test-remediation/test_open_pr.py
+++ b/.github/scripts/flaky-test-remediation/test_open_pr.py
@@ -1,0 +1,83 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("3-open-pr.py")
+SPEC = importlib.util.spec_from_file_location("flaky_test_remediation_open_pr", MODULE_PATH)
+open_pr = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC.loader.exec_module(open_pr)
+
+
+def selected_test():
+    return {
+        "class": "example.FlakyTest",
+        "method": "failsSometimes",
+        "fully_qualified": "example.FlakyTest.failsSometimes",
+        "flaky_count": 3,
+        "source_file": "example/FlakyTest.java",
+        "sample_build_id": "primary-build-id",
+        "sample_scan_url": "https://develocity.example/s/primary-build-id",
+        "sample_failure": "expected true but was false",
+        "recent_flaky_scans": [
+            {
+                "build_id": "other-build-id",
+                "scan_url": "https://develocity.example/s/other-build-id",
+                "outcome": "flaky",
+                "work_unit": "testJava17",
+            },
+            {
+                "build_id": "primary-build-id",
+                "scan_url": "https://develocity.example/s/primary-build-id",
+                "outcome": "failed",
+                "work_unit": "testJava21",
+            },
+        ],
+        "per_day_breakdown": [],
+        "window_days": 7,
+    }
+
+
+def render_without_diagnosis(selected):
+    with mock.patch.object(open_pr, "DIAGNOSIS") as diagnosis:
+        diagnosis.exists.return_value = False
+        return open_pr.render(selected)
+
+
+class RenderTest(unittest.TestCase):
+    def test_includes_each_gradle_build_scan_once(self):
+        body = render_without_diagnosis(selected_test())
+
+        self.assertIn("### Gradle Build Scans for the flaky failures", body)
+        self.assertIn(
+            "- [primary-build](https://develocity.example/s/primary-build-id) "
+            "(failed, `testJava21`)",
+            body,
+        )
+        self.assertIn(
+            "- [other-build-i](https://develocity.example/s/other-build-id) "
+            "(flaky, `testJava17`)",
+            body,
+        )
+        self.assertEqual(
+            body.count("https://develocity.example/s/primary-build-id"), 1
+        )
+
+    def test_includes_primary_scan_when_recent_scans_are_unavailable(self):
+        selected = selected_test()
+        selected["recent_flaky_scans"] = []
+
+        body = render_without_diagnosis(selected)
+
+        self.assertIn(
+            "- [primary-build](https://develocity.example/s/primary-build-id) (failed)",
+            body,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/flaky-test-remediation/test_open_pr.py
+++ b/.github/scripts/flaky-test-remediation/test_open_pr.py
@@ -78,6 +78,27 @@ class RenderTest(unittest.TestCase):
             body,
         )
 
+    def test_limits_scans_when_primary_scan_is_not_recent(self):
+        selected = selected_test()
+        selected["recent_flaky_scans"] = [
+            {
+                "build_id": f"build-{index}",
+                "scan_url": f"https://develocity.example/s/build-{index}",
+                "outcome": "flaky",
+                "work_unit": "test",
+            }
+            for index in range(1, 7)
+        ]
+        selected["sample_build_id"] = "build-6"
+        selected["sample_scan_url"] = "https://develocity.example/s/build-6"
+
+        scans = open_pr.failure_scans(selected)
+
+        self.assertEqual(
+            [scan["build_id"] for scan in scans],
+            ["build-6", "build-1", "build-2", "build-3", "build-4"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/flaky-test-remediation/test_select_flaky_test.py
+++ b/.github/scripts/flaky-test-remediation/test_select_flaky_test.py
@@ -39,7 +39,6 @@ class CollectFlakyScansByTimeTest(unittest.TestCase):
             (500000, 999999): history(2, "scan-4", "scan-5"),
             (0, 499999): history(3, "scan-2"),
             (250000, 499999): history(1, "scan-3"),
-            (0, 249999): history(2, "scan-1", "scan-2"),
         }
         requested_windows = []
 

--- a/.github/scripts/flaky-test-remediation/test_select_flaky_test.py
+++ b/.github/scripts/flaky-test-remediation/test_select_flaky_test.py
@@ -1,0 +1,75 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("1-select-flaky-test.py")
+SPEC = importlib.util.spec_from_file_location(
+    "flaky_test_remediation_select", MODULE_PATH
+)
+select_flaky_test = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC.loader.exec_module(select_flaky_test)
+
+
+def history(flaky_count, *build_ids):
+    return {
+        "outcomeTrend": {
+            "dataPoints": [
+                {"outcomeDistribution": {"flaky": flaky_count}}
+            ]
+        },
+        "testResults": [
+            {
+                "buildId": build_id,
+                "outcome": "flaky",
+                "startTimestamp": index,
+            }
+            for index, build_id in enumerate(build_ids)
+        ],
+    }
+
+
+class CollectFlakyScansByTimeTest(unittest.TestCase):
+    def test_splits_window_when_trend_exceeds_visible_flaky_results(self):
+        histories = {
+            (0, 999999): history(5, "scan-2"),
+            (500000, 999999): history(2, "scan-4", "scan-5"),
+            (0, 499999): history(3, "scan-2"),
+            (250000, 499999): history(1, "scan-3"),
+            (0, 249999): history(2, "scan-1", "scan-2"),
+        }
+        requested_windows = []
+
+        def fetch_history(since_ms, until_ms):
+            requested_windows.append((since_ms, until_ms))
+            return histories[(since_ms, until_ms)]
+
+        _, _, scans = select_flaky_test.collect_flaky_scans_by_time(
+            fetch_history,
+            base="https://develocity.example",
+            since_ms=0,
+            until_ms=999999,
+            limit=4,
+            seen={"scan-1"},
+        )
+
+        self.assertEqual(
+            [scan["build_id"] for scan in scans],
+            ["scan-2", "scan-4", "scan-5", "scan-3"],
+        )
+        self.assertEqual(
+            requested_windows,
+            [
+                (0, 999999),
+                (500000, 999999),
+                (0, 499999),
+                (250000, 499999),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/flaky-test-remediation.yml
+++ b/.github/workflows/flaky-test-remediation.yml
@@ -181,6 +181,7 @@ jobs:
           ARTIFACT_URL: ${{ steps.upload-fix-diagnostics.outputs.artifact-url }}
           PR_HEAD: ${{ steps.branch.outputs.name }}
           PR_BASE: main
+          PR_DRAFT: "true"
         run: python .github/scripts/flaky-test-remediation/3-open-pr.py
 
       - name: Check out progress branch

--- a/.github/workflows/flaky-test-remediation.yml
+++ b/.github/workflows/flaky-test-remediation.yml
@@ -80,6 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0  # Copilot inspects recent commits while diagnosing the flake
           # zizmor: ignore[artipacked] Credentials are required by the branch push below.
           persist-credentials: true
 


### PR DESCRIPTION
The flaky-test remediation workflow gives Copilot more failed runs and recent code changes to inspect, so it can fix the cause instead of weakening race-sensitive tests.

- Finds up to five flaky Gradle Build Scans when a broad Develocity query hides individual results, then links them in generated pull requests
- Tells Copilot to check the instrumentation before changing the test and rejects fixes that accept missing telemetry or serialize concurrency tests
- Opens generated fixes as draft pull requests
