### PR TITLE
Clarify inline conditional test assertions

### DIFF
--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -276,7 +276,7 @@ site.
 | `otel.semconv-stability.opt-in=…`              | `emitStableDatabaseSemconv()`, `emitOldDatabaseSemconv()`, `emitStableCodeSemconv()`, etc.                         | `io.opentelemetry.instrumentation.api.internal.SemconvStability`                |
 | `otel.instrumentation.<module>.experimental-*` | per-module `EXPERIMENTAL_ATTRIBUTES` constant — see [testing-experimental-flags.md](testing-experimental-flags.md) | within the test class                                                           |
 
-### Inline ternary in `equalTo(...)` with `null` for "absent"
+### Inline conditional expected values
 
 Push the ternary as deep as possible — into the `equalTo` value or single attribute key —
 rather than duplicating two whole `hasAttributesSatisfyingExactly(...)` blocks under a
@@ -285,7 +285,18 @@ rather than duplicating two whole `hasAttributesSatisfyingExactly(...)` blocks u
 ```java
 equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB)
 equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null)
-equalTo(SOME_KEY, EXPERIMENTAL_ATTRIBUTES ? "value" : null)
+equalTo(SOME_KEY, experimental("value"))
 span.hasName(testLatestDeps() ? "GET" : "HTTP GET")
 .hasParent(trace.getSpan(testLatestDeps() ? 0 : 1))
 ```
+
+Keep short conditional expected values directly in the assertion, even when several
+assertions repeat the same condition. Do not extract the branch selection into helpers such
+as `spanName(...)`, `oldOrExperimental(value)`, or `expectedNamespace()`. Those helpers hide
+the expected values at the point where a reader needs them. The conventional
+`experimental(value)` helper is the exception — it unambiguously means the value is expected
+only when experimental attributes are enabled, and `null` otherwise, so keep it instead of
+inlining `EXPERIMENTAL_ATTRIBUTES ? value : null`.
+
+A helper may obtain the mode flag or perform nontrivial derivation from test data. It should
+not choose between short expected values on the assertion's behalf.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -70,6 +70,30 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   when `value` is already an `int` — the `equalTo(AttributeKey<Long>, int)`
   overload exists.
 
+## [Testing] Inline Conditional Expected Values
+
+- Keep short conditional expected values directly in the assertion, especially
+  span names and attribute values:
+
+  ```java
+  span.hasName(emitStableMessagingSemconv() ? "send orders" : "orders publish");
+  equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null);
+  ```
+
+- Do not extract the ternary into a helper such as `spanName(...)`,
+  `oldOrExperimental(value)`, or `expectedNamespace()`. Inline it even when
+  several assertions repeat the same condition. Seeing both expected values at
+  the assertion is more useful than deduplicating a short expression.
+- The conventional `experimental(value)` helper is the one exception: keep it.
+  Its name unambiguously means the value is expected only when experimental
+  attributes are enabled, and `null` otherwise, so it reads clearer than the
+  inlined ternary it would otherwise become.
+- A helper may still obtain the mode flag or perform nontrivial derivation from
+  test data. It should not choose between short expected values on the
+  assertion's behalf.
+- Put the ternary around the narrowest value that changes. Do not duplicate a
+  whole assertion chain or attribute block for each mode.
+
 ## [Testing] `satisfies()` Lambda Parameters
 
 Inside a `satisfies(AttributeKey, lambda)` attribute-assertion the lambda


### PR DESCRIPTION
Clarifies that short mode-dependent expected values belong directly in test assertions so span names and attribute values remain visible at the point of use.

Keeps `experimental(value)` as the established exception, permits helpers that perform real derivation, and recommends placing ternaries around the narrowest changing value.

Repository-wide cleanup is tracked in #19984 to avoid conflicts with active pull requests.