### PR TITLE
Report fixed Vert.x SQL 5 targets in database spans

### DIFF
--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/build.gradle.kts
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/build.gradle.kts
@@ -38,6 +38,7 @@ tasks {
   withType<Test>().configureEach {
     usesService(gradle.sharedServices.registrations["testcontainersBuildService"].service)
     systemProperty("collectMetadata", otelProps.collectMetadata)
+    systemProperty("testLatestDeps", otelProps.testLatestDeps)
   }
 
   val testStableSemconv = register<Test>("testStableSemconv") {

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
@@ -124,6 +124,7 @@ class ClientBuilderInstrumentation implements TypeInstrumentation {
 
       BuildState state = (BuildState) enterState[1];
       state.constructionState.complete(client);
+      // Restore the original connect handler after onEnter temporarily replaced it.
       return new Object[] {state.connectHandler};
     }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
@@ -61,8 +61,7 @@ class ClientBuilderInstrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.This Object clientBuilder,
         @Advice.Argument(0) SqlConnectOptions sqlConnectOptions) {
-      VertxSqlClientSingletons.storeBuilderDatabases(
-          clientBuilder, singletonList(sqlConnectOptions));
+      VertxSqlClientSingletons.setBuilderDatabases(clientBuilder, singletonList(sqlConnectOptions));
     }
   }
 
@@ -70,7 +69,7 @@ class ClientBuilderInstrumentation implements TypeInstrumentation {
   public static class ConnectingToSupplierAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static void onEnter(@Advice.This Object clientBuilder) {
-      VertxSqlClientSingletons.storeBuilderDatabases(clientBuilder, null);
+      VertxSqlClientSingletons.setBuilderDatabases(clientBuilder, null);
     }
   }
 
@@ -79,7 +78,7 @@ class ClientBuilderInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.This Object clientBuilder, @Advice.Argument(0) List<SqlConnectOptions> databases) {
-      VertxSqlClientSingletons.storeBuilderDatabases(clientBuilder, databases);
+      VertxSqlClientSingletons.setBuilderDatabases(clientBuilder, databases);
     }
   }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/ClientBuilderInstrumentation.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
+
+import static java.util.Collections.singletonList;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientInfo;
+import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.SqlConnection;
+import java.util.List;
+import javax.annotation.Nullable;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.Advice.AssignReturned.ToFields.ToField;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+// All connectingTo overloads delegate to the Supplier overload, which clears the previous target.
+class ClientBuilderInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("io.vertx.sqlclient.impl.ClientBuilderBase");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("connectingTo")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("java.util.function.Supplier"))),
+        getClass().getName() + "$ConnectingToSupplierAdvice");
+
+    transformer.applyAdviceToMethod(
+        named("connectingTo")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("io.vertx.sqlclient.SqlConnectOptions"))),
+        getClass().getName() + "$ConnectingToOptionsAdvice");
+
+    transformer.applyAdviceToMethod(
+        named("connectingTo").and(takesArguments(1)).and(takesArgument(0, named("java.util.List"))),
+        getClass().getName() + "$ConnectingToListAdvice");
+
+    transformer.applyAdviceToMethod(
+        named("build").and(takesNoArguments()), getClass().getName() + "$BuildAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConnectingToOptionsAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This Object clientBuilder,
+        @Advice.Argument(0) SqlConnectOptions sqlConnectOptions) {
+      VertxSqlClientSingletons.storeBuilderDatabases(
+          clientBuilder, singletonList(sqlConnectOptions));
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConnectingToSupplierAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.This Object clientBuilder) {
+      VertxSqlClientSingletons.storeBuilderDatabases(clientBuilder, null);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConnectingToListAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This Object clientBuilder, @Advice.Argument(0) List<SqlConnectOptions> databases) {
+      VertxSqlClientSingletons.storeBuilderDatabases(clientBuilder, databases);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class BuildAdvice {
+    // The returned array contains the handler to install at index 0 and the exit state at index 1.
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    @Advice.AssignReturned.ToFields(@ToField(value = "connectHandler", index = 0))
+    @Nullable
+    public static Object[] onEnter(
+        @Advice.This Object clientBuilder,
+        @Advice.FieldValue("driver") Object driver,
+        @Advice.FieldValue("connectHandler") @Nullable Handler<SqlConnection> connectHandler) {
+      List<SqlConnectOptions> databases =
+          VertxSqlClientSingletons.getBuilderDatabases(clientBuilder);
+      if (databases == null || databases.isEmpty()) {
+        VertxSqlClientSingletons.setConstructionState(null);
+        return null;
+      }
+      VertxSqlClientConstructionState state =
+          new VertxSqlClientConstructionState(
+              databases, VertxSqlClientUtil.getDbSystemNameFromClassName(driver));
+      VertxSqlClientSingletons.setConstructionState(state);
+      VertxSqlClientInfo info = state.getInfo();
+      return new Object[] {
+        info != null
+            ? VertxSqlClientSingletons.wrapConnectHandler(connectHandler, info)
+            : connectHandler,
+        new BuildState(state, connectHandler)
+      };
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    @Advice.AssignReturned.ToFields(@ToField(value = "connectHandler", index = 0))
+    public static Object[] onExit(
+        @Advice.Return @Nullable Object client,
+        @Advice.FieldValue("connectHandler") @Nullable Handler<SqlConnection> connectHandler,
+        @Advice.Enter @Nullable Object[] enterState) {
+      VertxSqlClientSingletons.setConstructionState(null);
+      if (enterState == null) {
+        return new Object[] {connectHandler};
+      }
+
+      BuildState state = (BuildState) enterState[1];
+      state.constructionState.complete(client);
+      return new Object[] {state.connectHandler};
+    }
+
+    public static class BuildState {
+      public final VertxSqlClientConstructionState constructionState;
+      @Nullable public final Handler<SqlConnection> connectHandler;
+
+      public BuildState(
+          VertxSqlClientConstructionState constructionState,
+          @Nullable Handler<SqlConnection> connectHandler) {
+        this.constructionState = constructionState;
+        this.connectHandler = connectHandler;
+      }
+    }
+  }
+}

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/DriverInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/DriverInstrumentation.java
@@ -12,12 +12,11 @@ import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.vertx.sqlclient.Pool;
-import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -40,6 +39,7 @@ class DriverInstrumentation implements TypeInstrumentation {
         named("newPool")
             .and(not(isStatic()))
             .and(takesArguments(6))
+            .and(takesArgument(1, named("java.util.function.Supplier")))
             .and(returns(named("io.vertx.sqlclient.Pool"))),
         getClass().getName() + "$NewPoolAdvice");
   }
@@ -47,10 +47,11 @@ class DriverInstrumentation implements TypeInstrumentation {
   @SuppressWarnings("unused")
   public static class NewPoolAdvice {
 
-    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-    public static void onExit(@Advice.This Object driver, @Advice.Return @Nullable Pool pool) {
-      if (pool != null) {
-        VertxSqlClientSingletons.storePoolDbSystem(pool, getDbSystemNameFromClassName(driver));
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.This Object driver) {
+      VertxSqlClientConstructionState state = VertxSqlClientSingletons.getConstructionState();
+      if (state != null) {
+        state.setDbSystemName(getDbSystemNameFromClassName(driver));
       }
     }
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
@@ -7,10 +7,10 @@ package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.getPoolSqlConnectOptions;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.setPoolConnectOptions;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.setSqlConnectOptions;
+import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.getDbSystemNameFromClassName;
+import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.resolveDbSystemName;
 import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.wrapContext;
+import static java.util.Collections.singletonList;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -21,6 +21,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientInfo;
 import io.vertx.core.Future;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.SqlConnectOptions;
@@ -40,8 +41,6 @@ class PoolInstrumentation implements TypeInstrumentation {
 
   @Override
   public ElementMatcher<TypeDescription> typeMatcher() {
-    // Match both the Pool interface (for static pool() factory methods) and classes/interfaces
-    // that implement/extend Pool (for instance methods like getConnection())
     return implementsInterface(named("io.vertx.sqlclient.Pool"));
   }
 
@@ -64,31 +63,33 @@ class PoolInstrumentation implements TypeInstrumentation {
   public static class PoolAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static CallDepth onEnter(@Advice.Argument(1) SqlConnectOptions sqlConnectOptions) {
+    public static CallDepth onEnter(
+        @Advice.Argument(1) SqlConnectOptions sqlConnectOptions,
+        @Advice.Origin("#t") String declaringTypeName) {
       CallDepth callDepth = CallDepth.forClass(Pool.class);
-      if (callDepth.getAndIncrement() > 0) {
-        return callDepth;
+      if (callDepth.getAndIncrement() == 0) {
+        String dbSystemName = resolveDbSystemName(sqlConnectOptions, declaringTypeName);
+        VertxSqlClientSingletons.setConstructionState(
+            new VertxSqlClientConstructionState(singletonList(sqlConnectOptions), dbSystemName));
       }
-
-      // set connection options to ThreadLocal, they will be read in SqlClientBase constructor
-      setSqlConnectOptions(sqlConnectOptions);
       return callDepth;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.Return @Nullable Pool pool,
-        @Advice.Argument(1) SqlConnectOptions sqlConnectOptions,
-        @Advice.Enter CallDepth callDepth) {
+        @Advice.Return @Nullable Pool pool, @Advice.Enter CallDepth callDepth) {
       if (callDepth.decrementAndGet() > 0) {
         return;
       }
 
-      if (pool != null) {
-        setPoolConnectOptions(pool, sqlConnectOptions);
-        VertxSqlClientSingletons.resolveAndStoreDbSystem(pool, sqlConnectOptions);
+      VertxSqlClientConstructionState state = VertxSqlClientSingletons.getConstructionState();
+      VertxSqlClientSingletons.setConstructionState(null);
+      if (state != null) {
+        if (pool != null) {
+          state.setDbSystemName(getDbSystemNameFromClassName(pool));
+        }
+        state.complete(pool);
       }
-      setSqlConnectOptions(null);
     }
   }
 
@@ -98,10 +99,8 @@ class PoolInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static Future<SqlConnection> onExit(
         @Advice.This Pool pool, @Advice.Return Future<SqlConnection> future) {
-      // copy connect options stored on pool to new connection
-      SqlConnectOptions sqlConnectOptions = getPoolSqlConnectOptions(pool);
-
-      return wrapContext(VertxSqlClientSingletons.attachConnectOptions(future, sqlConnectOptions));
+      VertxSqlClientInfo info = VertxSqlClientSingletons.getPoolInfo(pool);
+      return wrapContext(VertxSqlClientSingletons.attachClientInfo(future, info));
     }
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
@@ -34,26 +34,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 class PoolInstrumentation implements TypeInstrumentation {
 
-  public static final class PoolConstructionState {
-    private final CallDepth callDepth;
-    @Nullable private final VertxSqlClientConstructionState constructionState;
-
-    public PoolConstructionState(
-        CallDepth callDepth, @Nullable VertxSqlClientConstructionState constructionState) {
-      this.callDepth = callDepth;
-      this.constructionState = constructionState;
-    }
-
-    public boolean isNested() {
-      return callDepth.decrementAndGet() > 0;
-    }
-
-    @Nullable
-    public VertxSqlClientConstructionState getConstructionState() {
-      return constructionState;
-    }
-  }
-
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("io.vertx.sqlclient.Pool");
@@ -112,6 +92,26 @@ class PoolInstrumentation implements TypeInstrumentation {
           constructionState.setDbSystemName(getDbSystemNameFromClassName(pool));
         }
         constructionState.complete(pool);
+      }
+    }
+
+    public static final class PoolConstructionState {
+      private final CallDepth callDepth;
+      @Nullable private final VertxSqlClientConstructionState constructionState;
+
+      public PoolConstructionState(
+          CallDepth callDepth, @Nullable VertxSqlClientConstructionState constructionState) {
+        this.callDepth = callDepth;
+        this.constructionState = constructionState;
+      }
+
+      public boolean isNested() {
+        return callDepth.decrementAndGet() > 0;
+      }
+
+      @Nullable
+      public VertxSqlClientConstructionState getConstructionState() {
+        return constructionState;
       }
     }
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PoolInstrumentation.java
@@ -34,6 +34,26 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 class PoolInstrumentation implements TypeInstrumentation {
 
+  public static final class PoolConstructionState {
+    private final CallDepth callDepth;
+    @Nullable private final VertxSqlClientConstructionState constructionState;
+
+    public PoolConstructionState(
+        CallDepth callDepth, @Nullable VertxSqlClientConstructionState constructionState) {
+      this.callDepth = callDepth;
+      this.constructionState = constructionState;
+    }
+
+    public boolean isNested() {
+      return callDepth.decrementAndGet() > 0;
+    }
+
+    @Nullable
+    public VertxSqlClientConstructionState getConstructionState() {
+      return constructionState;
+    }
+  }
+
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
     return hasClassesNamed("io.vertx.sqlclient.Pool");
@@ -63,32 +83,35 @@ class PoolInstrumentation implements TypeInstrumentation {
   public static class PoolAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-    public static CallDepth onEnter(
+    public static PoolConstructionState onEnter(
         @Advice.Argument(1) SqlConnectOptions sqlConnectOptions,
         @Advice.Origin("#t") String declaringTypeName) {
       CallDepth callDepth = CallDepth.forClass(Pool.class);
-      if (callDepth.getAndIncrement() == 0) {
-        String dbSystemName = resolveDbSystemName(sqlConnectOptions, declaringTypeName);
-        VertxSqlClientSingletons.setConstructionState(
-            new VertxSqlClientConstructionState(singletonList(sqlConnectOptions), dbSystemName));
+      if (callDepth.getAndIncrement() > 0) {
+        return new PoolConstructionState(callDepth, null);
       }
-      return callDepth;
+
+      String dbSystemName = resolveDbSystemName(sqlConnectOptions, declaringTypeName);
+      VertxSqlClientConstructionState constructionState =
+          new VertxSqlClientConstructionState(singletonList(sqlConnectOptions), dbSystemName);
+      VertxSqlClientSingletons.setConstructionState(constructionState);
+      return new PoolConstructionState(callDepth, constructionState);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
-        @Advice.Return @Nullable Pool pool, @Advice.Enter CallDepth callDepth) {
-      if (callDepth.decrementAndGet() > 0) {
+        @Advice.Return @Nullable Pool pool, @Advice.Enter PoolConstructionState state) {
+      if (state.isNested()) {
         return;
       }
 
-      VertxSqlClientConstructionState state = VertxSqlClientSingletons.getConstructionState();
+      VertxSqlClientConstructionState constructionState = state.getConstructionState();
       VertxSqlClientSingletons.setConstructionState(null);
-      if (state != null) {
+      if (constructionState != null) {
         if (pool != null) {
-          state.setDbSystemName(getDbSystemNameFromClassName(pool));
+          constructionState.setDbSystemName(getDbSystemNameFromClassName(pool));
         }
-        state.complete(pool);
+        constructionState.complete(pool);
       }
     }
   }
@@ -99,7 +122,7 @@ class PoolInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static Future<SqlConnection> onExit(
         @Advice.This Pool pool, @Advice.Return Future<SqlConnection> future) {
-      VertxSqlClientInfo info = VertxSqlClientSingletons.getPoolInfo(pool);
+      VertxSqlClientInfo info = VertxSqlClientSingletons.getPoolClientInfo(pool);
       return wrapContext(VertxSqlClientSingletons.attachClientInfo(future, info));
     }
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PreparedStatementInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/PreparedStatementInstrumentation.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
 
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.setDbSystem;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.setSqlConnectOptions;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -35,14 +33,10 @@ class PreparedStatementInstrumentation implements TypeInstrumentation {
     public static void onEnter(@Advice.This PreparedStatement preparedStatement) {
       VertxSqlClientSingletons.setClientInfo(
           VertxSqlClientSingletons.getPreparedStatementInfo(preparedStatement));
-      setSqlConnectOptions(null);
-      setDbSystem(null);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit() {
-      setSqlConnectOptions(null);
-      setDbSystem(null);
       VertxSqlClientSingletons.setClientInfo(null);
     }
   }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/QueryExecutorInstrumentation.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
 
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.getDbSystem;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.getSqlConnectOptions;
 import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0.VertxSqlClientSingletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -22,7 +20,6 @@ import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.Ve
 import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil;
 import io.vertx.core.Promise;
 import io.vertx.core.internal.PromiseInternal;
-import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.internal.PreparedStatement;
 import java.util.Collection;
 import javax.annotation.Nullable;
@@ -50,21 +47,8 @@ class QueryExecutorInstrumentation implements TypeInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.This Object queryExecutor) {
-      VertxSqlClientInfo info = VertxSqlClientSingletons.getClientInfo();
-      if (info != null) {
-        VertxSqlClientSingletons.setQueryExecutorInfo(queryExecutor, info);
-        return;
-      }
-      SqlConnectOptions connectOptions = getSqlConnectOptions();
-      String dbSystem = getDbSystem();
-      if (dbSystem == null && connectOptions != null) {
-        dbSystem = VertxSqlClientSingletons.getConnectOptionsDbSystem(connectOptions);
-      }
-      if (dbSystem == null) {
-        dbSystem = VertxSqlClientUtil.getDbSystemNameFromClassName(connectOptions);
-      }
       VertxSqlClientSingletons.setQueryExecutorInfo(
-          queryExecutor, VertxSqlClientInfo.createLegacy(connectOptions, dbSystem));
+          queryExecutor, VertxSqlClientSingletons.getClientInfo());
     }
   }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/SqlClientBaseInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/SqlClientBaseInstrumentation.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
 
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.getSqlConnectOptions;
-import static io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil.setSqlConnectOptions;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
@@ -14,7 +12,6 @@ import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.internal.SqlClientBase;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -38,8 +35,13 @@ class SqlClientBaseInstrumentation implements TypeInstrumentation {
   public static class ConstructorAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.This SqlClientBase sqlClientBase) {
-      // copy connection options from ThreadLocal to VirtualField
-      VertxSqlClientSingletons.attachConnectOptions(sqlClientBase, getSqlConnectOptions());
+      VertxSqlClientConstructionState state = VertxSqlClientSingletons.getConstructionState();
+      if (state != null) {
+        state.attachClient(sqlClientBase);
+      } else {
+        VertxSqlClientSingletons.attachClientInfo(
+            sqlClientBase, VertxSqlClientSingletons.getClientInfo());
+      }
     }
   }
 
@@ -52,10 +54,7 @@ class SqlClientBaseInstrumentation implements TypeInstrumentation {
         return callDepth;
       }
 
-      // set connection options to ThreadLocal, they will be read in QueryExecutor constructor
-      SqlConnectOptions sqlConnectOptions =
-          VertxSqlClientSingletons.getSqlConnectOptions(sqlClientBase);
-      setSqlConnectOptions(sqlConnectOptions);
+      VertxSqlClientSingletons.setClientInfo(VertxSqlClientSingletons.getClientInfo(sqlClientBase));
       return callDepth;
     }
 
@@ -65,7 +64,7 @@ class SqlClientBaseInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      setSqlConnectOptions(null);
+      VertxSqlClientSingletons.setClientInfo(null);
     }
   }
 }

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/SqlConnectionBaseInstrumentation.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/SqlConnectionBaseInstrumentation.java
@@ -15,7 +15,6 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientInfo;
 import io.vertx.core.Future;
 import io.vertx.sqlclient.PreparedStatement;
-import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.internal.SqlClientBase;
 import io.vertx.sqlclient.internal.SqlConnectionBase;
 import javax.annotation.Nullable;
@@ -61,13 +60,7 @@ class SqlConnectionBaseInstrumentation implements TypeInstrumentation {
         return future;
       }
 
-      SqlConnectOptions connectOptions =
-          VertxSqlClientSingletons.getSqlConnectOptions(sqlClientBase);
-      String dbSystem =
-          connectOptions != null
-              ? VertxSqlClientSingletons.getConnectOptionsDbSystem(connectOptions)
-              : null;
-      VertxSqlClientInfo info = VertxSqlClientInfo.createLegacy(connectOptions, dbSystem);
+      VertxSqlClientInfo info = VertxSqlClientSingletons.getClientInfo(sqlClientBase);
       return info == null
           ? future
           : wrapContext(VertxSqlClientSingletons.attachPreparedStatementInfo(future, info));

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientConstructionState.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientConstructionState.java
@@ -52,7 +52,7 @@ public final class VertxSqlClientConstructionState {
       publish(constructedClient);
     }
     if (client instanceof Pool) {
-      VertxSqlClientSingletons.setPoolInfo((Pool) client, info);
+      VertxSqlClientSingletons.setPoolClientInfo((Pool) client, info);
     }
   }
 

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientConstructionState.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientConstructionState.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.v5_0;
+
+import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientInfo;
+import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlClientUtil;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.internal.SqlClientBase;
+import io.vertx.sqlclient.internal.SqlConnectionBase;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public final class VertxSqlClientConstructionState {
+  private final List<SqlConnectOptions> databases;
+  private final List<SqlClientBase> clients = new ArrayList<>();
+  @Nullable private VertxSqlClientInfo info;
+
+  public VertxSqlClientConstructionState(List<SqlConnectOptions> databases, String dbSystemName) {
+    this.databases = databases;
+    updateInfo(dbSystemName);
+  }
+
+  @Nullable
+  public VertxSqlClientInfo getInfo() {
+    return info;
+  }
+
+  public void setDbSystemName(String dbSystemName) {
+    if (info == null || !VertxSqlClientUtil.isKnownDbSystem(info.getDbSystemName())) {
+      updateInfo(dbSystemName);
+    }
+  }
+
+  private void updateInfo(String dbSystemName) {
+    info = VertxSqlClientInfo.create(databases, dbSystemName);
+  }
+
+  public void attachClient(SqlClientBase client) {
+    if (!(client instanceof SqlConnectionBase)) {
+      clients.add(client);
+    }
+    publish(client);
+  }
+
+  public void complete(@Nullable Object client) {
+    for (SqlClientBase constructedClient : clients) {
+      publish(constructedClient);
+    }
+    if (client instanceof Pool) {
+      VertxSqlClientSingletons.setPoolInfo((Pool) client, info);
+    }
+  }
+
+  private void publish(SqlClientBase client) {
+    VertxSqlClientSingletons.attachClientInfo(client, info);
+  }
+}

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientInstrumentationModule.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientInstrumentationModule.java
@@ -45,6 +45,7 @@ public class VertxSqlClientInstrumentationModule extends InstrumentationModule
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return asList(
+        new ClientBuilderInstrumentation(),
         new CommandSchedulerInstrumentation(),
         new DriverInstrumentation(),
         new PoolInstrumentation(),

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
@@ -13,12 +13,15 @@ import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.Ve
 import io.opentelemetry.javaagent.instrumentation.vertx.sqlclient.common.v4_0.VertxSqlInstrumenterFactory;
 import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
 import io.vertx.sqlclient.impl.QueryExecutorUtil;
 import io.vertx.sqlclient.internal.SqlClientBase;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class VertxSqlClientSingletons {
@@ -27,17 +30,16 @@ public class VertxSqlClientSingletons {
       VertxSqlInstrumenterFactory.createInstrumenter(INSTRUMENTATION_NAME);
 
   private static final ThreadLocal<VertxSqlClientInfo> clientInfo = new ThreadLocal<>();
+  private static final ThreadLocal<VertxSqlClientConstructionState> constructionState =
+      new ThreadLocal<>();
   private static final VirtualField<PreparedStatement, VertxSqlClientInfo> PREPARED_STATEMENT_INFO =
       VirtualField.find(PreparedStatement.class, VertxSqlClientInfo.class);
-
-  private static final VirtualField<Pool, String> POOL_DB_SYSTEM =
-      VirtualField.find(Pool.class, String.class);
-
-  private static final VirtualField<SqlConnectOptions, String> CONNECT_OPTIONS_DB_SYSTEM =
-      VirtualField.find(SqlConnectOptions.class, String.class);
-
-  private static final VirtualField<SqlClientBase, SqlConnectOptions> CONNECT_OPTIONS =
-      VirtualField.find(SqlClientBase.class, SqlConnectOptions.class);
+  private static final VirtualField<Pool, VertxSqlClientInfo> POOL_INFO =
+      VirtualField.find(Pool.class, VertxSqlClientInfo.class);
+  private static final VirtualField<SqlClientBase, VertxSqlClientInfo> CLIENT_INFO =
+      VirtualField.find(SqlClientBase.class, VertxSqlClientInfo.class);
+  private static final VirtualField<ClientBuilderBase<?>, List<SqlConnectOptions>>
+      BUILDER_DATABASES = VirtualField.find(ClientBuilderBase.class, List.class);
 
   @Nullable
   private static final VirtualField<Object, Context> COMMAND_CONTEXT =
@@ -60,6 +62,11 @@ public class VertxSqlClientSingletons {
     return clientInfo.get();
   }
 
+  @Nullable
+  public static VertxSqlClientInfo getClientInfo(SqlClientBase sqlClientBase) {
+    return CLIENT_INFO.get(sqlClientBase);
+  }
+
   public static void setQueryExecutorInfo(Object queryExecutor, @Nullable VertxSqlClientInfo info) {
     QueryExecutorUtil.setData(queryExecutor, info);
   }
@@ -67,6 +74,15 @@ public class VertxSqlClientSingletons {
   @Nullable
   public static VertxSqlClientInfo getQueryExecutorInfo(Object queryExecutor) {
     return (VertxSqlClientInfo) QueryExecutorUtil.getData(queryExecutor);
+  }
+
+  public static void setPoolInfo(Pool pool, @Nullable VertxSqlClientInfo info) {
+    POOL_INFO.set(pool, info);
+  }
+
+  @Nullable
+  public static VertxSqlClientInfo getPoolInfo(Pool pool) {
+    return POOL_INFO.get(pool);
   }
 
   public static Future<PreparedStatement> attachPreparedStatementInfo(
@@ -118,41 +134,61 @@ public class VertxSqlClientSingletons {
     }
   }
 
-  public static void storePoolDbSystem(Pool pool, String dbSystem) {
-    POOL_DB_SYSTEM.set(pool, dbSystem);
+  public static void attachClientInfo(
+      SqlClientBase sqlClientBase, @Nullable VertxSqlClientInfo info) {
+    CLIENT_INFO.set(sqlClientBase, info);
+  }
+
+  public static Future<SqlConnection> attachClientInfo(
+      Future<SqlConnection> future, @Nullable VertxSqlClientInfo info) {
+    return future.map(
+        connection -> {
+          if (connection instanceof SqlClientBase) {
+            attachClientInfo((SqlClientBase) connection, info);
+          }
+          return connection;
+        });
   }
 
   @Nullable
-  public static String getConnectOptionsDbSystem(SqlConnectOptions sqlConnectOptions) {
-    return CONNECT_OPTIONS_DB_SYSTEM.get(sqlConnectOptions);
+  public static Handler<SqlConnection> wrapConnectHandler(
+      @Nullable Handler<SqlConnection> handler, VertxSqlClientInfo info) {
+    if (handler == null) {
+      return null;
+    }
+    return connection -> {
+      if (connection instanceof SqlClientBase) {
+        attachClientInfo((SqlClientBase) connection, info);
+      }
+      handler.handle(connection);
+    };
   }
 
-  public static void resolveAndStoreDbSystem(Pool pool, SqlConnectOptions sqlConnectOptions) {
-    String dbSystem = POOL_DB_SYSTEM.get(pool);
-    if (sqlConnectOptions != null && dbSystem != null) {
-      CONNECT_OPTIONS_DB_SYSTEM.set(sqlConnectOptions, dbSystem);
+  public static void setConstructionState(@Nullable VertxSqlClientConstructionState state) {
+    if (state == null) {
+      constructionState.remove();
+    } else {
+      constructionState.set(state);
     }
   }
 
   @Nullable
-  public static SqlConnectOptions getSqlConnectOptions(SqlClientBase sqlClientBase) {
-    return CONNECT_OPTIONS.get(sqlClientBase);
+  public static VertxSqlClientConstructionState getConstructionState() {
+    return constructionState.get();
   }
 
-  public static void attachConnectOptions(
-      SqlClientBase sqlClientBase, @Nullable SqlConnectOptions connectOptions) {
-    CONNECT_OPTIONS.set(sqlClientBase, connectOptions);
+  public static void storeBuilderDatabases(
+      Object clientBuilder, @Nullable List<SqlConnectOptions> databases) {
+    if (clientBuilder instanceof ClientBuilderBase) {
+      BUILDER_DATABASES.set((ClientBuilderBase<?>) clientBuilder, databases);
+    }
   }
 
-  public static Future<SqlConnection> attachConnectOptions(
-      Future<SqlConnection> future, @Nullable SqlConnectOptions connectOptions) {
-    return future.map(
-        sqlConnection -> {
-          if (sqlConnection instanceof SqlClientBase) {
-            CONNECT_OPTIONS.set((SqlClientBase) sqlConnection, connectOptions);
-          }
-          return sqlConnection;
-        });
+  @Nullable
+  public static List<SqlConnectOptions> getBuilderDatabases(Object clientBuilder) {
+    return clientBuilder instanceof ClientBuilderBase
+        ? BUILDER_DATABASES.get((ClientBuilderBase<?>) clientBuilder)
+        : null;
   }
 
   private VertxSqlClientSingletons() {}

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientSingletons.java
@@ -34,7 +34,7 @@ public class VertxSqlClientSingletons {
       new ThreadLocal<>();
   private static final VirtualField<PreparedStatement, VertxSqlClientInfo> PREPARED_STATEMENT_INFO =
       VirtualField.find(PreparedStatement.class, VertxSqlClientInfo.class);
-  private static final VirtualField<Pool, VertxSqlClientInfo> POOL_INFO =
+  private static final VirtualField<Pool, VertxSqlClientInfo> POOL_CLIENT_INFO =
       VirtualField.find(Pool.class, VertxSqlClientInfo.class);
   private static final VirtualField<SqlClientBase, VertxSqlClientInfo> CLIENT_INFO =
       VirtualField.find(SqlClientBase.class, VertxSqlClientInfo.class);
@@ -76,13 +76,13 @@ public class VertxSqlClientSingletons {
     return (VertxSqlClientInfo) QueryExecutorUtil.getData(queryExecutor);
   }
 
-  public static void setPoolInfo(Pool pool, @Nullable VertxSqlClientInfo info) {
-    POOL_INFO.set(pool, info);
+  public static void setPoolClientInfo(Pool pool, @Nullable VertxSqlClientInfo info) {
+    POOL_CLIENT_INFO.set(pool, info);
   }
 
   @Nullable
-  public static VertxSqlClientInfo getPoolInfo(Pool pool) {
-    return POOL_INFO.get(pool);
+  public static VertxSqlClientInfo getPoolClientInfo(Pool pool) {
+    return POOL_CLIENT_INFO.get(pool);
   }
 
   public static Future<PreparedStatement> attachPreparedStatementInfo(
@@ -177,7 +177,7 @@ public class VertxSqlClientSingletons {
     return constructionState.get();
   }
 
-  public static void storeBuilderDatabases(
+  public static void setBuilderDatabases(
       Object clientBuilder, @Nullable List<SqlConnectOptions> databases) {
     if (clientBuilder instanceof ClientBuilderBase) {
       BUILDER_DATABASES.set((ClientBuilderBase<?>) clientBuilder, databases);

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.DbClientMetricsTestUtil.assertDurationMetric;
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.instrumentation.testing.junit.service.SemconvServiceStabilityUtil.maybeStablePeerService;
+import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
@@ -34,22 +35,30 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.counting;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgException;
+import io.vertx.sqlclient.ClientBuilder;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.SqlClient;
+import io.vertx.sqlclient.SqlConnectOptions;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Tuple;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -69,6 +78,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -128,6 +138,432 @@ class VertxSqlClientTest {
         .toCompletionStage()
         .toCompletableFuture()
         .get(30, SECONDS);
+  }
+
+  @Test
+  void testConnectingToServerListReportsTheWholeConfiguredTarget() throws Exception {
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second = new PgConnectOptions(first).setPort(port + 1);
+    Pool listPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, second))
+            .with(new PoolOptions().setMaxSize(1))
+            .build();
+    cleanup.deferCleanup(listPool::close);
+
+    select(listPool);
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)));
+  }
+
+  @Test
+  void testConnectingToServerListWithUnixSocketOmitsStableTarget() throws Exception {
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second =
+        new PgConnectOptions(first).setHost("/var/run/postgres:primary").setPort(5432);
+    Pool listPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, second))
+            .with(new PoolOptions().setMaxSize(1))
+            .build();
+    cleanup.deferCleanup(listPool::close);
+
+    select(listPool);
+
+    testing.waitAndAssertTraces(trace -> assertServerGroup(trace, null));
+  }
+
+  @Test
+  void testConnectingToServerListFailureReportsTheWholeConfiguredTarget() {
+    PgConnectOptions first = new PgConnectOptions(connectOptions()).setHost("127.0.0.1").setPort(1);
+    PgConnectOptions second = new PgConnectOptions(first).setPort(2);
+    Pool listPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, second))
+            .with(new PoolOptions().setMaxSize(1).setConnectionTimeout(5))
+            .build();
+    cleanup.deferCleanup(listPool::close);
+
+    Throwable thrown = catchThrowable(() -> select(listPool));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class);
+    Throwable error = thrown.getCause();
+    assertThat(error).isNotNull();
+    testing.waitAndAssertTraces(
+        trace ->
+            assertServerGroup(
+                trace, "127.0.0.1", 1, "127.0.0.1:1,127.0.0.1:2", "select * from test", error));
+  }
+
+  @Test
+  void testConnectHandlerReportsTheWholeConfiguredTarget() throws Exception {
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second = new PgConnectOptions(first).setPort(port + 1);
+    CompletableFuture<Void> handlerInvoked = new CompletableFuture<>();
+    Pool listPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, second))
+            .withConnectHandler(
+                connection -> {
+                  connection
+                      .query("select * from test")
+                      .execute()
+                      .onComplete(ignored -> connection.close());
+                  handlerInvoked.complete(null);
+                })
+            .with(new PoolOptions().setMaxSize(1))
+            .build();
+    cleanup.deferCleanup(listPool::close);
+
+    SqlConnection connection =
+        listPool.getConnection().toCompletionStage().toCompletableFuture().get(30, SECONDS);
+    cleanup.deferCleanup(connection::close);
+    handlerInvoked.get(30, SECONDS);
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)));
+  }
+
+  @Test
+  void testGenericPoolOptionsUseDriverDbSystem() throws Exception {
+    SqlConnectOptions options = new PgConnectOptions(connectOptions()) {};
+    Pool genericPool = Pool.pool(vertx, options, new PoolOptions().setMaxSize(1));
+    cleanup.deferCleanup(genericPool::close);
+
+    select(genericPool);
+
+    testing.waitAndAssertTraces(VertxSqlClientTest::assertDirectTarget);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testExhaustedFixedPoolTimeoutRetainsConfiguredTarget(boolean serverList) throws Exception {
+    assumeTrue(testLatestDeps());
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second = new PgConnectOptions(first).setPort(port + 1);
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool()
+            .using(vertx)
+            .with(
+                new PoolOptions()
+                    .setMaxSize(1)
+                    .setConnectionTimeout(1)
+                    .setConnectionTimeoutUnit(SECONDS));
+    Pool fixedPool =
+        serverList
+            ? builder.connectingTo(asList(first, second)).build()
+            : builder.connectingTo(first).build();
+    cleanup.deferCleanup(
+        () -> fixedPool.close().toCompletionStage().toCompletableFuture().get(30, SECONDS));
+    SqlConnection connection =
+        fixedPool.getConnection().toCompletionStage().toCompletableFuture().get(30, SECONDS);
+    cleanup.deferCleanup(
+        () -> connection.close().toCompletionStage().toCompletableFuture().get(30, SECONDS));
+
+    Throwable thrown = catchThrowable(() -> select(fixedPool));
+
+    assertThat(thrown).isInstanceOf(ExecutionException.class);
+    Throwable timeout = thrown.getCause();
+    assertThat(timeout).hasMessage("Timeout waiting for connection");
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "select test" : "SELECT tempdb.test")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasNoParent()
+                        .hasStatus(StatusData.error())
+                        .hasEventsSatisfyingExactly(
+                            event ->
+                                event
+                                    .hasName("exception")
+                                    .hasAttributesSatisfyingExactly(
+                                        equalTo(EXCEPTION_TYPE, timeout.getClass().getName()),
+                                        equalTo(EXCEPTION_MESSAGE, timeout.getMessage()),
+                                        satisfies(
+                                            EXCEPTION_STACKTRACE,
+                                            val -> val.isInstanceOf(String.class))))
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(
+                                maybeStable(DB_SYSTEM),
+                                emitStableDatabaseSemconv() ? POSTGRESQL : null),
+                            equalTo(maybeStable(DB_NAME), DB),
+                            equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from test"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(
+                                maybeStable(DB_SQL_TABLE),
+                                emitStableDatabaseSemconv() ? null : "test"),
+                            equalTo(
+                                maybeStablePeerService(),
+                                emitStableDatabaseSemconv() && serverList
+                                    ? null
+                                    : "test-peer-service"),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv() && serverList
+                                    ? host + ":" + port + "," + host + ":" + (port + 1)
+                                    : host),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() && serverList
+                                    ? null
+                                    : Long.valueOf(port)),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? timeout.getClass().getName()
+                                    : null))));
+  }
+
+  @Test
+  void testConnectingToDirectOptionsCapturesTarget() throws Exception {
+    PgConnectOptions options = connectOptions();
+    Pool directPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(options)
+            .with(new PoolOptions().setMaxSize(1))
+            .build();
+    cleanup.deferCleanup(directPool::close);
+
+    select(directPool);
+
+    testing.waitAndAssertTraces(VertxSqlClientTest::assertDirectTarget);
+  }
+
+  @Test
+  void testExplicitPreparedStatementWithServerListReportsTheWholeConfiguredTarget()
+      throws Exception {
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second = new PgConnectOptions(first).setPort(port + 1);
+    Pool listPool =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, second))
+            .with(new PoolOptions().setMaxSize(1))
+            .build();
+    cleanup.deferCleanup(listPool::close);
+    String query = "select * from test where id = $1";
+
+    executePreparedStatement(listPool, query, Tuple.of(1), PreparedStatement::query)
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            assertServerGroup(trace, query, host + ":" + port + "," + host + ":" + (port + 1)));
+  }
+
+  @Test
+  void testOneBuilderGivesEachClientItsOwnTarget() throws Exception {
+    PgConnectOptions first = connectOptions();
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool().using(vertx).with(new PoolOptions().setMaxSize(1));
+
+    Pool firstPool =
+        builder.connectingTo(asList(first, new PgConnectOptions(first).setPort(port + 1))).build();
+    cleanup.deferCleanup(firstPool::close);
+    Pool secondPool =
+        builder.connectingTo(asList(first, new PgConnectOptions(first).setPort(port + 2))).build();
+    cleanup.deferCleanup(secondPool::close);
+
+    select(firstPool);
+    select(secondPool);
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)),
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 2)));
+  }
+
+  @Test
+  void testMutableServerListIsSnapshottedForEachBuild() throws Exception {
+    PgConnectOptions first = connectOptions();
+    String alternateHost = host.equals("localhost") ? "127.0.0.1" : "localhost";
+    PgConnectOptions second = new PgConnectOptions(first).setHost(alternateHost);
+    List<SqlConnectOptions> databases = new ArrayList<>(asList(first, second));
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool().using(vertx).connectingTo(databases).with(new PoolOptions().setMaxSize(1));
+
+    Pool firstPool = builder.build();
+    cleanup.deferCleanup(firstPool::close);
+    select(firstPool);
+    testing.waitForTraces(1);
+    testing.clearData();
+
+    first.setHost("mutated-first.example");
+    second.setHost("mutated-second.example");
+    databases.set(0, connectOptions());
+    databases.set(1, new PgConnectOptions(connectOptions()));
+    Pool secondPool = builder.build();
+    cleanup.deferCleanup(secondPool::close);
+
+    select(firstPool);
+    select(secondPool);
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerGroup(trace, host + ":" + port + "," + alternateHost + ":" + port),
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + port));
+  }
+
+  @Test
+  void testSwitchingTheBuilderToOneServerDropsTheServerList() throws Exception {
+    PgConnectOptions first = connectOptions();
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool().using(vertx).with(new PoolOptions().setMaxSize(1));
+    builder.connectingTo(asList(first, new PgConnectOptions(first).setPort(port + 1)));
+
+    Pool singlePool = builder.connectingTo(first).build();
+    cleanup.deferCleanup(singlePool::close);
+
+    select(singlePool);
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(
+                                maybeStable(DB_SYSTEM),
+                                emitStableDatabaseSemconv() ? POSTGRESQL : null),
+                            equalTo(maybeStable(DB_NAME), DB),
+                            equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from test"),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"),
+                            equalTo(
+                                maybeStable(DB_SQL_TABLE),
+                                emitStableDatabaseSemconv() ? null : "test"),
+                            equalTo(maybeStablePeerService(), "test-peer-service"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port))));
+  }
+
+  @Test
+  void testSwitchingTheBuilderToSupplierDropsTheFixedTarget() throws Exception {
+    PgConnectOptions first = connectOptions();
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(asList(first, new PgConnectOptions(first).setPort(port + 1)))
+            .with(new PoolOptions().setMaxSize(1));
+    Pool fixedPool = builder.build();
+    cleanup.deferCleanup(fixedPool::close);
+    Pool supplierPool = builder.connectingTo(() -> Future.succeededFuture(first)).build();
+    cleanup.deferCleanup(supplierPool::close);
+
+    select(fixedPool);
+    testing.runWithSpan("parent", () -> select(supplierPool));
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent()));
+  }
+
+  private static void assertServerGroup(TraceAssert trace, String expectedStableAddress) {
+    assertServerGroup(trace, "select * from test", expectedStableAddress);
+  }
+
+  private static void assertServerGroup(
+      TraceAssert trace, String statement, String expectedStableAddress) {
+    assertServerGroup(trace, host, port, expectedStableAddress, statement, null);
+  }
+
+  private static void assertServerGroup(
+      TraceAssert trace,
+      String firstHost,
+      int firstPort,
+      String expectedStableAddress,
+      String statement,
+      Throwable error) {
+    Consumer<SpanDataAssert> operationSpan =
+        span ->
+            span.hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(
+                        maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? POSTGRESQL : null),
+                    equalTo(maybeStable(DB_NAME), DB),
+                    equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                    equalTo(maybeStable(DB_STATEMENT), statement),
+                    equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select test" : null),
+                    equalTo(
+                        maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : "SELECT"),
+                    equalTo(maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : "test"),
+                    equalTo(
+                        maybeStablePeerService(),
+                        emitStableDatabaseSemconv() ? null : "test-peer-service"),
+                    equalTo(
+                        SERVER_ADDRESS,
+                        emitStableDatabaseSemconv() ? expectedStableAddress : firstHost),
+                    equalTo(
+                        SERVER_PORT, emitStableDatabaseSemconv() ? null : Long.valueOf(firstPort)),
+                    equalTo(
+                        ERROR_TYPE,
+                        emitStableDatabaseSemconv() && error != null
+                            ? "io.netty.channel.AbstractChannel$AnnotatedConnectException"
+                            : null));
+    if (error == null) {
+      trace.hasSpansSatisfyingExactly(operationSpan);
+    } else {
+      trace.hasSpansSatisfyingExactly(
+          operationSpan, span -> span.hasName("CONNECT").hasParent(trace.getSpan(0)));
+    }
+  }
+
+  private static void assertDirectTarget(TraceAssert trace) {
+    trace.hasSpansSatisfyingExactly(
+        span ->
+            span.hasName(emitStableDatabaseSemconv() ? "select test" : "SELECT tempdb.test")
+                .hasKind(SpanKind.CLIENT)
+                .hasAttributesSatisfyingExactly(
+                    equalTo(
+                        maybeStable(DB_SYSTEM), emitStableDatabaseSemconv() ? POSTGRESQL : null),
+                    equalTo(maybeStable(DB_NAME), DB),
+                    equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB),
+                    equalTo(maybeStable(DB_STATEMENT), "select * from test"),
+                    equalTo(DB_QUERY_SUMMARY, emitStableDatabaseSemconv() ? "select test" : null),
+                    equalTo(
+                        maybeStable(DB_OPERATION), emitStableDatabaseSemconv() ? null : "SELECT"),
+                    equalTo(maybeStable(DB_SQL_TABLE), emitStableDatabaseSemconv() ? null : "test"),
+                    equalTo(maybeStablePeerService(), "test-peer-service"),
+                    equalTo(SERVER_ADDRESS, host),
+                    equalTo(SERVER_PORT, port)));
+  }
+
+  private static void select(SqlClient client) throws Exception {
+    client
+        .query("select * from test")
+        .execute()
+        .toCompletionStage()
+        .toCompletableFuture()
+        .get(30, SECONDS);
+  }
+
+  private static PgConnectOptions connectOptions() {
+    return new PgConnectOptions()
+        .setPort(port)
+        .setHost(host)
+        .setDatabase(DB)
+        .setUser(USER_DB)
+        .setPassword(PW_DB);
   }
 
   @Test
@@ -423,7 +859,15 @@ class VertxSqlClientTest {
       String query,
       Tuple tuple,
       Function<PreparedStatement, PreparedQuery<?>> preparedQueryFactory) {
-    return pool.withConnection(
+    return executePreparedStatement(pool, query, tuple, preparedQueryFactory);
+  }
+
+  private static Future<?> executePreparedStatement(
+      Pool targetPool,
+      String query,
+      Tuple tuple,
+      Function<PreparedStatement, PreparedQuery<?>> preparedQueryFactory) {
+    return targetPool.withConnection(
         connection ->
             connection
                 .prepare(query)

--- a/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
+++ b/instrumentation/vertx/vertx-sql-client/vertx-sql-client-5.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/vertx/sqlclient/v5_0/VertxSqlClientTest.java
@@ -35,6 +35,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.counting;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -47,6 +48,7 @@ import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgBuilder;
 import io.vertx.pgclient.PgConnectOptions;
@@ -60,6 +62,8 @@ import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.SqlConnectOptions;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.impl.ClientBuilderBase;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -155,7 +159,7 @@ class VertxSqlClientTest {
     select(listPool);
 
     testing.waitAndAssertTraces(
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)));
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 1)));
   }
 
   @Test
@@ -173,7 +177,7 @@ class VertxSqlClientTest {
 
     select(listPool);
 
-    testing.waitAndAssertTraces(trace -> assertServerGroup(trace, null));
+    testing.waitAndAssertTraces(trace -> assertServerListTarget(trace, null));
   }
 
   @Test
@@ -195,7 +199,7 @@ class VertxSqlClientTest {
     assertThat(error).isNotNull();
     testing.waitAndAssertTraces(
         trace ->
-            assertServerGroup(
+            assertServerListTarget(
                 trace, "127.0.0.1", 1, "127.0.0.1:1,127.0.0.1:2", "select * from test", error));
   }
 
@@ -226,7 +230,7 @@ class VertxSqlClientTest {
     handlerInvoked.get(30, SECONDS);
 
     testing.waitAndAssertTraces(
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)));
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 1)));
   }
 
   @Test
@@ -238,6 +242,65 @@ class VertxSqlClientTest {
     select(genericPool);
 
     testing.waitAndAssertTraces(VertxSqlClientTest::assertDirectTarget);
+  }
+
+  @Test
+  void testNullServerDoesNotPoisonLaterPoolTarget() throws Exception {
+    assertThatThrownBy(
+            () -> Pool.pool(vertx, (SqlConnectOptions) null, new PoolOptions().setMaxSize(1)))
+        .isInstanceOf(NullPointerException.class);
+
+    Pool validPool = Pool.pool(vertx, connectOptions(), new PoolOptions().setMaxSize(1));
+    cleanup.deferCleanup(validPool::close);
+
+    select(validPool);
+
+    testing.waitAndAssertTraces(VertxSqlClientTest::assertDirectTarget);
+  }
+
+  @Test
+  void testFailedBuilderRestoresConnectHandler() throws Exception {
+    CompletableFuture<Void> handlerInvoked = new CompletableFuture<>();
+    Handler<SqlConnection> connectHandler =
+        connection ->
+            connection
+                .query("select * from test")
+                .execute()
+                .onComplete(
+                    result -> {
+                      connection.close();
+                      if (result.succeeded()) {
+                        handlerInvoked.complete(null);
+                      } else {
+                        handlerInvoked.completeExceptionally(result.cause());
+                      }
+                    });
+    ClientBuilder<Pool> builder =
+        PgBuilder.pool()
+            .using(vertx)
+            .connectingTo(connectOptions().setHost("failed.example"))
+            .withConnectHandler(connectHandler)
+            .with(new PoolOptions().setIdleTimeoutUnit(null));
+    Field connectHandlerField = ClientBuilderBase.class.getDeclaredField("connectHandler");
+    connectHandlerField.setAccessible(true);
+
+    assertThatThrownBy(builder::build).isInstanceOf(NullPointerException.class);
+    assertThat(connectHandlerField.get(builder)).isSameAs(connectHandler);
+
+    PgConnectOptions first = connectOptions();
+    PgConnectOptions second = new PgConnectOptions(first).setPort(port + 1);
+    Pool rebuiltPool =
+        builder.connectingTo(asList(first, second)).with(new PoolOptions().setMaxSize(1)).build();
+    cleanup.deferCleanup(rebuiltPool::close);
+    assertThat(connectHandlerField.get(builder)).isSameAs(connectHandler);
+
+    SqlConnection connection =
+        rebuiltPool.getConnection().toCompletionStage().toCompletableFuture().get(30, SECONDS);
+    cleanup.deferCleanup(connection::close);
+    handlerInvoked.get(30, SECONDS);
+
+    testing.waitAndAssertTraces(
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 1)));
   }
 
   @ParameterizedTest
@@ -363,7 +426,8 @@ class VertxSqlClientTest {
 
     testing.waitAndAssertTraces(
         trace ->
-            assertServerGroup(trace, query, host + ":" + port + "," + host + ":" + (port + 1)));
+            assertServerListTarget(
+                trace, query, host + ":" + port + "," + host + ":" + (port + 1)));
   }
 
   @Test
@@ -383,8 +447,8 @@ class VertxSqlClientTest {
     select(secondPool);
 
     testing.waitAndAssertTraces(
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)),
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 2)));
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 1)),
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 2)));
   }
 
   @Test
@@ -413,8 +477,9 @@ class VertxSqlClientTest {
     select(secondPool);
 
     testing.waitAndAssertTraces(
-        trace -> assertServerGroup(trace, host + ":" + port + "," + alternateHost + ":" + port),
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + port));
+        trace ->
+            assertServerListTarget(trace, host + ":" + port + "," + alternateHost + ":" + port),
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + port));
   }
 
   @Test
@@ -472,22 +537,22 @@ class VertxSqlClientTest {
     testing.runWithSpan("parent", () -> select(supplierPool));
 
     testing.waitAndAssertTraces(
-        trace -> assertServerGroup(trace, host + ":" + port + "," + host + ":" + (port + 1)),
+        trace -> assertServerListTarget(trace, host + ":" + port + "," + host + ":" + (port + 1)),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span -> span.hasName("parent").hasKind(SpanKind.INTERNAL).hasNoParent()));
   }
 
-  private static void assertServerGroup(TraceAssert trace, String expectedStableAddress) {
-    assertServerGroup(trace, "select * from test", expectedStableAddress);
+  private static void assertServerListTarget(TraceAssert trace, String expectedStableAddress) {
+    assertServerListTarget(trace, "select * from test", expectedStableAddress);
   }
 
-  private static void assertServerGroup(
+  private static void assertServerListTarget(
       TraceAssert trace, String statement, String expectedStableAddress) {
-    assertServerGroup(trace, host, port, expectedStableAddress, statement, null);
+    assertServerListTarget(trace, host, port, expectedStableAddress, statement, null);
   }
 
-  private static void assertServerGroup(
+  private static void assertServerListTarget(
       TraceAssert trace,
       String firstHost,
       int firstPort,


### PR DESCRIPTION
Stacked on #19983, this reports fixed single-server and server-list targets from Vert.x SQL 5 builders in stable database spans. Single-server spans use `server.address` and `server.port`. Server-list spans put the comma-separated target list in `server.address`.

Each build snapshots its target for queries, explicit connections, prepared statements, connection failures, and pool acquisition timeouts. Supplier-provided targets remain out of scope.
