### PR TITLE
Add instruction for generated instrumentation list

### DIFF
--- a/.github/instructions/instrumentation-list.instructions.md
+++ b/.github/instructions/instrumentation-list.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: "docs/instrumentation-list.yaml"
+---
+
+# Generated instrumentation list
+
+Do not edit `docs/instrumentation-list.yaml`. The nightly metadata update workflow in
+`.github/workflows/metadata-update.yml` regenerates this file.


### PR DESCRIPTION
Adds a file-scoped agent instruction that tells agents not to edit `docs/instrumentation-list.yaml`. The nightly metadata update workflow remains responsible for regenerating the file.