### PR TITLE
Fix JMS durable subscription listener race

### DIFF
--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
@@ -92,19 +92,24 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    // the name is recorded after registration rather than before, so that a setMessageListener
-    // call that throws leaves the listener's previous subscription name in place; that is what
-    // makes tracking and rolling back in-flight registrations unnecessary
-    //
-    // the trade-off is that a message the provider dispatches before setMessageListener returns
-    // reports no subscription name instead of the wrong one
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Nullable
+    public static Object onEnter(
+        @Advice.This MessageConsumer consumer,
+        @Advice.Argument(0) @Nullable MessageListener messageListener) {
+      if (messageListener == null) {
+        return null;
+      }
+      return JmsSubscriptionNames.beginListenerRegistration(consumer, messageListener);
+    }
+
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener,
+        @Advice.Enter @Nullable Object registration,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable == null) {
-        JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      if (messageListener != null && registration != null) {
+        JmsSubscriptionNames.endListenerRegistration(messageListener, registration, throwable);
       }
     }
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -35,6 +35,8 @@ public class JmsSubscriptionNames {
       VirtualField.find(MessageListener.class, String.class);
   private static final VirtualField<MessageListener, Object[]> LISTENER_REGISTRATION =
       VirtualField.find(MessageListener.class, Object[].class);
+  // an agent owned lock, so that the agent never blocks on a monitor that application code holds
+  private static final Object registrationLock = new Object();
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -46,7 +48,7 @@ public class JmsSubscriptionNames {
 
   public static Object beginListenerRegistration(
       MessageConsumer consumer, MessageListener messageListener) {
-    synchronized (messageListener) {
+    synchronized (registrationLock) {
       Object[] registration = {
         CONSUMER_SUBSCRIPTION_NAME.get(consumer),
         currentRegistration(LISTENER_REGISTRATION.get(messageListener)),
@@ -60,7 +62,7 @@ public class JmsSubscriptionNames {
   public static void endListenerRegistration(
       MessageListener messageListener, Object registrationToken, @Nullable Throwable throwable) {
     Object[] registration = (Object[]) registrationToken;
-    synchronized (messageListener) {
+    synchronized (registrationLock) {
       if (throwable == null) {
         registration[PREVIOUS_REGISTRATION] = null;
         return;

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -15,13 +15,17 @@ import javax.jms.MessageListener;
  * Remembers the subscription name that a durable or shared consumer was created with, so that it
  * can be reported on the spans for the messages that the consumer delivers.
  *
- * <p>The name is copied from the consumer to the message listener once the listener has been
- * registered, because providers dispatch messages to the listener without exposing the consumer
+ * <p>The name is copied from the consumer to the message listener before registering the listener,
+ * because providers may dispatch messages before registration returns without exposing the consumer
  * they came from. Registering the same listener instance on several consumers reports the name of
  * the most recently registered consumer, and closing a consumer doesn't restore the name of an
  * earlier one, because the listener is shared and there is no owner to hand it back to.
  */
 public class JmsSubscriptionNames {
+
+  private static final int SUBSCRIPTION_NAME = 0;
+  private static final int PREVIOUS_REGISTRATION = 1;
+  private static final int FAILED = 2;
 
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageConsumer.class, String.class);
@@ -29,6 +33,8 @@ public class JmsSubscriptionNames {
       VirtualField.find(Message.class, String.class);
   private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageListener.class, String.class);
+  private static final VirtualField<MessageListener, Object[]> LISTENER_REGISTRATION =
+      VirtualField.find(MessageListener.class, Object[].class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -38,12 +44,33 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void copyToListener(
-      MessageConsumer consumer, @Nullable MessageListener messageListener) {
-    if (messageListener == null) {
-      return;
+  public static Object beginListenerRegistration(
+      MessageConsumer consumer, MessageListener messageListener) {
+    synchronized (messageListener) {
+      Object[] registration = {
+        CONSUMER_SUBSCRIPTION_NAME.get(consumer),
+        currentRegistration(LISTENER_REGISTRATION.get(messageListener)),
+        false
+      };
+      setCurrentRegistration(messageListener, registration);
+      return registration;
     }
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+  }
+
+  public static void endListenerRegistration(
+      MessageListener messageListener, Object registrationToken, @Nullable Throwable throwable) {
+    Object[] registration = (Object[]) registrationToken;
+    synchronized (messageListener) {
+      if (throwable == null) {
+        registration[PREVIOUS_REGISTRATION] = null;
+        return;
+      }
+      registration[FAILED] = true;
+      if (LISTENER_REGISTRATION.get(messageListener) == registration) {
+        setCurrentRegistration(
+            messageListener, currentRegistration((Object[]) registration[PREVIOUS_REGISTRATION]));
+      }
+    }
   }
 
   @Nullable
@@ -59,6 +86,21 @@ public class JmsSubscriptionNames {
   @Nullable
   public static String get(MessageListener messageListener) {
     return LISTENER_SUBSCRIPTION_NAME.get(messageListener);
+  }
+
+  @Nullable
+  private static Object[] currentRegistration(@Nullable Object[] registration) {
+    while (registration != null && Boolean.TRUE.equals(registration[FAILED])) {
+      registration = (Object[]) registration[PREVIOUS_REGISTRATION];
+    }
+    return registration;
+  }
+
+  private static void setCurrentRegistration(
+      MessageListener messageListener, @Nullable Object[] registration) {
+    LISTENER_REGISTRATION.set(messageListener, registration);
+    LISTENER_SUBSCRIPTION_NAME.set(
+        messageListener, registration == null ? null : (String) registration[SUBSCRIPTION_NAME]);
   }
 
   private JmsSubscriptionNames() {}

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -83,40 +83,6 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
   }
 
   @Test
-  void setsSubscriptionNameBeforeListenerRegistrationReturns() throws JMSException {
-    Topic topic = session.createTopic("early-dispatch-topic");
-    MessageConsumer consumer =
-        session.createDurableSubscriber(topic, "early-dispatch-subscription");
-    cleanup.deferCleanup(consumer::close);
-    MessageListener listener = ignored -> {};
-
-    Object registration = JmsSubscriptionNames.beginListenerRegistration(consumer, listener);
-
-    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("early-dispatch-subscription");
-    JmsSubscriptionNames.endListenerRegistration(listener, registration, null);
-  }
-
-  @Test
-  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws JMSException {
-    Topic topic = session.createTopic("concurrent-registration-topic");
-    MessageConsumer firstConsumer = session.createDurableSubscriber(topic, "first-subscription");
-    cleanup.deferCleanup(firstConsumer::close);
-    MessageConsumer secondConsumer = session.createDurableSubscriber(topic, "second-subscription");
-    cleanup.deferCleanup(secondConsumer::close);
-    MessageListener listener = ignored -> {};
-
-    Object firstRegistration =
-        JmsSubscriptionNames.beginListenerRegistration(firstConsumer, listener);
-    Object secondRegistration =
-        JmsSubscriptionNames.beginListenerRegistration(secondConsumer, listener);
-    JmsSubscriptionNames.endListenerRegistration(listener, secondRegistration, null);
-    JmsSubscriptionNames.endListenerRegistration(
-        listener, firstRegistration, new JMSException("failed"));
-
-    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("second-subscription");
-  }
-
-  @Test
   void overwritesSubscriptionNameWhenListenerIsReregistered() throws JMSException {
     String topicName = "reregistered-listener-topic";
     Topic topic = session.createTopic(topicName);

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -222,7 +222,7 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
         (MessageConsumer)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {TopicSubscriber.class},
+                new Class<?>[] {TestTopicSubscriber.class},
                 (proxy, method, args) -> {
                   if (method.getName().equals("setMessageListener")) {
                     olderRegistrationEntered.countDown();
@@ -235,7 +235,7 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
         (MessageConsumer)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {TopicSubscriber.class},
+                new Class<?>[] {TestTopicSubscriber.class},
                 (proxy, method, args) -> {
                   if (method.getName().equals("setMessageListener")) {
                     ((MessageListener) args[0]).onMessage(message);
@@ -246,7 +246,7 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
         (Session)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {Session.class},
+                new Class<?>[] {TestSession.class},
                 (proxy, method, args) ->
                     args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
     registrationSession.createDurableSubscriber(topic, "older-subscription");
@@ -265,7 +265,24 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
     }
     failedRegistration.get(10, SECONDS);
 
+    TextMessage messageAfterFailure = session.createTextMessage("another message");
+    messageAfterFailure.setJMSDestination(topic);
+    listener.onMessage(messageAfterFailure);
+
     testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -417,4 +434,10 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
+
+  // these interfaces are package private so that the proxy classes above are defined in this
+  // package, instead of in com.sun.proxy, which the agent doesn't instrument
+  interface TestSession extends Session {}
+
+  interface TestTopicSubscriber extends TopicSubscriber {}
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -83,6 +83,40 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
   }
 
   @Test
+  void setsSubscriptionNameBeforeListenerRegistrationReturns() throws JMSException {
+    Topic topic = session.createTopic("early-dispatch-topic");
+    MessageConsumer consumer =
+        session.createDurableSubscriber(topic, "early-dispatch-subscription");
+    cleanup.deferCleanup(consumer::close);
+    MessageListener listener = ignored -> {};
+
+    Object registration = JmsSubscriptionNames.beginListenerRegistration(consumer, listener);
+
+    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("early-dispatch-subscription");
+    JmsSubscriptionNames.endListenerRegistration(listener, registration, null);
+  }
+
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws JMSException {
+    Topic topic = session.createTopic("concurrent-registration-topic");
+    MessageConsumer firstConsumer = session.createDurableSubscriber(topic, "first-subscription");
+    cleanup.deferCleanup(firstConsumer::close);
+    MessageConsumer secondConsumer = session.createDurableSubscriber(topic, "second-subscription");
+    cleanup.deferCleanup(secondConsumer::close);
+    MessageListener listener = ignored -> {};
+
+    Object firstRegistration =
+        JmsSubscriptionNames.beginListenerRegistration(firstConsumer, listener);
+    Object secondRegistration =
+        JmsSubscriptionNames.beginListenerRegistration(secondConsumer, listener);
+    JmsSubscriptionNames.endListenerRegistration(listener, secondRegistration, null);
+    JmsSubscriptionNames.endListenerRegistration(
+        listener, firstRegistration, new JMSException("failed"));
+
+    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("second-subscription");
+  }
+
+  @Test
   void overwritesSubscriptionNameWhenListenerIsReregistered() throws JMSException {
     String topicName = "reregistered-listener-topic";
     Topic topic = session.createTopic(topicName);

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -19,17 +19,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageListener;
 import javax.jms.MessageProducer;
+import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
+import javax.jms.TopicSubscriber;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -201,6 +205,77 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             operationType("process"),
                             messagingTempDestination(false),
                             subscriptionName("registered-subscription"))));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws Exception {
+    String topicName = "concurrent-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("a message");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+    CountDownLatch olderRegistrationEntered = new CountDownLatch(1);
+    CountDownLatch failOlderRegistration = new CountDownLatch(1);
+
+    MessageConsumer olderConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    olderRegistrationEntered.countDown();
+                    assertThat(failOlderRegistration.await(10, SECONDS)).isTrue();
+                    throw new JMSException("failed");
+                  }
+                  return null;
+                });
+    MessageConsumer newerConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TopicSubscriber.class},
+                (proxy, method, args) -> null);
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {Session.class},
+                (proxy, method, args) ->
+                    args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
+    registrationSession.createDurableSubscriber(topic, "older-subscription");
+    registrationSession.createDurableSubscriber(topic, "newer-subscription");
+
+    CompletableFuture<Void> failedRegistration =
+        CompletableFuture.runAsync(
+            () ->
+                assertThatThrownBy(() -> olderConsumer.setMessageListener(listener))
+                    .isInstanceOf(JMSException.class));
+    try {
+      assertThat(olderRegistrationEntered.await(10, SECONDS)).isTrue();
+      newerConsumer.setMessageListener(listener);
+    } finally {
+      failOlderRegistration.countDown();
+    }
+    failedRegistration.get(10, SECONDS);
+
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -236,7 +236,12 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
                 new Class<?>[] {TopicSubscriber.class},
-                (proxy, method, args) -> null);
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    ((MessageListener) args[0]).onMessage(message);
+                  }
+                  return null;
+                });
     Session registrationSession =
         (Session)
             Proxy.newProxyInstance(
@@ -259,8 +264,6 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
       failOlderRegistration.countDown();
     }
     failedRegistration.get(10, SECONDS);
-
-    listener.onMessage(message);
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
@@ -92,19 +92,24 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    // the name is recorded after registration rather than before, so that a setMessageListener
-    // call that throws leaves the listener's previous subscription name in place; that is what
-    // makes tracking and rolling back in-flight registrations unnecessary
-    //
-    // the trade-off is that a message the provider dispatches before setMessageListener returns
-    // reports no subscription name instead of the wrong one
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Nullable
+    public static Object onEnter(
+        @Advice.This MessageConsumer consumer,
+        @Advice.Argument(0) @Nullable MessageListener messageListener) {
+      if (messageListener == null) {
+        return null;
+      }
+      return JmsSubscriptionNames.beginListenerRegistration(consumer, messageListener);
+    }
+
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener,
+        @Advice.Enter @Nullable Object registration,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable == null) {
-        JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      if (messageListener != null && registration != null) {
+        JmsSubscriptionNames.endListenerRegistration(messageListener, registration, throwable);
       }
     }
   }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -35,6 +35,8 @@ public class JmsSubscriptionNames {
       VirtualField.find(MessageListener.class, String.class);
   private static final VirtualField<MessageListener, Object[]> LISTENER_REGISTRATION =
       VirtualField.find(MessageListener.class, Object[].class);
+  // an agent owned lock, so that the agent never blocks on a monitor that application code holds
+  private static final Object registrationLock = new Object();
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -46,7 +48,7 @@ public class JmsSubscriptionNames {
 
   public static Object beginListenerRegistration(
       MessageConsumer consumer, MessageListener messageListener) {
-    synchronized (messageListener) {
+    synchronized (registrationLock) {
       Object[] registration = {
         CONSUMER_SUBSCRIPTION_NAME.get(consumer),
         currentRegistration(LISTENER_REGISTRATION.get(messageListener)),
@@ -60,7 +62,7 @@ public class JmsSubscriptionNames {
   public static void endListenerRegistration(
       MessageListener messageListener, Object registrationToken, @Nullable Throwable throwable) {
     Object[] registration = (Object[]) registrationToken;
-    synchronized (messageListener) {
+    synchronized (registrationLock) {
       if (throwable == null) {
         registration[PREVIOUS_REGISTRATION] = null;
         return;

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -15,13 +15,17 @@ import javax.annotation.Nullable;
  * Remembers the subscription name that a durable or shared consumer was created with, so that it
  * can be reported on the spans for the messages that the consumer delivers.
  *
- * <p>The name is copied from the consumer to the message listener once the listener has been
- * registered, because providers dispatch messages to the listener without exposing the consumer
+ * <p>The name is copied from the consumer to the message listener before registering the listener,
+ * because providers may dispatch messages before registration returns without exposing the consumer
  * they came from. Registering the same listener instance on several consumers reports the name of
  * the most recently registered consumer, and closing a consumer doesn't restore the name of an
  * earlier one, because the listener is shared and there is no owner to hand it back to.
  */
 public class JmsSubscriptionNames {
+
+  private static final int SUBSCRIPTION_NAME = 0;
+  private static final int PREVIOUS_REGISTRATION = 1;
+  private static final int FAILED = 2;
 
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageConsumer.class, String.class);
@@ -29,6 +33,8 @@ public class JmsSubscriptionNames {
       VirtualField.find(Message.class, String.class);
   private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageListener.class, String.class);
+  private static final VirtualField<MessageListener, Object[]> LISTENER_REGISTRATION =
+      VirtualField.find(MessageListener.class, Object[].class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -38,12 +44,33 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void copyToListener(
-      MessageConsumer consumer, @Nullable MessageListener messageListener) {
-    if (messageListener == null) {
-      return;
+  public static Object beginListenerRegistration(
+      MessageConsumer consumer, MessageListener messageListener) {
+    synchronized (messageListener) {
+      Object[] registration = {
+        CONSUMER_SUBSCRIPTION_NAME.get(consumer),
+        currentRegistration(LISTENER_REGISTRATION.get(messageListener)),
+        false
+      };
+      setCurrentRegistration(messageListener, registration);
+      return registration;
     }
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+  }
+
+  public static void endListenerRegistration(
+      MessageListener messageListener, Object registrationToken, @Nullable Throwable throwable) {
+    Object[] registration = (Object[]) registrationToken;
+    synchronized (messageListener) {
+      if (throwable == null) {
+        registration[PREVIOUS_REGISTRATION] = null;
+        return;
+      }
+      registration[FAILED] = true;
+      if (LISTENER_REGISTRATION.get(messageListener) == registration) {
+        setCurrentRegistration(
+            messageListener, currentRegistration((Object[]) registration[PREVIOUS_REGISTRATION]));
+      }
+    }
   }
 
   @Nullable
@@ -59,6 +86,21 @@ public class JmsSubscriptionNames {
   @Nullable
   public static String get(MessageListener messageListener) {
     return LISTENER_SUBSCRIPTION_NAME.get(messageListener);
+  }
+
+  @Nullable
+  private static Object[] currentRegistration(@Nullable Object[] registration) {
+    while (registration != null && Boolean.TRUE.equals(registration[FAILED])) {
+      registration = (Object[]) registration[PREVIOUS_REGISTRATION];
+    }
+    return registration;
+  }
+
+  private static void setCurrentRegistration(
+      MessageListener messageListener, @Nullable Object[] registration) {
+    LISTENER_REGISTRATION.set(messageListener, registration);
+    LISTENER_SUBSCRIPTION_NAME.set(
+        messageListener, registration == null ? null : (String) registration[SUBSCRIPTION_NAME]);
   }
 
   private JmsSubscriptionNames() {}

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -28,9 +28,11 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
@@ -205,6 +207,77 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                             operationType("process"),
                             messagingTempDestination(false),
                             subscriptionName("registered-subscription"))));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated semconv
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws Exception {
+    String topicName = "concurrent-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("hello there");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+    CountDownLatch olderRegistrationEntered = new CountDownLatch(1);
+    CountDownLatch failOlderRegistration = new CountDownLatch(1);
+
+    MessageConsumer olderConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {MessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    olderRegistrationEntered.countDown();
+                    assertThat(failOlderRegistration.await(10, SECONDS)).isTrue();
+                    throw new JMSException("failed");
+                  }
+                  return null;
+                });
+    MessageConsumer newerConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {MessageConsumer.class},
+                (proxy, method, args) -> null);
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {Session.class},
+                (proxy, method, args) ->
+                    args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
+    registrationSession.createDurableConsumer(topic, "older-subscription");
+    registrationSession.createDurableConsumer(topic, "newer-subscription");
+
+    CompletableFuture<Void> failedRegistration =
+        CompletableFuture.runAsync(
+            () ->
+                assertThatThrownBy(() -> olderConsumer.setMessageListener(listener))
+                    .isInstanceOf(JMSException.class));
+    try {
+      assertThat(olderRegistrationEntered.await(10, SECONDS)).isTrue();
+      newerConsumer.setMessageListener(listener);
+    } finally {
+      failOlderRegistration.countDown();
+    }
+    failedRegistration.get(10, SECONDS);
+
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -88,39 +88,6 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
   }
 
   @Test
-  void setsSubscriptionNameBeforeListenerRegistrationReturns() throws JMSException {
-    Topic topic = session.createTopic("early-dispatch-topic");
-    MessageConsumer consumer = session.createDurableConsumer(topic, "early-dispatch-subscription");
-    cleanup.deferCleanup(consumer);
-    MessageListener listener = ignored -> {};
-
-    Object registration = JmsSubscriptionNames.beginListenerRegistration(consumer, listener);
-
-    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("early-dispatch-subscription");
-    JmsSubscriptionNames.endListenerRegistration(listener, registration, null);
-  }
-
-  @Test
-  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws JMSException {
-    Topic topic = session.createTopic("concurrent-registration-topic");
-    MessageConsumer firstConsumer = session.createDurableConsumer(topic, "first-subscription");
-    cleanup.deferCleanup(firstConsumer);
-    MessageConsumer secondConsumer = session.createDurableConsumer(topic, "second-subscription");
-    cleanup.deferCleanup(secondConsumer);
-    MessageListener listener = ignored -> {};
-
-    Object firstRegistration =
-        JmsSubscriptionNames.beginListenerRegistration(firstConsumer, listener);
-    Object secondRegistration =
-        JmsSubscriptionNames.beginListenerRegistration(secondConsumer, listener);
-    JmsSubscriptionNames.endListenerRegistration(listener, secondRegistration, null);
-    JmsSubscriptionNames.endListenerRegistration(
-        listener, firstRegistration, new JMSException("failed"));
-
-    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("second-subscription");
-  }
-
-  @Test
   void overwritesSubscriptionNameWhenListenerIsReregistered() throws JMSException {
     String topicName = "reregistered-listener-topic";
     Topic topic = session.createTopic(topicName);

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -224,7 +224,7 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
         (MessageConsumer)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {MessageConsumer.class},
+                new Class<?>[] {TestMessageConsumer.class},
                 (proxy, method, args) -> {
                   if (method.getName().equals("setMessageListener")) {
                     olderRegistrationEntered.countDown();
@@ -237,7 +237,7 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
         (MessageConsumer)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {MessageConsumer.class},
+                new Class<?>[] {TestMessageConsumer.class},
                 (proxy, method, args) -> {
                   if (method.getName().equals("setMessageListener")) {
                     ((MessageListener) args[0]).onMessage(message);
@@ -248,7 +248,7 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
         (Session)
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {Session.class},
+                new Class<?>[] {TestSession.class},
                 (proxy, method, args) ->
                     args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
     registrationSession.createDurableConsumer(topic, "older-subscription");
@@ -267,7 +267,24 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
     }
     failedRegistration.get(10, SECONDS);
 
+    TextMessage messageAfterFailure = session.createTextMessage("another message");
+    messageAfterFailure.setJMSDestination(topic);
+    listener.onMessage(messageAfterFailure);
+
     testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -573,4 +590,10 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
     MessageConsumer create(Session session, Topic topic, String subscriptionName)
         throws JMSException;
   }
+
+  // these interfaces are package private so that the proxy classes above are defined in this
+  // package, instead of in com.sun.proxy, which the agent doesn't instrument
+  interface TestSession extends Session {}
+
+  interface TestMessageConsumer extends MessageConsumer {}
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -238,7 +238,12 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
             Proxy.newProxyInstance(
                 getClass().getClassLoader(),
                 new Class<?>[] {MessageConsumer.class},
-                (proxy, method, args) -> null);
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    ((MessageListener) args[0]).onMessage(message);
+                  }
+                  return null;
+                });
     Session registrationSession =
         (Session)
             Proxy.newProxyInstance(
@@ -261,8 +266,6 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
       failOlderRegistration.countDown();
     }
     failedRegistration.get(10, SECONDS);
-
-    listener.onMessage(message);
 
     testing.waitAndAssertTraces(
         trace ->

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -88,6 +88,39 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
   }
 
   @Test
+  void setsSubscriptionNameBeforeListenerRegistrationReturns() throws JMSException {
+    Topic topic = session.createTopic("early-dispatch-topic");
+    MessageConsumer consumer = session.createDurableConsumer(topic, "early-dispatch-subscription");
+    cleanup.deferCleanup(consumer);
+    MessageListener listener = ignored -> {};
+
+    Object registration = JmsSubscriptionNames.beginListenerRegistration(consumer, listener);
+
+    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("early-dispatch-subscription");
+    JmsSubscriptionNames.endListenerRegistration(listener, registration, null);
+  }
+
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSubscriptionName() throws JMSException {
+    Topic topic = session.createTopic("concurrent-registration-topic");
+    MessageConsumer firstConsumer = session.createDurableConsumer(topic, "first-subscription");
+    cleanup.deferCleanup(firstConsumer);
+    MessageConsumer secondConsumer = session.createDurableConsumer(topic, "second-subscription");
+    cleanup.deferCleanup(secondConsumer);
+    MessageListener listener = ignored -> {};
+
+    Object firstRegistration =
+        JmsSubscriptionNames.beginListenerRegistration(firstConsumer, listener);
+    Object secondRegistration =
+        JmsSubscriptionNames.beginListenerRegistration(secondConsumer, listener);
+    JmsSubscriptionNames.endListenerRegistration(listener, secondRegistration, null);
+    JmsSubscriptionNames.endListenerRegistration(
+        listener, firstRegistration, new JMSException("failed"));
+
+    assertThat(JmsSubscriptionNames.get(listener)).isEqualTo("second-subscription");
+  }
+
+  @Test
   void overwritesSubscriptionNameWhenListenerIsReregistered() throws JMSException {
     String topicName = "reregistered-listener-topic";
     Topic topic = session.createTopic(topicName);


### PR DESCRIPTION
Ensures JMS message spans include the durable subscription name when a provider dispatches queued messages before `setMessageListener` returns.

If listener registration fails, the instrumentation restores the previous subscription name without overwriting a newer concurrent registration. The fix applies to JMS 1.1 and JMS 3.0.

### Flaky build scans

`Jms1InstrumentationTest.capturesDurableSubscriberName()` failed in these scans:

- https://develocity.opentelemetry.io/s/37bolidgcehtw
- https://develocity.opentelemetry.io/s/grwsroy6rcexm
- https://develocity.opentelemetry.io/s/2nhoe3zrsf7eg
- https://develocity.opentelemetry.io/s/2ekjdlgot2ihg
- https://develocity.opentelemetry.io/s/23s6wr5qoedja

`Jms3InstrumentationTest.capturesDurableConsumerName()` failed in these scans:

- https://develocity.opentelemetry.io/s/4zv75velgrnae
- https://develocity.opentelemetry.io/s/ocvy3ek6s3tgc
- https://develocity.opentelemetry.io/s/4iqourpsertx4
- https://develocity.opentelemetry.io/s/zwxvkdnd6akdo
- https://develocity.opentelemetry.io/s/g2r57gnbl2coq