### PR TITLE
Fix JMS durable subscription listener race

### DIFF
--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
@@ -92,19 +92,26 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    // the name is recorded after registration rather than before, so that a setMessageListener
-    // call that throws leaves the listener's previous subscription name in place; that is what
-    // makes tracking and rolling back in-flight registrations unnecessary
-    //
-    // the trade-off is that a message the provider dispatches before setMessageListener returns
-    // reports no subscription name instead of the wrong one
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static String onEnter(
+        @Advice.This MessageConsumer consumer,
+        @Advice.Argument(0) @Nullable MessageListener messageListener) {
+      if (messageListener == null) {
+        return null;
+      }
+      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
+      JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      return previousSubscriptionName;
+    }
+
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener,
+        @Advice.Enter @Nullable String previousSubscriptionName,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable == null) {
-        JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      if (throwable != null && messageListener != null) {
+        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
       }
     }
   }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
@@ -92,27 +92,11 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static String onEnter(
+    public static void onEnter(
         @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener) {
-      if (messageListener == null) {
-        return null;
-      }
-      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
       JmsSubscriptionNames.copyToListener(consumer, messageListener);
-      return previousSubscriptionName;
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
-    public static void onExit(
-        @Advice.Argument(0) @Nullable MessageListener messageListener,
-        @Advice.Enter @Nullable String previousSubscriptionName,
-        @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable != null && messageListener != null) {
-        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
-      }
     }
   }
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -15,8 +15,8 @@ import javax.jms.MessageListener;
  * Remembers the subscription name that a durable or shared consumer was created with, so that it
  * can be reported on the spans for the messages that the consumer delivers.
  *
- * <p>The name is copied from the consumer to the message listener once the listener has been
- * registered, because providers dispatch messages to the listener without exposing the consumer
+ * <p>The name is copied from the consumer to the message listener before registering the listener,
+ * because providers may dispatch messages before registration returns without exposing the consumer
  * they came from. Registering the same listener instance on several consumers reports the name of
  * the most recently registered consumer, and closing a consumer doesn't restore the name of an
  * earlier one, because the listener is shared and there is no owner to hand it back to.
@@ -38,12 +38,16 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
+  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
+    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
+  }
+
   public static void copyToListener(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
       return;
     }
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
   }
 
   @Nullable

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -17,9 +17,7 @@ import javax.jms.MessageListener;
  *
  * <p>The name is copied from the consumer to the message listener before registering the listener,
  * because providers may dispatch messages before registration returns without exposing the consumer
- * they came from. Registering the same listener instance on several consumers reports the name of
- * the most recently registered consumer, and closing a consumer doesn't restore the name of an
- * earlier one, because the listener is shared and there is no owner to hand it back to.
+ * they came from. A listener is expected to be registered with only one consumer.
  */
 public class JmsSubscriptionNames {
 
@@ -38,16 +36,12 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
-  }
-
   public static void copyToListener(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
       return;
     }
-    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
   }
 
   @Nullable

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -14,7 +14,6 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -213,43 +212,6 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             operationName("process"),
                             operationType("process"),
                             messagingTempDestination(false))));
-  }
-
-  @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs
-  @Test
-  void keepsSubscriptionNameWhenListenerRegistrationFails() throws JMSException {
-    String topicName = "failed-listener-registration-topic";
-    Topic topic = session.createTopic(topicName);
-    TextMessage message = session.createTextMessage("a message");
-    message.setJMSDestination(topic);
-    MessageListener listener = ignored -> {};
-
-    MessageConsumer registeredConsumer =
-        session.createDurableSubscriber(topic, "registered-subscription");
-    cleanup.deferCleanup(registeredConsumer::close);
-    registeredConsumer.setMessageListener(listener);
-
-    MessageConsumer closedConsumer = session.createDurableSubscriber(topic, "closed-subscription");
-    closedConsumer.close();
-    assertThatThrownBy(() -> closedConsumer.setMessageListener(listener))
-        .isInstanceOf(JMSException.class);
-
-    listener.onMessage(message);
-
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasKind(CONSUMER)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "jms"),
-                            messagingDestinationName(topicName, false),
-                            oldOperation("process"),
-                            operationName("process"),
-                            operationType("process"),
-                            messagingTempDestination(false),
-                            subscriptionName("registered-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
@@ -28,8 +29,10 @@ import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageListener;
 import javax.jms.MessageProducer;
+import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
+import javax.jms.TopicSubscriber;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -80,6 +83,52 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(false),
                             subscriptionName("durable-subscription"))));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs
+  @Test
+  void capturesDurableSubscriberNameBeforeListenerRegistrationReturns() throws JMSException {
+    String topicName = "early-listener-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("a message");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    TopicSubscriber consumer =
+        (TopicSubscriber)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    ((MessageListener) args[0]).onMessage(message);
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) -> consumer);
+
+    registrationSession.createDurableSubscriber(topic, "early-listener-subscription");
+    consumer.setMessageListener(listener);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("early-listener-subscription"))));
   }
 
   @Test
@@ -339,4 +388,9 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(isTemporary))));
   }
+
+  // These interfaces are package-private so that the agent instruments the generated proxy classes.
+  interface TestSession extends Session {}
+
+  interface TestTopicSubscriber extends TopicSubscriber {}
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
@@ -92,19 +92,26 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    // the name is recorded after registration rather than before, so that a setMessageListener
-    // call that throws leaves the listener's previous subscription name in place; that is what
-    // makes tracking and rolling back in-flight registrations unnecessary
-    //
-    // the trade-off is that a message the provider dispatches before setMessageListener returns
-    // reports no subscription name instead of the wrong one
+    @Nullable
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static String onEnter(
+        @Advice.This MessageConsumer consumer,
+        @Advice.Argument(0) @Nullable MessageListener messageListener) {
+      if (messageListener == null) {
+        return null;
+      }
+      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
+      JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      return previousSubscriptionName;
+    }
+
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener,
+        @Advice.Enter @Nullable String previousSubscriptionName,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable == null) {
-        JmsSubscriptionNames.copyToListener(consumer, messageListener);
+      if (throwable != null && messageListener != null) {
+        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
       }
     }
   }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
@@ -92,27 +92,11 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class SetMessageListenerAdvice {
 
-    @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static String onEnter(
+    public static void onEnter(
         @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener) {
-      if (messageListener == null) {
-        return null;
-      }
-      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
       JmsSubscriptionNames.copyToListener(consumer, messageListener);
-      return previousSubscriptionName;
-    }
-
-    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
-    public static void onExit(
-        @Advice.Argument(0) @Nullable MessageListener messageListener,
-        @Advice.Enter @Nullable String previousSubscriptionName,
-        @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable != null && messageListener != null) {
-        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
-      }
     }
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -17,9 +17,7 @@ import javax.annotation.Nullable;
  *
  * <p>The name is copied from the consumer to the message listener before registering the listener,
  * because providers may dispatch messages before registration returns without exposing the consumer
- * they came from. Registering the same listener instance on several consumers reports the name of
- * the most recently registered consumer, and closing a consumer doesn't restore the name of an
- * earlier one, because the listener is shared and there is no owner to hand it back to.
+ * they came from. A listener is expected to be registered with only one consumer.
  */
 public class JmsSubscriptionNames {
 
@@ -38,16 +36,12 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
-  }
-
   public static void copyToListener(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
       return;
     }
-    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
   }
 
   @Nullable

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -15,8 +15,8 @@ import javax.annotation.Nullable;
  * Remembers the subscription name that a durable or shared consumer was created with, so that it
  * can be reported on the spans for the messages that the consumer delivers.
  *
- * <p>The name is copied from the consumer to the message listener once the listener has been
- * registered, because providers dispatch messages to the listener without exposing the consumer
+ * <p>The name is copied from the consumer to the message listener before registering the listener,
+ * because providers may dispatch messages before registration returns without exposing the consumer
  * they came from. Registering the same listener instance on several consumers reports the name of
  * the most recently registered consumer, and closing a consumer doesn't restore the name of an
  * earlier one, because the listener is shared and there is no owner to hand it back to.
@@ -38,12 +38,16 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
+  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
+    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
+  }
+
   public static void copyToListener(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
       return;
     }
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
   }
 
   @Nullable

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -14,7 +14,6 @@ import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.sdk.trace.data.LinkData;
@@ -215,42 +214,6 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                             operationName("process"),
                             operationType("process"),
                             messagingTempDestination(false))));
-  }
-
-  @Test
-  void keepsSubscriptionNameWhenListenerRegistrationFails() throws JMSException {
-    String topicName = "failed-listener-registration-topic";
-    Topic topic = session.createTopic(topicName);
-    TextMessage message = session.createTextMessage("hello there");
-    message.setJMSDestination(topic);
-    MessageListener listener = ignored -> {};
-
-    MessageConsumer registeredConsumer =
-        session.createDurableConsumer(topic, "registered-subscription");
-    cleanup.deferCleanup(registeredConsumer);
-    registeredConsumer.setMessageListener(listener);
-
-    MessageConsumer closedConsumer = session.createDurableConsumer(topic, "closed-subscription");
-    closedConsumer.close();
-    assertThatThrownBy(() -> closedConsumer.setMessageListener(listener))
-        .isInstanceOf(JMSException.class);
-
-    listener.onMessage(message);
-
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasKind(CONSUMER)
-                        .hasNoParent()
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(MESSAGING_SYSTEM, "jms"),
-                            messagingDestinationName(topicName, topicName),
-                            oldOperation("process"),
-                            operationName("process"),
-                            operationType("process"),
-                            messagingTempDestination(false),
-                            subscriptionName("registered-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -28,6 +28,7 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
@@ -85,6 +86,51 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                             equalTo(MESSAGING_MESSAGE_ID, messageId),
                             messagingTempDestination(false),
                             subscriptionName("durable-subscription"))));
+  }
+
+  @Test
+  void capturesDurableConsumerNameBeforeListenerRegistrationReturns() throws JMSException {
+    String topicName = "early-listener-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("hello there");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    MessageConsumer consumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    ((MessageListener) args[0]).onMessage(message);
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) -> consumer);
+
+    registrationSession.createDurableConsumer(topic, "early-listener-subscription");
+    consumer.setMessageListener(listener);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("early-listener-subscription"))));
   }
 
   @Test
@@ -497,4 +543,9 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
     MessageConsumer create(Session session, Topic topic, String subscriptionName)
         throws JMSException;
   }
+
+  // These interfaces are package-private so that the agent instruments the generated proxy classes.
+  interface TestSession extends Session {}
+
+  interface TestMessageConsumer extends MessageConsumer {}
 }


### PR DESCRIPTION
Records durable and shared Java Message Service (JMS) subscription names before `setMessageListener` returns, so messages delivered during listener registration include the correct name. Listener instances are expected to be registered with only one consumer.

This applies to the JMS 1.1 and JMS 3.0 instrumentations.

### Flaky build scans

`Jms1InstrumentationTest.capturesDurableSubscriberName()` failed in these scans:

- https://develocity.opentelemetry.io/s/37bolidgcehtw
- https://develocity.opentelemetry.io/s/grwsroy6rcexm
- https://develocity.opentelemetry.io/s/2nhoe3zrsf7eg
- https://develocity.opentelemetry.io/s/2ekjdlgot2ihg
- https://develocity.opentelemetry.io/s/23s6wr5qoedja

`Jms3InstrumentationTest.capturesDurableConsumerName()` failed in these scans:

- https://develocity.opentelemetry.io/s/4zv75velgrnae
- https://develocity.opentelemetry.io/s/ocvy3ek6s3tgc
- https://develocity.opentelemetry.io/s/4iqourpsertx4
- https://develocity.opentelemetry.io/s/zwxvkdnd6akdo
- https://develocity.opentelemetry.io/s/g2r57gnbl2coq