### PR TITLE
Support stable selector configuration in SelectorConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### 🚫 Deprecations
 
+- Deprecate `SelectorConfig.resolve` overloads that do not specify `SelectorConfig.Stability` in favor
+  of overloads that require callers to choose the stability explicitly.
+  ([#19969](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19969))
 - Deprecate `otel.instrumentation.opensearch.capture-search-query`. There is no replacement.
 - Deprecate `otel.instrumentation.elasticsearch.capture-search-query` There is no replacement.
   ([#19675](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19675))

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -127,21 +127,21 @@ public final class SelectorConfig {
     if (selector != null) {
       return selector;
     }
-    String replacementFlatProperty =
-        flatProperty(instrumentationName, selectorName, ".included", stability);
+    String replacementFlatProperties =
+        selectorFlatProperties(instrumentationName, selectorName, stability);
     List<String> deprecated =
         getDeprecated(
             config,
             instrumentationName,
             selectorName,
-            replacementFlatProperty,
+            replacementFlatProperties,
             systemPropertyFallback);
     return DeprecatedCaptureNames.toSelector(
         deprecated,
         "the "
             + deprecatedFlatProperty(instrumentationName, selectorName)
             + " setting or equivalent declarative configuration",
-        replacementFlatProperty + " or equivalent declarative configuration");
+        replacementFlatProperties + " or equivalent declarative configuration");
   }
 
   /**
@@ -166,7 +166,7 @@ public final class SelectorConfig {
             config,
             instrumentationName,
             selectorName,
-            flatProperty(instrumentationName, selectorName, ".included", Stability.EXPERIMENTAL),
+            selectorFlatProperties(instrumentationName, selectorName, Stability.EXPERIMENTAL),
             false);
     return deprecated == null ? null : resolveLegacyLiteral(deprecated);
   }
@@ -232,7 +232,7 @@ public final class SelectorConfig {
     warnDeprecated(
         instrumentationName,
         deprecatedSelectorName,
-        flatProperty(instrumentationName, selectorName, ".included", Stability.EXPERIMENTAL));
+        selectorFlatProperties(instrumentationName, selectorName, Stability.EXPERIMENTAL));
     return deprecated ? value -> true : null;
   }
 
@@ -279,7 +279,7 @@ public final class SelectorConfig {
       DeclarativeConfigProperties config,
       String instrumentationName,
       String selectorName,
-      String replacementFlatProperty,
+      String replacementFlatProperties,
       boolean systemPropertyFallback) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, selectorName);
     List<String> deprecated =
@@ -291,12 +291,12 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    warnDeprecated(instrumentationName, selectorName, replacementFlatProperty);
+    warnDeprecated(instrumentationName, selectorName, replacementFlatProperties);
     return deprecated;
   }
 
   private static void warnDeprecated(
-      String instrumentationName, String deprecatedSelectorName, String replacementFlatProperty) {
+      String instrumentationName, String deprecatedSelectorName, String replacementFlatProperties) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, deprecatedSelectorName);
     warnOnce(
         flatProperty + ":deprecated",
@@ -304,7 +304,7 @@ public final class SelectorConfig {
             + flatProperty
             + " setting and the equivalent declarative configuration property are deprecated and"
             + " may be removed in the next minor release. Use "
-            + replacementFlatProperty
+            + replacementFlatProperties
             + " or equivalent declarative configuration instead.");
   }
 
@@ -334,6 +334,13 @@ public final class SelectorConfig {
   private static String selectorNodeName(String selectorName, Stability stability) {
     String nodeName = nodeName(selectorName);
     return stability == Stability.EXPERIMENTAL ? nodeName + "/development" : nodeName;
+  }
+
+  private static String selectorFlatProperties(
+      String instrumentationName, String selectorName, Stability stability) {
+    return flatProperty(instrumentationName, selectorName, ".included", stability)
+        + " or "
+        + flatProperty(instrumentationName, selectorName, ".excluded", stability);
   }
 
   private static String flatProperty(

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -52,7 +52,11 @@ public final class SelectorConfig {
    *
    * <p>Values of the deprecated include-only setting that contain {@code *} or {@code ?} are
    * ignored and logged, since that setting matches values literally and never supported wildcards.
+   *
+   * @deprecated Use {@link #resolve(DeclarativeConfigProperties, String, String, Stability)} and
+   *     specify the selector configuration stability explicitly.
    */
+  @Deprecated
   @Nullable
   public static IncludeExclude resolve(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
@@ -68,7 +72,10 @@ public final class SelectorConfig {
    * @param systemPropertyFallback whether to fall back to the flat system properties when the
    *     declarative configuration does not contain a value. This is needed by library
    *     instrumentation entry points that have no programmatic configuration surface.
+   * @deprecated Use {@link #resolve(DeclarativeConfigProperties, String, String, Stability,
+   *     boolean)} and specify the selector configuration stability explicitly.
    */
+  @Deprecated
   @Nullable
   public static IncludeExclude resolve(
       DeclarativeConfigProperties config,

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -32,6 +32,10 @@ import javax.annotation.Nullable;
  * experimental {@code capture_headers/development} node and {@code
  * otel.instrumentation.messaging.experimental.capture-headers} flat property.
  *
+ * <p>Flat system properties are read directly only when {@code systemPropertyFallback} is {@code
+ * true}; otherwise the flat names describe the equivalent form of the supplied declarative
+ * configuration.
+ *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -133,7 +133,8 @@ public final class SelectorConfig {
         "the "
             + deprecatedFlatProperty(instrumentationName, selectorName)
             + " setting or equivalent declarative configuration",
-        replacementFlatProperties + " or equivalent declarative configuration");
+        flatProperty(instrumentationName, selectorName, ".included", stability)
+            + " or equivalent declarative configuration");
   }
 
   /**

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -24,9 +24,13 @@ import javax.annotation.Nullable;
  * Resolves an {@code included}/{@code excluded} selector and its deprecated include-only
  * predecessor, so that precedence and deprecation warnings are uniform across instrumentations.
  *
- * <p>The property names are derived from the instrumentation and selector names. Existing overloads
- * resolve experimental included/excluded selectors. Overloads accepting {@link Stability} can
- * instead resolve stable selectors. Deprecated capture settings remain experimental.
+ * <p>The property names are derived from the instrumentation and selector names. For {@code
+ * ("messaging", "headers")}, experimental resolution reads the {@code headers/development} node and
+ * {@code otel.instrumentation.messaging.experimental.headers.included|excluded}. Stable resolution
+ * reads the {@code headers} node and {@code
+ * otel.instrumentation.messaging.headers.included|excluded}. Both modes fall back to the deprecated
+ * experimental {@code capture_headers/development} node and {@code
+ * otel.instrumentation.messaging.experimental.capture-headers} flat property.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -123,15 +127,21 @@ public final class SelectorConfig {
     if (selector != null) {
       return selector;
     }
+    String replacementFlatProperty =
+        flatProperty(instrumentationName, selectorName, ".included", stability);
     List<String> deprecated =
-        getDeprecated(config, instrumentationName, selectorName, stability, systemPropertyFallback);
+        getDeprecated(
+            config,
+            instrumentationName,
+            selectorName,
+            replacementFlatProperty,
+            systemPropertyFallback);
     return DeprecatedCaptureNames.toSelector(
         deprecated,
         "the "
             + deprecatedFlatProperty(instrumentationName, selectorName)
             + " setting or equivalent declarative configuration",
-        flatProperty(instrumentationName, selectorName, ".included", stability)
-            + " or equivalent declarative configuration");
+        replacementFlatProperty + " or equivalent declarative configuration");
   }
 
   /**
@@ -146,33 +156,18 @@ public final class SelectorConfig {
   @Nullable
   public static Predicate<String> resolveLegacyLiteral(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
-    return resolveLegacyLiteral(config, instrumentationName, selectorName, Stability.EXPERIMENTAL);
-  }
-
-  /**
-   * Returns a predicate matching the configured selector, or {@code null} when nothing is
-   * configured to be captured.
-   *
-   * <p>Unlike {@link #resolve}, the values of the deprecated include-only setting are matched
-   * literally, except for the single value {@code "*"} which matches everything. This preserves the
-   * behavior of settings that documented {@code "*"} as capturing all values, where interpreting
-   * the remaining values as globs would silently widen what is captured.
-   *
-   * @param stability whether the included/excluded selector is stable or experimental
-   */
-  @Nullable
-  public static Predicate<String> resolveLegacyLiteral(
-      DeclarativeConfigProperties config,
-      String instrumentationName,
-      String selectorName,
-      Stability stability) {
     IncludeExclude selector =
-        getSelector(config, instrumentationName, selectorName, stability, false);
+        getSelector(config, instrumentationName, selectorName, Stability.EXPERIMENTAL, false);
     if (selector != null) {
       return selector::matches;
     }
     List<String> deprecated =
-        getDeprecated(config, instrumentationName, selectorName, stability, false);
+        getDeprecated(
+            config,
+            instrumentationName,
+            selectorName,
+            flatProperty(instrumentationName, selectorName, ".included", Stability.EXPERIMENTAL),
+            false);
     return deprecated == null ? null : resolveLegacyLiteral(deprecated);
   }
 
@@ -207,26 +202,7 @@ public final class SelectorConfig {
   @Nullable
   public static Predicate<String> resolveLegacyBoolean(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
-    return resolveLegacyBoolean(
-        config, instrumentationName, selectorName, selectorName, Stability.EXPERIMENTAL);
-  }
-
-  /**
-   * Returns a predicate matching the configured selector, or {@code null} when nothing is
-   * configured to be captured.
-   *
-   * <p>Unlike {@link #resolve}, the deprecated setting is a boolean, where {@code true} selects
-   * every value and {@code false} selects none.
-   *
-   * @param stability whether the included/excluded selector is stable or experimental
-   */
-  @Nullable
-  public static Predicate<String> resolveLegacyBoolean(
-      DeclarativeConfigProperties config,
-      String instrumentationName,
-      String selectorName,
-      Stability stability) {
-    return resolveLegacyBoolean(config, instrumentationName, selectorName, selectorName, stability);
+    return resolveLegacyBoolean(config, instrumentationName, selectorName, selectorName);
   }
 
   /**
@@ -243,30 +219,8 @@ public final class SelectorConfig {
       String instrumentationName,
       String selectorName,
       String deprecatedSelectorName) {
-    return resolveLegacyBoolean(
-        config, instrumentationName, selectorName, deprecatedSelectorName, Stability.EXPERIMENTAL);
-  }
-
-  /**
-   * Returns a predicate matching the configured selector, or {@code null} when nothing is
-   * configured to be captured.
-   *
-   * <p>Unlike {@link #resolveLegacyBoolean(DeclarativeConfigProperties, String, String,
-   * Stability)}, the deprecated boolean setting is named after {@code deprecatedSelectorName}
-   * instead of {@code selectorName}, for settings that were not renamed consistently with their
-   * replacement.
-   *
-   * @param stability whether the included/excluded selector is stable or experimental
-   */
-  @Nullable
-  public static Predicate<String> resolveLegacyBoolean(
-      DeclarativeConfigProperties config,
-      String instrumentationName,
-      String selectorName,
-      String deprecatedSelectorName,
-      Stability stability) {
     IncludeExclude selector =
-        getSelector(config, instrumentationName, selectorName, stability, false);
+        getSelector(config, instrumentationName, selectorName, Stability.EXPERIMENTAL, false);
     if (selector != null) {
       return selector::matches;
     }
@@ -275,7 +229,10 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    warnDeprecated(instrumentationName, selectorName, deprecatedSelectorName, stability);
+    warnDeprecated(
+        instrumentationName,
+        deprecatedSelectorName,
+        flatProperty(instrumentationName, selectorName, ".included", Stability.EXPERIMENTAL));
     return deprecated ? value -> true : null;
   }
 
@@ -322,7 +279,7 @@ public final class SelectorConfig {
       DeclarativeConfigProperties config,
       String instrumentationName,
       String selectorName,
-      Stability stability,
+      String replacementFlatProperty,
       boolean systemPropertyFallback) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, selectorName);
     List<String> deprecated =
@@ -334,23 +291,20 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    warnDeprecated(instrumentationName, selectorName, selectorName, stability);
+    warnDeprecated(instrumentationName, selectorName, replacementFlatProperty);
     return deprecated;
   }
 
   private static void warnDeprecated(
-      String instrumentationName,
-      String selectorName,
-      String deprecatedSelectorName,
-      Stability stability) {
+      String instrumentationName, String deprecatedSelectorName, String replacementFlatProperty) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, deprecatedSelectorName);
     warnOnce(
-        flatProperty + ":" + stability + ":deprecated",
+        flatProperty + ":deprecated",
         "The "
             + flatProperty
             + " setting and the equivalent declarative configuration property are deprecated and"
             + " may be removed in the next minor release. Use "
-            + flatProperty(instrumentationName, selectorName, ".included", stability)
+            + replacementFlatProperty
             + " or equivalent declarative configuration instead.");
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -45,18 +45,6 @@ public final class SelectorConfig {
   private static final Set<String> warnings = ConcurrentHashMap.newKeySet();
 
   /**
-   * The stability of the included/excluded selector configuration. This does not change the
-   * stability of the deprecated capture setting.
-   *
-   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
-   * at any time.
-   */
-  public enum Stability {
-    STABLE,
-    EXPERIMENTAL
-  }
-
-  /**
    * Returns the configured selector, or {@code null} when nothing is configured to be captured.
    *
    * <p>Note that {@code null} is returned rather than an {@linkplain IncludeExclude#isEmpty()
@@ -361,4 +349,16 @@ public final class SelectorConfig {
   }
 
   private SelectorConfig() {}
+
+  /**
+   * The stability of the included/excluded selector configuration. This does not change the
+   * stability of the deprecated capture setting.
+   *
+   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+   * at any time.
+   */
+  public enum Stability {
+    STABLE,
+    EXPERIMENTAL
+  }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -54,9 +54,10 @@ public final class SelectorConfig {
    * ignored and logged, since that setting matches values literally and never supported wildcards.
    *
    * @deprecated Use {@link #resolve(DeclarativeConfigProperties, String, String, Stability)} and
-   *     specify the selector configuration stability explicitly.
+   *     specify the selector configuration stability explicitly. May be removed in the next minor
+   *     release.
    */
-  @Deprecated
+  @Deprecated // may be removed in the next minor release
   @Nullable
   public static IncludeExclude resolve(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
@@ -73,9 +74,10 @@ public final class SelectorConfig {
    *     declarative configuration does not contain a value. This is needed by library
    *     instrumentation entry points that have no programmatic configuration surface.
    * @deprecated Use {@link #resolve(DeclarativeConfigProperties, String, String, Stability,
-   *     boolean)} and specify the selector configuration stability explicitly.
+   *     boolean)} and specify the selector configuration stability explicitly. May be removed in
+   *     the next minor release.
    */
-  @Deprecated
+  @Deprecated // may be removed in the next minor release
   @Nullable
   public static IncludeExclude resolve(
       DeclarativeConfigProperties config,

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfig.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.incubator.config.internal;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
@@ -23,12 +24,9 @@ import javax.annotation.Nullable;
  * Resolves an {@code included}/{@code excluded} selector and its deprecated include-only
  * predecessor, so that precedence and deprecation warnings are uniform across instrumentations.
  *
- * <p>The property names are derived from the instrumentation and selector names. For {@code
- * ("messaging", "headers")} the declarative configuration is read from the {@code
- * headers/development} node of the supplied configuration, falling back to the deprecated {@code
- * capture_headers/development} node, and the corresponding flat properties are {@code
- * otel.instrumentation.messaging.experimental.headers.included}, {@code ...headers.excluded} and
- * {@code otel.instrumentation.messaging.experimental.capture-headers}.
+ * <p>The property names are derived from the instrumentation and selector names. Existing overloads
+ * resolve experimental included/excluded selectors. Overloads accepting {@link Stability} can
+ * instead resolve stable selectors. Deprecated capture settings remain experimental.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -37,6 +35,18 @@ public final class SelectorConfig {
 
   private static final Logger logger = Logger.getLogger(SelectorConfig.class.getName());
   private static final Set<String> warnings = ConcurrentHashMap.newKeySet();
+
+  /**
+   * The stability of the included/excluded selector configuration. This does not change the
+   * stability of the deprecated capture setting.
+   *
+   * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+   * at any time.
+   */
+  public enum Stability {
+    STABLE,
+    EXPERIMENTAL
+  }
 
   /**
    * Returns the configured selector, or {@code null} when nothing is configured to be captured.
@@ -50,7 +60,7 @@ public final class SelectorConfig {
   @Nullable
   public static IncludeExclude resolve(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
-    return resolve(config, instrumentationName, selectorName, false);
+    return resolve(config, instrumentationName, selectorName, Stability.EXPERIMENTAL, false);
   }
 
   /**
@@ -69,19 +79,58 @@ public final class SelectorConfig {
       String instrumentationName,
       String selectorName,
       boolean systemPropertyFallback) {
+    return resolve(
+        config, instrumentationName, selectorName, Stability.EXPERIMENTAL, systemPropertyFallback);
+  }
+
+  /**
+   * Returns the configured selector, or {@code null} when nothing is configured to be captured.
+   *
+   * <p>Values of the deprecated include-only setting that contain {@code *} or {@code ?} are
+   * ignored and logged, since that setting matches values literally and never supported wildcards.
+   *
+   * @param stability whether the included/excluded selector is stable or experimental
+   */
+  @Nullable
+  public static IncludeExclude resolve(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      Stability stability) {
+    return resolve(config, instrumentationName, selectorName, stability, false);
+  }
+
+  /**
+   * Returns the configured selector, or {@code null} when nothing is configured to be captured.
+   *
+   * <p>Values of the deprecated include-only setting that contain {@code *} or {@code ?} are
+   * ignored and logged, since that setting matches values literally and never supported wildcards.
+   *
+   * @param stability whether the included/excluded selector is stable or experimental
+   * @param systemPropertyFallback whether to fall back to the flat system properties when the
+   *     declarative configuration does not contain a value. This is needed by library
+   *     instrumentation entry points that have no programmatic configuration surface.
+   */
+  @Nullable
+  public static IncludeExclude resolve(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      Stability stability,
+      boolean systemPropertyFallback) {
     IncludeExclude selector =
-        getSelector(config, instrumentationName, selectorName, systemPropertyFallback);
+        getSelector(config, instrumentationName, selectorName, stability, systemPropertyFallback);
     if (selector != null) {
       return selector;
     }
     List<String> deprecated =
-        getDeprecated(config, instrumentationName, selectorName, systemPropertyFallback);
+        getDeprecated(config, instrumentationName, selectorName, stability, systemPropertyFallback);
     return DeprecatedCaptureNames.toSelector(
         deprecated,
         "the "
             + deprecatedFlatProperty(instrumentationName, selectorName)
             + " setting or equivalent declarative configuration",
-        flatProperty(instrumentationName, selectorName, ".included")
+        flatProperty(instrumentationName, selectorName, ".included", stability)
             + " or equivalent declarative configuration");
   }
 
@@ -97,11 +146,33 @@ public final class SelectorConfig {
   @Nullable
   public static Predicate<String> resolveLegacyLiteral(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
-    IncludeExclude selector = getSelector(config, instrumentationName, selectorName, false);
+    return resolveLegacyLiteral(config, instrumentationName, selectorName, Stability.EXPERIMENTAL);
+  }
+
+  /**
+   * Returns a predicate matching the configured selector, or {@code null} when nothing is
+   * configured to be captured.
+   *
+   * <p>Unlike {@link #resolve}, the values of the deprecated include-only setting are matched
+   * literally, except for the single value {@code "*"} which matches everything. This preserves the
+   * behavior of settings that documented {@code "*"} as capturing all values, where interpreting
+   * the remaining values as globs would silently widen what is captured.
+   *
+   * @param stability whether the included/excluded selector is stable or experimental
+   */
+  @Nullable
+  public static Predicate<String> resolveLegacyLiteral(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      Stability stability) {
+    IncludeExclude selector =
+        getSelector(config, instrumentationName, selectorName, stability, false);
     if (selector != null) {
       return selector::matches;
     }
-    List<String> deprecated = getDeprecated(config, instrumentationName, selectorName, false);
+    List<String> deprecated =
+        getDeprecated(config, instrumentationName, selectorName, stability, false);
     return deprecated == null ? null : resolveLegacyLiteral(deprecated);
   }
 
@@ -136,7 +207,26 @@ public final class SelectorConfig {
   @Nullable
   public static Predicate<String> resolveLegacyBoolean(
       DeclarativeConfigProperties config, String instrumentationName, String selectorName) {
-    return resolveLegacyBoolean(config, instrumentationName, selectorName, selectorName);
+    return resolveLegacyBoolean(
+        config, instrumentationName, selectorName, selectorName, Stability.EXPERIMENTAL);
+  }
+
+  /**
+   * Returns a predicate matching the configured selector, or {@code null} when nothing is
+   * configured to be captured.
+   *
+   * <p>Unlike {@link #resolve}, the deprecated setting is a boolean, where {@code true} selects
+   * every value and {@code false} selects none.
+   *
+   * @param stability whether the included/excluded selector is stable or experimental
+   */
+  @Nullable
+  public static Predicate<String> resolveLegacyBoolean(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      Stability stability) {
+    return resolveLegacyBoolean(config, instrumentationName, selectorName, selectorName, stability);
   }
 
   /**
@@ -153,7 +243,30 @@ public final class SelectorConfig {
       String instrumentationName,
       String selectorName,
       String deprecatedSelectorName) {
-    IncludeExclude selector = getSelector(config, instrumentationName, selectorName, false);
+    return resolveLegacyBoolean(
+        config, instrumentationName, selectorName, deprecatedSelectorName, Stability.EXPERIMENTAL);
+  }
+
+  /**
+   * Returns a predicate matching the configured selector, or {@code null} when nothing is
+   * configured to be captured.
+   *
+   * <p>Unlike {@link #resolveLegacyBoolean(DeclarativeConfigProperties, String, String,
+   * Stability)}, the deprecated boolean setting is named after {@code deprecatedSelectorName}
+   * instead of {@code selectorName}, for settings that were not renamed consistently with their
+   * replacement.
+   *
+   * @param stability whether the included/excluded selector is stable or experimental
+   */
+  @Nullable
+  public static Predicate<String> resolveLegacyBoolean(
+      DeclarativeConfigProperties config,
+      String instrumentationName,
+      String selectorName,
+      String deprecatedSelectorName,
+      Stability stability) {
+    IncludeExclude selector =
+        getSelector(config, instrumentationName, selectorName, stability, false);
     if (selector != null) {
       return selector::matches;
     }
@@ -162,7 +275,7 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    warnDeprecated(instrumentationName, selectorName, deprecatedSelectorName);
+    warnDeprecated(instrumentationName, selectorName, deprecatedSelectorName, stability);
     return deprecated ? value -> true : null;
   }
 
@@ -176,19 +289,21 @@ public final class SelectorConfig {
       DeclarativeConfigProperties config,
       String instrumentationName,
       String selectorName,
+      Stability stability,
       boolean systemPropertyFallback) {
-    DeclarativeConfigProperties node = config.get(nodeName(selectorName) + "/development");
+    requireNonNull(stability, "stability");
+    DeclarativeConfigProperties node = config.get(selectorNodeName(selectorName, stability));
     List<String> included =
         getList(
             node,
             "included",
-            flatProperty(instrumentationName, selectorName, ".included"),
+            flatProperty(instrumentationName, selectorName, ".included", stability),
             systemPropertyFallback);
     List<String> excluded =
         getList(
             node,
             "excluded",
-            flatProperty(instrumentationName, selectorName, ".excluded"),
+            flatProperty(instrumentationName, selectorName, ".excluded", stability),
             systemPropertyFallback);
     IncludeExclude selector =
         IncludeExclude.builder()
@@ -207,6 +322,7 @@ public final class SelectorConfig {
       DeclarativeConfigProperties config,
       String instrumentationName,
       String selectorName,
+      Stability stability,
       boolean systemPropertyFallback) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, selectorName);
     List<String> deprecated =
@@ -218,20 +334,23 @@ public final class SelectorConfig {
     if (deprecated == null) {
       return null;
     }
-    warnDeprecated(instrumentationName, selectorName, selectorName);
+    warnDeprecated(instrumentationName, selectorName, selectorName, stability);
     return deprecated;
   }
 
   private static void warnDeprecated(
-      String instrumentationName, String selectorName, String deprecatedSelectorName) {
+      String instrumentationName,
+      String selectorName,
+      String deprecatedSelectorName,
+      Stability stability) {
     String flatProperty = deprecatedFlatProperty(instrumentationName, deprecatedSelectorName);
     warnOnce(
-        flatProperty + ":deprecated",
+        flatProperty + ":" + stability + ":deprecated",
         "The "
             + flatProperty
             + " setting and the equivalent declarative configuration property are deprecated and"
             + " may be removed in the next minor release. Use "
-            + flatProperty(instrumentationName, selectorName, ".included")
+            + flatProperty(instrumentationName, selectorName, ".included", stability)
             + " or equivalent declarative configuration instead.");
   }
 
@@ -258,9 +377,18 @@ public final class SelectorConfig {
     return selectorName.replace('-', '_');
   }
 
+  private static String selectorNodeName(String selectorName, Stability stability) {
+    String nodeName = nodeName(selectorName);
+    return stability == Stability.EXPERIMENTAL ? nodeName + "/development" : nodeName;
+  }
+
   private static String flatProperty(
-      String instrumentationName, String selectorName, String suffix) {
-    return "otel.instrumentation." + instrumentationName + ".experimental." + selectorName + suffix;
+      String instrumentationName, String selectorName, String suffix, Stability stability) {
+    return "otel.instrumentation."
+        + instrumentationName
+        + (stability == Stability.EXPERIMENTAL ? ".experimental." : ".")
+        + selectorName
+        + suffix;
   }
 
   private static String deprecatedFlatProperty(String instrumentationName, String selectorName) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfig.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/internal/MessagingConfig.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig.Stability.EXPERIMENTAL;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
@@ -50,7 +52,8 @@ public final class MessagingConfig {
   static IncludeExclude getHeaders(
       DeclarativeConfigProperties messagingConfig, boolean systemPropertyFallback) {
     IncludeExclude selector =
-        SelectorConfig.resolve(messagingConfig, "messaging", "headers", systemPropertyFallback);
+        SelectorConfig.resolve(
+            messagingConfig, "messaging", "headers", EXPERIMENTAL, systemPropertyFallback);
     return selector == null ? NONE : selector;
   }
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -25,6 +25,8 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 class SelectorConfigTest {
 
@@ -280,6 +282,7 @@ class SelectorConfigTest {
   }
 
   @Test
+  @ResourceLock(Resources.SYSTEM_PROPERTIES)
   void stableSystemPropertyFallbackIsOnlyUsedWhenEnabled() {
     DeclarativeConfigProperties config = mockStableConfig();
     System.setProperty(

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.config.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig.Stability.EXPERIMENTAL;
 import static io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig.Stability.STABLE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -130,8 +131,8 @@ class SelectorConfigTest {
 
     assertThat(SelectorConfig.resolveLegacyLiteral(absent, "test", SELECTOR)).isNull();
     assertThat(SelectorConfig.resolveLegacyLiteral(empty, "test", SELECTOR)).isNull();
-    assertThat(SelectorConfig.resolve(absent, "test", SELECTOR)).isNull();
-    assertThat(SelectorConfig.resolve(empty, "test", SELECTOR)).isNull();
+    assertThat(SelectorConfig.resolve(absent, "test", SELECTOR, EXPERIMENTAL)).isNull();
+    assertThat(SelectorConfig.resolve(empty, "test", SELECTOR, EXPERIMENTAL)).isNull();
   }
 
   @Test
@@ -145,6 +146,26 @@ class SelectorConfigTest {
 
     assertThat(SelectorConfig.resolve(absent, "stable-absent", SELECTOR, STABLE)).isNull();
     assertThat(SelectorConfig.resolve(empty, "stable-empty", SELECTOR, STABLE)).isNull();
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void deprecatedResolveOverloadsUseExperimentalStability() {
+    DeclarativeConfigProperties config = mockConfig();
+    when(config.get("mdc_attributes/development").getScalarList("included", String.class))
+        .thenReturn(singletonList("experimental"));
+    when(config.get("mdc_attributes").getScalarList("included", String.class))
+        .thenReturn(singletonList("stable"));
+
+    IncludeExclude selector = SelectorConfig.resolve(config, "test", SELECTOR);
+    IncludeExclude selectorWithFallback = SelectorConfig.resolve(config, "test", SELECTOR, false);
+
+    assertThat(selector).isNotNull();
+    assertThat(selector.matches("experimental")).isTrue();
+    assertThat(selector.matches("stable")).isFalse();
+    assertThat(selectorWithFallback).isNotNull();
+    assertThat(selectorWithFallback.matches("experimental")).isTrue();
+    assertThat(selectorWithFallback.matches("stable")).isFalse();
   }
 
   @Test
@@ -231,7 +252,8 @@ class SelectorConfigTest {
         .thenReturn(emptyList());
 
     assertThat(SelectorConfig.resolveLegacyLiteral(config, "deprecated-empty", SELECTOR)).isNull();
-    assertThat(SelectorConfig.resolve(config, "deprecated-empty-resolve", SELECTOR)).isNull();
+    assertThat(SelectorConfig.resolve(config, "deprecated-empty-resolve", SELECTOR, EXPERIMENTAL))
+        .isNull();
   }
 
   @Test
@@ -246,7 +268,8 @@ class SelectorConfigTest {
       Predicate<String> first = SelectorConfig.resolveLegacyLiteral(config, "precedence", SELECTOR);
       Predicate<String> second =
           SelectorConfig.resolveLegacyLiteral(config, "precedence", SELECTOR);
-      IncludeExclude resolved = SelectorConfig.resolve(config, "precedence", SELECTOR);
+      IncludeExclude resolved =
+          SelectorConfig.resolve(config, "precedence", SELECTOR, EXPERIMENTAL);
 
       assertThat(first).isNotNull();
       assertThat(first.test("new")).isTrue();
@@ -322,7 +345,8 @@ class SelectorConfigTest {
     when(config.getScalarList("capture_mdc_attributes/development", String.class))
         .thenReturn(asList("exact.name", "prefix.*"));
 
-    IncludeExclude selector = SelectorConfig.resolve(config, "resolve-deprecated", SELECTOR);
+    IncludeExclude selector =
+        SelectorConfig.resolve(config, "resolve-deprecated", SELECTOR, EXPERIMENTAL);
 
     assertThat(selector).isNotNull();
     assertThat(selector.matches("exact.name")).isTrue();
@@ -361,7 +385,8 @@ class SelectorConfigTest {
     when(config.getScalarList("capture_mdc_attributes/development", String.class))
         .thenReturn(singletonList("*"));
 
-    assertThat(SelectorConfig.resolve(config, "resolve-all-wildcards", SELECTOR)).isNull();
+    assertThat(SelectorConfig.resolve(config, "resolve-all-wildcards", SELECTOR, EXPERIMENTAL))
+        .isNull();
   }
 
   @Test
@@ -375,7 +400,8 @@ class SelectorConfigTest {
     when(config.getScalarList("capture_request_parameters/development", String.class))
         .thenReturn(null);
 
-    IncludeExclude selector = SelectorConfig.resolve(config, "servlet", "request-parameters");
+    IncludeExclude selector =
+        SelectorConfig.resolve(config, "servlet", "request-parameters", EXPERIMENTAL);
 
     assertThat(selector).isNotNull();
     assertThat(selector.matches("id")).isTrue();

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -174,6 +174,7 @@ class SelectorConfigTest {
                   + " setting and the equivalent declarative configuration property are deprecated"
                   + " and may be removed in the next minor release. Use"
                   + " otel.instrumentation.exact-matching.experimental.mdc-attributes.included"
+                  + " or otel.instrumentation.exact-matching.experimental.mdc-attributes.excluded"
                   + " or equivalent declarative configuration instead.");
     } finally {
       detachWarningHandler(handler);
@@ -201,6 +202,7 @@ class SelectorConfigTest {
                   + " setting and the equivalent declarative configuration property are deprecated"
                   + " and may be removed in the next minor release. Use"
                   + " otel.instrumentation.stable-deprecated.mdc-attributes.included"
+                  + " or otel.instrumentation.stable-deprecated.mdc-attributes.excluded"
                   + " or equivalent declarative configuration instead.");
     } finally {
       detachWarningHandler(handler);
@@ -409,8 +411,9 @@ class SelectorConfigTest {
                   + ".capture-key-value-pair-attributes setting and the equivalent declarative"
                   + " configuration property are deprecated and may be removed in the next minor"
                   + " release. Use otel.instrumentation.boolean-enabled.experimental"
-                  + ".key-value-pair-attributes.included or equivalent declarative configuration"
-                  + " instead.");
+                  + ".key-value-pair-attributes.included or otel.instrumentation.boolean-enabled"
+                  + ".experimental.key-value-pair-attributes.excluded or equivalent declarative"
+                  + " configuration instead.");
     } finally {
       detachWarningHandler(handler);
     }
@@ -462,7 +465,9 @@ class SelectorConfigTest {
                   + ".capture-logstash-structured-arguments setting and the equivalent declarative"
                   + " configuration property are deprecated and may be removed in the next minor"
                   + " release. Use otel.instrumentation.boolean-renamed.experimental"
-                  + ".logstash-structured-argument-attributes.included or equivalent declarative"
+                  + ".logstash-structured-argument-attributes.included or"
+                  + " otel.instrumentation.boolean-renamed.experimental"
+                  + ".logstash-structured-argument-attributes.excluded or equivalent declarative"
                   + " configuration instead.");
     } finally {
       detachWarningHandler(handler);

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -68,17 +68,12 @@ class SelectorConfigTest {
         .thenReturn(singletonList("wrong"));
 
     IncludeExclude selector = SelectorConfig.resolve(config, "test", SELECTOR, STABLE);
-    Predicate<String> legacyLiteral =
-        SelectorConfig.resolveLegacyLiteral(config, "test", SELECTOR, STABLE);
 
     assertThat(selector).isNotNull();
     assertThat(selector.matches("exact")).isTrue();
     assertThat(selector.matches("prefix.value")).isTrue();
     assertThat(selector.matches("prefix.secret")).isFalse();
     assertThat(selector.matches("wrong")).isFalse();
-    assertThat(legacyLiteral).isNotNull();
-    assertThat(legacyLiteral.test("prefix.value")).isTrue();
-    assertThat(legacyLiteral.test("prefix.secret")).isFalse();
   }
 
   @Test
@@ -146,8 +141,6 @@ class SelectorConfigTest {
 
     assertThat(SelectorConfig.resolve(absent, "stable-absent", SELECTOR, STABLE)).isNull();
     assertThat(SelectorConfig.resolve(empty, "stable-empty", SELECTOR, STABLE)).isNull();
-    assertThat(SelectorConfig.resolveLegacyLiteral(empty, "stable-empty-literal", SELECTOR, STABLE))
-        .isNull();
   }
 
   @Test
@@ -392,56 +385,6 @@ class SelectorConfigTest {
   }
 
   @Test
-  void legacyBooleanReadsStableSelector() {
-    DeclarativeConfigProperties config = mockStableRenamedBooleanConfig();
-    when(config
-            .get("logstash_structured_argument_attributes")
-            .getScalarList("included", String.class))
-        .thenReturn(singletonList("new"));
-    when(config
-            .get("logstash_structured_argument_attributes/development")
-            .getScalarList("included", String.class))
-        .thenReturn(singletonList("wrong"));
-    when(config.getBoolean("capture_logstash_structured_arguments/development")).thenReturn(true);
-
-    Predicate<String> selector =
-        SelectorConfig.resolveLegacyBoolean(
-            config, "stable-boolean", RENAMED_SELECTOR, DEPRECATED_RENAMED_SELECTOR, STABLE);
-
-    assertThat(selector).isNotNull();
-    assertThat(selector.test("new")).isTrue();
-    assertThat(selector.test("wrong")).isFalse();
-    verify(config, never()).getBoolean("capture_logstash_structured_arguments/development");
-  }
-
-  @Test
-  void stableLegacyBooleanFallsBackToExperimentalDeprecatedConfig() {
-    DeclarativeConfigProperties config = mockStableBooleanConfig();
-    when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(true);
-    TestHandler handler = attachWarningHandler();
-    try {
-      Predicate<String> selector =
-          SelectorConfig.resolveLegacyBoolean(
-              config, "stable-boolean-deprecated", BOOLEAN_SELECTOR, STABLE);
-
-      assertThat(selector).isNotNull();
-      assertThat(selector.test("anything")).isTrue();
-      verify(config, never()).getBoolean("capture_key_value_pair_attributes");
-      assertThat(handler.records).hasSize(1);
-      assertThat(handler.records.get(0).getMessage())
-          .isEqualTo(
-              "The otel.instrumentation.stable-boolean-deprecated.experimental"
-                  + ".capture-key-value-pair-attributes setting and the equivalent declarative"
-                  + " configuration property are deprecated and may be removed in the next minor"
-                  + " release. Use otel.instrumentation.stable-boolean-deprecated"
-                  + ".key-value-pair-attributes.included or equivalent declarative configuration"
-                  + " instead.");
-    } finally {
-      detachWarningHandler(handler);
-    }
-  }
-
-  @Test
   void legacyBooleanTrueCapturesEverythingAndWarnsOnce() {
     DeclarativeConfigProperties config = mockBooleanConfig();
     when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(true);
@@ -556,31 +499,10 @@ class SelectorConfigTest {
     return config;
   }
 
-  private static DeclarativeConfigProperties mockStableRenamedBooleanConfig() {
-    DeclarativeConfigProperties config =
-        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
-    DeclarativeConfigProperties selectorNode =
-        config.get("logstash_structured_argument_attributes");
-    when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
-    when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
-    when(config.getBoolean("capture_logstash_structured_arguments/development")).thenReturn(null);
-    return config;
-  }
-
   private static DeclarativeConfigProperties mockBooleanConfig() {
     DeclarativeConfigProperties config =
         mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
     DeclarativeConfigProperties selectorNode = config.get("key_value_pair_attributes/development");
-    when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
-    when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
-    when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(null);
-    return config;
-  }
-
-  private static DeclarativeConfigProperties mockStableBooleanConfig() {
-    DeclarativeConfigProperties config =
-        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
-    DeclarativeConfigProperties selectorNode = config.get("key_value_pair_attributes");
     when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
     when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
     when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(null);

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
+import io.opentelemetry.instrumentation.api.internal.DeprecatedCaptureNames;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -322,6 +323,31 @@ class SelectorConfigTest {
     assertThat(selector.matches("exact.name")).isTrue();
     assertThat(selector.matches("prefix.value")).isFalse();
     assertThat(selector.matches("other")).isFalse();
+  }
+
+  @Test
+  void ignoredDeprecatedWildcardsPointToTheIncludedProperty() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    when(config.getScalarList("capture_mdc_attributes/development", String.class))
+        .thenReturn(asList("exact.name", "prefix.*"));
+    TestHandler handler = new TestHandler();
+    Logger logger = Logger.getLogger(DeprecatedCaptureNames.class.getName());
+    logger.addHandler(handler);
+    try {
+      assertThat(SelectorConfig.resolve(config, "ignored-wildcards", SELECTOR, STABLE)).isNotNull();
+
+      assertThat(handler.records).hasSize(1);
+      assertThat(handler.records.get(0).getMessage())
+          .isEqualTo(
+              "Ignoring [prefix.*] configured in the"
+                  + " otel.instrumentation.ignored-wildcards.experimental.capture-mdc-attributes"
+                  + " setting or equivalent declarative configuration, which matches names"
+                  + " literally and never supported wildcards. Use"
+                  + " otel.instrumentation.ignored-wildcards.mdc-attributes.included or equivalent"
+                  + " declarative configuration to match names by pattern.");
+    } finally {
+      logger.removeHandler(handler);
+    }
   }
 
   @Test

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.config.internal;
 
+import static io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig.Stability.STABLE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -40,6 +41,8 @@ class SelectorConfigTest {
         .thenReturn(asList("exact", "prefix.*", "single?"));
     when(selectorNode.getScalarList("excluded", String.class))
         .thenReturn(singletonList("prefix.secret"));
+    when(config.get("mdc_attributes").getScalarList("included", String.class))
+        .thenReturn(singletonList("stable-only"));
 
     Predicate<String> selector = SelectorConfig.resolveLegacyLiteral(config, "test", SELECTOR);
 
@@ -49,7 +52,46 @@ class SelectorConfigTest {
     assertThat(selector.test("single1")).isTrue();
     assertThat(selector.test("single22")).isFalse();
     assertThat(selector.test("prefix.secret")).isFalse();
+    assertThat(selector.test("stable-only")).isFalse();
     assertThat(selector.test("other")).isFalse();
+  }
+
+  @Test
+  void readsStableSelector() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    DeclarativeConfigProperties selectorNode = config.get("mdc_attributes");
+    when(selectorNode.getScalarList("included", String.class))
+        .thenReturn(asList("exact", "prefix.*"));
+    when(selectorNode.getScalarList("excluded", String.class))
+        .thenReturn(singletonList("prefix.secret"));
+    when(config.get("mdc_attributes/development").getScalarList("included", String.class))
+        .thenReturn(singletonList("wrong"));
+
+    IncludeExclude selector = SelectorConfig.resolve(config, "test", SELECTOR, STABLE);
+    Predicate<String> legacyLiteral =
+        SelectorConfig.resolveLegacyLiteral(config, "test", SELECTOR, STABLE);
+
+    assertThat(selector).isNotNull();
+    assertThat(selector.matches("exact")).isTrue();
+    assertThat(selector.matches("prefix.value")).isTrue();
+    assertThat(selector.matches("prefix.secret")).isFalse();
+    assertThat(selector.matches("wrong")).isFalse();
+    assertThat(legacyLiteral).isNotNull();
+    assertThat(legacyLiteral.test("prefix.value")).isTrue();
+    assertThat(legacyLiteral.test("prefix.secret")).isFalse();
+  }
+
+  @Test
+  void stableExcludeOnlySelectorSelectsAllExceptExclusions() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    when(config.get("mdc_attributes").getScalarList("excluded", String.class))
+        .thenReturn(singletonList("secret*"));
+
+    IncludeExclude selector = SelectorConfig.resolve(config, "test", SELECTOR, STABLE);
+
+    assertThat(selector).isNotNull();
+    assertThat(selector.matches("public")).isTrue();
+    assertThat(selector.matches("secret-token")).isFalse();
   }
 
   @Test
@@ -94,6 +136,21 @@ class SelectorConfigTest {
   }
 
   @Test
+  void absentAndEmptyStableSelectorsCaptureNothing() {
+    DeclarativeConfigProperties absent = mockStableConfig();
+    DeclarativeConfigProperties empty = mockStableConfig();
+    when(empty.get("mdc_attributes").getScalarList("included", String.class))
+        .thenReturn(emptyList());
+    when(empty.get("mdc_attributes").getScalarList("excluded", String.class))
+        .thenReturn(emptyList());
+
+    assertThat(SelectorConfig.resolve(absent, "stable-absent", SELECTOR, STABLE)).isNull();
+    assertThat(SelectorConfig.resolve(empty, "stable-empty", SELECTOR, STABLE)).isNull();
+    assertThat(SelectorConfig.resolveLegacyLiteral(empty, "stable-empty-literal", SELECTOR, STABLE))
+        .isNull();
+  }
+
+  @Test
   void deprecatedConfigUsesExactMatchingAndWarnsOnce() {
     DeclarativeConfigProperties config = mockConfig();
     when(config.getScalarList("capture_mdc_attributes/development", String.class))
@@ -121,6 +178,33 @@ class SelectorConfigTest {
                   + " setting and the equivalent declarative configuration property are deprecated"
                   + " and may be removed in the next minor release. Use"
                   + " otel.instrumentation.exact-matching.experimental.mdc-attributes.included"
+                  + " or equivalent declarative configuration instead.");
+    } finally {
+      detachWarningHandler(handler);
+    }
+  }
+
+  @Test
+  void stableSelectorFallsBackToExperimentalDeprecatedConfig() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    when(config.getScalarList("capture_mdc_attributes/development", String.class))
+        .thenReturn(singletonList("legacy"));
+    TestHandler handler = attachWarningHandler();
+    try {
+      IncludeExclude selector =
+          SelectorConfig.resolve(config, "stable-deprecated", SELECTOR, STABLE);
+
+      assertThat(selector).isNotNull();
+      assertThat(selector.matches("legacy")).isTrue();
+      assertThat(selector.matches("other")).isFalse();
+      verify(config, never()).getScalarList("capture_mdc_attributes", String.class);
+      assertThat(handler.records).hasSize(1);
+      assertThat(handler.records.get(0).getMessage())
+          .isEqualTo(
+              "The otel.instrumentation.stable-deprecated.experimental.capture-mdc-attributes"
+                  + " setting and the equivalent declarative configuration property are deprecated"
+                  + " and may be removed in the next minor release. Use"
+                  + " otel.instrumentation.stable-deprecated.mdc-attributes.included"
                   + " or equivalent declarative configuration instead.");
     } finally {
       detachWarningHandler(handler);
@@ -177,6 +261,53 @@ class SelectorConfigTest {
       verify(config, never()).getScalarList("capture_mdc_attributes/development", String.class);
     } finally {
       detachWarningHandler(handler);
+    }
+  }
+
+  @Test
+  void stableSelectorTakesPrecedenceOverExperimentalDeprecatedConfig() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    when(config.get("mdc_attributes").getScalarList("included", String.class))
+        .thenReturn(singletonList("new"));
+    when(config.getScalarList("capture_mdc_attributes/development", String.class))
+        .thenReturn(singletonList("legacy"));
+    TestHandler handler = attachWarningHandler();
+    try {
+      IncludeExclude selector =
+          SelectorConfig.resolve(config, "stable-precedence", SELECTOR, STABLE);
+
+      assertThat(selector).isNotNull();
+      assertThat(selector.matches("new")).isTrue();
+      assertThat(selector.matches("legacy")).isFalse();
+      assertThat(handler.records).isEmpty();
+      verify(config, never()).getScalarList("capture_mdc_attributes/development", String.class);
+    } finally {
+      detachWarningHandler(handler);
+    }
+  }
+
+  @Test
+  void stableSystemPropertyFallbackIsOnlyUsedWhenEnabled() {
+    DeclarativeConfigProperties config = mockStableConfig();
+    System.setProperty(
+        "otel.instrumentation.stable-flat.mdc-attributes.included", "public*,secret*");
+    System.setProperty("otel.instrumentation.stable-flat.mdc-attributes.excluded", "secret*");
+    System.setProperty(
+        "otel.instrumentation.stable-flat.experimental.mdc-attributes.included", "wrong");
+    try {
+      assertThat(SelectorConfig.resolve(config, "stable-flat", SELECTOR, STABLE)).isNull();
+
+      IncludeExclude selector =
+          SelectorConfig.resolve(config, "stable-flat", SELECTOR, STABLE, true);
+
+      assertThat(selector).isNotNull();
+      assertThat(selector.matches("public-value")).isTrue();
+      assertThat(selector.matches("secret-value")).isFalse();
+      assertThat(selector.matches("wrong")).isFalse();
+    } finally {
+      System.clearProperty("otel.instrumentation.stable-flat.mdc-attributes.included");
+      System.clearProperty("otel.instrumentation.stable-flat.mdc-attributes.excluded");
+      System.clearProperty("otel.instrumentation.stable-flat.experimental.mdc-attributes.included");
     }
   }
 
@@ -255,6 +386,56 @@ class SelectorConfigTest {
       assertThat(selector.test("other")).isFalse();
       assertThat(handler.records).isEmpty();
       verify(config, never()).getBoolean("capture_key_value_pair_attributes/development");
+    } finally {
+      detachWarningHandler(handler);
+    }
+  }
+
+  @Test
+  void legacyBooleanReadsStableSelector() {
+    DeclarativeConfigProperties config = mockStableRenamedBooleanConfig();
+    when(config
+            .get("logstash_structured_argument_attributes")
+            .getScalarList("included", String.class))
+        .thenReturn(singletonList("new"));
+    when(config
+            .get("logstash_structured_argument_attributes/development")
+            .getScalarList("included", String.class))
+        .thenReturn(singletonList("wrong"));
+    when(config.getBoolean("capture_logstash_structured_arguments/development")).thenReturn(true);
+
+    Predicate<String> selector =
+        SelectorConfig.resolveLegacyBoolean(
+            config, "stable-boolean", RENAMED_SELECTOR, DEPRECATED_RENAMED_SELECTOR, STABLE);
+
+    assertThat(selector).isNotNull();
+    assertThat(selector.test("new")).isTrue();
+    assertThat(selector.test("wrong")).isFalse();
+    verify(config, never()).getBoolean("capture_logstash_structured_arguments/development");
+  }
+
+  @Test
+  void stableLegacyBooleanFallsBackToExperimentalDeprecatedConfig() {
+    DeclarativeConfigProperties config = mockStableBooleanConfig();
+    when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(true);
+    TestHandler handler = attachWarningHandler();
+    try {
+      Predicate<String> selector =
+          SelectorConfig.resolveLegacyBoolean(
+              config, "stable-boolean-deprecated", BOOLEAN_SELECTOR, STABLE);
+
+      assertThat(selector).isNotNull();
+      assertThat(selector.test("anything")).isTrue();
+      verify(config, never()).getBoolean("capture_key_value_pair_attributes");
+      assertThat(handler.records).hasSize(1);
+      assertThat(handler.records.get(0).getMessage())
+          .isEqualTo(
+              "The otel.instrumentation.stable-boolean-deprecated.experimental"
+                  + ".capture-key-value-pair-attributes setting and the equivalent declarative"
+                  + " configuration property are deprecated and may be removed in the next minor"
+                  + " release. Use otel.instrumentation.stable-boolean-deprecated"
+                  + ".key-value-pair-attributes.included or equivalent declarative configuration"
+                  + " instead.");
     } finally {
       detachWarningHandler(handler);
     }
@@ -375,6 +556,17 @@ class SelectorConfigTest {
     return config;
   }
 
+  private static DeclarativeConfigProperties mockStableRenamedBooleanConfig() {
+    DeclarativeConfigProperties config =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    DeclarativeConfigProperties selectorNode =
+        config.get("logstash_structured_argument_attributes");
+    when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
+    when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
+    when(config.getBoolean("capture_logstash_structured_arguments/development")).thenReturn(null);
+    return config;
+  }
+
   private static DeclarativeConfigProperties mockBooleanConfig() {
     DeclarativeConfigProperties config =
         mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
@@ -385,10 +577,30 @@ class SelectorConfigTest {
     return config;
   }
 
+  private static DeclarativeConfigProperties mockStableBooleanConfig() {
+    DeclarativeConfigProperties config =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    DeclarativeConfigProperties selectorNode = config.get("key_value_pair_attributes");
+    when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
+    when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
+    when(config.getBoolean("capture_key_value_pair_attributes/development")).thenReturn(null);
+    return config;
+  }
+
   private static DeclarativeConfigProperties mockConfig() {
     DeclarativeConfigProperties config =
         mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
     DeclarativeConfigProperties selectorNode = config.get("mdc_attributes/development");
+    when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
+    when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
+    when(config.getScalarList("capture_mdc_attributes/development", String.class)).thenReturn(null);
+    return config;
+  }
+
+  private static DeclarativeConfigProperties mockStableConfig() {
+    DeclarativeConfigProperties config =
+        mock(DeclarativeConfigProperties.class, RETURNS_DEEP_STUBS);
+    DeclarativeConfigProperties selectorNode = config.get("mdc_attributes");
     when(selectorNode.getScalarList("included", String.class)).thenReturn(null);
     when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
     when(config.getScalarList("capture_mdc_attributes/development", String.class)).thenReturn(null);

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -289,11 +289,16 @@ class SelectorConfigTest {
   @ResourceLock(Resources.SYSTEM_PROPERTIES)
   void stableSystemPropertyFallbackIsOnlyUsedWhenEnabled() {
     DeclarativeConfigProperties config = mockStableConfig();
-    System.setProperty(
-        "otel.instrumentation.stable-flat.mdc-attributes.included", "public*,secret*");
-    System.setProperty("otel.instrumentation.stable-flat.mdc-attributes.excluded", "secret*");
-    System.setProperty(
-        "otel.instrumentation.stable-flat.experimental.mdc-attributes.included", "wrong");
+    String includedProperty = "otel.instrumentation.stable-flat.mdc-attributes.included";
+    String excludedProperty = "otel.instrumentation.stable-flat.mdc-attributes.excluded";
+    String experimentalIncludedProperty =
+        "otel.instrumentation.stable-flat.experimental.mdc-attributes.included";
+    String previousIncluded = System.getProperty(includedProperty);
+    String previousExcluded = System.getProperty(excludedProperty);
+    String previousExperimentalIncluded = System.getProperty(experimentalIncludedProperty);
+    System.setProperty(includedProperty, "public*,secret*");
+    System.setProperty(excludedProperty, "secret*");
+    System.setProperty(experimentalIncludedProperty, "wrong");
     try {
       assertThat(SelectorConfig.resolve(config, "stable-flat", SELECTOR, STABLE)).isNull();
 
@@ -305,9 +310,9 @@ class SelectorConfigTest {
       assertThat(selector.matches("secret-value")).isFalse();
       assertThat(selector.matches("wrong")).isFalse();
     } finally {
-      System.clearProperty("otel.instrumentation.stable-flat.mdc-attributes.included");
-      System.clearProperty("otel.instrumentation.stable-flat.mdc-attributes.excluded");
-      System.clearProperty("otel.instrumentation.stable-flat.experimental.mdc-attributes.included");
+      restoreSystemProperty(includedProperty, previousIncluded);
+      restoreSystemProperty(excludedProperty, previousExcluded);
+      restoreSystemProperty(experimentalIncludedProperty, previousExperimentalIncluded);
     }
   }
 
@@ -562,6 +567,14 @@ class SelectorConfigTest {
     when(selectorNode.getScalarList("excluded", String.class)).thenReturn(null);
     when(config.getScalarList("capture_mdc_attributes/development", String.class)).thenReturn(null);
     return config;
+  }
+
+  private static void restoreSystemProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
   }
 
   private static TestHandler attachWarningHandler() {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/config/internal/SelectorConfigTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
+@ResourceLock("SelectorConfig.logger")
 class SelectorConfigTest {
 
   private static final String SELECTOR = "mdc-attributes";

--- a/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/ServletConfig.java
+++ b/instrumentation/servlet/servlet-common/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/common/ServletConfig.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.servlet.common;
 
+import static io.opentelemetry.instrumentation.api.incubator.config.internal.SelectorConfig.Stability.EXPERIMENTAL;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
@@ -24,7 +26,8 @@ class ServletConfig {
   }
 
   ServletConfig(DeclarativeConfigProperties config, boolean v3Preview) {
-    requestParameters = SelectorConfig.resolve(config, "servlet", "request-parameters");
+    requestParameters =
+        SelectorConfig.resolve(config, "servlet", "request-parameters", EXPERIMENTAL);
     captureExperimentalAttributes =
         config.getBoolean("experimental_span_attributes/development", false);
     traceIdRequestAttributeEnabled =


### PR DESCRIPTION
Adds a stability mode to `SelectorConfig.resolve` so instrumentation can use stable included and excluded selector names without duplicating parsing or compatibility logic.

```java
SelectorConfig.resolve(config, "jmx", "metrics", SelectorConfig.Stability.STABLE);
```

Needed for https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/19828 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19782.