### PR TITLE
thrift: fix scope leak for async server requests

### DIFF
--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseAsyncProcessorInstrumentation.java
@@ -57,6 +57,8 @@ class ThriftTBaseAsyncProcessorInstrumentation implements TypeInstrumentation {
           (ServerInProtocolDecorator) fb.getInputProtocol();
       ServerOutProtocolDecorator serverOutProtocolDecorator =
           (ServerOutProtocolDecorator) fb.getOutputProtocol();
+
+      serverInProtocolDecorator.closeScope();
       if (serverInProtocolDecorator.isOneway()
           || serverOutProtocolDecorator.hasException()
           || throwable != null) {

--- a/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseProcessorInstrumentation.java
+++ b/instrumentation/thrift-0.13/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/thrift/v0_13/ThriftTBaseProcessorInstrumentation.java
@@ -68,6 +68,7 @@ class ThriftTBaseProcessorInstrumentation implements TypeInstrumentation {
       ServerInProtocolDecorator serverInProtocolDecorator = (ServerInProtocolDecorator) enter[0];
       ServerOutProtocolDecorator serverOutProtocolDecorator = (ServerOutProtocolDecorator) enter[1];
 
+      serverInProtocolDecorator.closeScope();
       serverInProtocolDecorator.endSpan(throwable, serverOutProtocolDecorator.hasException());
     }
   }

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerAsyncProcessorDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerAsyncProcessorDecorator.java
@@ -52,6 +52,7 @@ public final class ServerAsyncProcessorDecorator implements TAsyncProcessor, TPr
       throw t;
     } finally {
       serverCallContext.end();
+      serverInProtocolDecorator.closeScope();
       if (serverInProtocolDecorator.isOneway()
           || serverOutProtocolDecorator.hasException()
           || error != null) {

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerInProtocolDecorator.java
@@ -127,19 +127,22 @@ public final class ServerInProtocolDecorator extends TProtocolDecorator {
     return socket;
   }
 
+  public void closeScope() {
+    if (currentScope != null) {
+      currentScope.close();
+    }
+    currentScope = null;
+  }
+
   public void endSpan(@Nullable Throwable throwable, boolean failed) {
     if (currentContext == null || currentRequest == null) {
       return;
-    }
-    if (currentScope != null) {
-      currentScope.close();
     }
     instrumenter.end(
         currentContext, currentRequest, failed ? ThriftResponse.FAILED : null, throwable);
     // Avoid duplicate end invocations from exceptions in asynchronous workflows
     currentContext = null;
     currentRequest = null;
-    currentScope = null;
   }
 
   private boolean isContextPropagationField(TField field) {

--- a/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerProcessorDecorator.java
+++ b/instrumentation/thrift-0.13/library/src/main/java/io/opentelemetry/instrumentation/thrift/v0_13/internal/ServerProcessorDecorator.java
@@ -44,6 +44,7 @@ public final class ServerProcessorDecorator implements TProcessor {
       error = t;
       throw t;
     } finally {
+      serverInProtocolDecorator.closeScope();
       serverInProtocolDecorator.endSpan(error, serverOutProtocolDecorator.hasException());
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19924
Close scope when the processing method ends, span may be ended from async callback that runs on a different thread.
