### PR TITLE
Allow naming virtual fields

### DIFF
--- a/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-instrumentation-api.txt
@@ -1,2 +1,6 @@
 Comparing source compatibility of opentelemetry-instrumentation-api-2.32.0-SNAPSHOT.jar against opentelemetry-instrumentation-api-2.31.1.jar
-No changes.
+***  MODIFIED CLASS: PUBLIC ABSTRACT io.opentelemetry.instrumentation.api.util.VirtualField  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	GENERIC TEMPLATES: === F:java.lang.Object, === T:java.lang.Object
+	+++  NEW METHOD: PUBLIC(+) STATIC(+) io.opentelemetry.instrumentation.api.util.VirtualField<U,V> find(java.lang.String, java.lang.Class<T>, java.lang.Class<F>)
+		GENERIC TEMPLATES: +++ F:java.lang.Object, +++ T:java.lang.Object, +++ U:T, +++ V:F

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/RuntimeVirtualFieldSupplier.java
@@ -7,6 +7,8 @@ package io.opentelemetry.instrumentation.api.internal;
 
 import io.opentelemetry.instrumentation.api.internal.cache.Cache;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -19,12 +21,15 @@ public final class RuntimeVirtualFieldSupplier {
   private static final Logger logger =
       Logger.getLogger(RuntimeVirtualFieldSupplier.class.getName());
 
+  public static final String DEFAULT_FIELD_NAME = "";
+
   /**
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
    * any time.
    */
   public interface VirtualFieldSupplier {
-    <U extends T, V extends F, T, F> VirtualField<U, V> find(Class<T> type, Class<F> fieldType);
+    <U extends T, V extends F, T, F> VirtualField<U, V> find(
+        String fieldName, Class<T> type, Class<F> fieldType);
   }
 
   private static final VirtualFieldSupplier DEFAULT = new CacheBasedVirtualFieldSupplier();
@@ -47,18 +52,19 @@ public final class RuntimeVirtualFieldSupplier {
 
   private static final class CacheBasedVirtualFieldSupplier implements VirtualFieldSupplier {
 
-    private final Cache<Class<?>, Cache<Class<?>, VirtualField<?, ?>>>
+    private final Cache<Class<?>, Cache<Class<?>, Map<String, VirtualField<?, ?>>>>
         ownerToFieldToImplementationMap = Cache.weak();
 
     @Override
     // storing VirtualField instances in a map loses the generic types
     @SuppressWarnings("unchecked")
     public <U extends T, V extends F, T, F> VirtualField<U, V> find(
-        Class<T> type, Class<F> fieldType) {
+        String fieldName, Class<T> type, Class<F> fieldType) {
       return (VirtualField<U, V>)
           ownerToFieldToImplementationMap
               .computeIfAbsent(type, c -> Cache.weak())
-              .computeIfAbsent(fieldType, c -> new CacheBasedVirtualField<>());
+              .computeIfAbsent(fieldType, c -> new ConcurrentHashMap<>())
+              .computeIfAbsent(fieldName, s -> new CacheBasedVirtualField<>());
     }
   }
 

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/util/VirtualField.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/util/VirtualField.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.util;
 
+import static java.util.Objects.requireNonNull;
+
 import io.opentelemetry.instrumentation.api.internal.RuntimeVirtualFieldSupplier;
 import javax.annotation.Nullable;
 
@@ -24,21 +26,47 @@ public abstract class VirtualField<T, F> {
   /**
    * Finds a {@link VirtualField} instance for given {@code type} and {@code fieldType}.
    *
-   * <p>Conceptually this can be thought of as a map lookup to fetch a second level map given {@code
-   * type}.
-   *
    * <p>In runtime, when using the javaagent, the <em>calls</em> to this method are rewritten to
-   * something more performant while injecting advice into a method.
+   * something more performant while injecting <em>inline</em> advice into a method. This rewriting
+   * is not performed for <em>non-inline</em> advice. Users are advised not to rely on agent
+   * automatically rewriting the virtual field usages and instead look up {@link VirtualField} once
+   * and stored in a field to avoid repeatedly calling this method. Rewriting calls to this method
+   * may be removed in a future agent release.
    *
-   * <p>When using this method outside of Advice method, the {@link VirtualField} should be looked
-   * up once and stored in a field to avoid repeatedly calling this method.
+   * @param type The type that will contain the new virtual field.
+   * @param fieldType The field type that will be added to {@code type}.
+   * @see VirtualField#find(String, Class, Class)
+   */
+  public static <U extends T, V extends F, T, F> VirtualField<U, V> find(
+      Class<T> type, Class<F> fieldType) {
+    return find(RuntimeVirtualFieldSupplier.DEFAULT_FIELD_NAME, type, fieldType);
+  }
+
+  /**
+   * Finds a {@link VirtualField} instance for given {@code fieldName}, {@code type} and {@code
+   * fieldType}.
    *
+   * <p>Conceptually this can be thought of as adding a field with name {@code fieldName} to class
+   * {@code type} with type {@code fieldType}. Alternatively this can be viewed as a map where an
+   * object of type {@code type} is associated with another map where they key is composed of {@code
+   * fieldName} and {@code fieldType} and the value is the value of the virtual field.
+   *
+   * <p>Calls to this method may be expensive, caller should keep the returned {@link VirtualField}
+   * and reuse it instead of repeatedly calling this method.
+   *
+   * <p>Unlike calls to {@link VirtualField#find(Class, Class)} calls to this method are never
+   * rewritten.
+   *
+   * @param fieldName The name of the virtual field.
    * @param type The type that will contain the new virtual field.
    * @param fieldType The field type that will be added to {@code type}.
    */
   public static <U extends T, V extends F, T, F> VirtualField<U, V> find(
-      Class<T> type, Class<F> fieldType) {
-    return RuntimeVirtualFieldSupplier.get().find(type, fieldType);
+      String fieldName, Class<T> type, Class<F> fieldType) {
+    requireNonNull(fieldName);
+    requireNonNull(type);
+    requireNonNull(fieldType);
+    return RuntimeVirtualFieldSupplier.get().find(fieldName, type, fieldType);
   }
 
   /** Gets the value of this virtual field. */

--- a/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-1.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v1_1/JmsSubscriptionNames.java
@@ -22,11 +22,11 @@ import javax.jms.MessageListener;
 public class JmsSubscriptionNames {
 
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageConsumer.class, String.class);
+      VirtualField.find("subscriptionName", MessageConsumer.class, String.class);
   private static final VirtualField<Message, String> MESSAGE_SUBSCRIPTION_NAME =
-      VirtualField.find(Message.class, String.class);
+      VirtualField.find("subscriptionName", Message.class, String.class);
   private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageListener.class, String.class);
+      VirtualField.find("subscriptionName", MessageListener.class, String.class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);

--- a/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
+++ b/instrumentation/jms/jms-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jms/v3_0/JmsSubscriptionNames.java
@@ -22,11 +22,11 @@ import javax.annotation.Nullable;
 public class JmsSubscriptionNames {
 
   private static final VirtualField<MessageConsumer, String> CONSUMER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageConsumer.class, String.class);
+      VirtualField.find("subscriptionName", MessageConsumer.class, String.class);
   private static final VirtualField<Message, String> MESSAGE_SUBSCRIPTION_NAME =
-      VirtualField.find(Message.class, String.class);
+      VirtualField.find("subscriptionName", Message.class, String.class);
   private static final VirtualField<MessageListener, String> LISTENER_SUBSCRIPTION_NAME =
-      VirtualField.find(MessageListener.class, String.class);
+      VirtualField.find("subscriptionName", MessageListener.class, String.class);
 
   public static void set(MessageConsumer consumer, String subscriptionName) {
     CONSUMER_SUBSCRIPTION_NAME.set(consumer, subscriptionName);

--- a/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Singletons.java
+++ b/instrumentation/servlet/servlet-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/servlet/v2_2/Servlet2Singletons.java
@@ -21,7 +21,7 @@ public class Servlet2Singletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.servlet-2.2";
 
   public static final VirtualField<ServletResponse, Integer> RESPONSE_STATUS =
-      VirtualField.find(ServletResponse.class, Integer.class);
+      VirtualField.find("responseStatus", ServletResponse.class, Integer.class);
 
   private static final Servlet2Helper helper;
   private static final Instrumenter<ClassAndMethod, Void> responseInstrumenter;

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientInstrumentationModule.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientInstrumentationModule.java
@@ -15,7 +15,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModul
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
 import java.util.List;
-import java.util.function.BiConsumer;
 import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(InstrumentationModule.class)
@@ -58,14 +57,14 @@ public class VertxSqlClientInstrumentationModule extends InstrumentationModule
   }
 
   @Override
-  public void registerVirtualFields(BiConsumer<String, String> virtualFieldRegistrar) {
+  public void registerVirtualFields(VirtualFieldRegistration virtualFieldRegistration) {
     // we add the virtual field to CommandBase manually because it is in different package in 5.0
     // and 5.1
     // used in 5.0
-    virtualFieldRegistrar.accept(
+    virtualFieldRegistration.register(
         "io.vertx.sqlclient.internal.command.CommandBase", Context.class.getName());
     // used in 5.1
-    virtualFieldRegistrar.accept(
+    virtualFieldRegistration.register(
         "io.vertx.sqlclient.spi.protocol.CommandBase", Context.class.getName());
   }
 }

--- a/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/ExperimentalInstrumentationModule.java
+++ b/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/instrumentation/internal/ExperimentalInstrumentationModule.java
@@ -10,7 +10,6 @@ import static java.util.Collections.emptyMap;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import net.bytebuddy.utility.JavaModule;
 
 /**
@@ -19,11 +18,8 @@ import net.bytebuddy.utility.JavaModule;
  */
 public interface ExperimentalInstrumentationModule {
 
-  /**
-   * Register virtual field. First argument for the consumer is dot class name of the type where the
-   * field is added and the second argument is the dot class name of the field type.
-   */
-  default void registerVirtualFields(BiConsumer<String, String> virtualFieldRegistrar) {}
+  /** Register virtual field. */
+  default void registerVirtualFields(VirtualFieldRegistration virtualFieldRegistration) {}
 
   /**
    * Some instrumentations need to invoke classes which are present both in the agent classloader
@@ -77,5 +73,29 @@ public interface ExperimentalInstrumentationModule {
      * application.
      */
     ISOLATED
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  interface VirtualFieldRegistration {
+
+    /**
+     * Register a virtual field.
+     *
+     * @param typeName Dot class name of the type where the field is added.
+     * @param fieldTypeName Dot class name of the field type.
+     */
+    void register(String typeName, String fieldTypeName);
+
+    /**
+     * Register a virtual field.
+     *
+     * @param fieldName Name of the field
+     * @param typeName Dot class name of the type where the field is added.
+     * @param fieldTypeName Dot class name of the field type.
+     */
+    void register(String fieldName, String typeName, String fieldTypeName);
   }
 }

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfaces.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfaces.java
@@ -21,8 +21,9 @@ final class FieldAccessorInterfaces {
     this.fieldAccessorInterfaces = fieldAccessorInterfaces;
   }
 
-  TypeDescription find(String typeName, String fieldTypeName) {
-    String accessorInterfaceName = getFieldAccessorInterfaceName(typeName, fieldTypeName);
+  TypeDescription find(String fieldName, String typeName, String fieldTypeName) {
+    String accessorInterfaceName =
+        getFieldAccessorInterfaceName(fieldName, typeName, fieldTypeName);
     DynamicType.Unloaded<?> type = fieldAccessorInterfaces.get(accessorInterfaceName);
     if (type == null) {
       throw new IllegalStateException(

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldAccessorInterfacesGenerator.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.javaagent.tooling.field.GeneratedVirtualFieldName
 
 import io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessorMarker;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings.Mapping;
 import java.util.HashMap;
 import java.util.Map;
 import net.bytebuddy.ByteBuddy;
@@ -31,8 +32,10 @@ final class FieldAccessorInterfacesGenerator {
       VirtualFieldMappings virtualFieldMappings) {
     Map<String, DynamicType.Unloaded<?>> fieldAccessorInterfaces =
         new HashMap<>(virtualFieldMappings.size());
-    for (Map.Entry<String, String> entry : virtualFieldMappings.entrySet()) {
-      DynamicType.Unloaded<?> type = makeFieldAccessorInterface(entry.getKey(), entry.getValue());
+    for (Mapping mapping : virtualFieldMappings.getMappings()) {
+      DynamicType.Unloaded<?> type =
+          makeFieldAccessorInterface(
+              mapping.getFieldName(), mapping.getTypeName(), mapping.getFieldTypeName());
       fieldAccessorInterfaces.put(type.getTypeDescription().getName(), type);
     }
     return new FieldAccessorInterfaces(fieldAccessorInterfaces);
@@ -42,28 +45,29 @@ final class FieldAccessorInterfacesGenerator {
    * Generate an interface that provides field accessor methods for given key class name and context
    * class name.
    *
+   * @param fieldName field name
    * @param typeName key class name
    * @param fieldTypeName context class name
    * @return unloaded dynamic type containing generated interface
    */
   private DynamicType.Unloaded<?> makeFieldAccessorInterface(
-      String typeName, String fieldTypeName) {
+      String fieldName, String typeName, String fieldTypeName) {
     // We are using Object class name instead of fieldTypeName here because this gets injected
     // onto the bootstrap class loader where context class may be unavailable
     TypeDescription fieldTypeDesc = TypeDescription.ForLoadedType.of(Object.class);
     return byteBuddy
         .makeInterface()
         .merge(SyntheticState.SYNTHETIC)
-        .name(getFieldAccessorInterfaceName(typeName, fieldTypeName))
+        .name(getFieldAccessorInterfaceName(fieldName, typeName, fieldTypeName))
         .implement(VirtualFieldAccessorMarker.class)
         .defineMethod(
-            getRealGetterName(typeName, fieldTypeName),
+            getRealGetterName(fieldName, typeName, fieldTypeName),
             fieldTypeDesc,
             Visibility.PUBLIC,
             SyntheticState.SYNTHETIC)
         .withoutCode()
         .defineMethod(
-            getRealSetterName(typeName, fieldTypeName),
+            getRealSetterName(fieldName, typeName, fieldTypeName),
             TypeDescription.ForLoadedType.of(void.class),
             Visibility.PUBLIC,
             SyntheticState.SYNTHETIC)

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/FieldBackedImplementationInstaller.java
@@ -19,13 +19,13 @@ import io.opentelemetry.javaagent.tooling.HelperInjector;
 import io.opentelemetry.javaagent.tooling.TransformSafeLogger;
 import io.opentelemetry.javaagent.tooling.instrumentation.InstrumentationModuleInstaller;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings.Mapping;
 import io.opentelemetry.javaagent.tooling.util.IgnoreFailedTypeMatcher;
 import io.opentelemetry.javaagent.tooling.util.NamedMatcher;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import net.bytebuddy.ByteBuddy;
@@ -166,18 +166,18 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
   }
 
   /*
-  Set of pairs (type name, field type name) for which we have matchers installed.
+  Set of mappings (field name, type name, field type name) for which we have matchers installed.
   We use this to make sure we do not install matchers repeatedly for cases when same
   context class is used by multiple instrumentations.
    */
-  private final Set<Map.Entry<String, String>> installedVirtualFieldMatchers = new HashSet<>();
+  private final Set<Mapping> installedVirtualFieldMatchers = new HashSet<>();
 
   @Override
   public AgentBuilder.Identified.Extendable injectFields(
       AgentBuilder.Identified.Extendable builder) {
 
     if (FieldBackedImplementationConfiguration.isFieldInjectionEnabled()) {
-      for (Map.Entry<String, String> entry : virtualFieldMappings.entrySet()) {
+      for (Mapping mapping : virtualFieldMappings.getMappings()) {
         /*
          * For each virtual field defined in a current instrumentation we create an agent builder
          * that injects necessary fields.
@@ -186,12 +186,12 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
          * class transformation.
          */
         synchronized (installedVirtualFieldMatchers) {
-          if (installedVirtualFieldMatchers.contains(entry)) {
+          if (installedVirtualFieldMatchers.contains(mapping)) {
             if (logger.isLoggable(FINEST)) {
               logger.log(
                   FINEST,
                   "Skipping builder for {0} {1}",
-                  new Object[] {instrumenterClass.getName(), entry});
+                  new Object[] {instrumenterClass.getName(), mapping});
             }
             continue;
           }
@@ -200,9 +200,9 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
             logger.log(
                 FINEST,
                 "Making builder for {0} {1}",
-                new Object[] {instrumenterClass.getName(), entry});
+                new Object[] {instrumenterClass.getName(), mapping});
           }
-          installedVirtualFieldMatchers.add(entry);
+          installedVirtualFieldMatchers.add(mapping);
 
           /*
            * For each virtual field defined in a current instrumentation we create an agent builder
@@ -212,12 +212,16 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
               new NamedMatcher<>(
                   "VirtualField",
                   new IgnoreFailedTypeMatcher(
-                      not(isAbstract()).and(hasSuperType(named(entry.getKey())))));
+                      not(isAbstract()).and(hasSuperType(named(mapping.getTypeName())))));
 
           builder =
               builder
                   .type(typeMatcher)
-                  .and(safeToInjectFieldMatcher(entry.getKey(), entry.getValue()))
+                  .and(
+                      safeToInjectFieldMatcher(
+                          mapping.getFieldName(),
+                          mapping.getTypeName(),
+                          mapping.getFieldTypeName()))
                   .and(InstrumentationModuleInstaller.NOT_DECORATOR_MATCHER)
                   .transform(NoOpTransformer.INSTANCE);
 
@@ -232,7 +236,10 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
               builder.transform(
                   getTransformerForAsmVisitor(
                       new RealFieldInjector(
-                          fieldAccessorInterfaces, entry.getKey(), entry.getValue())));
+                          fieldAccessorInterfaces,
+                          mapping.getFieldName(),
+                          mapping.getTypeName(),
+                          mapping.getFieldTypeName())));
         }
       }
     }
@@ -240,7 +247,7 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
   }
 
   private static AgentBuilder.RawMatcher safeToInjectFieldMatcher(
-      String typeName, String fieldTypeName) {
+      String fieldName, String typeName, String fieldTypeName) {
     return (typeDescription, classLoader, module, classBeingRedefined, protectionDomain) -> {
       /*
        * The idea here is that we can add fields if class is just being loaded
@@ -249,7 +256,8 @@ final class FieldBackedImplementationInstaller implements VirtualFieldImplementa
        */
       return classBeingRedefined == null
           || VirtualFieldDetector.hasVirtualField(
-              classBeingRedefined, getFieldAccessorInterfaceName(typeName, fieldTypeName));
+              classBeingRedefined,
+              getFieldAccessorInterfaceName(fieldName, typeName, fieldTypeName));
     };
   }
 

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNames.java
@@ -24,35 +24,40 @@ final class GeneratedVirtualFieldNames {
     return className.startsWith(DYNAMIC_CLASSES_PACKAGE + "VirtualFieldAccessor$");
   }
 
-  static String getVirtualFieldImplementationClassName(String typeName, String fieldTypeName) {
+  static String getVirtualFieldImplementationClassName(
+      String fieldName, String typeName, String fieldTypeName) {
     return DYNAMIC_CLASSES_PACKAGE
         + "VirtualFieldImpl$"
+        + (!fieldName.isEmpty() ? fieldName + "$" : "")
         + sanitizeClassName(typeName)
         + "$"
         + sanitizeClassName(fieldTypeName);
   }
 
-  static String getFieldAccessorInterfaceName(String typeName, String fieldTypeName) {
+  static String getFieldAccessorInterfaceName(
+      String fieldName, String typeName, String fieldTypeName) {
     return DYNAMIC_CLASSES_PACKAGE
         + "VirtualFieldAccessor$"
+        + (!fieldName.isEmpty() ? fieldName + "$" : "")
         + sanitizeClassName(typeName)
         + "$"
         + sanitizeClassName(fieldTypeName);
   }
 
-  static String getRealFieldName(String typeName, String fieldTypeName) {
+  static String getRealFieldName(String fieldName, String typeName, String fieldTypeName) {
     return "__opentelemetryVirtualField$"
+        + (!fieldName.isEmpty() ? fieldName + "$" : "")
         + sanitizeClassName(typeName)
         + "$"
         + sanitizeClassName(fieldTypeName);
   }
 
-  static String getRealGetterName(String typeName, String fieldTypeName) {
-    return "__get" + getRealFieldName(typeName, fieldTypeName);
+  static String getRealGetterName(String fieldName, String typeName, String fieldTypeName) {
+    return "__get" + getRealFieldName(fieldName, typeName, fieldTypeName);
   }
 
-  static String getRealSetterName(String typeName, String fieldTypeName) {
-    return "__set" + getRealFieldName(typeName, fieldTypeName);
+  static String getRealSetterName(String fieldName, String typeName, String fieldTypeName) {
+    return "__set" + getRealFieldName(fieldName, typeName, fieldTypeName);
   }
 
   private static String sanitizeClassName(String className) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RealFieldInjector.java
@@ -36,12 +36,17 @@ final class RealFieldInjector implements AsmVisitorWrapper {
       Type.getInternalName(VirtualFieldInstalledMarker.class);
 
   private final FieldAccessorInterfaces fieldAccessorInterfaces;
+  private final String fieldName;
   private final String typeName;
   private final String fieldTypeName;
 
   RealFieldInjector(
-      FieldAccessorInterfaces fieldAccessorInterfaces, String typeName, String fieldTypeName) {
+      FieldAccessorInterfaces fieldAccessorInterfaces,
+      String fieldName,
+      String typeName,
+      String fieldTypeName) {
     this.fieldAccessorInterfaces = fieldAccessorInterfaces;
+    this.fieldName = fieldName;
     this.typeName = typeName;
     this.fieldTypeName = fieldTypeName;
   }
@@ -72,11 +77,11 @@ final class RealFieldInjector implements AsmVisitorWrapper {
       // We are using Object class name instead of fieldTypeName here because this gets
       // injected onto the bootstrap class loader where context class may be unavailable
       private final TypeDescription fieldType = TypeDescription.ForLoadedType.of(Object.class);
-      private final String fieldName = getRealFieldName(typeName, fieldTypeName);
-      private final String getterMethodName = getRealGetterName(typeName, fieldTypeName);
-      private final String setterMethodName = getRealSetterName(typeName, fieldTypeName);
+      private final String realFieldName = getRealFieldName(fieldName, typeName, fieldTypeName);
+      private final String getterMethodName = getRealGetterName(fieldName, typeName, fieldTypeName);
+      private final String setterMethodName = getRealSetterName(fieldName, typeName, fieldTypeName);
       private final TypeDescription interfaceType =
-          fieldAccessorInterfaces.find(typeName, fieldTypeName);
+          fieldAccessorInterfaces.find(fieldName, typeName, fieldTypeName);
       private boolean foundField = false;
       private boolean foundGetter = false;
       private boolean foundSetter = false;
@@ -101,7 +106,7 @@ final class RealFieldInjector implements AsmVisitorWrapper {
       @Override
       public FieldVisitor visitField(
           int access, String name, String descriptor, String signature, Object value) {
-        if (name.equals(fieldName)) {
+        if (name.equals(realFieldName)) {
           foundField = true;
         }
         return super.visitField(access, name, descriptor, signature, value);
@@ -132,7 +137,7 @@ final class RealFieldInjector implements AsmVisitorWrapper {
                   | Opcodes.ACC_VOLATILE
                   | Opcodes.ACC_TRANSIENT
                   | Opcodes.ACC_SYNTHETIC,
-              fieldName,
+              realFieldName,
               fieldType.getDescriptor(),
               null,
               null);
@@ -154,7 +159,7 @@ final class RealFieldInjector implements AsmVisitorWrapper {
         mv.visitFieldInsn(
             Opcodes.GETFIELD,
             instrumentedType.getInternalName(),
-            fieldName,
+            realFieldName,
             fieldType.getDescriptor());
         mv.visitInsn(Opcodes.ARETURN);
         mv.visitMaxs(0, 0);
@@ -170,7 +175,7 @@ final class RealFieldInjector implements AsmVisitorWrapper {
         mv.visitFieldInsn(
             Opcodes.PUTFIELD,
             instrumentedType.getInternalName(),
-            fieldName,
+            realFieldName,
             fieldType.getDescriptor());
         mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(0, 0);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RuntimeFieldBasedImplementationSupplier.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/RuntimeFieldBasedImplementationSupplier.java
@@ -18,19 +18,20 @@ final class RuntimeFieldBasedImplementationSupplier
 
   @Override
   public <U extends T, V extends F, T, F> VirtualField<U, V> find(
-      Class<T> type, Class<F> fieldType) {
+      String fieldName, Class<T> type, Class<F> fieldType) {
     if (System.getSecurityManager() == null) {
-      return findInternal(type, fieldType);
+      return findInternal(fieldName, type, fieldType);
     }
     return java.security.AccessController.doPrivileged(
-        (PrivilegedAction<VirtualField<U, V>>) () -> findInternal(type, fieldType));
+        (PrivilegedAction<VirtualField<U, V>>) () -> findInternal(fieldName, type, fieldType));
   }
 
   private static <U extends T, V extends F, T, F> VirtualField<U, V> findInternal(
-      Class<T> type, Class<F> fieldType) {
+      String fieldName, Class<T> type, Class<F> fieldType) {
     try {
       String virtualFieldImplClassName =
-          getVirtualFieldImplementationClassName(type.getTypeName(), fieldType.getTypeName());
+          getVirtualFieldImplementationClassName(
+              fieldName, type.getTypeName(), fieldType.getTypeName());
       Class<?> contextStoreClass = Class.forName(virtualFieldImplClassName, false, null);
       Method method = contextStoreClass.getMethod("getVirtualField", Class.class, Class.class);
       @SuppressWarnings("unchecked") // casting reflection result

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldFindRewriter.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldFindRewriter.java
@@ -6,8 +6,11 @@
 package io.opentelemetry.javaagent.tooling.field;
 
 import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.WARNING;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.instrumentation.api.internal.RuntimeVirtualFieldSupplier;
+import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AsmApi;
 import io.opentelemetry.javaagent.tooling.TransformSafeLogger;
@@ -33,11 +36,14 @@ final class VirtualFieldFindRewriter implements AsmVisitorWrapper {
       TransformSafeLogger.getLogger(VirtualFieldFindRewriter.class);
 
   private static final Method FIND_VIRTUAL_FIELD_METHOD;
+  private static final Method FIND_VIRTUAL_FIELD_WITH_NAME_METHOD;
   private static final Method FIND_VIRTUAL_FIELD_IMPL_METHOD;
 
   static {
     try {
       FIND_VIRTUAL_FIELD_METHOD = VirtualField.class.getMethod("find", Class.class, Class.class);
+      FIND_VIRTUAL_FIELD_WITH_NAME_METHOD =
+          VirtualField.class.getMethod("find", String.class, Class.class, Class.class);
       FIND_VIRTUAL_FIELD_IMPL_METHOD =
           VirtualFieldImplementationsGenerator.VirtualFieldImplementationTemplate.class.getMethod(
               "getVirtualField", Class.class, Class.class);
@@ -117,24 +123,25 @@ final class VirtualFieldFindRewriter implements AsmVisitorWrapper {
                 String fieldTypeName = ((Type) stack[0]).getClassName();
                 String typeName = ((Type) stack[1]).getClassName();
                 TypeDescription virtualFieldImplementationClass =
-                    virtualFieldImplementations.find(typeName, fieldTypeName);
+                    virtualFieldImplementations.find(
+                        RuntimeVirtualFieldSupplier.DEFAULT_FIELD_NAME, typeName, fieldTypeName);
                 if (logger.isLoggable(FINEST)) {
                   logger.log(
                       FINEST,
                       "Rewriting VirtualField#find() for instrumenter {0}: {1} -> {2}",
                       new Object[] {instrumentationModuleClass.getName(), typeName, fieldTypeName});
                 }
-                if (virtualFieldImplementationClass == null) {
-                  throw new IllegalStateException(
-                      String.format(
-                          "Incorrect VirtualField usage detected. Cannot find implementation for VirtualField<%s, %s>. Was that field registered in %s#registerMuzzleVirtualFields()?",
-                          typeName, fieldTypeName, instrumentationModuleClass.getName()));
-                }
                 if (!virtualFieldMappings.hasMapping(typeName, fieldTypeName)) {
                   throw new IllegalStateException(
                       String.format(
                           "Incorrect VirtualField usage detected. Cannot find mapping for VirtualField<%s, %s>. Was that field registered in %s#registerMuzzleVirtualFields()?",
                           typeName, fieldTypeName, instrumentationModuleClass.getName()));
+                }
+                if (SemconvStability.v3Preview()) {
+                  logger.log(
+                      WARNING,
+                      "Rewriting VirtualField#find(Class, Class) access in {0}. This rewriting is deprecated and may be removed in a future version.",
+                      instrumentationModuleClass.getName());
                 }
                 // stack: fieldType | type
                 mv.visitMethodInsn(
@@ -147,9 +154,19 @@ final class VirtualFieldFindRewriter implements AsmVisitorWrapper {
               }
               throw new IllegalStateException(
                   "Incorrect VirtualField usage detected. Type and field type must be class-literals. Example of correct usage: VirtualField.find(Runnable.class, RunnableContext.class)");
-            } else {
-              super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
             }
+            if (Type.getInternalName(FIND_VIRTUAL_FIELD_WITH_NAME_METHOD.getDeclaringClass())
+                    .equals(owner)
+                && FIND_VIRTUAL_FIELD_WITH_NAME_METHOD.getName().equals(name)
+                && Type.getMethodDescriptor(FIND_VIRTUAL_FIELD_WITH_NAME_METHOD)
+                    .equals(descriptor)) {
+              logger.log(
+                  WARNING,
+                  "Found VirtualField#find(String, Class, Class) access in {0}. Unlike calls to VirtualField#find(Class, Class) the call to this method is not rewritten and may have a performance impact.",
+                  instrumentationModuleClass.getName());
+            }
+
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
           }
 
           // Tracking the most recently used opcodes to assert proper api usage.

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationInstallerFactory.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationInstallerFactory.java
@@ -10,6 +10,7 @@ import static java.util.logging.Level.FINE;
 import io.opentelemetry.instrumentation.api.internal.RuntimeVirtualFieldSupplier;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.internal.ExperimentalInstrumentationModule.VirtualFieldRegistration;
 import io.opentelemetry.javaagent.tooling.TransformSafeLogger;
 import io.opentelemetry.javaagent.tooling.muzzle.InstrumentationModuleMuzzle;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
@@ -34,7 +35,18 @@ public final class VirtualFieldImplementationInstallerFactory {
     VirtualFieldMappingsBuilderImpl builder = new VirtualFieldMappingsBuilderImpl();
     if (instrumentationModule instanceof ExperimentalInstrumentationModule) {
       ((ExperimentalInstrumentationModule) instrumentationModule)
-          .registerVirtualFields(builder::register);
+          .registerVirtualFields(
+              new VirtualFieldRegistration() {
+                @Override
+                public void register(String typeName, String fieldTypeName) {
+                  builder.register(typeName, fieldTypeName);
+                }
+
+                @Override
+                public void register(String fieldName, String typeName, String fieldTypeName) {
+                  builder.register(fieldName, typeName, fieldTypeName);
+                }
+              });
     }
     if (instrumentationModule instanceof InstrumentationModuleMuzzle) {
       ((InstrumentationModuleMuzzle) instrumentationModule).registerMuzzleVirtualFields(builder);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementations.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementations.java
@@ -21,9 +21,9 @@ final class VirtualFieldImplementations {
     this.virtualFieldImplementations = virtualFieldImplementations;
   }
 
-  TypeDescription find(String typeName, String fieldTypeName) {
+  TypeDescription find(String fieldName, String typeName, String fieldTypeName) {
     String virtualFieldImplementationClassName =
-        getVirtualFieldImplementationClassName(typeName, fieldTypeName);
+        getVirtualFieldImplementationClassName(fieldName, typeName, fieldTypeName);
     DynamicType.Unloaded<?> type =
         virtualFieldImplementations.get(virtualFieldImplementationClassName);
     if (type == null) {

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AsmApi;
 import io.opentelemetry.javaagent.tooling.Utils;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings.Mapping;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -49,10 +50,13 @@ final class VirtualFieldImplementationsGenerator {
       VirtualFieldMappings virtualFieldMappings, FieldAccessorInterfaces fieldAccessorInterfaces) {
     Map<String, DynamicType.Unloaded<?>> virtualFieldImplementations =
         new HashMap<>(virtualFieldMappings.size());
-    for (Map.Entry<String, String> entry : virtualFieldMappings.entrySet()) {
+    for (Mapping mapping : virtualFieldMappings.getMappings()) {
       DynamicType.Unloaded<?> type =
           makeVirtualFieldImplementationClass(
-              entry.getKey(), entry.getValue(), fieldAccessorInterfaces);
+              mapping.getFieldName(),
+              mapping.getTypeName(),
+              mapping.getFieldTypeName(),
+              fieldAccessorInterfaces);
       virtualFieldImplementations.put(type.getTypeDescription().getName(), type);
     }
     return new VirtualFieldImplementations(virtualFieldImplementations);
@@ -67,13 +71,17 @@ final class VirtualFieldImplementationsGenerator {
    * @return unloaded dynamic type containing generated class
    */
   private DynamicType.Unloaded<?> makeVirtualFieldImplementationClass(
-      String typeName, String fieldTypeName, FieldAccessorInterfaces fieldAccessorInterfaces) {
+      String fieldName,
+      String typeName,
+      String fieldTypeName,
+      FieldAccessorInterfaces fieldAccessorInterfaces) {
     return byteBuddy
         .rebase(VirtualFieldImplementationTemplate.class)
         .modifiers(Visibility.PUBLIC, TypeManifestation.FINAL, SyntheticState.SYNTHETIC)
-        .name(getVirtualFieldImplementationClassName(typeName, fieldTypeName))
+        .name(getVirtualFieldImplementationClassName(fieldName, typeName, fieldTypeName))
         .visit(
-            getVirtualFieldImplementationVisitor(typeName, fieldTypeName, fieldAccessorInterfaces))
+            getVirtualFieldImplementationVisitor(
+                fieldName, typeName, fieldTypeName, fieldAccessorInterfaces))
         .make();
   }
 
@@ -82,12 +90,16 @@ final class VirtualFieldImplementationsGenerator {
    * VirtualFieldImplementationsGenerator.VirtualFieldImplementationTemplate} for given key class
    * name and context class name.
    *
+   * @param fieldName field name
    * @param typeName key class name
    * @param fieldTypeName context class name
    * @return visitor that adds implementation for methods that need to be generated
    */
   private AsmVisitorWrapper getVirtualFieldImplementationVisitor(
-      String typeName, String fieldTypeName, FieldAccessorInterfaces fieldAccessorInterfaces) {
+      String fieldName,
+      String typeName,
+      String fieldTypeName,
+      FieldAccessorInterfaces fieldAccessorInterfaces) {
     return new AsmVisitorWrapper() {
 
       @Override
@@ -114,7 +126,7 @@ final class VirtualFieldImplementationsGenerator {
         return new ClassVisitor(AsmApi.VERSION, classVisitor) {
 
           private final TypeDescription accessorInterface =
-              fieldAccessorInterfaces.find(typeName, fieldTypeName);
+              fieldAccessorInterfaces.find(fieldName, typeName, fieldTypeName);
           private final String accessorInterfaceInternalName = accessorInterface.getInternalName();
           private final String instrumentedTypeInternalName = instrumentedType.getInternalName();
           private final boolean frames =
@@ -155,7 +167,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealGetMethod(String name) {
-            String getterName = getRealGetterName(typeName, fieldTypeName);
+            String getterName = getRealGetterName(fieldName, typeName, fieldTypeName);
             Label elseLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);
             mv.visitCode();
@@ -208,7 +220,7 @@ final class VirtualFieldImplementationsGenerator {
            * @param name name of the method being visited
            */
           private void generateRealPutMethod(String name) {
-            String setterName = getRealSetterName(typeName, fieldTypeName);
+            String setterName = getRealSetterName(fieldName, typeName, fieldTypeName);
             Label elseLabel = new Label();
             Label endLabel = new Label();
             MethodVisitor mv = getMethodVisitor(name);

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/field/VirtualFieldImplementationsGenerator.java
@@ -63,9 +63,10 @@ final class VirtualFieldImplementationsGenerator {
   }
 
   /**
-   * Generate an 'implementation' of a context store class for given key class name and context
-   * class name.
+   * Generate an 'implementation' of a context store class for given field name, key class name and
+   * context class name.
    *
+   * @param fieldName field name
    * @param typeName key class name
    * @param fieldTypeName context class name
    * @return unloaded dynamic type containing generated class

--- a/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/VirtualFieldChecker.java
+++ b/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/instrumentation/indy/VirtualFieldChecker.java
@@ -18,10 +18,11 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 
 /**
- * Check that advice does not call {@link VirtualField#find(Class, Class)}. For inline advice {@link
- * VirtualField#find(Class, Class)} calls in advice are rewritten for efficiency. In non-inline
- * advice we don't do such rewriting, we expect users to keep the result of {@link
- * VirtualField#find(Class, Class)} in a static field.
+ * Check that advice does not call {@link VirtualField#find(Class, Class)} or {@link
+ * VirtualField#find(String, Class, Class)}. For inline advice {@link VirtualField#find(Class,
+ * Class)} calls in advice are rewritten for efficiency. In non-inline advice we don't do such
+ * rewriting, we expect users to keep the result of {@link VirtualField#find(Class, Class)} in a
+ * static field.
  */
 class VirtualFieldChecker {
   private static final boolean ENABLE_VIRTUAL_FIELD_USAGE_CHECKER =

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNamesTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/field/GeneratedVirtualFieldNamesTest.java
@@ -8,49 +8,78 @@ package io.opentelemetry.javaagent.tooling.field;
 import static net.bytebuddy.jar.asm.Type.getType;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class GeneratedVirtualFieldNamesTest {
 
-  @Test
-  void virtualFieldImplementation() {
+  @ParameterizedTest
+  @CsvSource({
+    "'', io.opentelemetry.javaagent.bootstrap.field.VirtualFieldImpl$java$lang$Runnable$java$lang$String____",
+    "test, io.opentelemetry.javaagent.bootstrap.field.VirtualFieldImpl$test$java$lang$Runnable$java$lang$String____"
+  })
+  void virtualFieldImplementation(String fieldName, String expected) {
     assertThat(
             GeneratedVirtualFieldNames.getVirtualFieldImplementationClassName(
-                getType(Runnable.class).getClassName(), getType(String[][].class).getClassName()))
-        .isEqualTo(
-            "io.opentelemetry.javaagent.bootstrap.field.VirtualFieldImpl$java$lang$Runnable$java$lang$String____");
+                fieldName,
+                getType(Runnable.class).getClassName(),
+                getType(String[][].class).getClassName()))
+        .isEqualTo(expected);
   }
 
-  @Test
-  void accessorInterface() {
+  @ParameterizedTest
+  @CsvSource({
+    "'', io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessor$java$lang$Runnable$java$lang$String__",
+    "test, io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessor$test$java$lang$Runnable$java$lang$String__"
+  })
+  void accessorInterface(String fieldName, String expected) {
     assertThat(
             GeneratedVirtualFieldNames.getFieldAccessorInterfaceName(
-                getType(Runnable.class).getClassName(), getType(String[].class).getClassName()))
-        .isEqualTo(
-            "io.opentelemetry.javaagent.bootstrap.field.VirtualFieldAccessor$java$lang$Runnable$java$lang$String__");
+                fieldName,
+                getType(Runnable.class).getClassName(),
+                getType(String[].class).getClassName()))
+        .isEqualTo(expected);
   }
 
-  @Test
-  void field() {
+  @ParameterizedTest
+  @CsvSource({
+    "'', __opentelemetryVirtualField$java$lang$Runnable$java$lang$String__",
+    "test, __opentelemetryVirtualField$test$java$lang$Runnable$java$lang$String__"
+  })
+  void field(String fieldName, String expected) {
     assertThat(
             GeneratedVirtualFieldNames.getRealFieldName(
-                getType(Runnable.class).getClassName(), getType(String[].class).getClassName()))
-        .isEqualTo("__opentelemetryVirtualField$java$lang$Runnable$java$lang$String__");
+                fieldName,
+                getType(Runnable.class).getClassName(),
+                getType(String[].class).getClassName()))
+        .isEqualTo(expected);
   }
 
-  @Test
-  void setter() {
+  @ParameterizedTest
+  @CsvSource({
+    "'', __set__opentelemetryVirtualField$java$lang$Runnable$java$lang$String__",
+    "test, __set__opentelemetryVirtualField$test$java$lang$Runnable$java$lang$String__"
+  })
+  void setter(String fieldName, String expected) {
     assertThat(
             GeneratedVirtualFieldNames.getRealSetterName(
-                getType(Runnable.class).getClassName(), getType(String[].class).getClassName()))
-        .isEqualTo("__set__opentelemetryVirtualField$java$lang$Runnable$java$lang$String__");
+                fieldName,
+                getType(Runnable.class).getClassName(),
+                getType(String[].class).getClassName()))
+        .isEqualTo(expected);
   }
 
-  @Test
-  void getter() {
+  @ParameterizedTest
+  @CsvSource({
+    "'', __get__opentelemetryVirtualField$java$lang$Runnable$java$lang$String__",
+    "test, __get__opentelemetryVirtualField$test$java$lang$Runnable$java$lang$String__"
+  })
+  void getter(String fieldName, String expected) {
     assertThat(
             GeneratedVirtualFieldNames.getRealGetterName(
-                getType(Runnable.class).getClassName(), getType(String[].class).getClassName()))
-        .isEqualTo("__get__opentelemetryVirtualField$java$lang$Runnable$java$lang$String__");
+                fieldName,
+                getType(Runnable.class).getClassName(),
+                getType(String[].class).getClassName()))
+        .isEqualTo(expected);
   }
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectingClassVisitor.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectingClassVisitor.java
@@ -7,7 +7,7 @@ package io.opentelemetry.javaagent.tooling.muzzle;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.EvictingQueue;
+import io.opentelemetry.instrumentation.api.internal.RuntimeVirtualFieldSupplier;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.extension.instrumentation.internal.AsmApi;
 import io.opentelemetry.javaagent.tooling.muzzle.references.ClassRef;
@@ -18,7 +18,9 @@ import io.opentelemetry.javaagent.tooling.muzzle.references.Flag.MinimumVisibili
 import io.opentelemetry.javaagent.tooling.muzzle.references.Flag.OwnershipFlag;
 import io.opentelemetry.javaagent.tooling.muzzle.references.Flag.VisibilityFlag;
 import io.opentelemetry.javaagent.tooling.muzzle.references.Source;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -562,9 +564,9 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
   }
 
   private class VirtualFieldCollectingMethodVisitor extends MethodVisitor {
-    // this data structure will remember last two LDC <class> instructions before
+    // this data structure will remember last three LDC <class>/<string> instructions before
     // VirtualField.find() call
-    private final EvictingQueue<Type> lastTwoClassConstants = EvictingQueue.create(2);
+    private final Deque<Object> lastConstants = new ArrayDeque<>();
 
     VirtualFieldCollectingMethodVisitor(MethodVisitor methodVisitor) {
       super(AsmApi.VERSION, methodVisitor);
@@ -604,9 +606,15 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
     public void visitMethodInsn(
         int opcode, String owner, String name, String descriptor, boolean isInterface) {
 
-      String getVirtualFieldDescriptor =
+      String getVirtualField2ArgDescriptor =
           Type.getMethodDescriptor(
               Type.getType(VirtualField.class),
+              Type.getType(Class.class),
+              Type.getType(Class.class));
+      String getVirtualField3ArgDescriptor =
+          Type.getMethodDescriptor(
+              Type.getType(VirtualField.class),
+              Type.getType(String.class),
               Type.getType(Class.class),
               Type.getType(Class.class));
 
@@ -616,29 +624,45 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
       // remember used context classes if this is an VirtualField.find() call
       if ("io.opentelemetry.instrumentation.api.util.VirtualField".equals(ownerType.getClassName())
           && "find".equals(name)
-          && methodType.getDescriptor().equals(getVirtualFieldDescriptor)) {
+          && (methodType.getDescriptor().equals(getVirtualField2ArgDescriptor)
+              || methodType.getDescriptor().equals(getVirtualField3ArgDescriptor))) {
+        int argCount = methodType.getDescriptor().equals(getVirtualField2ArgDescriptor) ? 2 : 3;
+        String methodName =
+            "VirtualField#find(" + (argCount == 3 ? "String, " : "") + " Class, Class)";
+
         // in case of invalid scenario (not using .class ref directly) don't store anything and
         // clear the last LDC <class> stack
         // note that FieldBackedProvider also check for an invalid context call in the runtime
-        if (lastTwoClassConstants.remainingCapacity() == 0) {
-          Type type = requireNonNull(lastTwoClassConstants.poll());
-          Type fieldType = requireNonNull(lastTwoClassConstants.poll());
+        if (lastConstants.size() >= argCount) {
+          Type fieldType = removeLastConstant(Type.class);
+          Type type = removeLastConstant(Type.class);
+          String fieldName = RuntimeVirtualFieldSupplier.DEFAULT_FIELD_NAME;
+          if (argCount == 3) {
+            fieldName = removeLastConstant(String.class);
+          }
 
           if (type.getSort() != Type.OBJECT) {
             throw new MuzzleCompilationException(
-                "Invalid VirtualField#find(Class, Class) usage: you cannot pass array or primitive"
+                "Invalid "
+                    + methodName
+                    + " usage: you cannot pass array or primitive"
                     + " types as the field owner type");
           }
           if (fieldType.getSort() != Type.OBJECT && fieldType.getSort() != Type.ARRAY) {
             throw new MuzzleCompilationException(
-                "Invalid VirtualField#find(Class, Class) usage: you cannot pass primitive types as"
+                "Invalid "
+                    + methodName
+                    + " usage: you cannot pass primitive types as"
                     + " the field type");
           }
 
-          virtualFieldMappingsBuilder.register(type.getClassName(), fieldType.getClassName());
+          virtualFieldMappingsBuilder.register(
+              fieldName, type.getClassName(), fieldType.getClassName());
         } else {
           throw new MuzzleCompilationException(
-              "Invalid VirtualField#find(Class, Class) usage: you cannot pass variables,"
+              "Invalid "
+                  + methodName
+                  + " usage: you cannot pass variables,"
                   + " method parameters, compute classes; class references need to be passed"
                   + " directly to the find() method");
         }
@@ -665,16 +689,27 @@ final class ReferenceCollectingClassVisitor extends ClassVisitor {
       // we need to remember last two LDC <class> instructions that were executed before
       // VirtualField.get() call
       if (opcode == Opcodes.LDC) {
-        if (value instanceof Type) {
-          Type type = (Type) value;
-          lastTwoClassConstants.add(type);
+        if (value instanceof Type || value instanceof String) {
+          lastConstants.add(value);
+          if (lastConstants.size() > 3) {
+            lastConstants.removeFirst();
+          }
           return;
         }
       }
 
-      // instruction other than LDC <class> visited; pop the first element if present - this will
-      // prevent adding wrong context key pairs in case of an invalid scenario
-      lastTwoClassConstants.poll();
+      // instruction other than LDC <class>/<string> visited; clear the queue - this will
+      // prevent adding wrong context keys in case of an invalid scenario
+      lastConstants.clear();
+    }
+
+    private <T> T removeLastConstant(Class<T> type) {
+      Object constant = requireNonNull(lastConstants.removeLast());
+      if (!type.isInstance(constant)) {
+        throw new MuzzleCompilationException(
+            "Expecting " + type + " but got " + constant.getClass());
+      }
+      return type.cast(constant);
     }
   }
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappings.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappings.java
@@ -5,37 +5,91 @@
 
 package io.opentelemetry.javaagent.tooling.muzzle;
 
-import java.util.AbstractMap;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public final class VirtualFieldMappings {
-  private final Set<Map.Entry<String, String>> entrySet;
+  private final Set<Mapping> mappings;
 
-  public VirtualFieldMappings(Set<Map.Entry<String, String>> entrySet) {
-    this.entrySet = entrySet;
+  public VirtualFieldMappings(Set<Mapping> mappings) {
+    this.mappings = mappings;
   }
 
   public int size() {
-    return entrySet.size();
+    return mappings.size();
   }
 
   public boolean isEmpty() {
-    return entrySet.isEmpty();
+    return mappings.isEmpty();
   }
 
   public boolean hasMapping(String typeName, String fieldTypeName) {
-    return entrySet.contains(new AbstractMap.SimpleImmutableEntry<>(typeName, fieldTypeName));
+    return mappings.contains(new Mapping("", typeName, fieldTypeName));
   }
 
-  public Set<Map.Entry<String, String>> entrySet() {
-    return entrySet;
+  public Set<Mapping> getMappings() {
+    return mappings;
   }
 
-  public void forEach(BiConsumer<String, String> action) {
-    for (Map.Entry<String, String> e : entrySet) {
-      action.accept(e.getKey(), e.getValue());
+  public void forEach(Consumer<Mapping> action) {
+    for (Mapping mapping : mappings) {
+      action.accept(mapping);
+    }
+  }
+
+  public static final class Mapping {
+    private final String fieldName;
+    private final String typeName;
+    private final String fieldTypeName;
+
+    Mapping(String fieldName, String typeName, String fieldTypeName) {
+      this.fieldName = fieldName;
+      this.typeName = typeName;
+      this.fieldTypeName = fieldTypeName;
+    }
+
+    public String getFieldName() {
+      return fieldName;
+    }
+
+    public String getTypeName() {
+      return typeName;
+    }
+
+    public String getFieldTypeName() {
+      return fieldTypeName;
+    }
+
+    @Override
+    public String toString() {
+      return "Mapping{"
+          + "fieldName='"
+          + fieldName
+          + '\''
+          + ", typeName='"
+          + typeName
+          + '\''
+          + ", fieldTypeName='"
+          + fieldTypeName
+          + '\''
+          + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof Mapping)) {
+        return false;
+      }
+      Mapping mapping = (Mapping) o;
+      return Objects.equals(fieldName, mapping.fieldName)
+          && Objects.equals(typeName, mapping.typeName)
+          && Objects.equals(fieldTypeName, mapping.fieldTypeName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(fieldName, typeName, fieldTypeName);
     }
   }
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder.java
@@ -29,4 +29,19 @@ public interface VirtualFieldMappingsBuilder {
    */
   @CanIgnoreReturnValue
   VirtualFieldMappingsBuilder register(String typeName, String fieldTypeName);
+
+  /**
+   * Register the association between the {@code typeName} and the {@code fieldTypeName}. Class
+   * pairs registered using this method will be available as {@link VirtualField}s in the runtime;
+   * obtainable by calling {@link VirtualField#find(Class, Class)}.
+   *
+   * @param filedName The name of the virtual field.
+   * @param typeName The name of the type that will contain the virtual field of type named {@code
+   *     fieldTypeName}.
+   * @param fieldTypeName The name of the field type that will be added to {@code type}.
+   * @return {@code this}.
+   * @see VirtualField
+   */
+  @CanIgnoreReturnValue
+  VirtualFieldMappingsBuilder register(String filedName, String typeName, String fieldTypeName);
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder.java
@@ -33,9 +33,9 @@ public interface VirtualFieldMappingsBuilder {
   /**
    * Register the association between the {@code typeName} and the {@code fieldTypeName}. Class
    * pairs registered using this method will be available as {@link VirtualField}s in the runtime;
-   * obtainable by calling {@link VirtualField#find(Class, Class)}.
+   * obtainable by calling {@link VirtualField#find(String, Class, Class)}.
    *
-   * @param filedName The name of the virtual field.
+   * @param fieldName The name of the virtual field.
    * @param typeName The name of the type that will contain the virtual field of type named {@code
    *     fieldTypeName}.
    * @param fieldTypeName The name of the field type that will be added to {@code type}.
@@ -43,5 +43,5 @@ public interface VirtualFieldMappingsBuilder {
    * @see VirtualField
    */
   @CanIgnoreReturnValue
-  VirtualFieldMappingsBuilder register(String filedName, String typeName, String fieldTypeName);
+  VirtualFieldMappingsBuilder register(String fieldName, String typeName, String fieldTypeName);
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilderImpl.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilderImpl.java
@@ -6,26 +6,32 @@
 package io.opentelemetry.javaagent.tooling.muzzle;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.AbstractMap;
+import io.opentelemetry.instrumentation.api.internal.RuntimeVirtualFieldSupplier;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings.Mapping;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 public final class VirtualFieldMappingsBuilderImpl implements VirtualFieldMappingsBuilder {
-  private final Set<Map.Entry<String, String>> entrySet = new HashSet<>();
+  private final Set<Mapping> mappingSet = new HashSet<>();
 
   @Override
   @CanIgnoreReturnValue
   public VirtualFieldMappingsBuilder register(String typeName, String fieldTypeName) {
-    entrySet.add(new AbstractMap.SimpleImmutableEntry<>(typeName, fieldTypeName));
+    return register(RuntimeVirtualFieldSupplier.DEFAULT_FIELD_NAME, typeName, fieldTypeName);
+  }
+
+  @Override
+  public VirtualFieldMappingsBuilder register(
+      String filedName, String typeName, String fieldTypeName) {
+    mappingSet.add(new Mapping(filedName, typeName, fieldTypeName));
     return this;
   }
 
   void registerAll(VirtualFieldMappings mappings) {
-    entrySet.addAll(mappings.entrySet());
+    mappingSet.addAll(mappings.getMappings());
   }
 
   public VirtualFieldMappings build() {
-    return new VirtualFieldMappings(entrySet);
+    return new VirtualFieldMappings(mappingSet);
   }
 }

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilderImpl.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilderImpl.java
@@ -22,9 +22,32 @@ public final class VirtualFieldMappingsBuilderImpl implements VirtualFieldMappin
 
   @Override
   public VirtualFieldMappingsBuilder register(
-      String filedName, String typeName, String fieldTypeName) {
-    mappingSet.add(new Mapping(filedName, typeName, fieldTypeName));
+      String fieldName, String typeName, String fieldTypeName) {
+    // since we are going to use the field name as part of generated class and method names we are
+    // not going to allow all kinds of names
+    if (!isIdentifier(fieldName)) {
+      throw new IllegalArgumentException("Invalid field name: " + fieldName);
+    }
+    mappingSet.add(new Mapping(fieldName, typeName, fieldTypeName));
     return this;
+  }
+
+  private static boolean isIdentifier(String name) {
+    if (name.isEmpty()) {
+      return true;
+    }
+
+    int cp = name.codePointAt(0);
+    if (!Character.isJavaIdentifierStart(cp)) {
+      return false;
+    }
+    for (int i = Character.charCount(cp); i < name.length(); i += Character.charCount(cp)) {
+      cp = name.codePointAt(i);
+      if (!Character.isJavaIdentifierPart(cp)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void registerAll(VirtualFieldMappings mappings) {

--- a/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/generation/MuzzleCodeGenerator.java
+++ b/muzzle/src/main/java/io/opentelemetry/javaagent/tooling/muzzle/generation/MuzzleCodeGenerator.java
@@ -570,16 +570,18 @@ final class MuzzleCodeGenerator implements AsmVisitorWrapper {
       mv.visitVarInsn(Opcodes.ALOAD, 1);
       // stack: builder
       virtualFieldMappings.forEach(
-          (typeName, fieldTypeName) -> {
-            mv.visitLdcInsn(typeName);
-            // stack: builder, typeName
-            mv.visitLdcInsn(fieldTypeName);
-            // stack: builder, typeName, fieldTypeName
+          (mapping) -> {
+            mv.visitLdcInsn(mapping.getFieldName());
+            // stack: builder, fieldName
+            mv.visitLdcInsn(mapping.getTypeName());
+            // stack: builder, fieldName, typeName
+            mv.visitLdcInsn(mapping.getFieldTypeName());
+            // stack: builder, fieldName, typeName, fieldTypeName
             mv.visitMethodInsn(
                 Opcodes.INVOKEINTERFACE,
                 "io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder",
                 "register",
-                "(Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder;",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/javaagent/tooling/muzzle/VirtualFieldMappingsBuilder;",
                 /* isInterface= */ true);
             // stack: builder
           });

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/ReferenceCollectorTest.java
@@ -10,13 +10,13 @@ import static io.opentelemetry.javaagent.tooling.muzzle.references.Flag.MinimumV
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import external.instrumentation.ExternalHelper;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.OtherTestHelperClasses;
 import io.opentelemetry.instrumentation.TestHelperClasses;
+import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldMappings.Mapping;
 import io.opentelemetry.javaagent.tooling.muzzle.VirtualFieldTestClasses.State;
 import io.opentelemetry.javaagent.tooling.muzzle.references.ClassRef;
 import io.opentelemetry.javaagent.tooling.muzzle.references.FieldRef;
@@ -344,10 +344,13 @@ class ReferenceCollectorTest {
     collector.prune();
 
     VirtualFieldMappings virtualFieldMappings = collector.getVirtualFieldMappings();
-    assertThat(virtualFieldMappings.entrySet())
+    assertThat(virtualFieldMappings.getMappings())
         .containsExactlyInAnyOrder(
-            entry(VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
-            entry(VirtualFieldTestClasses.Key2.class.getName(), Context.class.getName()));
+            new Mapping("", VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
+            new Mapping(
+                "namedField",
+                VirtualFieldTestClasses.Key2.class.getName(),
+                Context.class.getName()));
   }
 
   @Test
@@ -358,10 +361,11 @@ class ReferenceCollectorTest {
     collector.prune();
 
     VirtualFieldMappings virtualFieldMappings = collector.getVirtualFieldMappings();
-    assertThat(virtualFieldMappings.entrySet())
+    assertThat(virtualFieldMappings.getMappings())
         .containsExactlyInAnyOrder(
-            entry(VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
-            entry(VirtualFieldTestClasses.Key1.class.getName(), State.class.getName()));
+            new Mapping("", VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
+            new Mapping(
+                "namedField", VirtualFieldTestClasses.Key1.class.getName(), State.class.getName()));
   }
 
   @Test
@@ -372,10 +376,10 @@ class ReferenceCollectorTest {
     collector.prune();
 
     VirtualFieldMappings virtualFieldMappings = collector.getVirtualFieldMappings();
-    assertThat(virtualFieldMappings.entrySet())
+    assertThat(virtualFieldMappings.getMappings())
         .containsExactlyInAnyOrder(
-            entry(VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
-            entry(VirtualFieldTestClasses.Key2.class.getName(), Context.class.getName()));
+            new Mapping("", VirtualFieldTestClasses.Key1.class.getName(), Context.class.getName()),
+            new Mapping("", VirtualFieldTestClasses.Key2.class.getName(), Context.class.getName()));
   }
 
   @ParameterizedTest
@@ -419,9 +423,10 @@ class ReferenceCollectorTest {
     collector.prune();
 
     VirtualFieldMappings virtualFieldMappings = collector.getVirtualFieldMappings();
-    assertThat(virtualFieldMappings.entrySet())
+    assertThat(virtualFieldMappings.getMappings())
         .containsExactly(
-            entry(
+            new Mapping(
+                "",
                 VirtualFieldTestClasses.Key1.class.getName(),
                 Type.getType(Context[].class).getClassName()));
   }

--- a/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
+++ b/muzzle/src/test/java/io/opentelemetry/javaagent/tooling/muzzle/VirtualFieldTestClasses.java
@@ -17,7 +17,7 @@ public class VirtualFieldTestClasses {
       VirtualField.find(Key1.class, Context.class);
       Key2.class.getName();
       Key1.class.getName();
-      VirtualField.find(Key2.class, Context.class);
+      VirtualField.find("namedField", Key2.class, Context.class);
     }
   }
 
@@ -42,7 +42,7 @@ public class VirtualFieldTestClasses {
   public static class TwoVirtualFieldsInTheSameClassAdvice {
     public static void advice() {
       VirtualField.find(Key1.class, Context.class);
-      VirtualField.find(Key1.class, State.class);
+      VirtualField.find("namedField", Key1.class, State.class);
     }
   }
 

--- a/testing-common/integration-tests/src/main/java/field/VirtualFieldTestHelper.java
+++ b/testing-common/integration-tests/src/main/java/field/VirtualFieldTestHelper.java
@@ -16,7 +16,7 @@ public class VirtualFieldTestHelper {
     VirtualFieldTestClass instance = new VirtualFieldTestClass();
     {
       VirtualField<VirtualFieldTestClass, String> field =
-          VirtualField.find(VirtualFieldTestClass.class, String.class);
+          VirtualField.find("name", VirtualFieldTestClass.class, String.class);
       field.set(instance, "test");
       field.get(instance);
     }


### PR DESCRIPTION
Lately there have been a couple of PRs where concern has been raised about virtual fields with common type such as `String` clashing. This PR allows naming the virtual fields to reduce the risk of 2 instrumentations accidentally sharing a field.