### PR TITLE
Use ubuntu-slim for required status check

### DIFF
--- a/.github/workflows/reusable-pr-build.yml
+++ b/.github/workflows/reusable-pr-build.yml
@@ -65,7 +65,7 @@ jobs:
       - muzzle
       - lint
       - build-servlet-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ always() }}
     steps:
       - if: |


### PR DESCRIPTION
Runs the lightweight `required-status-check` job on [`ubuntu-slim`](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners) instead of `ubuntu-latest`.

> ubuntu-slim runners execute Actions workflows in Ubuntu Linux, inside a container rather than a full VM instance.

Sometimes it takes a while for `required-status-check` job to pick up a runner, hoping this might help.