### PR TITLE
Limit final class guidance to public API

### DIFF
--- a/.github/agents/knowledge/general-rules.md
+++ b/.github/agents/knowledge/general-rules.md
@@ -191,7 +191,6 @@ variable (`MyGetter g = MyGetter.INSTANCE`), keep the variable and only change t
 right-hand side to `new MyGetter()`.
 
 Convert the class declaration from `enum` / singleton-holder to a plain `class`.
-If the implementation is a private nested class, omit the `final` keyword.
 
 **Exception — Kotlin `object` declarations**: Kotlin `object` is an idiomatic
 language-level singleton. Do not convert `object` declarations to `class`. This

--- a/.github/agents/knowledge/javaagent-module-patterns.md
+++ b/.github/agents/knowledge/javaagent-module-patterns.md
@@ -472,7 +472,7 @@ sufficient for optimization.
 
 ### Rules
 
-- Do not flag or change the visibility or `final` modifier on advice classes.
+- Do not flag or change the visibility of advice classes.
 - `typeMatcher()` should match only the types the instrumentation genuinely needs. Prefer
   `named("fully.qualified.ClassName")` or `namedOneOf(...)` for single classes.
   `extendsClass(...)` and `implementsInterface(...)` are appropriate when the instrumentation

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -9,10 +9,6 @@ Follow `docs/contributing/style-guide.md`.
 - **Visibility**: principle of least access. Use the most restrictive modifier
   that still works. Static fields should be `private` unless they are
   constant-like with a `SCREAMING_SNAKE_CASE` name.
-- **`final` on classes**: declare public API classes `final` where possible. Do
-  **not** add `final` in `javaagent/src/main/`, in `.internal` packages, or in
-  test code (paths under `src/test/` or modules whose name starts/ends with
-  `testing` or `tests`).
 - **`final` on parameters and local variables**: never declare them `final`.
 - **Null comparisons**: use `value == null` / `value != null`, not
   `null == value` / `null != value`. Applies to Java, Kotlin, and Scala.

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -9,6 +9,7 @@ Follow `docs/contributing/style-guide.md`.
 - **Visibility**: principle of least access. Use the most restrictive modifier
   that still works. Static fields should be `private` unless they are
   constant-like with a `SCREAMING_SNAKE_CASE` name.
+- **`final` on classes**: declare public API classes `final` where possible.
 - **`final` on parameters and local variables**: never declare them `final`.
 - **Null comparisons**: use `value == null` / `value != null`, not
   `null == value` / `null != value`. Applies to Java, Kotlin, and Scala.

--- a/.github/instructions/java-style.instructions.md
+++ b/.github/instructions/java-style.instructions.md
@@ -9,7 +9,9 @@ Follow `docs/contributing/style-guide.md`.
 - **Visibility**: principle of least access. Use the most restrictive modifier
   that still works. Static fields should be `private` unless they are
   constant-like with a `SCREAMING_SNAKE_CASE` name.
-- **`final` on classes**: declare public API classes `final` where possible.
+- **`final` on classes**: declare
+  [public API classes](../../docs/contributing/style-guide.md#public-api) `final`
+  where possible.
 - **`final` on parameters and local variables**: never declare them `final`.
 - **Null comparisons**: use `value == null` / `value != null`, not
   `null == value` / `null != value`. Applies to Java, Kotlin, and Scala.

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -59,6 +59,12 @@ still allows the code to function correctly.
 Static fields should be `private`, except for constant-like static fields with an
 uppercase (`SCREAMING_SNAKE_CASE`) name.
 
+### Public API
+
+Public API consists of Java types that published artifacts intentionally expose for use by external
+code. A `public` modifier alone does not make a class public API. Determine API status from the
+artifact's published contract and intended use, not source path or visibility alone.
+
 ### Internal packages
 
 Classes in `.internal` packages are not considered public API and may change without notice. These

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -96,17 +96,6 @@ methods.
 
 ### `final` keyword usage
 
-**Classes**: Declare public classes `final` where possible, but only in public API code.
-
-The following are **not** public API — do not add `final` to classes there:
-
-- `javaagent/src/main/` — internal implementation detail, even when classes are `public` for
-  service loading or cross-package access
-- `.internal` packages
-- Test code — `src/test/` directories and modules whose directory name starts or ends with
-  `testing` or `tests` (e.g., `testing/`, `testing-common/`, `quarkus-2.0-testing/`,
-  `smoke-tests/`)
-
 **Methods**: Declare `final` only in non-final public API classes.
 
 **Fields**: Declare `final` where possible.

--- a/docs/contributing/style-guide.md
+++ b/docs/contributing/style-guide.md
@@ -96,6 +96,8 @@ methods.
 
 ### `final` keyword usage
 
+**Classes**: Declare public API classes `final` where possible.
+
 **Methods**: Declare `final` only in non-final public API classes.
 
 **Fields**: Declare `final` where possible.


### PR DESCRIPTION
Limits the `final` class style rule to public API classes, where preventing unplanned extension matters.

Removes review guidance that tells agents to enforce or special-case `final` on internal implementation and advice classes.