### PR TITLE
Prefer semconv utilities for mapped test attributes

### DIFF
--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -276,11 +276,27 @@ site.
 | `otel.semconv-stability.opt-in=…`              | `emitStableDatabaseSemconv()`, `emitOldDatabaseSemconv()`, `emitStableCodeSemconv()`, etc.                         | `io.opentelemetry.instrumentation.api.internal.SemconvStability`                |
 | `otel.instrumentation.<module>.experimental-*` | per-module `EXPERIMENTAL_ATTRIBUTES` constant — see [testing-experimental-flags.md](testing-experimental-flags.md) | within the test class                                                           |
 
-### Inline conditional expected values
+### Mode-dependent expected values
 
-Push the ternary as deep as possible — into the `equalTo` value or single attribute key —
-rather than duplicating two whole `hasAttributesSatisfyingExactly(...)` blocks under a
-`flag ? a : b`. The assertion API treats `null` as "expect attribute absent":
+Use an established semconv test utility when it directly represents the
+expected key mapping. For database attributes whose old and stable keys carry
+the same value, use `SemconvStabilityUtil.maybeStable(...)`:
+
+```java
+equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH)
+equalTo(maybeStable(DB_OPERATION), "info")
+```
+
+Do not expand these into separate null-gated assertions such as
+`equalTo(DB_SYSTEM, emitOldDatabaseSemconv() ? ELASTICSEARCH : null)` and
+`equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null)`.
+
+When no established semconv utility applies, put the ternary inside the
+`equalTo` value or single attribute key. Do not duplicate two whole
+`hasAttributesSatisfyingExactly(...)` blocks under a `flag ? a : b`. This
+includes attributes that exist in only one mode and attributes whose expected
+values differ by mode. The assertion API treats `null` as "expect attribute
+absent":
 
 ```java
 equalTo(DB_USER, emitStableDatabaseSemconv() ? null : USER_DB)
@@ -290,13 +306,15 @@ span.hasName(testLatestDeps() ? "GET" : "HTTP GET")
 .hasParent(trace.getSpan(testLatestDeps() ? 0 : 1))
 ```
 
-Keep short conditional expected values directly in the assertion, even when several
-assertions repeat the same condition. Do not extract the branch selection into helpers such
-as `spanName(...)`, `oldOrExperimental(value)`, or `expectedNamespace()`. Those helpers hide
-the expected values at the point where a reader needs them. The conventional
-`experimental(value)` helper is the exception — it unambiguously means the value is expected
-only when experimental attributes are enabled, and `null` otherwise, so keep it instead of
-inlining `EXPERIMENTAL_ATTRIBUTES ? value : null`.
+Keep short conditional expected values directly in the assertion when no
+established semconv utility applies, even when several assertions repeat the
+same condition. Do not extract the branch selection into helpers such as
+`spanName(...)`, `oldOrExperimental(value)`, or `expectedNamespace()`. Those
+helpers hide the expected values at the point where a reader needs them. The
+conventional `experimental(value)` helper is the exception. It means the value
+is expected only when experimental attributes are enabled, and `null`
+otherwise, so keep it instead of inlining
+`EXPERIMENTAL_ATTRIBUTES ? value : null`.
 
-A helper may obtain the mode flag or perform nontrivial derivation from test data. It should
+A helper may obtain the mode flag or derive a value from test data. It should
 not choose between short expected values on the assertion's behalf.

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -280,16 +280,34 @@ site.
 
 Use an established semconv test utility when it directly represents the
 expected key mapping. For database attributes whose old and stable keys carry
-the same value, use `SemconvStabilityUtil.maybeStable(...)`:
+the same value, use `SemconvStabilityUtil.maybeStable(...)` when the test does
+not exercise `database/dup`:
 
 ```java
 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH)
 equalTo(maybeStable(DB_OPERATION), "info")
 ```
 
-Do not expand these into separate null-gated assertions such as
-`equalTo(DB_SYSTEM, emitOldDatabaseSemconv() ? ELASTICSEARCH : null)` and
-`equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null)`.
+For a dup-aware test, build a `List<AttributeAssertion>` and conditionally add
+the real assertions for each enabled mode:
+
+```java
+List<AttributeAssertion> attributes = new ArrayList<>();
+if (emitOldDatabaseSemconv()) {
+  attributes.add(equalTo(DB_SYSTEM, ELASTICSEARCH));
+}
+if (emitStableDatabaseSemconv()) {
+  attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+}
+```
+
+Do not model this as two always-present assertions whose expected values become
+`null` when their mode is disabled:
+
+```java
+equalTo(DB_SYSTEM, emitOldDatabaseSemconv() ? ELASTICSEARCH : null)
+equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null)
+```
 
 When no established semconv utility applies, put the ternary inside the
 `equalTo` value or single attribute key. Do not duplicate two whole

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -325,4 +325,25 @@ otherwise, so keep it instead of inlining
 `EXPERIMENTAL_ATTRIBUTES ? value : null`.
 
 A helper may obtain the mode flag or derive a value from test data. It should
-not choose between short expected values on the assertion's behalf.
+not choose between short expected values on the assertion's behalf, build or
+augment a `List<AttributeAssertion>` with mode-dependent entries, or otherwise
+hide the expected assertion shape. Keep helpers for genuinely nontrivial
+derivation only:
+
+```java
+// Bad: the helper conditionally builds a list and hides the expected shape.
+private static List<AttributeAssertion> databaseAttributes() {
+  List<AttributeAssertion> attributes = new ArrayList<>();
+  if (emitStableDatabaseSemconv()) {
+    attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+  }
+  return attributes;
+}
+assertNodeListTarget(span, databaseAttributes());
+
+// Good: each mode-dependent expectation remains visible at the assertion.
+assertNodeListTarget(
+    span,
+    equalTo(DB_SYSTEM, emitStableDatabaseSemconv() ? null : ELASTICSEARCH),
+    equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null));
+```

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -278,31 +278,21 @@ site.
 
 ### Mode-dependent expected values
 
-Use an established semconv test utility when it directly represents the
-expected key mapping. For database attributes whose old and stable keys carry
-the same value, use `SemconvStabilityUtil.maybeStable(...)` when the test does
-not exercise `database/dup`:
+Database instrumentation tests run either the default or stable database
+semconv mode. Do not add `database/dup` test tasks or expand assertions to
+cover both modes at once. Duplicate-mode coverage belongs in tests for the
+semconv stability API itself.
+
+Use `SemconvStabilityUtil.maybeStable(...)` when old and stable database keys
+carry the same expected value:
 
 ```java
 equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH)
 equalTo(maybeStable(DB_OPERATION), "info")
 ```
 
-For a dup-aware test, build a `List<AttributeAssertion>` and conditionally add
-the real assertions for each enabled mode:
-
-```java
-List<AttributeAssertion> attributes = new ArrayList<>();
-if (emitOldDatabaseSemconv()) {
-  attributes.add(equalTo(DB_SYSTEM, ELASTICSEARCH));
-}
-if (emitStableDatabaseSemconv()) {
-  attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
-}
-```
-
-Do not model this as two always-present assertions whose expected values become
-`null` when their mode is disabled:
+Do not replace these with separate null-gated assertions for the old and stable
+keys:
 
 ```java
 equalTo(DB_SYSTEM, emitOldDatabaseSemconv() ? ELASTICSEARCH : null)

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -324,23 +324,29 @@ is expected only when experimental attributes are enabled, and `null`
 otherwise, so keep it instead of inlining
 `EXPERIMENTAL_ATTRIBUTES ? value : null`.
 
-A helper may obtain the mode flag or derive a value from test data. It should
-not choose between short expected values on the assertion's behalf, build or
-augment a `List<AttributeAssertion>` with mode-dependent entries, or otherwise
-hide the expected assertion shape. Keep helpers for genuinely nontrivial
+A helper may obtain the mode flag or derive a value from test data. Do not
+conditionally build a `List<AttributeAssertion>` and then pass that list to an
+otherwise ordinary assertion helper. Pass each assertion directly and keep the
+mode check with its expected value. Keep helpers for genuinely nontrivial
 derivation only:
 
 ```java
 // Bad: the helper conditionally builds a list and hides the expected shape.
 private static List<AttributeAssertion> databaseAttributes() {
   List<AttributeAssertion> attributes = new ArrayList<>();
+  if (emitOldDatabaseSemconv()) {
+    attributes.add(equalTo(DB_USER, USER_DB));
+  }
   if (emitStableDatabaseSemconv()) {
-    attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+    attributes.add(equalTo(ERROR_TYPE, "42601"));
   }
   return attributes;
 }
 assertNodeListTarget(span, databaseAttributes());
 
-// Good: the mapped expectation remains visible at the assertion.
-assertNodeListTarget(span, equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH));
+// Good: pass each assertion directly and keep its mode check visible.
+assertNodeListTarget(
+    span,
+    equalTo(DB_USER, emitOldDatabaseSemconv() ? USER_DB : null),
+    equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null));
 ```

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -325,9 +325,9 @@ otherwise, so keep it instead of inlining
 `EXPERIMENTAL_ATTRIBUTES ? value : null`.
 
 A helper may obtain the mode flag or derive a value from test data. Do not
-conditionally build a `List<AttributeAssertion>` and then pass that list to an
-otherwise ordinary assertion helper. Pass each assertion directly and keep the
-mode check with its expected value. Keep helpers for genuinely nontrivial
+conditionally build a `List<AttributeAssertion>` and then pass that list to
+`hasAttributesSatisfyingExactly(...)`. Pass each assertion directly and keep
+the mode check with its expected value. Keep helpers for genuinely nontrivial
 derivation only:
 
 ```java
@@ -342,11 +342,10 @@ private static List<AttributeAssertion> databaseAttributes() {
   }
   return attributes;
 }
-assertNodeListTarget(span, databaseAttributes());
+span.hasAttributesSatisfyingExactly(databaseAttributes());
 
 // Good: pass each assertion directly and keep its mode check visible.
-assertNodeListTarget(
-    span,
+span.hasAttributesSatisfyingExactly(
     equalTo(DB_USER, emitOldDatabaseSemconv() ? USER_DB : null),
     equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null));
 ```

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -341,9 +341,6 @@ private static List<AttributeAssertion> databaseAttributes() {
 }
 assertNodeListTarget(span, databaseAttributes());
 
-// Good: each mode-dependent expectation remains visible at the assertion.
-assertNodeListTarget(
-    span,
-    equalTo(DB_SYSTEM, emitStableDatabaseSemconv() ? null : ELASTICSEARCH),
-    equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null));
+// Good: the mapped expectation remains visible at the assertion.
+assertNodeListTarget(span, equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH));
 ```

--- a/.github/agents/knowledge/testing-semconv-stability.md
+++ b/.github/agents/knowledge/testing-semconv-stability.md
@@ -95,22 +95,24 @@ semconv and the value is identical:
 span.hasAttribute(equalTo(maybeStable(DB_STATEMENT), "SELECT ?"));
 ```
 
-`maybeStable()` does **not** cover `/dup` mode (it returns one key, not both), and does
-**not** apply where the mapping isn't 1:1 — for example `DB_RESPONSE_STATUS_CODE` →
-`ERROR_TYPE`. Use `emitOld*()` / `emitStable*()` `if` blocks for those.
+`maybeStable()` returns one key, so use it for database tests that run only the default
+and stable modes. Do not add a `database/dup` test task. It does **not** apply where the
+mapping isn't 1:1 or where tests run in `/dup` mode.
 
-### `if` blocks (not `if/else`) when structure differs
+### Inline mode-dependent expectations
 
-When the _set_ of asserted attributes differs between modes — not just values — use
-separate top-level `if` blocks rather than `if/else`. For domains that support `/dup` mode
-(currently RPC), this is required so both branches run; for other domains it's a habit
-that keeps the assertion `/dup`-safe if the domain ever adopts it:
+When no established semconv utility applies, keep each mode-dependent expectation at the
+assertion site. Gate the expected value with the matching `emitOld*()` or `emitStable*()`
+accessor and use `null` to expect the attribute to be absent:
 
 ```java
-if (emitStableCodeSemconv()) {
-  assertThat(attributes).containsEntry(CODE_FUNCTION_NAME, "MyClass.myMethod");
-}
-if (emitOldCodeSemconv()) {
-  assertThat(attributes).containsEntry(CODE_NAMESPACE, "MyClass");
-}
+equalTo(
+    RPC_GRPC_STATUS_CODE,
+    emitOldRpcSemconv() ? (long) Status.Code.OK.value() : null)
+equalTo(
+    RPC_RESPONSE_STATUS_CODE,
+    emitStableRpcSemconv() ? Status.Code.OK.name() : null)
 ```
+
+This paired form also covers `/dup` mode because both accessors return true. Do not hide
+these expectations in separate conditional attribute blocks or helper-built lists.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -97,6 +97,29 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   `oldOrExperimental(value)`, or `expectedNamespace()` when no established
   semconv utility applies. Seeing both expected values at the assertion is more
   useful than deduplicating a short expression.
+- Do not hide mode-dependent expectations in a helper that builds or augments a
+  `List<AttributeAssertion>`, such as `databaseAttributes()`, and passes it to
+  an assertion helper. Keep each individual attribute expectation at the
+  assertion site; retain helpers only for genuinely nontrivial derivation:
+
+  ```java
+  // Bad: the helper conditionally builds a list and hides the expected shape.
+  private static List<AttributeAssertion> databaseAttributes() {
+    List<AttributeAssertion> attributes = new ArrayList<>();
+    if (emitStableDatabaseSemconv()) {
+      attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+    }
+    return attributes;
+  }
+  assertNodeListTarget(span, databaseAttributes());
+
+  // Good: each mode-dependent expectation remains visible at the assertion.
+  assertNodeListTarget(
+      span,
+      equalTo(DB_SYSTEM, emitStableDatabaseSemconv() ? null : ELASTICSEARCH),
+      equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null));
+  ```
+
 - The conventional `experimental(value)` helper is the one exception: keep it.
   Its name unambiguously means the value is expected only when experimental
   attributes are enabled, and `null` otherwise, so it reads clearer than the

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -70,10 +70,21 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   when `value` is already an `int` — the `equalTo(AttributeKey<Long>, int)`
   overload exists.
 
-## [Testing] Inline Conditional Expected Values
+## [Testing] Mode-Dependent Expected Values
 
-- Keep short conditional expected values directly in the assertion, especially
-  span names and attribute values:
+- Use an established semconv test utility when it directly represents the
+  expected key mapping. For database attributes whose old and stable keys carry
+  the same value, use `SemconvStabilityUtil.maybeStable(...)`:
+
+  ```java
+  equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH);
+  equalTo(maybeStable(DB_OPERATION), "info");
+  ```
+
+  Do not expand these into separate null-gated assertions for the old and stable
+  keys.
+- Keep short conditional expected values directly in the assertion when the
+  expected values differ by mode or an attribute exists in only one mode:
 
   ```java
   span.hasName(emitStableMessagingSemconv() ? "send orders" : "orders publish");
@@ -81,9 +92,9 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   ```
 
 - Do not extract the ternary into a helper such as `spanName(...)`,
-  `oldOrExperimental(value)`, or `expectedNamespace()`. Inline it even when
-  several assertions repeat the same condition. Seeing both expected values at
-  the assertion is more useful than deduplicating a short expression.
+  `oldOrExperimental(value)`, or `expectedNamespace()` when no established
+  semconv utility applies. Seeing both expected values at the assertion is more
+  useful than deduplicating a short expression.
 - The conventional `experimental(value)` helper is the one exception: keep it.
   Its name unambiguously means the value is expected only when experimental
   attributes are enabled, and `null` otherwise, so it reads clearer than the

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -72,30 +72,19 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
 
 ## [Testing] Mode-Dependent Expected Values
 
-- Use an established semconv test utility when it directly represents the
-  expected key mapping. For database attributes whose old and stable keys carry
-  the same value, use `SemconvStabilityUtil.maybeStable(...)` when the test does
-  not exercise `database/dup`:
+- Database instrumentation tests run either the default or stable database
+  semconv mode. Do not add `database/dup` test tasks or expand assertions to
+  cover both modes at once.
+- Use `SemconvStabilityUtil.maybeStable(...)` when old and stable database keys
+  carry the same expected value:
 
   ```java
   equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH);
   equalTo(maybeStable(DB_OPERATION), "info");
   ```
 
-  For a dup-aware test, build a `List<AttributeAssertion>` and conditionally add
-  the real assertions for each enabled mode:
-
-  ```java
-  if (emitOldDatabaseSemconv()) {
-    attributes.add(equalTo(DB_SYSTEM, ELASTICSEARCH));
-  }
-  if (emitStableDatabaseSemconv()) {
-    attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
-  }
-  ```
-
-  Do not model this as two always-present assertions whose expected values
-  become `null` when their mode is disabled.
+  Do not replace these with separate null-gated assertions for the old and
+  stable keys.
 - Keep short conditional expected values directly in the assertion when the
   expected values differ by mode or an attribute exists in only one mode:
 

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -74,15 +74,28 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
 
 - Use an established semconv test utility when it directly represents the
   expected key mapping. For database attributes whose old and stable keys carry
-  the same value, use `SemconvStabilityUtil.maybeStable(...)`:
+  the same value, use `SemconvStabilityUtil.maybeStable(...)` when the test does
+  not exercise `database/dup`:
 
   ```java
   equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH);
   equalTo(maybeStable(DB_OPERATION), "info");
   ```
 
-  Do not expand these into separate null-gated assertions for the old and stable
-  keys.
+  For a dup-aware test, build a `List<AttributeAssertion>` and conditionally add
+  the real assertions for each enabled mode:
+
+  ```java
+  if (emitOldDatabaseSemconv()) {
+    attributes.add(equalTo(DB_SYSTEM, ELASTICSEARCH));
+  }
+  if (emitStableDatabaseSemconv()) {
+    attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+  }
+  ```
+
+  Do not model this as two always-present assertions whose expected values
+  become `null` when their mode is disabled.
 - Keep short conditional expected values directly in the assertion when the
   expected values differ by mode or an attribute exists in only one mode:
 

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -97,24 +97,30 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   `oldOrExperimental(value)`, or `expectedNamespace()` when no established
   semconv utility applies. Seeing both expected values at the assertion is more
   useful than deduplicating a short expression.
-- Do not hide mode-dependent expectations in a helper that builds or augments a
-  `List<AttributeAssertion>`, such as `databaseAttributes()`, and passes it to
-  an assertion helper. Keep each individual attribute expectation at the
-  assertion site; retain helpers only for genuinely nontrivial derivation:
+- Do not conditionally build a `List<AttributeAssertion>` and then pass that
+  list to an otherwise ordinary assertion helper. Pass each assertion directly
+  and keep the mode check with its expected value. Retain helpers only for
+  genuinely nontrivial derivation:
 
   ```java
   // Bad: the helper conditionally builds a list and hides the expected shape.
   private static List<AttributeAssertion> databaseAttributes() {
     List<AttributeAssertion> attributes = new ArrayList<>();
+    if (emitOldDatabaseSemconv()) {
+      attributes.add(equalTo(DB_USER, USER_DB));
+    }
     if (emitStableDatabaseSemconv()) {
-      attributes.add(equalTo(DB_SYSTEM_NAME, ELASTICSEARCH));
+      attributes.add(equalTo(ERROR_TYPE, "42601"));
     }
     return attributes;
   }
   assertNodeListTarget(span, databaseAttributes());
 
-  // Good: the mapped expectation remains visible at the assertion.
-  assertNodeListTarget(span, equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH));
+  // Good: pass each assertion directly and keep its mode check visible.
+  assertNodeListTarget(
+      span,
+      equalTo(DB_USER, emitOldDatabaseSemconv() ? USER_DB : null),
+      equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null));
   ```
 
 - The conventional `experimental(value)` helper is the one exception: keep it.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -113,11 +113,8 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   }
   assertNodeListTarget(span, databaseAttributes());
 
-  // Good: each mode-dependent expectation remains visible at the assertion.
-  assertNodeListTarget(
-      span,
-      equalTo(DB_SYSTEM, emitStableDatabaseSemconv() ? null : ELASTICSEARCH),
-      equalTo(DB_SYSTEM_NAME, emitStableDatabaseSemconv() ? ELASTICSEARCH : null));
+  // Good: the mapped expectation remains visible at the assertion.
+  assertNodeListTarget(span, equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH));
   ```
 
 - The conventional `experimental(value)` helper is the one exception: keep it.

--- a/.github/instructions/java-tests.instructions.md
+++ b/.github/instructions/java-tests.instructions.md
@@ -98,7 +98,7 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
   semconv utility applies. Seeing both expected values at the assertion is more
   useful than deduplicating a short expression.
 - Do not conditionally build a `List<AttributeAssertion>` and then pass that
-  list to an otherwise ordinary assertion helper. Pass each assertion directly
+  list to `hasAttributesSatisfyingExactly(...)`. Pass each assertion directly
   and keep the mode check with its expected value. Retain helpers only for
   genuinely nontrivial derivation:
 
@@ -114,11 +114,10 @@ Same shape applies to `String.length()`, `Map.size()`, and `array.length` →
     }
     return attributes;
   }
-  assertNodeListTarget(span, databaseAttributes());
+  span.hasAttributesSatisfyingExactly(databaseAttributes());
 
   // Good: pass each assertion directly and keep its mode check visible.
-  assertNodeListTarget(
-      span,
+  span.hasAttributesSatisfyingExactly(
       equalTo(DB_USER, emitOldDatabaseSemconv() ? USER_DB : null),
       equalTo(ERROR_TYPE, emitStableDatabaseSemconv() ? "42601" : null));
   ```


### PR DESCRIPTION
Clarifies mode-dependent assertion guidance for database instrumentation tests: run either the default or stable database semconv mode, and do not add `database/dup` tasks or expand assertions to cover both modes at once.

Direct old-to-stable key mappings use the existing utility:

```java
equalTo(maybeStable(DB_SYSTEM), ELASTICSEARCH);
```

Inline ternaries remain preferred for one-sided attributes or expectations that genuinely differ by mode. Pass those assertions directly instead of conditionally building a list in a helper and handing the list to an ordinary assertion helper.

This corrects the guidance added in #19985 and prevents the paired assertion and duplicate-mode leakage found in PRs linked from #19899.
