### PR TITLE
Handle concurrent JMS listener registration rollback

### DIFF
--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsMessageConsumerInstrumentation.java
@@ -94,25 +94,19 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static String onEnter(
+    public static Object onEnter(
         @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener) {
-      if (messageListener == null) {
-        return null;
-      }
-      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
-      JmsSubscriptionNames.copyToListener(consumer, messageListener);
-      return previousSubscriptionName;
+      return JmsSubscriptionNames.beginListenerRegistration(consumer, messageListener);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Argument(0) @Nullable MessageListener messageListener,
-        @Advice.Enter @Nullable String previousSubscriptionName,
+        @Advice.Enter @Nullable Object registration,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable != null && messageListener != null) {
-        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
-      }
+      JmsSubscriptionNames.endListenerRegistration(
+          messageListener, registration, throwable == null);
     }
   }
 }

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -23,12 +23,18 @@ import javax.jms.MessageListener;
  */
 public class JmsSubscriptionNames {
 
+  private static final int STATE_LOCK_INDEX = 0;
+  private static final int CURRENT_REGISTRATION_INDEX = 1;
+  private static final int REGISTRATION_SUBSCRIPTION_NAME_INDEX = 0;
+  private static final int REGISTRATION_PREVIOUS_INDEX = 1;
+  private static final int REGISTRATION_FAILED_INDEX = 2;
+
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageConsumer.class, String.class);
   private static final VirtualField<Message, String> MESSAGE_SUBSCRIPTION_NAME =
       VirtualField.find(Message.class, String.class);
-  private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageListener.class, String.class);
+  private static final VirtualField<MessageListener, Object[]> LISTENER_SUBSCRIPTION_STATE =
+      VirtualField.find(MessageListener.class, Object[].class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -38,16 +44,51 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
-  }
-
-  public static void copyToListener(
+  @Nullable
+  public static Object beginListenerRegistration(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
+      return null;
+    }
+    Object[] state = listenerState(messageListener);
+    synchronized (state[STATE_LOCK_INDEX]) {
+      Object[] registration = {
+        CONSUMER_SUBSCRIPTION_NAME.get(consumer), state[CURRENT_REGISTRATION_INDEX], false
+      };
+      state[CURRENT_REGISTRATION_INDEX] = registration;
+      return registration;
+    }
+  }
+
+  public static void endListenerRegistration(
+      @Nullable MessageListener messageListener,
+      @Nullable Object registrationToken,
+      boolean succeeded) {
+    if (messageListener == null || registrationToken == null) {
       return;
     }
-    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    Object[] registration = (Object[]) registrationToken;
+    Object[] state = listenerState(messageListener);
+    synchronized (state[STATE_LOCK_INDEX]) {
+      if (succeeded) {
+        registration[REGISTRATION_PREVIOUS_INDEX] = null;
+        return;
+      }
+
+      registration[REGISTRATION_FAILED_INDEX] = true;
+      if (state[CURRENT_REGISTRATION_INDEX] != registration) {
+        return;
+      }
+
+      Object[] previous = (Object[]) registration[REGISTRATION_PREVIOUS_INDEX];
+      while (previous != null && Boolean.TRUE.equals(previous[REGISTRATION_FAILED_INDEX])) {
+        Object[] failedRegistration = previous;
+        previous = (Object[]) previous[REGISTRATION_PREVIOUS_INDEX];
+        failedRegistration[REGISTRATION_PREVIOUS_INDEX] = null;
+      }
+      state[CURRENT_REGISTRATION_INDEX] = previous;
+      registration[REGISTRATION_PREVIOUS_INDEX] = null;
+    }
   }
 
   @Nullable
@@ -62,7 +103,31 @@ public class JmsSubscriptionNames {
 
   @Nullable
   public static String get(MessageListener messageListener) {
-    return LISTENER_SUBSCRIPTION_NAME.get(messageListener);
+    Object[] state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+    if (state == null) {
+      return null;
+    }
+    synchronized (state[STATE_LOCK_INDEX]) {
+      Object[] registration = (Object[]) state[CURRENT_REGISTRATION_INDEX];
+      return registration == null
+          ? null
+          : (String) registration[REGISTRATION_SUBSCRIPTION_NAME_INDEX];
+    }
+  }
+
+  private static Object[] listenerState(MessageListener messageListener) {
+    Object[] state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+    if (state != null) {
+      return state;
+    }
+    synchronized (LISTENER_SUBSCRIPTION_STATE) {
+      state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+      if (state == null) {
+        state = new Object[] {new Object(), null};
+        LISTENER_SUBSCRIPTION_STATE.set(messageListener, state);
+      }
+      return state;
+    }
   }
 
   private JmsSubscriptionNames() {}

--- a/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/Jms1InstrumentationTest.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -250,6 +251,236 @@ class Jms1InstrumentationTest extends AbstractJms1Test {
                             operationType("process"),
                             messagingTempDestination(false),
                             subscriptionName("registered-subscription"))));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated JMS API
+  @Test
+  void doesNotLockListenerDuringRegistration() throws Exception {
+    Topic topic = session.createTopic("listener-lock-topic");
+    MessageConsumer consumer = session.createDurableSubscriber(topic, "listener-lock-subscription");
+    cleanup.deferCleanup(consumer::close);
+    MessageListener listener = ignored -> {};
+
+    synchronized (listener) {
+      CompletableFuture<Void> registration =
+          CompletableFuture.runAsync(
+              () -> {
+                try {
+                  consumer.setMessageListener(listener);
+                } catch (JMSException e) {
+                  throw new IllegalStateException(e);
+                }
+              });
+      registration.get(10, SECONDS);
+    }
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSuccessfulRegistration() throws JMSException {
+    String topicName = "overlapping-listener-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("a message");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    MessageConsumer newerConsumer = session.createDurableSubscriber(topic, "newer-subscription");
+    cleanup.deferCleanup(newerConsumer::close);
+    TopicSubscriber failingConsumer =
+        (TopicSubscriber)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerConsumer.setMessageListener((MessageListener) args[0]);
+                    throw new JMSException("registration failed");
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) -> failingConsumer);
+    registrationSession.createDurableSubscriber(topic, "failed-subscription");
+
+    assertThatThrownBy(() -> failingConsumer.setMessageListener(listener))
+        .isInstanceOf(JMSException.class);
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
+  }
+
+  @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs
+  @Test
+  void restoresOriginalSubscriptionAfterOverlappingFailures() throws Exception {
+    String topicName = "overlapping-failed-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("a message");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    MessageConsumer originalConsumer =
+        session.createDurableSubscriber(topic, "original-subscription");
+    cleanup.deferCleanup(originalConsumer::close);
+    originalConsumer.setMessageListener(listener);
+
+    CompletableFuture<Void> newerRegistrationPending = new CompletableFuture<>();
+    CompletableFuture<Void> allowNewerFailure = new CompletableFuture<>();
+    TopicSubscriber newerFailingConsumer =
+        (TopicSubscriber)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerRegistrationPending.complete(null);
+                    allowNewerFailure.join();
+                    throw new JMSException("newer registration failed");
+                  }
+                  return null;
+                });
+    AtomicReference<CompletableFuture<JMSException>> newerRegistration = new AtomicReference<>();
+    TopicSubscriber olderFailingConsumer =
+        (TopicSubscriber)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerRegistration.set(
+                        CompletableFuture.supplyAsync(
+                            () -> {
+                              try {
+                                newerFailingConsumer.setMessageListener((MessageListener) args[0]);
+                                throw new AssertionError("registration did not fail");
+                              } catch (JMSException e) {
+                                return e;
+                              }
+                            }));
+                    newerRegistrationPending.join();
+                    throw new JMSException("older registration failed");
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) ->
+                    ((String) args[1]).equals("older-failed-subscription")
+                        ? olderFailingConsumer
+                        : newerFailingConsumer);
+    registrationSession.createDurableSubscriber(topic, "older-failed-subscription");
+    registrationSession.createDurableSubscriber(topic, "newer-failed-subscription");
+
+    assertThatThrownBy(() -> olderFailingConsumer.setMessageListener(listener))
+        .isInstanceOf(JMSException.class)
+        .hasMessage("older registration failed");
+    allowNewerFailure.complete(null);
+    assertThat(newerRegistration.get().get(10, SECONDS)).hasMessage("newer registration failed");
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("original-subscription"))));
+  }
+
+  @Test
+  void keepsNewerSubscriptionNameWhenOlderRegistrationFails() throws Exception {
+    String topicName = "concurrent-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    MessageListener listener = ignored -> {};
+    CountDownLatch olderRegistrationEntered = new CountDownLatch(1);
+    CountDownLatch failOlderRegistration = new CountDownLatch(1);
+
+    MessageConsumer olderConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    olderRegistrationEntered.countDown();
+                    assertThat(failOlderRegistration.await(10, SECONDS)).isTrue();
+                    throw new JMSException("failed");
+                  }
+                  return null;
+                });
+    MessageConsumer newerConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestTopicSubscriber.class},
+                (proxy, method, args) -> null);
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) ->
+                    args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
+    registrationSession.createDurableSubscriber(topic, "older-subscription");
+    registrationSession.createDurableSubscriber(topic, "newer-subscription");
+
+    CompletableFuture<Void> failedRegistration =
+        CompletableFuture.runAsync(
+            () ->
+                assertThatThrownBy(() -> olderConsumer.setMessageListener(listener))
+                    .isInstanceOf(JMSException.class));
+    try {
+      assertThat(olderRegistrationEntered.await(10, SECONDS)).isTrue();
+      newerConsumer.setMessageListener(listener);
+    } finally {
+      failOlderRegistration.countDown();
+    }
+    failedRegistration.get(10, SECONDS);
+
+    TextMessage message = session.createTextMessage("a message");
+    message.setJMSDestination(topic);
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, false),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated JMS and semconv APIs

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsMessageConsumerInstrumentation.java
@@ -94,25 +94,19 @@ class JmsMessageConsumerInstrumentation implements TypeInstrumentation {
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static String onEnter(
+    public static Object onEnter(
         @Advice.This MessageConsumer consumer,
         @Advice.Argument(0) @Nullable MessageListener messageListener) {
-      if (messageListener == null) {
-        return null;
-      }
-      String previousSubscriptionName = JmsSubscriptionNames.get(messageListener);
-      JmsSubscriptionNames.copyToListener(consumer, messageListener);
-      return previousSubscriptionName;
+      return JmsSubscriptionNames.beginListenerRegistration(consumer, messageListener);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Argument(0) @Nullable MessageListener messageListener,
-        @Advice.Enter @Nullable String previousSubscriptionName,
+        @Advice.Enter @Nullable Object registration,
         @Advice.Thrown @Nullable Throwable throwable) {
-      if (throwable != null && messageListener != null) {
-        JmsSubscriptionNames.set(messageListener, previousSubscriptionName);
-      }
+      JmsSubscriptionNames.endListenerRegistration(
+          messageListener, registration, throwable == null);
     }
   }
 }

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -23,12 +23,18 @@ import javax.annotation.Nullable;
  */
 public class JmsSubscriptionNames {
 
+  private static final int STATE_LOCK_INDEX = 0;
+  private static final int CURRENT_REGISTRATION_INDEX = 1;
+  private static final int REGISTRATION_SUBSCRIPTION_NAME_INDEX = 0;
+  private static final int REGISTRATION_PREVIOUS_INDEX = 1;
+  private static final int REGISTRATION_FAILED_INDEX = 2;
+
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
       VirtualField.find(MessageConsumer.class, String.class);
   private static final VirtualField<Message, String> MESSAGE_SUBSCRIPTION_NAME =
       VirtualField.find(Message.class, String.class);
-  private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageListener.class, String.class);
+  private static final VirtualField<MessageListener, Object[]> LISTENER_SUBSCRIPTION_STATE =
+      VirtualField.find(MessageListener.class, Object[].class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);
@@ -38,16 +44,51 @@ public class JmsSubscriptionNames {
     MESSAGE_SUBSCRIPTION_NAME.set(message, subscriptionName);
   }
 
-  public static void set(MessageListener messageListener, @Nullable String subscriptionName) {
-    LISTENER_SUBSCRIPTION_NAME.set(messageListener, subscriptionName);
-  }
-
-  public static void copyToListener(
+  @Nullable
+  public static Object beginListenerRegistration(
       MessageConsumer consumer, @Nullable MessageListener messageListener) {
     if (messageListener == null) {
+      return null;
+    }
+    Object[] state = listenerState(messageListener);
+    synchronized (state[STATE_LOCK_INDEX]) {
+      Object[] registration = {
+        CONSUMER_SUBSCRIPTION_NAME.get(consumer), state[CURRENT_REGISTRATION_INDEX], false
+      };
+      state[CURRENT_REGISTRATION_INDEX] = registration;
+      return registration;
+    }
+  }
+
+  public static void endListenerRegistration(
+      @Nullable MessageListener messageListener,
+      @Nullable Object registrationToken,
+      boolean succeeded) {
+    if (messageListener == null || registrationToken == null) {
       return;
     }
-    set(messageListener, CONSUMER_SUBSCRIPTION_NAME.get(consumer));
+    Object[] registration = (Object[]) registrationToken;
+    Object[] state = listenerState(messageListener);
+    synchronized (state[STATE_LOCK_INDEX]) {
+      if (succeeded) {
+        registration[REGISTRATION_PREVIOUS_INDEX] = null;
+        return;
+      }
+
+      registration[REGISTRATION_FAILED_INDEX] = true;
+      if (state[CURRENT_REGISTRATION_INDEX] != registration) {
+        return;
+      }
+
+      Object[] previous = (Object[]) registration[REGISTRATION_PREVIOUS_INDEX];
+      while (previous != null && Boolean.TRUE.equals(previous[REGISTRATION_FAILED_INDEX])) {
+        Object[] failedRegistration = previous;
+        previous = (Object[]) previous[REGISTRATION_PREVIOUS_INDEX];
+        failedRegistration[REGISTRATION_PREVIOUS_INDEX] = null;
+      }
+      state[CURRENT_REGISTRATION_INDEX] = previous;
+      registration[REGISTRATION_PREVIOUS_INDEX] = null;
+    }
   }
 
   @Nullable
@@ -62,7 +103,31 @@ public class JmsSubscriptionNames {
 
   @Nullable
   public static String get(MessageListener messageListener) {
-    return LISTENER_SUBSCRIPTION_NAME.get(messageListener);
+    Object[] state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+    if (state == null) {
+      return null;
+    }
+    synchronized (state[STATE_LOCK_INDEX]) {
+      Object[] registration = (Object[]) state[CURRENT_REGISTRATION_INDEX];
+      return registration == null
+          ? null
+          : (String) registration[REGISTRATION_SUBSCRIPTION_NAME_INDEX];
+    }
+  }
+
+  private static Object[] listenerState(MessageListener messageListener) {
+    Object[] state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+    if (state != null) {
+      return state;
+    }
+    synchronized (LISTENER_SUBSCRIPTION_STATE) {
+      state = LISTENER_SUBSCRIPTION_STATE.get(messageListener);
+      if (state == null) {
+        state = new Object[] {new Object(), null};
+        LISTENER_SUBSCRIPTION_STATE.set(messageListener, state);
+      }
+      return state;
+    }
   }
 
   private JmsSubscriptionNames() {}

--- a/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/Jms3InstrumentationTest.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
@@ -251,6 +252,233 @@ class Jms3InstrumentationTest extends AbstractJms3Test {
                             operationType("process"),
                             messagingTempDestination(false),
                             subscriptionName("registered-subscription"))));
+  }
+
+  @Test
+  void doesNotLockListenerDuringRegistration() throws Exception {
+    Topic topic = session.createTopic("listener-lock-topic");
+    MessageConsumer consumer = session.createDurableConsumer(topic, "listener-lock-subscription");
+    cleanup.deferCleanup(consumer);
+    MessageListener listener = ignored -> {};
+
+    synchronized (listener) {
+      CompletableFuture<Void> registration =
+          CompletableFuture.runAsync(
+              () -> {
+                try {
+                  consumer.setMessageListener(listener);
+                } catch (JMSException e) {
+                  throw new IllegalStateException(e);
+                }
+              });
+      registration.get(10, SECONDS);
+    }
+  }
+
+  @Test
+  void failedRegistrationDoesNotOverwriteNewerSuccessfulRegistration() throws JMSException {
+    String topicName = "overlapping-listener-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("hello there");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    MessageConsumer newerConsumer = session.createDurableConsumer(topic, "newer-subscription");
+    cleanup.deferCleanup(newerConsumer);
+    MessageConsumer failingConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerConsumer.setMessageListener((MessageListener) args[0]);
+                    throw new JMSException("registration failed");
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) -> failingConsumer);
+    registrationSession.createDurableConsumer(topic, "failed-subscription");
+
+    assertThatThrownBy(() -> failingConsumer.setMessageListener(listener))
+        .isInstanceOf(JMSException.class);
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
+  }
+
+  @Test
+  void restoresOriginalSubscriptionAfterOverlappingFailures() throws Exception {
+    String topicName = "overlapping-failed-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    TextMessage message = session.createTextMessage("hello there");
+    message.setJMSDestination(topic);
+    MessageListener listener = ignored -> {};
+
+    MessageConsumer originalConsumer =
+        session.createDurableConsumer(topic, "original-subscription");
+    cleanup.deferCleanup(originalConsumer);
+    originalConsumer.setMessageListener(listener);
+
+    CompletableFuture<Void> newerRegistrationPending = new CompletableFuture<>();
+    CompletableFuture<Void> allowNewerFailure = new CompletableFuture<>();
+    MessageConsumer newerFailingConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerRegistrationPending.complete(null);
+                    allowNewerFailure.join();
+                    throw new JMSException("newer registration failed");
+                  }
+                  return null;
+                });
+    AtomicReference<CompletableFuture<JMSException>> newerRegistration = new AtomicReference<>();
+    MessageConsumer olderFailingConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    newerRegistration.set(
+                        CompletableFuture.supplyAsync(
+                            () -> {
+                              try {
+                                newerFailingConsumer.setMessageListener((MessageListener) args[0]);
+                                throw new AssertionError("registration did not fail");
+                              } catch (JMSException e) {
+                                return e;
+                              }
+                            }));
+                    newerRegistrationPending.join();
+                    throw new JMSException("older registration failed");
+                  }
+                  return null;
+                });
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) ->
+                    ((String) args[1]).equals("older-failed-subscription")
+                        ? olderFailingConsumer
+                        : newerFailingConsumer);
+    registrationSession.createDurableConsumer(topic, "older-failed-subscription");
+    registrationSession.createDurableConsumer(topic, "newer-failed-subscription");
+
+    assertThatThrownBy(() -> olderFailingConsumer.setMessageListener(listener))
+        .isInstanceOf(JMSException.class)
+        .hasMessage("older registration failed");
+    allowNewerFailure.complete(null);
+    assertThat(newerRegistration.get().get(10, SECONDS)).hasMessage("newer registration failed");
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("original-subscription"))));
+  }
+
+  @Test
+  void keepsNewerSubscriptionNameWhenOlderRegistrationFails() throws Exception {
+    String topicName = "concurrent-registration-topic";
+    Topic topic = session.createTopic(topicName);
+    MessageListener listener = ignored -> {};
+    CountDownLatch olderRegistrationEntered = new CountDownLatch(1);
+    CountDownLatch failOlderRegistration = new CountDownLatch(1);
+
+    MessageConsumer olderConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> {
+                  if (method.getName().equals("setMessageListener")) {
+                    olderRegistrationEntered.countDown();
+                    assertThat(failOlderRegistration.await(10, SECONDS)).isTrue();
+                    throw new JMSException("failed");
+                  }
+                  return null;
+                });
+    MessageConsumer newerConsumer =
+        (MessageConsumer)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestMessageConsumer.class},
+                (proxy, method, args) -> null);
+    Session registrationSession =
+        (Session)
+            Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {TestSession.class},
+                (proxy, method, args) ->
+                    args[1].equals("older-subscription") ? olderConsumer : newerConsumer);
+    registrationSession.createDurableConsumer(topic, "older-subscription");
+    registrationSession.createDurableConsumer(topic, "newer-subscription");
+
+    CompletableFuture<Void> failedRegistration =
+        CompletableFuture.runAsync(
+            () ->
+                assertThatThrownBy(() -> olderConsumer.setMessageListener(listener))
+                    .isInstanceOf(JMSException.class));
+    try {
+      assertThat(olderRegistrationEntered.await(10, SECONDS)).isTrue();
+      newerConsumer.setMessageListener(listener);
+    } finally {
+      failOlderRegistration.countDown();
+    }
+    failedRegistration.get(10, SECONDS);
+
+    TextMessage message = session.createTextMessage("hello there");
+    message.setJMSDestination(topic);
+    listener.onMessage(message);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(CONSUMER)
+                        .hasNoParent()
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(MESSAGING_SYSTEM, "jms"),
+                            messagingDestinationName(topicName, topicName),
+                            oldOperation("process"),
+                            operationName("process"),
+                            operationType("process"),
+                            messagingTempDestination(false),
+                            subscriptionName("newer-subscription"))));
   }
 
   @SuppressWarnings("deprecation") // using deprecated semconv


### PR DESCRIPTION
Protects JMS durable and shared listener subscription names when registrations overlap and one of them fails.

The JMS 1.1 and 3.0 instrumentations now keep agent-owned per-listener registration state, publish names before provider callbacks can run, and roll back only the failed registration that still owns the current state. Coverage includes reentrant delivery, failed registration rollback, a newer success followed by an older failure, two overlapping failures, and child-classloader listeners.