### PR TITLE
Migrate to the OSS Community Develocity Instance

### DIFF
--- a/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
+++ b/.github/scripts/flaky-test-remediation/1-select-flaky-test.py
@@ -22,7 +22,7 @@ from urllib.request import Request, urlopen
 
 from _paths import OUT_DIR, SELECTED, SKIP
 
-DEFAULT_DEVELOCITY_URL = "https://develocity.opentelemetry.io"
+DEFAULT_DEVELOCITY_URL = "https://community.develocity.cloud"
 PROJECT_NAME = "opentelemetry-java-instrumentation"
 WORKSPACE_ROOT = Path(subprocess.check_output(
     ["git", "rev-parse", "--show-toplevel"], text=True).strip())

--- a/.github/scripts/flaky-test-remediation/README.md
+++ b/.github/scripts/flaky-test-remediation/README.md
@@ -52,5 +52,5 @@ and opens an automated draft PR when Copilot produces a change.
 
 ## Environment
 
-`DEVELOCITY_URL` (defaults to `https://develocity.opentelemetry.io`). The
+`DEVELOCITY_URL` (defaults to `https://community.develocity.cloud`). The
 dashboard data endpoints used here are unauthenticated; no access key needed.

--- a/.github/workflows/flaky-test-remediation.yml
+++ b/.github/workflows/flaky-test-remediation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Find top flaky test
         id: select
         env:
-          DEVELOCITY_URL: https://develocity.opentelemetry.io
+          DEVELOCITY_URL: https://community.develocity.cloud
         run: |
           python .github/scripts/flaky-test-remediation/1-select-flaky-test.py
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -68,7 +68,7 @@ dependencyResolutionManagement {
   }
 }
 
-val develocityServer = "https://develocity.opentelemetry.io"
+val develocityServer = "https://community.develocity.cloud"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
 val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
@@ -78,6 +78,7 @@ val shouldDisableLocalBuildCache =
 develocity {
   if (develocityAccessKey.isNotEmpty()) {
     server = develocityServer
+    projectId = "OpenTelemetry"
   }
 
   buildScan {


### PR DESCRIPTION
# Migrate to the OSS Community Develocity Instance

OpenTelemetry's dedicated Develocity instance (`https://develocity.opentelemetry.io`) is being
retired in favour of the shared **OSS Community Develocity Instance** at
<https://community.develocity.cloud>, which Develocity (Gradle Inc.) runs for OSS projects.
Build Scans and the remote build cache keep working exactly as they do today — only the host
changes, and builds are now associated with the `OpenTelemetry` project on the shared instance.

## What this PR changes

- `settings.gradle.kts`: `develocityServer` now points at `https://community.develocity.cloud`.
- `settings.gradle.kts`: adds `projectId = "OpenTelemetry"` so Build Scans and cache entries are
  scoped to the OpenTelemetry project on the shared instance.

- `.github/workflows/flaky-test-remediation.yml` and
  `.github/scripts/flaky-test-remediation/`: the `DEVELOCITY_URL` default now points at the
  community instance too.

  Heads-up on this one: the script's README notes that the dashboard data endpoints it uses are
  unauthenticated. That is true of the dedicated instance, but on `community.develocity.cloud`
  those endpoints are likely to require an access key, since the instance is shared across many
  projects. If the flaky-test job starts returning empty results after the migration, it probably
  needs `DEVELOCITY_ACCESS_KEY` plumbed through to that step — happy to follow up with a patch.

No other workflow edits are needed: the build workflows already read `DEVELOCITY_ACCESS_KEY`
from secrets. Build Scan publishing, remote cache push, and the
`build-scan.txt` output all behave as before.

## Action required before/when merging

The `DEVELOCITY_ACCESS_KEY` secret must be updated, because the access key format is
`<host>=<key>` and the host is changing:

```
DEVELOCITY_ACCESS_KEY = community.develocity.cloud=<access-key-for-the-community-instance>
```

Access keys for the OpenTelemetry CI service account on `community.develocity.cloud` have been
provisioned by the Develocity team and shared with the maintainers out of band. If the secret
still carries the `develocity.opentelemetry.io=` prefix after this PR merges, the key is silently
ignored: CI builds will publish no Build Scans and will not push to the remote cache.

Because the secret is shared across the OpenTelemetry JVM repositories, the cleanest sequence is
to update the (org-level) secret and merge the per-repository PRs together.

## Related PRs

This is part of the OpenTelemetry migration to the Community Instance. Companion PRs:

- open-telemetry/opentelemetry-java#8760
- open-telemetry/opentelemetry-java-instrumentation#19927  ← this PR
- open-telemetry/opentelemetry-java-contrib#3085
- open-telemetry/opentelemetry-java-examples#1262
- open-telemetry/semantic-conventions-java#569
- open-telemetry/opentelemetry-proto-java#279

## Questions

Happy to adjust anything here — feel free to ping me on this PR or in the CNCF Slack.
