### PR TITLE
Fix Ratpack protocol version capture race

### DIFF
--- a/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
+++ b/instrumentation/ratpack/ratpack-1.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/ratpack/v1_7/RequestActionSupportInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.ratpack.v1_7.internal.ContextHolder;
@@ -46,6 +47,11 @@ class RequestActionSupportInstrumentation implements TypeInstrumentation {
             .and(takesArgument(1, named("io.netty.channel.Channel"))),
         getClass().getName() + "$SendAdvice");
     transformer.applyAdviceToMethod(
+        isPrivate()
+            .and(named("addCommonResponseHandlers"))
+            .and(takesArgument(0, named("io.netty.channel.ChannelPipeline"))),
+        getClass().getName() + "$AddCommonResponseHandlersAdvice");
+    transformer.applyAdviceToMethod(
         named("connect").and(takesArgument(0, named("ratpack.exec.Downstream"))),
         getClass().getName() + "$ConnectDownstreamAdvice");
     transformer.applyAdviceToMethod(
@@ -61,11 +67,16 @@ class RequestActionSupportInstrumentation implements TypeInstrumentation {
         @Advice.FieldValue("execution") Execution execution, @Advice.Argument(1) Channel channel) {
       RatpackSingletons.propagateContextToChannel(execution, channel);
     }
+  }
+
+  @SuppressWarnings("unused")
+  public static class AddCommonResponseHandlersAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.FieldValue("execution") Execution execution, @Advice.Argument(1) Channel channel) {
-      RatpackSingletons.captureProtocolVersion(execution, channel);
+        @Advice.FieldValue("execution") Execution execution,
+        @Advice.Argument(0) ChannelPipeline pipeline) {
+      RatpackSingletons.captureProtocolVersion(execution, pipeline.channel());
     }
   }
 


### PR DESCRIPTION
Moves Ratpack protocol capture handler installation into response-pipeline construction, after Ratpack's redirect handler is available and before the request can be written. This closes a race where fast pooled responses could complete before the handler was installed, leaving client spans without `network.protocol.version`.

### Flaky build scans

`RatpackPooledHttpClientTest.highConcurrency()` failed in these scans:

- https://develocity.opentelemetry.io/s/wycmbsuhx3j72
- https://develocity.opentelemetry.io/s/y2zueqm42bje6
- https://develocity.opentelemetry.io/s/gpxobiwlobumq
- https://develocity.opentelemetry.io/s/5ow7pm7xgu436
- https://develocity.opentelemetry.io/s/tk4j5i5vpf36k