### PR TITLE
Increase JMX library test timeout

### DIFF
--- a/instrumentation/jmx-metrics/library/build.gradle.kts
+++ b/instrumentation/jmx-metrics/library/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.time.Duration
 
 plugins {
   id("otel.library-instrumentation")
@@ -47,6 +48,7 @@ dependencies {
 tasks {
   test {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
+    timeout.set(Duration.ofMinutes(30))
 
     // the base agent only contains the agent machinery and the internal instrumentations that it
     // requires, the JMX instrumentation is added on top of it. Using the full agent would capture


### PR DESCRIPTION
Raises only `:instrumentation:jmx-metrics:library:test` from the repository-wide 15-minute timeout to 30 minutes, preventing slow JMX integration runs from being terminated prematurely.

Longer-term runtime improvements are tracked in #19939.