### PR TITLE
Normalize configured R2DBC server targets

### DIFF
--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -10,14 +10,18 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -29,6 +33,7 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DbExecution {
+  private static final int MAX_ENDPOINTS = 5;
   // copied from DbAttributes.DbSystemNameValues
   private static final String POSTGRESQL = "postgresql";
   // copied from DbAttributes.DbSystemNameValues
@@ -50,17 +55,29 @@ public final class DbExecution {
 
   // R2DBC driver identifier → stable semconv db.system.name value
   private static final Map<String, String> DRIVER_TO_SYSTEM_NAME = buildDriverToSystemName();
+  private static final Map<String, Integer> DRIVER_TO_DEFAULT_PORT = buildDriverToDefaultPort();
 
   private static Map<String, String> buildDriverToSystemName() {
     Map<String, String> map = new HashMap<>();
-    map.put("postgresql", POSTGRESQL);
-    map.put("mysql", MYSQL);
-    map.put("mariadb", MARIADB);
+    map.put(POSTGRESQL, POSTGRESQL);
+    map.put(MYSQL, MYSQL);
+    map.put(MARIADB, MARIADB);
     map.put("mssql", MICROSOFT_SQL_SERVER);
     map.put("oracle", ORACLE_DB);
     map.put("db2", IBM_DB2);
-    map.put("clickhouse", CLICKHOUSE);
+    map.put(CLICKHOUSE, CLICKHOUSE);
     map.put("h2", H2DATABASE);
+    return map;
+  }
+
+  private static Map<String, Integer> buildDriverToDefaultPort() {
+    Map<String, Integer> map = new HashMap<>();
+    map.put(POSTGRESQL, 5432);
+    map.put(MYSQL, 3306);
+    map.put(MARIADB, 3306);
+    map.put("mssql", 1433);
+    map.put("oracle", 1521);
+    map.put("db2", 50000);
     return map;
   }
 
@@ -70,6 +87,8 @@ public final class DbExecution {
   @Nullable private final String namespace;
   @Nullable private final String serverAddress;
   @Nullable private final Integer serverPort;
+  @Nullable private final String configuredServerAddress;
+  @Nullable private final Integer configuredServerPort;
   private final String connectionString;
   private final List<String> rawQueryTexts;
   @Nullable private final Long batchSize;
@@ -94,11 +113,26 @@ public final class DbExecution {
         factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
     String protocol =
         factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
-    this.systemName = resolveDbSystemName(driver, protocol);
+    String resolvedDriver = resolveDriver(driver, protocol);
+    String resolvedProtocol = resolveProtocol(driver, protocol);
+    this.systemName = resolveDbSystemName(resolvedDriver);
     this.serverAddress =
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
+    Integer defaultPort =
+        resolveDefaultPort(
+            resolvedDriver,
+            resolvedProtocol,
+            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
+    ConfiguredServerTarget configuredServerTarget =
+        isUnixDomainSocket(serverAddress)
+            ? ConfiguredServerTarget.from(DbServerTarget.unixSocket(serverAddress))
+            : isServerAddressGroupCandidate(serverAddress)
+                ? buildServerAddressGroup(serverAddress, serverPort, defaultPort)
+                : buildServerTarget(serverAddress, serverPort, defaultPort);
+    this.configuredServerAddress = configuredServerTarget.address;
+    this.configuredServerPort = configuredServerTarget.port;
     this.connectionString =
         String.format(
             "%s%s:%s%s",
@@ -132,6 +166,16 @@ public final class DbExecution {
   @Nullable
   public Integer getServerPort() {
     return serverPort;
+  }
+
+  @Nullable
+  public String getConfiguredServerAddress() {
+    return configuredServerAddress;
+  }
+
+  @Nullable
+  public Integer getConfiguredServerPort() {
+    return configuredServerPort;
   }
 
   public String getSystemName() {
@@ -179,10 +223,258 @@ public final class DbExecution {
     this.context = context;
   }
 
-  private static String resolveDbSystemName(@Nullable String driver, @Nullable String protocol) {
-    // Use PROTOCOL when DRIVER is "pool" (r2dbc-pool wraps the real driver in PROTOCOL),
-    // otherwise use DRIVER directly.
-    String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
-    return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
+  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.startsWith("/");
+  }
+
+  private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.indexOf(',') >= 0;
+  }
+
+  private static ConfiguredServerTarget buildServerAddressGroup(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (serverAddress == null
+        || serverAddress.indexOf('/') >= 0
+        || serverAddress.indexOf('?') >= 0
+        || serverAddress.indexOf('#') >= 0
+        || (serverPort != null && !isValidPort(serverPort))) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+
+    int firstComma = serverAddress.indexOf(',');
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd > firstComma
+        || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+
+    String hostList = stripUserInfo(serverAddress);
+    String[] hosts = hostList.split(",", -1);
+    List<ParsedEndpoint> endpoints = new ArrayList<>(hosts.length);
+    for (String host : hosts) {
+      ParsedEndpoint endpoint = parseEndpoint(host, serverPort);
+      if (endpoint == null) {
+        return ConfiguredServerTarget.EMPTY;
+      }
+      endpoints.add(endpoint);
+    }
+    if (defaultPort == null) {
+      return buildUnknownDefaultPortGroup(endpoints);
+    }
+
+    DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort);
+    for (ParsedEndpoint endpoint : endpoints) {
+      builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
+    }
+    return ConfiguredServerTarget.from(builder.build());
+  }
+
+  private static String stripUserInfo(String serverAddress) {
+    int at = serverAddress.lastIndexOf('@');
+    return at < 0 ? serverAddress : serverAddress.substring(at + 1);
+  }
+
+  private static ConfiguredServerTarget buildServerTarget(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (serverAddress != null
+        && (serverAddress.indexOf('/') >= 0
+            || serverAddress.indexOf('?') >= 0
+            || serverAddress.indexOf('#') >= 0)) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    if (serverPort != null && !isValidPort(serverPort)) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    ParsedEndpoint endpoint = parseEndpoint(serverAddress, serverPort);
+    if (endpoint == null) {
+      return ConfiguredServerTarget.EMPTY;
+    }
+    int effectiveDefaultPort = defaultPort != null ? defaultPort : endpoint.port == null ? 1 : -1;
+    return ConfiguredServerTarget.from(
+        DbServerTarget.builder(effectiveDefaultPort)
+            .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
+            .build());
+  }
+
+  private static ConfiguredServerTarget buildUnknownDefaultPortGroup(
+      List<ParsedEndpoint> endpoints) {
+    for (ParsedEndpoint endpoint : endpoints) {
+      int validationDefaultPort = endpoint.port == null ? 1 : -1;
+      if (DbServerTarget.builder(validationDefaultPort)
+              .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
+              .build()
+          == null) {
+        return ConfiguredServerTarget.EMPTY;
+      }
+    }
+
+    StringBuilder addressGroup = new StringBuilder();
+    for (int i = 0; i < Math.min(endpoints.size(), MAX_ENDPOINTS); i++) {
+      ParsedEndpoint endpoint = endpoints.get(i);
+      if (addressGroup.length() > 0) {
+        addressGroup.append(',');
+      }
+      appendEndpoint(addressGroup, endpoint);
+    }
+    return new ConfiguredServerTarget(addressGroup.toString(), null);
+  }
+
+  private static void appendEndpoint(StringBuilder result, ParsedEndpoint endpoint) {
+    if (endpoint.port != null && endpoint.host.indexOf(':') >= 0) {
+      result.append('[').append(endpoint.host).append(']');
+    } else {
+      result.append(endpoint.host);
+    }
+    if (endpoint.port != null) {
+      result.append(':').append(endpoint.port);
+    }
+  }
+
+  @Nullable
+  private static ParsedEndpoint parseEndpoint(
+      @Nullable String serverAddress, @Nullable Integer serverPort) {
+    if (serverAddress == null) {
+      return null;
+    }
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
+      return null;
+    }
+
+    String host = stripUserInfo(serverAddress).trim();
+    if (host.startsWith("[")) {
+      int closingBracket = host.indexOf(']');
+      if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {
+        return null;
+      }
+      String rest = host.substring(closingBracket + 1);
+      Integer port =
+          rest.isEmpty() ? serverPort : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
+      return !rest.isEmpty() && port == null
+          ? null
+          : new ParsedEndpoint(host.substring(1, closingBracket), port);
+    }
+    if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
+      return null;
+    }
+
+    int firstColon = host.indexOf(':');
+    int lastColon = host.lastIndexOf(':');
+    if (firstColon >= 0 && firstColon == lastColon) {
+      Integer port = parsePort(host.substring(firstColon + 1));
+      return port == null ? null : new ParsedEndpoint(host.substring(0, firstColon), port);
+    }
+    return new ParsedEndpoint(host, serverPort);
+  }
+
+  @Nullable
+  private static Integer parsePort(String value) {
+    if (value.isEmpty()) {
+      return null;
+    }
+    int port = 0;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9') {
+        return null;
+      }
+      port = port * 10 + c - '0';
+      if (port > 65535) {
+        return null;
+      }
+    }
+    return port;
+  }
+
+  private static boolean isValidPort(int port) {
+    return port >= 1 && port <= 65535;
+  }
+
+  @Nullable
+  private static String resolveDriver(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return driver;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? protocol : protocol.substring(0, separator);
+  }
+
+  @Nullable
+  private static String resolveProtocol(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return protocol;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? null : protocol.substring(separator + 1);
+  }
+
+  @Nullable
+  private static Integer resolveDefaultPort(
+      @Nullable String driver, @Nullable String protocol, boolean ssl) {
+    if (CLICKHOUSE.equals(driver)) {
+      return resolveClickHouseDefaultPort(protocol, ssl);
+    }
+    if ("h2".equals(driver) && "tcp".equals(protocol)) {
+      return 9092;
+    }
+    return DRIVER_TO_DEFAULT_PORT.get(driver);
+  }
+
+  @Nullable
+  private static Integer resolveClickHouseDefaultPort(@Nullable String protocol, boolean ssl) {
+    if (protocol == null || "http".equals(protocol)) {
+      return ssl ? 8443 : 8123;
+    }
+    if ("https".equals(protocol)) {
+      return 8443;
+    }
+    if ("native".equals(protocol) || "tcp".equals(protocol)) {
+      return ssl ? 9440 : 9000;
+    }
+    if ("tcps".equals(protocol)) {
+      return 9440;
+    }
+    if ("mysql".equals(protocol)) {
+      return 9004;
+    }
+    if ("postgres".equals(protocol) || "postgresql".equals(protocol) || "pgsql".equals(protocol)) {
+      return 9005;
+    }
+    if ("grpc".equals(protocol) || "grpcs".equals(protocol)) {
+      return 9100;
+    }
+    return null;
+  }
+
+  private static String resolveDbSystemName(@Nullable String driver) {
+    return driver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(driver, OTHER_SQL) : OTHER_SQL;
+  }
+
+  private static class ParsedEndpoint {
+    private final String host;
+    @Nullable private final Integer port;
+
+    private ParsedEndpoint(String host, @Nullable Integer port) {
+      this.host = host;
+      this.port = port;
+    }
+  }
+
+  private static class ConfiguredServerTarget {
+    private static final ConfiguredServerTarget EMPTY = new ConfiguredServerTarget(null, null);
+
+    @Nullable private final String address;
+    @Nullable private final Integer port;
+
+    private static ConfiguredServerTarget from(@Nullable DbServerTarget target) {
+      return target == null
+          ? EMPTY
+          : new ConfiguredServerTarget(target.getAddress(), target.getPort());
+    }
+
+    private ConfiguredServerTarget(@Nullable String address, @Nullable Integer port) {
+      this.address = address;
+      this.port = port;
+    }
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -16,12 +16,10 @@ import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
-import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -33,7 +31,6 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DbExecution {
-  private static final int MAX_ENDPOINTS = 5;
   // copied from DbAttributes.DbSystemNameValues
   private static final String POSTGRESQL = "postgresql";
   // copied from DbAttributes.DbSystemNameValues
@@ -125,14 +122,12 @@ public final class DbExecution {
             resolvedDriver,
             resolvedProtocol,
             factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
-    ConfiguredServerTarget configuredServerTarget =
-        isUnixDomainSocket(serverAddress)
-            ? ConfiguredServerTarget.from(DbServerTarget.unixSocket(serverAddress))
-            : isServerAddressGroupCandidate(serverAddress)
-                ? buildServerAddressGroup(serverAddress, serverPort, defaultPort)
-                : buildServerTarget(serverAddress, serverPort, defaultPort);
-    this.configuredServerAddress = configuredServerTarget.address;
-    this.configuredServerPort = configuredServerTarget.port;
+    DbServerTarget configuredServerTarget =
+        R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
+    this.configuredServerAddress =
+        configuredServerTarget == null ? null : configuredServerTarget.getAddress();
+    this.configuredServerPort =
+        configuredServerTarget == null ? null : configuredServerTarget.getPort();
     this.connectionString =
         String.format(
             "%s%s:%s%s",
@@ -223,173 +218,6 @@ public final class DbExecution {
     this.context = context;
   }
 
-  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
-    return serverAddress != null && serverAddress.startsWith("/");
-  }
-
-  private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
-    return serverAddress != null && serverAddress.indexOf(',') >= 0;
-  }
-
-  private static ConfiguredServerTarget buildServerAddressGroup(
-      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
-    if (serverAddress == null
-        || serverAddress.indexOf('/') >= 0
-        || serverAddress.indexOf('?') >= 0
-        || serverAddress.indexOf('#') >= 0
-        || (serverPort != null && !isValidPort(serverPort))) {
-      return ConfiguredServerTarget.EMPTY;
-    }
-
-    int firstComma = serverAddress.indexOf(',');
-    int userInfoEnd = serverAddress.indexOf('@');
-    if (userInfoEnd > firstComma
-        || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
-      return ConfiguredServerTarget.EMPTY;
-    }
-
-    String hostList = stripUserInfo(serverAddress);
-    String[] hosts = hostList.split(",", -1);
-    List<ParsedEndpoint> endpoints = new ArrayList<>(hosts.length);
-    for (String host : hosts) {
-      ParsedEndpoint endpoint = parseEndpoint(host, serverPort);
-      if (endpoint == null) {
-        return ConfiguredServerTarget.EMPTY;
-      }
-      endpoints.add(endpoint);
-    }
-    if (defaultPort == null) {
-      return buildUnknownDefaultPortGroup(endpoints);
-    }
-
-    DbServerTargetBuilder builder = DbServerTarget.builder(defaultPort);
-    for (ParsedEndpoint endpoint : endpoints) {
-      builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
-    }
-    return ConfiguredServerTarget.from(builder.build());
-  }
-
-  private static String stripUserInfo(String serverAddress) {
-    int at = serverAddress.lastIndexOf('@');
-    return at < 0 ? serverAddress : serverAddress.substring(at + 1);
-  }
-
-  private static ConfiguredServerTarget buildServerTarget(
-      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
-    if (serverAddress != null
-        && (serverAddress.indexOf('/') >= 0
-            || serverAddress.indexOf('?') >= 0
-            || serverAddress.indexOf('#') >= 0)) {
-      return ConfiguredServerTarget.EMPTY;
-    }
-    if (serverPort != null && !isValidPort(serverPort)) {
-      return ConfiguredServerTarget.EMPTY;
-    }
-    ParsedEndpoint endpoint = parseEndpoint(serverAddress, serverPort);
-    if (endpoint == null) {
-      return ConfiguredServerTarget.EMPTY;
-    }
-    int effectiveDefaultPort = defaultPort != null ? defaultPort : endpoint.port == null ? 1 : -1;
-    return ConfiguredServerTarget.from(
-        DbServerTarget.builder(effectiveDefaultPort)
-            .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
-            .build());
-  }
-
-  private static ConfiguredServerTarget buildUnknownDefaultPortGroup(
-      List<ParsedEndpoint> endpoints) {
-    for (ParsedEndpoint endpoint : endpoints) {
-      int validationDefaultPort = endpoint.port == null ? 1 : -1;
-      if (DbServerTarget.builder(validationDefaultPort)
-              .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
-              .build()
-          == null) {
-        return ConfiguredServerTarget.EMPTY;
-      }
-    }
-
-    StringBuilder addressGroup = new StringBuilder();
-    for (int i = 0; i < Math.min(endpoints.size(), MAX_ENDPOINTS); i++) {
-      ParsedEndpoint endpoint = endpoints.get(i);
-      if (addressGroup.length() > 0) {
-        addressGroup.append(',');
-      }
-      appendEndpoint(addressGroup, endpoint);
-    }
-    return new ConfiguredServerTarget(addressGroup.toString(), null);
-  }
-
-  private static void appendEndpoint(StringBuilder result, ParsedEndpoint endpoint) {
-    if (endpoint.port != null && endpoint.host.indexOf(':') >= 0) {
-      result.append('[').append(endpoint.host).append(']');
-    } else {
-      result.append(endpoint.host);
-    }
-    if (endpoint.port != null) {
-      result.append(':').append(endpoint.port);
-    }
-  }
-
-  @Nullable
-  private static ParsedEndpoint parseEndpoint(
-      @Nullable String serverAddress, @Nullable Integer serverPort) {
-    if (serverAddress == null) {
-      return null;
-    }
-    int userInfoEnd = serverAddress.indexOf('@');
-    if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
-      return null;
-    }
-
-    String host = stripUserInfo(serverAddress).trim();
-    if (host.startsWith("[")) {
-      int closingBracket = host.indexOf(']');
-      if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {
-        return null;
-      }
-      String rest = host.substring(closingBracket + 1);
-      Integer port =
-          rest.isEmpty() ? serverPort : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
-      return !rest.isEmpty() && port == null
-          ? null
-          : new ParsedEndpoint(host.substring(1, closingBracket), port);
-    }
-    if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
-      return null;
-    }
-
-    int firstColon = host.indexOf(':');
-    int lastColon = host.lastIndexOf(':');
-    if (firstColon >= 0 && firstColon == lastColon) {
-      Integer port = parsePort(host.substring(firstColon + 1));
-      return port == null ? null : new ParsedEndpoint(host.substring(0, firstColon), port);
-    }
-    return new ParsedEndpoint(host, serverPort);
-  }
-
-  @Nullable
-  private static Integer parsePort(String value) {
-    if (value.isEmpty()) {
-      return null;
-    }
-    int port = 0;
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      if (c < '0' || c > '9') {
-        return null;
-      }
-      port = port * 10 + c - '0';
-      if (port > 65535) {
-        return null;
-      }
-    }
-    return port;
-  }
-
-  private static boolean isValidPort(int port) {
-    return port >= 1 && port <= 65535;
-  }
-
   @Nullable
   private static String resolveDriver(@Nullable String driver, @Nullable String protocol) {
     if (!"pool".equals(driver) || protocol == null) {
@@ -448,33 +276,5 @@ public final class DbExecution {
 
   private static String resolveDbSystemName(@Nullable String driver) {
     return driver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(driver, OTHER_SQL) : OTHER_SQL;
-  }
-
-  private static class ParsedEndpoint {
-    private final String host;
-    @Nullable private final Integer port;
-
-    private ParsedEndpoint(String host, @Nullable Integer port) {
-      this.host = host;
-      this.port = port;
-    }
-  }
-
-  private static class ConfiguredServerTarget {
-    private static final ConfiguredServerTarget EMPTY = new ConfiguredServerTarget(null, null);
-
-    @Nullable private final String address;
-    @Nullable private final Integer port;
-
-    private static ConfiguredServerTarget from(@Nullable DbServerTarget target) {
-      return target == null
-          ? EMPTY
-          : new ConfiguredServerTarget(target.getAddress(), target.getPort());
-    }
-
-    private ConfiguredServerTarget(@Nullable String address, @Nullable Integer port) {
-      this.address = address;
-      this.port = port;
-    }
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -94,6 +94,13 @@ public final class DbExecution {
   @Nullable private Context context;
 
   public DbExecution(QueryExecutionInfo queryInfo, ConnectionFactoryOptions factoryOptions) {
+    this(queryInfo, factoryOptions, createConfiguredServerTarget(factoryOptions));
+  }
+
+  DbExecution(
+      QueryExecutionInfo queryInfo,
+      ConnectionFactoryOptions factoryOptions,
+      @Nullable DbServerTarget configuredServerTarget) {
     Connection originalConnection = queryInfo.getConnectionInfo().getOriginalConnection();
     this.system =
         originalConnection != null
@@ -110,20 +117,11 @@ public final class DbExecution {
         factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
     String protocol =
         factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
-    String resolvedDriver = resolveDriver(driver, protocol);
-    String resolvedProtocol = resolveProtocol(driver, protocol);
     this.systemName = resolveDbSystemName(driver, protocol);
     this.serverAddress =
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    Integer defaultPort =
-        resolveDefaultPort(
-            resolvedDriver,
-            resolvedProtocol,
-            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
-    DbServerTarget configuredServerTarget =
-        R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
     this.configuredServerAddress =
         configuredServerTarget == null ? null : configuredServerTarget.getAddress();
     this.configuredServerPort =
@@ -151,6 +149,24 @@ public final class DbExecution {
         queryInfo.getQueries().stream()
             .anyMatch(queryInfo1 -> !queryInfo1.getBindingsList().isEmpty());
     R2dbcSqlCommenterUtil.clearQueries(queryInfo.getConnectionInfo());
+  }
+
+  @Nullable
+  static DbServerTarget createConfiguredServerTarget(ConnectionFactoryOptions factoryOptions) {
+    String driver =
+        factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
+    String protocol =
+        factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
+    Integer defaultPort =
+        resolveDefaultPort(
+            resolveDriver(driver, protocol),
+            resolveProtocol(driver, protocol),
+            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
+    String serverAddress =
+        factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
+    Integer serverPort =
+        factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
+    return R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -5,13 +5,6 @@
 
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
-import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
-import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
-import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
-import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
-import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
-import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 import static java.util.stream.Collectors.toList;
 
 import io.opentelemetry.context.Context;
@@ -20,10 +13,8 @@ import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.core.QueryInfo;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -31,62 +22,11 @@ import javax.annotation.Nullable;
  * any time.
  */
 public final class DbExecution {
-  // copied from DbAttributes.DbSystemNameValues
-  private static final String POSTGRESQL = "postgresql";
-  // copied from DbAttributes.DbSystemNameValues
-  private static final String MYSQL = "mysql";
-  // copied from DbAttributes.DbSystemNameValues
-  private static final String MARIADB = "mariadb";
-  // copied from DbAttributes.DbSystemNameValues
-  private static final String MICROSOFT_SQL_SERVER = "microsoft.sql_server";
-  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
-  private static final String ORACLE_DB = "oracle.db";
-  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
-  private static final String IBM_DB2 = "ibm.db2";
-  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
-  private static final String CLICKHOUSE = "clickhouse";
-  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
-  private static final String H2DATABASE = "h2database";
   // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
   private static final String OTHER_SQL = "other_sql";
 
-  // R2DBC driver identifier → stable semconv db.system.name value
-  private static final Map<String, String> DRIVER_TO_SYSTEM_NAME = buildDriverToSystemName();
-  private static final Map<String, Integer> DRIVER_TO_DEFAULT_PORT = buildDriverToDefaultPort();
-
-  private static Map<String, String> buildDriverToSystemName() {
-    Map<String, String> map = new HashMap<>();
-    map.put(POSTGRESQL, POSTGRESQL);
-    map.put(MYSQL, MYSQL);
-    map.put(MARIADB, MARIADB);
-    map.put("mssql", MICROSOFT_SQL_SERVER);
-    map.put("oracle", ORACLE_DB);
-    map.put("db2", IBM_DB2);
-    map.put(CLICKHOUSE, CLICKHOUSE);
-    map.put("h2", H2DATABASE);
-    return map;
-  }
-
-  private static Map<String, Integer> buildDriverToDefaultPort() {
-    Map<String, Integer> map = new HashMap<>();
-    map.put(POSTGRESQL, 5432);
-    map.put(MYSQL, 3306);
-    map.put(MARIADB, 3306);
-    map.put("mssql", 1433);
-    map.put("oracle", 1521);
-    map.put("db2", 50000);
-    return map;
-  }
-
-  private final String systemName;
+  private final R2dbcConnectionInfo connectionInfo;
   private final String system;
-  @Nullable private final String user;
-  @Nullable private final String namespace;
-  @Nullable private final String serverAddress;
-  @Nullable private final Integer serverPort;
-  @Nullable private final String configuredServerAddress;
-  @Nullable private final Integer configuredServerPort;
-  private final String connectionString;
   private final List<String> rawQueryTexts;
   @Nullable private final Long batchSize;
   private final boolean parameterizedQuery;
@@ -94,13 +34,11 @@ public final class DbExecution {
   @Nullable private Context context;
 
   public DbExecution(QueryExecutionInfo queryInfo, ConnectionFactoryOptions factoryOptions) {
-    this(queryInfo, factoryOptions, createConfiguredServerTarget(factoryOptions));
+    this(queryInfo, new R2dbcConnectionInfo(factoryOptions));
   }
 
-  DbExecution(
-      QueryExecutionInfo queryInfo,
-      ConnectionFactoryOptions factoryOptions,
-      @Nullable DbServerTarget configuredServerTarget) {
+  DbExecution(QueryExecutionInfo queryInfo, R2dbcConnectionInfo connectionInfo) {
+    this.connectionInfo = connectionInfo;
     Connection originalConnection = queryInfo.getConnectionInfo().getOriginalConnection();
     this.system =
         originalConnection != null
@@ -110,29 +48,6 @@ public final class DbExecution {
                 .toLowerCase(Locale.ROOT)
                 .split(" ")[0]
             : OTHER_SQL;
-    this.user = factoryOptions.hasOption(USER) ? (String) factoryOptions.getValue(USER) : null;
-    this.namespace =
-        factoryOptions.hasOption(DATABASE) ? (String) factoryOptions.getValue(DATABASE) : null;
-    String driver =
-        factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
-    String protocol =
-        factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
-    this.systemName = resolveDbSystemName(driver, protocol);
-    this.serverAddress =
-        factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
-    this.serverPort =
-        factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    this.configuredServerAddress =
-        configuredServerTarget == null ? null : configuredServerTarget.getAddress();
-    this.configuredServerPort =
-        configuredServerTarget == null ? null : configuredServerTarget.getPort();
-    this.connectionString =
-        String.format(
-            "%s%s:%s%s",
-            driver != null ? driver : "",
-            protocol != null ? ":" + protocol : "",
-            serverAddress != null ? "//" + serverAddress : "",
-            serverPort != null ? ":" + serverPort : "");
     this.rawQueryTexts =
         queryInfo.getQueries().stream()
             .map(QueryInfo::getQuery)
@@ -151,46 +66,34 @@ public final class DbExecution {
     R2dbcSqlCommenterUtil.clearQueries(queryInfo.getConnectionInfo());
   }
 
-  @Nullable
-  static DbServerTarget createConfiguredServerTarget(ConnectionFactoryOptions factoryOptions) {
-    String driver =
-        factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
-    String protocol =
-        factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
-    Integer defaultPort =
-        resolveDefaultPort(
-            resolveDriver(driver, protocol),
-            resolveProtocol(driver, protocol),
-            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
-    String serverAddress =
-        factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
-    Integer serverPort =
-        factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
-    return R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
+  R2dbcConnectionInfo connectionInfo() {
+    return connectionInfo;
   }
 
   @Nullable
   public String getServerAddress() {
-    return serverAddress;
+    return connectionInfo.getServerAddress();
   }
 
   @Nullable
   public Integer getServerPort() {
-    return serverPort;
+    return connectionInfo.getServerPort();
   }
 
   @Nullable
   public String getConfiguredServerAddress() {
-    return configuredServerAddress;
+    DbServerTarget target = connectionInfo.getConfiguredServerTarget();
+    return target == null ? null : target.getAddress();
   }
 
   @Nullable
   public Integer getConfiguredServerPort() {
-    return configuredServerPort;
+    DbServerTarget target = connectionInfo.getConfiguredServerTarget();
+    return target == null ? null : target.getPort();
   }
 
   public String getSystemName() {
-    return systemName;
+    return connectionInfo.getSystemName();
   }
 
   @Deprecated // to be removed in 3.0
@@ -200,16 +103,16 @@ public final class DbExecution {
 
   @Nullable
   public String getUser() {
-    return user;
+    return connectionInfo.getUser();
   }
 
   @Nullable
   public String getNamespace() {
-    return namespace;
+    return connectionInfo.getNamespace();
   }
 
   public String getConnectionString() {
-    return connectionString;
+    return connectionInfo.getConnectionString();
   }
 
   public List<String> getRawQueryTexts() {
@@ -232,66 +135,5 @@ public final class DbExecution {
 
   public void setContext(Context context) {
     this.context = context;
-  }
-
-  @Nullable
-  private static String resolveDriver(@Nullable String driver, @Nullable String protocol) {
-    if (!"pool".equals(driver) || protocol == null) {
-      return driver;
-    }
-    int separator = protocol.indexOf(':');
-    return separator < 0 ? protocol : protocol.substring(0, separator);
-  }
-
-  @Nullable
-  private static String resolveProtocol(@Nullable String driver, @Nullable String protocol) {
-    if (!"pool".equals(driver) || protocol == null) {
-      return protocol;
-    }
-    int separator = protocol.indexOf(':');
-    return separator < 0 ? null : protocol.substring(separator + 1);
-  }
-
-  @Nullable
-  private static Integer resolveDefaultPort(
-      @Nullable String driver, @Nullable String protocol, boolean ssl) {
-    if (CLICKHOUSE.equals(driver)) {
-      return resolveClickHouseDefaultPort(protocol, ssl);
-    }
-    if ("h2".equals(driver) && "tcp".equals(protocol)) {
-      return 9092;
-    }
-    return DRIVER_TO_DEFAULT_PORT.get(driver);
-  }
-
-  @Nullable
-  private static Integer resolveClickHouseDefaultPort(@Nullable String protocol, boolean ssl) {
-    if (protocol == null || "http".equals(protocol)) {
-      return ssl ? 8443 : 8123;
-    }
-    if ("https".equals(protocol)) {
-      return 8443;
-    }
-    if ("native".equals(protocol) || "tcp".equals(protocol)) {
-      return ssl ? 9440 : 9000;
-    }
-    if ("tcps".equals(protocol)) {
-      return 9440;
-    }
-    if ("mysql".equals(protocol)) {
-      return 9004;
-    }
-    if ("postgres".equals(protocol) || "postgresql".equals(protocol) || "pgsql".equals(protocol)) {
-      return 9005;
-    }
-    if ("grpc".equals(protocol) || "grpcs".equals(protocol)) {
-      return 9100;
-    }
-    return null;
-  }
-
-  private static String resolveDbSystemName(@Nullable String driver, @Nullable String protocol) {
-    String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
-    return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/DbExecution.java
@@ -112,7 +112,7 @@ public final class DbExecution {
         factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
     String resolvedDriver = resolveDriver(driver, protocol);
     String resolvedProtocol = resolveProtocol(driver, protocol);
-    this.systemName = resolveDbSystemName(resolvedDriver);
+    this.systemName = resolveDbSystemName(driver, protocol);
     this.serverAddress =
         factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
     this.serverPort =
@@ -274,7 +274,8 @@ public final class DbExecution {
     return null;
   }
 
-  private static String resolveDbSystemName(@Nullable String driver) {
-    return driver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(driver, OTHER_SQL) : OTHER_SQL;
+  private static String resolveDbSystemName(@Nullable String driver, @Nullable String protocol) {
+    String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
+    return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcConnectionInfo.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcConnectionInfo.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+final class R2dbcConnectionInfo {
+  // copied from DbAttributes.DbSystemNameValues
+  private static final String POSTGRESQL = "postgresql";
+  // copied from DbAttributes.DbSystemNameValues
+  private static final String MYSQL = "mysql";
+  // copied from DbAttributes.DbSystemNameValues
+  private static final String MARIADB = "mariadb";
+  // copied from DbAttributes.DbSystemNameValues
+  private static final String MICROSOFT_SQL_SERVER = "microsoft.sql_server";
+  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
+  private static final String ORACLE_DB = "oracle.db";
+  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
+  private static final String IBM_DB2 = "ibm.db2";
+  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
+  private static final String CLICKHOUSE = "clickhouse";
+  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
+  private static final String H2DATABASE = "h2database";
+  // copied from DbIncubatingAttributes.DbSystemNameIncubatingValues
+  private static final String OTHER_SQL = "other_sql";
+
+  // R2DBC driver identifier -> stable semconv db.system.name value
+  private static final Map<String, String> DRIVER_TO_SYSTEM_NAME = buildDriverToSystemName();
+  private static final Map<String, Integer> DRIVER_TO_DEFAULT_PORT = buildDriverToDefaultPort();
+
+  private final String systemName;
+  @Nullable private final String user;
+  @Nullable private final String namespace;
+  @Nullable private final String serverAddress;
+  @Nullable private final Integer serverPort;
+  @Nullable private final DbServerTarget configuredServerTarget;
+  private final String connectionString;
+
+  R2dbcConnectionInfo(ConnectionFactoryOptions factoryOptions) {
+    String driver =
+        factoryOptions.hasOption(DRIVER) ? (String) factoryOptions.getValue(DRIVER) : null;
+    String protocol =
+        factoryOptions.hasOption(PROTOCOL) ? (String) factoryOptions.getValue(PROTOCOL) : null;
+    String resolvedDriver = resolveDriver(driver, protocol);
+    String resolvedProtocol = resolveProtocol(driver, protocol);
+    this.systemName = resolveDbSystemName(driver, protocol);
+    this.user = factoryOptions.hasOption(USER) ? (String) factoryOptions.getValue(USER) : null;
+    this.namespace =
+        factoryOptions.hasOption(DATABASE) ? (String) factoryOptions.getValue(DATABASE) : null;
+    this.serverAddress =
+        factoryOptions.hasOption(HOST) ? (String) factoryOptions.getValue(HOST) : null;
+    this.serverPort =
+        factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
+    Integer defaultPort =
+        resolveDefaultPort(
+            resolvedDriver,
+            resolvedProtocol,
+            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
+    this.configuredServerTarget = R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
+    this.connectionString =
+        String.format(
+            "%s%s:%s%s",
+            driver != null ? driver : "",
+            protocol != null ? ":" + protocol : "",
+            serverAddress != null ? "//" + serverAddress : "",
+            serverPort != null ? ":" + serverPort : "");
+  }
+
+  String getSystemName() {
+    return systemName;
+  }
+
+  @Nullable
+  String getUser() {
+    return user;
+  }
+
+  @Nullable
+  String getNamespace() {
+    return namespace;
+  }
+
+  @Nullable
+  String getServerAddress() {
+    return serverAddress;
+  }
+
+  @Nullable
+  Integer getServerPort() {
+    return serverPort;
+  }
+
+  @Nullable
+  DbServerTarget getConfiguredServerTarget() {
+    return configuredServerTarget;
+  }
+
+  String getConnectionString() {
+    return connectionString;
+  }
+
+  private static Map<String, String> buildDriverToSystemName() {
+    Map<String, String> map = new HashMap<>();
+    map.put(POSTGRESQL, POSTGRESQL);
+    map.put(MYSQL, MYSQL);
+    map.put(MARIADB, MARIADB);
+    map.put("mssql", MICROSOFT_SQL_SERVER);
+    map.put("oracle", ORACLE_DB);
+    map.put("db2", IBM_DB2);
+    map.put(CLICKHOUSE, CLICKHOUSE);
+    map.put("h2", H2DATABASE);
+    return map;
+  }
+
+  private static Map<String, Integer> buildDriverToDefaultPort() {
+    Map<String, Integer> map = new HashMap<>();
+    map.put(POSTGRESQL, 5432);
+    map.put(MYSQL, 3306);
+    map.put(MARIADB, 3306);
+    map.put("mssql", 1433);
+    map.put("oracle", 1521);
+    map.put("db2", 50000);
+    return map;
+  }
+
+  @Nullable
+  private static String resolveDriver(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return driver;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? protocol : protocol.substring(0, separator);
+  }
+
+  @Nullable
+  private static String resolveProtocol(@Nullable String driver, @Nullable String protocol) {
+    if (!"pool".equals(driver) || protocol == null) {
+      return protocol;
+    }
+    int separator = protocol.indexOf(':');
+    return separator < 0 ? null : protocol.substring(separator + 1);
+  }
+
+  @Nullable
+  private static Integer resolveDefaultPort(
+      @Nullable String driver, @Nullable String protocol, boolean ssl) {
+    if (CLICKHOUSE.equals(driver)) {
+      return resolveClickHouseDefaultPort(protocol, ssl);
+    }
+    if ("h2".equals(driver) && "tcp".equals(protocol)) {
+      return 9092;
+    }
+    return DRIVER_TO_DEFAULT_PORT.get(driver);
+  }
+
+  @Nullable
+  private static Integer resolveClickHouseDefaultPort(@Nullable String protocol, boolean ssl) {
+    if (protocol == null || "http".equals(protocol)) {
+      return ssl ? 8443 : 8123;
+    }
+    if ("https".equals(protocol)) {
+      return 8443;
+    }
+    if ("native".equals(protocol) || "tcp".equals(protocol)) {
+      return ssl ? 9440 : 9000;
+    }
+    if ("tcps".equals(protocol)) {
+      return 9440;
+    }
+    if ("mysql".equals(protocol)) {
+      return 9004;
+    }
+    if ("postgres".equals(protocol) || "postgresql".equals(protocol) || "pgsql".equals(protocol)) {
+      return 9005;
+    }
+    if ("grpc".equals(protocol) || "grpcs".equals(protocol)) {
+      return 9100;
+    }
+    return null;
+  }
+
+  private static String resolveDbSystemName(@Nullable String driver, @Nullable String protocol) {
+    String rawDriver = "pool".equals(driver) && protocol != null ? protocol : driver;
+    return rawDriver != null ? DRIVER_TO_SYSTEM_NAME.getOrDefault(rawDriver, OTHER_SQL) : OTHER_SQL;
+  }
+}

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcConnectionInfo.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcConnectionInfo.java
@@ -67,10 +67,7 @@ final class R2dbcConnectionInfo {
     this.serverPort =
         factoryOptions.hasOption(PORT) ? (Integer) factoryOptions.getValue(PORT) : null;
     Integer defaultPort =
-        resolveDefaultPort(
-            resolvedDriver,
-            resolvedProtocol,
-            factoryOptions.hasOption(SSL) && Boolean.TRUE.equals(factoryOptions.getValue(SSL)));
+        resolveDefaultPort(resolvedDriver, resolvedProtocol, isSslEnabled(factoryOptions));
     this.configuredServerTarget = R2dbcServerTarget.create(serverAddress, serverPort, defaultPort);
     this.connectionString =
         String.format(
@@ -154,6 +151,14 @@ final class R2dbcConnectionInfo {
     }
     int separator = protocol.indexOf(':');
     return separator < 0 ? null : protocol.substring(separator + 1);
+  }
+
+  private static boolean isSslEnabled(ConnectionFactoryOptions factoryOptions) {
+    Object ssl = factoryOptions.hasOption(SSL) ? factoryOptions.getValue(SSL) : null;
+    // a connection url query parameter keeps its string form, while the r2dbcs scheme and the
+    // programmatic option carry a boolean
+    return Boolean.TRUE.equals(ssl)
+        || (ssl instanceof String && Boolean.parseBoolean((String) ssl));
   }
 
   @Nullable

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
@@ -102,12 +102,14 @@ final class R2dbcServerTarget {
       if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {
         return null;
       }
+      String bracketedHost = host.substring(1, closingBracket);
+      if (bracketedHost.indexOf(':') < 0) {
+        return null;
+      }
       String rest = host.substring(closingBracket + 1);
       Integer port =
           rest.isEmpty() ? serverPort : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
-      return !rest.isEmpty() && port == null
-          ? null
-          : new ParsedEndpoint(host.substring(1, closingBracket), port);
+      return !rest.isEmpty() && port == null ? null : new ParsedEndpoint(bracketedHost, port);
     }
     if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
       return null;

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
+import javax.annotation.Nullable;
+
+final class R2dbcServerTarget {
+
+  @Nullable
+  static DbServerTarget create(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (isUnixDomainSocket(serverAddress)) {
+      return DbServerTarget.unixSocket(serverAddress);
+    }
+    return isServerAddressGroupCandidate(serverAddress)
+        ? buildServerAddressGroup(serverAddress, serverPort, defaultPort)
+        : buildServerTarget(serverAddress, serverPort, defaultPort);
+  }
+
+  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.startsWith("/");
+  }
+
+  private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.indexOf(',') >= 0;
+  }
+
+  @Nullable
+  private static DbServerTarget buildServerAddressGroup(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (serverAddress == null
+        || serverAddress.indexOf('/') >= 0
+        || serverAddress.indexOf('?') >= 0
+        || serverAddress.indexOf('#') >= 0
+        || (serverPort != null && !isValidPort(serverPort))) {
+      return null;
+    }
+
+    int firstComma = serverAddress.indexOf(',');
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd > firstComma
+        || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
+      return null;
+    }
+
+    String[] hosts = stripUserInfo(serverAddress).split(",", -1);
+    DbServerTargetBuilder builder = builder(defaultPort);
+    for (String host : hosts) {
+      ParsedEndpoint endpoint = parseEndpoint(host, serverPort);
+      if (endpoint == null) {
+        return null;
+      }
+      builder.addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port);
+    }
+    return builder.build();
+  }
+
+  @Nullable
+  private static DbServerTarget buildServerTarget(
+      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
+    if (serverAddress != null
+        && (serverAddress.indexOf('/') >= 0
+            || serverAddress.indexOf('?') >= 0
+            || serverAddress.indexOf('#') >= 0)) {
+      return null;
+    }
+    if (serverPort != null && !isValidPort(serverPort)) {
+      return null;
+    }
+    ParsedEndpoint endpoint = parseEndpoint(serverAddress, serverPort);
+    if (endpoint == null) {
+      return null;
+    }
+    return builder(defaultPort)
+        .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
+        .build();
+  }
+
+  private static DbServerTargetBuilder builder(@Nullable Integer defaultPort) {
+    return defaultPort == null ? DbServerTarget.builder() : DbServerTarget.builder(defaultPort);
+  }
+
+  @Nullable
+  private static ParsedEndpoint parseEndpoint(
+      @Nullable String serverAddress, @Nullable Integer serverPort) {
+    if (serverAddress == null) {
+      return null;
+    }
+    int userInfoEnd = serverAddress.indexOf('@');
+    if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
+      return null;
+    }
+
+    String host = stripUserInfo(serverAddress).trim();
+    if (host.startsWith("[")) {
+      int closingBracket = host.indexOf(']');
+      if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {
+        return null;
+      }
+      String rest = host.substring(closingBracket + 1);
+      Integer port =
+          rest.isEmpty() ? serverPort : parsePort(rest.startsWith(":") ? rest.substring(1) : "");
+      return !rest.isEmpty() && port == null
+          ? null
+          : new ParsedEndpoint(host.substring(1, closingBracket), port);
+    }
+    if (host.indexOf('[') >= 0 || host.indexOf(']') >= 0) {
+      return null;
+    }
+
+    int firstColon = host.indexOf(':');
+    int lastColon = host.lastIndexOf(':');
+    if (firstColon >= 0 && firstColon == lastColon) {
+      Integer port = parsePort(host.substring(firstColon + 1));
+      return port == null ? null : new ParsedEndpoint(host.substring(0, firstColon), port);
+    }
+    return new ParsedEndpoint(host, serverPort);
+  }
+
+  private static String stripUserInfo(String serverAddress) {
+    int at = serverAddress.lastIndexOf('@');
+    return at < 0 ? serverAddress : serverAddress.substring(at + 1);
+  }
+
+  @Nullable
+  private static Integer parsePort(String value) {
+    if (value.isEmpty()) {
+      return null;
+    }
+    int port = 0;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c < '0' || c > '9') {
+        return null;
+      }
+      port = port * 10 + c - '0';
+      if (port > 65535) {
+        return null;
+      }
+    }
+    return port;
+  }
+
+  private static boolean isValidPort(int port) {
+    return port >= 1 && port <= 65535;
+  }
+
+  private static final class ParsedEndpoint {
+    private final String host;
+    @Nullable private final Integer port;
+
+    private ParsedEndpoint(String host, @Nullable Integer port) {
+      this.host = host;
+      this.port = port;
+    }
+  }
+
+  private R2dbcServerTarget() {}
+}

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcServerTarget.java
@@ -17,22 +17,6 @@ final class R2dbcServerTarget {
     if (isUnixDomainSocket(serverAddress)) {
       return DbServerTarget.unixSocket(serverAddress);
     }
-    return isServerAddressGroupCandidate(serverAddress)
-        ? buildServerAddressGroup(serverAddress, serverPort, defaultPort)
-        : buildServerTarget(serverAddress, serverPort, defaultPort);
-  }
-
-  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
-    return serverAddress != null && serverAddress.startsWith("/");
-  }
-
-  private static boolean isServerAddressGroupCandidate(@Nullable String serverAddress) {
-    return serverAddress != null && serverAddress.indexOf(',') >= 0;
-  }
-
-  @Nullable
-  private static DbServerTarget buildServerAddressGroup(
-      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
     if (serverAddress == null
         || serverAddress.indexOf('/') >= 0
         || serverAddress.indexOf('?') >= 0
@@ -43,14 +27,14 @@ final class R2dbcServerTarget {
 
     int firstComma = serverAddress.indexOf(',');
     int userInfoEnd = serverAddress.indexOf('@');
-    if (userInfoEnd > firstComma
+    // user info belongs to the whole address, so it must appear once and ahead of every host
+    if ((firstComma >= 0 && userInfoEnd > firstComma)
         || (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@'))) {
       return null;
     }
 
-    String[] hosts = stripUserInfo(serverAddress).split(",", -1);
     DbServerTargetBuilder builder = builder(defaultPort);
-    for (String host : hosts) {
+    for (String host : stripUserInfo(serverAddress).split(",", -1)) {
       ParsedEndpoint endpoint = parseEndpoint(host, serverPort);
       if (endpoint == null) {
         return null;
@@ -60,25 +44,8 @@ final class R2dbcServerTarget {
     return builder.build();
   }
 
-  @Nullable
-  private static DbServerTarget buildServerTarget(
-      @Nullable String serverAddress, @Nullable Integer serverPort, @Nullable Integer defaultPort) {
-    if (serverAddress != null
-        && (serverAddress.indexOf('/') >= 0
-            || serverAddress.indexOf('?') >= 0
-            || serverAddress.indexOf('#') >= 0)) {
-      return null;
-    }
-    if (serverPort != null && !isValidPort(serverPort)) {
-      return null;
-    }
-    ParsedEndpoint endpoint = parseEndpoint(serverAddress, serverPort);
-    if (endpoint == null) {
-      return null;
-    }
-    return builder(defaultPort)
-        .addEndpoint(endpoint.host, endpoint.port == null ? -1 : endpoint.port)
-        .build();
+  private static boolean isUnixDomainSocket(@Nullable String serverAddress) {
+    return serverAddress != null && serverAddress.startsWith("/");
   }
 
   private static DbServerTargetBuilder builder(@Nullable Integer defaultPort) {
@@ -86,17 +53,8 @@ final class R2dbcServerTarget {
   }
 
   @Nullable
-  private static ParsedEndpoint parseEndpoint(
-      @Nullable String serverAddress, @Nullable Integer serverPort) {
-    if (serverAddress == null) {
-      return null;
-    }
-    int userInfoEnd = serverAddress.indexOf('@');
-    if (userInfoEnd >= 0 && userInfoEnd != serverAddress.lastIndexOf('@')) {
-      return null;
-    }
-
-    String host = stripUserInfo(serverAddress).trim();
+  private static ParsedEndpoint parseEndpoint(String serverAddress, @Nullable Integer serverPort) {
+    String host = serverAddress.trim();
     if (host.startsWith("[")) {
       int closingBracket = host.indexOf(']');
       if (closingBracket < 0 || host.indexOf(']', closingBracket + 1) >= 0) {

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/R2dbcSqlAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.SqlDialectUtil.fromDbSystemName;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static java.util.Collections.singleton;
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlClientAttributesGetter;
@@ -98,13 +99,17 @@ public final class R2dbcSqlAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DbExecution request) {
-    return request.getServerAddress();
+    return emitStableDatabaseSemconv()
+        ? request.getConfiguredServerAddress()
+        : request.getServerAddress();
   }
 
   @Nullable
   @Override
   public Integer getServerPort(DbExecution request) {
-    return request.getServerPort();
+    return emitStableDatabaseSemconv()
+        ? request.getConfiguredServerPort()
+        : request.getServerPort();
   }
 
   @Override

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListener.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListener.java
@@ -6,12 +6,10 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.listener.ProxyMethodExecutionListener;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import javax.annotation.Nullable;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -22,20 +20,18 @@ public final class TraceProxyListener implements ProxyMethodExecutionListener {
   private static final String KEY_DB_EXECUTION = "dbExecution";
 
   private final Instrumenter<DbExecution, Void> instrumenter;
-  private final ConnectionFactoryOptions factoryOptions;
-  @Nullable private final DbServerTarget configuredServerTarget;
+  private final R2dbcConnectionInfo connectionInfo;
 
   public TraceProxyListener(
       Instrumenter<DbExecution, Void> instrumenter, ConnectionFactoryOptions factoryOptions) {
     this.instrumenter = instrumenter;
-    this.factoryOptions = factoryOptions;
-    this.configuredServerTarget = DbExecution.createConfiguredServerTarget(factoryOptions);
+    this.connectionInfo = new R2dbcConnectionInfo(factoryOptions);
   }
 
   @Override
   public void beforeQuery(QueryExecutionInfo queryInfo) {
     Context parentContext = Context.current();
-    DbExecution dbExecution = new DbExecution(queryInfo, factoryOptions, configuredServerTarget);
+    DbExecution dbExecution = new DbExecution(queryInfo, connectionInfo);
     if (!instrumenter.shouldStart(parentContext, dbExecution)) {
       return;
     }

--- a/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListener.java
+++ b/instrumentation/r2dbc-1.0/library/src/main/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListener.java
@@ -6,10 +6,12 @@
 package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.r2dbc.proxy.core.QueryExecutionInfo;
 import io.r2dbc.proxy.listener.ProxyMethodExecutionListener;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import javax.annotation.Nullable;
 
 /**
  * This class is internal and is hence not for public use. Its APIs are unstable and can change at
@@ -21,17 +23,19 @@ public final class TraceProxyListener implements ProxyMethodExecutionListener {
 
   private final Instrumenter<DbExecution, Void> instrumenter;
   private final ConnectionFactoryOptions factoryOptions;
+  @Nullable private final DbServerTarget configuredServerTarget;
 
   public TraceProxyListener(
       Instrumenter<DbExecution, Void> instrumenter, ConnectionFactoryOptions factoryOptions) {
     this.instrumenter = instrumenter;
     this.factoryOptions = factoryOptions;
+    this.configuredServerTarget = DbExecution.createConfiguredServerTarget(factoryOptions);
   }
 
   @Override
   public void beforeQuery(QueryExecutionInfo queryInfo) {
     Context parentContext = Context.current();
-    DbExecution dbExecution = new DbExecution(queryInfo, factoryOptions);
+    DbExecution dbExecution = new DbExecution(queryInfo, factoryOptions, configuredServerTarget);
     if (!instrumenter.shouldStart(parentContext, dbExecution)) {
       return;
     }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -305,7 +305,7 @@ class DbExecutionTest {
 
     DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
 
-    assertThat(dbExecution.getSystemName()).isEqualTo("clickhouse");
+    assertThat(dbExecution.getSystemName()).isEqualTo("other_sql");
     assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
     assertThat(dbExecution.getConfiguredServerPort()).isNull();
   }
@@ -507,6 +507,7 @@ class DbExecutionTest {
         "host1?email=user@example.com,host2",
         "host1#fragment,host2",
         "[]:5432,host2",
+        "[host1]:5432,host2",
         ":5432,host2",
         "host1,not:an:ipv6",
         "host1,[not:an:ipv6]",

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -470,6 +470,20 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionValidatesConfiguredHostsAfterTheLimitWithUnknownDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "unknown")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host six")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
   void dbExecutionSanitizesUserInfoFromMultiHostAddress() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -152,4 +152,462 @@ class DbExecutionTest {
     DbExecution dbExecution = new DbExecution(queryExecutionInfo, factoryOptions);
     assertThat(dbExecution.getSystemName()).isEqualTo(expectedSystemName);
   }
+
+  @Test
+  void dbExecutionKeepsMultiHostAddressVerbatim() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host2:3307,host1:3306/db");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo("host2:3307,host1:3306");
+    assertThat(dbExecution.getServerPort()).isNull();
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host2:3307,host1:3306");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionInlinesASharedNonDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2")
+            .option(ConnectionFactoryOptions.PORT, 3307)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getServerPort()).isEqualTo(3307);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:3307,host2:3307");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "postgresql, 5432",
+    "mysql, 3306",
+    "mariadb, 3306",
+    "mssql, 1433",
+    "oracle, 1521",
+    "db2, 50000",
+    "clickhouse, 8123"
+  })
+  void dbExecutionOmitsKnownDefaultPorts(String driver, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, driver)
+            .option(ConnectionFactoryOptions.HOST, "host1:" + defaultPort + ",host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "postgresql, 5432",
+    "mysql, 3306",
+    "mariadb, 3306",
+    "mssql, 1433",
+    "oracle, 1521",
+    "db2, 50000",
+    "clickhouse, 8123"
+  })
+  void dbExecutionOmitsKnownDefaultPortForSingleHost(String driver, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, driver)
+            .option(ConnectionFactoryOptions.HOST, "host1")
+            .option(ConnectionFactoryOptions.PORT, defaultPort)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerPort()).isEqualTo(defaultPort);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionPreservesSingleNonDefaultAndUnknownDriverPorts() {
+    ConnectionFactoryOptions postgresqlOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1")
+            .option(ConnectionFactoryOptions.PORT, 15432)
+            .build();
+    ConnectionFactoryOptions unknownOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "unknown")
+            .option(ConnectionFactoryOptions.HOST, "host2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution postgresqlExecution = new DbExecution(queryExecutionInfo(), postgresqlOptions);
+    DbExecution unknownExecution = new DbExecution(queryExecutionInfo(), unknownOptions);
+
+    assertThat(postgresqlExecution.getConfiguredServerPort()).isEqualTo(15432);
+    assertThat(unknownExecution.getConfiguredServerPort()).isEqualTo(5432);
+  }
+
+  @Test
+  void dbExecutionUsesTheWrappedDriverProtocolDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1:5432,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "http, false, 8123",
+    "http, true, 8443",
+    "tcp, false, 9000",
+    "tcp, true, 9440",
+    "mysql, false, 9004",
+    "postgresql, false, 9005",
+    "grpc, false, 9100"
+  })
+  void dbExecutionUsesClickHouseProtocolAndSslDefaultPorts(
+      String protocol, boolean ssl, int defaultPort) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "clickhouse")
+            .option(ConnectionFactoryOptions.PROTOCOL, protocol)
+            .option(ConnectionFactoryOptions.SSL, ssl)
+            .option(ConnectionFactoryOptions.HOST, "host1:" + defaultPort + ",host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionUsesNestedPoolProtocolDefaults() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "pool")
+            .option(ConnectionFactoryOptions.PROTOCOL, "clickhouse:http")
+            .option(ConnectionFactoryOptions.HOST, "host1:8123,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getSystemName()).isEqualTo("clickhouse");
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionUsesH2TcpDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "h2")
+            .option(ConnectionFactoryOptions.PROTOCOL, "tcp")
+            .option(ConnectionFactoryOptions.HOST, "host1:9092,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionDoesNotGuessAnUnknownDriverDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "unknown")
+            .option(ConnectionFactoryOptions.HOST, "host1:1234,2001:db8::2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:1234,2001:db8::2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionDoesNotGuessAnUnknownClickHouseProtocolDefaultPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "clickhouse")
+            .option(ConnectionFactoryOptions.PROTOCOL, "custom")
+            .option(ConnectionFactoryOptions.HOST, "host1:8123,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1:8123,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionKeepsTheHostsThatAlreadyCarryAPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+            .option(
+                ConnectionFactoryOptions.HOST, "host1:3307,[2001:db8::1]:3308,host3,[2001:db8::2]")
+            .option(ConnectionFactoryOptions.PORT, 3306)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("host1:3307,[2001:db8::1]:3308,host3:3306,[2001:db8::2]:3306");
+  }
+
+  @Test
+  void dbExecutionKeepsUnbracketedIpv6HostsWhenOmittingDefaultPorts() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "2001:db8::1,2001:db8::2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("2001:db8::1,2001:db8::2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionKeepsUnbracketedIpv6HostsThatHaveNoPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "2001:db8::1,2001:db8::2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("2001:db8::1,2001:db8::2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionPreservesConfiguredHostOrderAndDuplicates() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host2,2001:db8::2,host1,host2")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host2,2001:db8::2,host1,host2");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionIncludesAtMostFiveConfiguredHosts() {
+    ConnectionFactoryOptions fiveHostOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+    ConnectionFactoryOptions sixHostOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution fiveHostExecution = new DbExecution(queryExecutionInfo(), fiveHostOptions);
+    DbExecution sixHostExecution = new DbExecution(queryExecutionInfo(), sixHostOptions);
+
+    assertThat(fiveHostExecution.getConfiguredServerAddress())
+        .isEqualTo("host1,host2,host3,host4,host5");
+    assertThat(sixHostExecution.getConfiguredServerAddress())
+        .isEqualTo("host1,host2,host3,host4,host5");
+  }
+
+  @Test
+  void dbExecutionUsesPortModeFromAllConfiguredHosts() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6:15432")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("host1:5432,host2:5432,host3:5432,host4:5432,host5:5432");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionValidatesConfiguredHostsAfterTheLimit() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2,host3,host4,host5,host6:invalid")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionSanitizesUserInfoFromMultiHostAddress() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "user:secret@host1,host2")
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1,host2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "host1:invalid,host2",
+        "host1,,host2",
+        "host1,host=value",
+        "[2001:db8::1,host2",
+        "host1/path,host2",
+        "host1?email=user@example.com,host2",
+        "host1#fragment,host2",
+        "[]:5432,host2",
+        ":5432,host2",
+        "host1,not:an:ipv6",
+        "host1,[not:an:ipv6]",
+        "host1,12345::1",
+        "host1,1::999.999.999.999",
+        "host1:65536,host2",
+        "host1,user:secret@host2,host3",
+        "host1,host two",
+        "host1,[fe80::1%eth 0]"
+      })
+  void dbExecutionRejectsMalformedMultiHostAddress(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 65536, 70000})
+  void dbExecutionRejectsOutOfRangeSharedPort(int port) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "host1,host2")
+            .option(ConnectionFactoryOptions.PORT, port)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
+  void dbExecutionPreservesUnixDomainSocketWithoutPort() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "/var/run/postgresql/.s.PGSQL.5432")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress())
+        .isEqualTo("/var/run/postgresql/.s.PGSQL.5432");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/",
+        "/var/run/postgresql,host2",
+        "/var/run/postgresql=secret",
+        "/var/run/postgresql%3Fpassword%3Dsecret",
+        "/var/run/user:secret@postgresql",
+        "/var/run/postgresql?password=secret",
+        "/var/run/postgresql#fragment"
+      })
+  void dbExecutionRejectsMalformedOrSensitiveUnixDomainSocket(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"host1,host1", "[2001:db8::1],2001:db8::1", "[fe80::1%eth0],fe80::1%eth0"})
+  void dbExecutionTreatsSingleHostAsSingular(String host, String configuredAddress) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getServerAddress()).isEqualTo(host);
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo(configuredAddress);
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"host%3Fpassword%3Dsecret", "host%3fpassword%3dsecret:5432"})
+  void dbExecutionRejectsPercentEscapesInNonIpv6Hosts(String host) {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, host)
+            .build();
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isNull();
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  private static QueryExecutionInfo queryExecutionInfo() {
+    return MockQueryExecutionInfo.builder()
+        .queryInfo(new QueryInfo("SELECT 1"))
+        .connectionInfo(MockConnectionInfo.builder().build())
+        .build();
+  }
 }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/DbExecutionTest.java
@@ -295,6 +295,17 @@ class DbExecutionTest {
   }
 
   @Test
+  void dbExecutionReadsTheSslOptionFromAConnectionUrl() {
+    ConnectionFactoryOptions factoryOptions =
+        ConnectionFactoryOptions.parse("r2dbc:clickhouse:tcp://host1:9440/db?ssl=true");
+
+    DbExecution dbExecution = new DbExecution(queryExecutionInfo(), factoryOptions);
+
+    assertThat(dbExecution.getConfiguredServerAddress()).isEqualTo("host1");
+    assertThat(dbExecution.getConfiguredServerPort()).isNull();
+  }
+
+  @Test
   void dbExecutionUsesNestedPoolProtocolDefaults() {
     ConnectionFactoryOptions factoryOptions =
         ConnectionFactoryOptions.builder()

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.r2dbc.v1_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_IDENTIFIERS;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.SqlDialect.DOUBLE_QUOTES_ARE_STRING_LITERALS;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -94,5 +95,146 @@ class R2dbcSqlAttributesGetterTest {
         argumentSet("MySQL", "r2dbc:mysql://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS),
         argumentSet("SQL Server", "r2dbc:mssql://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS),
         argumentSet("unknown", "r2dbc:unknown://localhost/db", DOUBLE_QUOTES_ARE_STRING_LITERALS));
+  }
+
+  @Test
+  void multiHostUrlKeepsAddressAndHasNoPort() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.parse("r2dbc:mariadb:sequential://host1:3306,host2:3307/db"));
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1:3306,host2:3307");
+    assertThat(getter.getServerPort(dbExecution)).isNull();
+  }
+
+  @Test
+  void multiHostOptionsOmitTheKnownDefaultPortInStableSemconv() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+                .option(ConnectionFactoryOptions.HOST, "host1,host2")
+                .option(ConnectionFactoryOptions.PORT, 3306)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1,host2");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 3306);
+  }
+
+  @Test
+  void multiHostOptionsInlineASharedNonDefaultPortInStableSemconv() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "mariadb")
+                .option(ConnectionFactoryOptions.HOST, "host1,host2")
+                .option(ConnectionFactoryOptions.PORT, 3307)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1:3307,host2:3307" : "host1,host2");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 3307);
+  }
+
+  @Test
+  void multiHostOptionsRemoveUserInfoFromTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "user:secret@host1,host2")
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1,host2" : "user:secret@host1,host2");
+  }
+
+  @Test
+  void malformedMultiHostOptionsOmitTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "host1:invalid,host2")
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : "host1:invalid,host2");
+  }
+
+  @Test
+  void singleHostOptionsRemoveUserInfoFromTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "user:secret@host1")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? "host1" : "user:secret@host1");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
+  @Test
+  void malformedSingleHostOptionsOmitTheStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "host1:invalid")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : "host1:invalid");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
+  @Test
+  void singleHostOmitsKnownDefaultPortInStableMode() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.parse("r2dbc:postgresql://host1:5432/db"));
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("host1");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
+  @Test
+  void unixDomainSocketOmitsPortFromStableTarget() {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, "/var/run/postgresql/.s.PGSQL.5432")
+                .option(ConnectionFactoryOptions.PORT, 5432)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution)).isEqualTo("/var/run/postgresql/.s.PGSQL.5432");
+    assertThat(getter.getServerPort(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : 5432);
+  }
+
+  private static QueryExecutionInfo queryExecutionInfo() {
+    return MockQueryExecutionInfo.builder()
+        .queryInfo(new QueryInfo("SELECT 1"))
+        .connectionInfo(MockConnectionInfo.builder().build())
+        .build();
   }
 }

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/R2dbcSqlAttributesGetterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("deprecation") // testing old database semantic conventions
 class R2dbcSqlAttributesGetterTest {
@@ -167,6 +168,22 @@ class R2dbcSqlAttributesGetterTest {
 
     assertThat(getter.getServerAddress(dbExecution))
         .isEqualTo(emitStableDatabaseSemconv() ? null : "host1:invalid,host2");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"[host1]:5432", "[host1]:5432,host2"})
+  void bracketedNonIpv6OptionsOmitTheStableTarget(String host) {
+    DbExecution dbExecution =
+        new DbExecution(
+            queryExecutionInfo(),
+            ConnectionFactoryOptions.builder()
+                .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+                .option(ConnectionFactoryOptions.HOST, host)
+                .build());
+
+    assertThat(getter.getServerAddress(dbExecution))
+        .isEqualTo(emitStableDatabaseSemconv() ? null : host);
+    assertThat(getter.getServerPort(dbExecution)).isNull();
   }
 
   @Test

--- a/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListenerTest.java
+++ b/instrumentation/r2dbc-1.0/library/src/test/java/io/opentelemetry/instrumentation/r2dbc/v1_0/internal/TraceProxyListenerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.r2dbc.v1_0.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import io.r2dbc.proxy.core.QueryExecutionInfo;
+import io.r2dbc.proxy.core.QueryInfo;
+import io.r2dbc.proxy.test.MockConnectionInfo;
+import io.r2dbc.proxy.test.MockQueryExecutionInfo;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.ConnectionMetadata;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class TraceProxyListenerTest {
+
+  @Test
+  @SuppressWarnings("deprecation") // testing deprecated semconv
+  void sharesConfigurationSnapshotAcrossExecutions() {
+    Connection firstConnection = connection("firstdb");
+    Connection secondConnection = connection("seconddb");
+    QueryExecutionInfo firstQuery = queryExecutionInfo(firstConnection, "SELECT first");
+    QueryExecutionInfo secondQuery = queryExecutionInfo(secondConnection, "SELECT second");
+    Context firstContext = mock(Context.class);
+    Context secondContext = mock(Context.class);
+    @SuppressWarnings("unchecked")
+    Instrumenter<DbExecution, Void> instrumenter = mock(Instrumenter.class);
+    when(instrumenter.shouldStart(any(), any())).thenReturn(true);
+    when(instrumenter.start(any(), any())).thenReturn(firstContext, secondContext);
+    TraceProxyListener listener =
+        new TraceProxyListener(
+            instrumenter,
+            ConnectionFactoryOptions.parse("r2dbc:pool:clickhouse:http://dbhost:8123/mydb"));
+
+    listener.beforeQuery(firstQuery);
+    listener.beforeQuery(secondQuery);
+
+    ArgumentCaptor<DbExecution> executionCaptor = ArgumentCaptor.forClass(DbExecution.class);
+    verify(instrumenter, times(2)).start(any(), executionCaptor.capture());
+    DbExecution firstExecution = executionCaptor.getAllValues().get(0);
+    DbExecution secondExecution = executionCaptor.getAllValues().get(1);
+    assertThat(firstExecution).isNotSameAs(secondExecution);
+    assertThat(firstExecution.connectionInfo()).isSameAs(secondExecution.connectionInfo());
+    assertThat(firstExecution.getSystem()).isEqualTo("firstdb");
+    assertThat(secondExecution.getSystem()).isEqualTo("seconddb");
+    assertThat(firstExecution.getRawQueryTexts()).containsExactly("SELECT first");
+    assertThat(secondExecution.getRawQueryTexts()).containsExactly("SELECT second");
+    assertThat(firstExecution.getContext()).isSameAs(firstContext);
+    assertThat(secondExecution.getContext()).isSameAs(secondContext);
+    assertThat(firstExecution.getSystemName()).isEqualTo("other_sql");
+    assertThat(secondExecution.getConfiguredServerAddress()).isEqualTo("dbhost");
+    assertThat(secondExecution.getConfiguredServerPort()).isNull();
+  }
+
+  private static Connection connection(String databaseProductName) {
+    ConnectionMetadata metadata = mock(ConnectionMetadata.class);
+    when(metadata.getDatabaseProductName()).thenReturn(databaseProductName);
+    Connection connection = mock(Connection.class);
+    when(connection.getMetadata()).thenReturn(metadata);
+    return connection;
+  }
+
+  private static QueryExecutionInfo queryExecutionInfo(Connection connection, String query) {
+    return MockQueryExecutionInfo.builder()
+        .queryInfo(new QueryInfo(query))
+        .connectionInfo(MockConnectionInfo.builder().originalConnection(connection).build())
+        .build();
+  }
+}


### PR DESCRIPTION
Report configured R2DBC targets through stable `server.address` and `server.port` attributes without changing legacy database semantic conventions. This does not add `network.peer.*` attributes.

For PostgreSQL configured with `host1,host2` and shared port `6432`, stable telemetry reports `server.address=host1:6432,host2:6432` and omits `server.port`.

The stable attributes omit known default ports, keep explicit non-default ports, and include at most five endpoints. They preserve Unix-domain socket paths without a port and remove user info from valid targets. Malformed or ambiguous targets are omitted.

Part of #19899