### PR TITLE
Support an agent JAR already on the bootstrap class path

### DIFF
--- a/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/javaagent-bootstrap/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -23,10 +23,11 @@ import javax.annotation.Nullable;
  * <p>The bootstrap process of the agent is somewhat complicated and care has to be taken to make
  * sure things do not get broken by accident.
  *
- * <p>JVM loads this class onto app's class loader, afterwards agent needs to inject its classes
- * onto bootstrap classpath. This leads to this class being visible on bootstrap. This in turn means
- * that this class may be loaded again on bootstrap by accident if we ever reference it after
- * bootstrap has been setup.
+ * <p>The JVM normally loads this class onto the application's class loader, after which the agent
+ * injects its classes onto the bootstrap class path. This leads to this class being visible on
+ * bootstrap. This in turn means that this class may be loaded again on bootstrap by accident if we
+ * ever reference it after bootstrap has been set up. When the agent jar is already on the bootstrap
+ * class path, the JVM loads this class from bootstrap and no injection is needed.
  *
  * <p>In order to avoid this we need to make sure we do a few things:
  *
@@ -69,7 +70,8 @@ public final class OpenTelemetryAgent {
     // we are not using OpenTelemetryAgent.class.getProtectionDomain().getCodeSource() to get agent
     // location because getProtectionDomain does a permission check with security manager
     ClassLoader classLoader = OpenTelemetryAgent.class.getClassLoader();
-    if (classLoader == null) {
+    boolean loadedByBootstrap = classLoader == null;
+    if (loadedByBootstrap) {
       classLoader = ClassLoader.getSystemClassLoader();
     }
     URL url =
@@ -93,9 +95,12 @@ public final class OpenTelemetryAgent {
 
     // verification is very slow before the JIT compiler starts up, which on Java 8 is not until
     // after premain execution completes
-    JarFile agentJar = new JarFile(javaagentFile, false);
-    verifyJarManifestMainClassIsThis(javaagentFile, agentJar);
-    inst.appendToBootstrapClassLoaderSearch(agentJar);
+    try (JarFile agentJar = new JarFile(javaagentFile, false)) {
+      verifyJarManifestMainClassIsThis(javaagentFile, agentJar);
+      if (!loadedByBootstrap) {
+        inst.appendToBootstrapClassLoaderSearch(agentJar);
+      }
+    }
     return javaagentFile;
   }
 

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/AgentLoadedIntoBootstrapTest.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/AgentLoadedIntoBootstrapTest.java
@@ -24,6 +24,24 @@ class AgentLoadedIntoBootstrapTest {
     assertThat(exitCode).isZero();
   }
 
+  @Test
+  void agentLoadsWhenAgentJarIsAlreadyOnBootstrapClasspath() throws Exception {
+    String agentJarPath = IntegrationTestUtils.getAgentJarPath();
+
+    IntegrationTestUtils.ProcessResult result =
+        IntegrationTestUtils.runOnSeparateJvmAndCaptureOutput(
+            AgentLoadedChecker.class.getName(),
+            new String[] {"-Xbootclasspath/a:" + agentJarPath, "-Djdk.instrument.traceUsage=true"},
+            new String[0],
+            emptyMap(),
+            System.getProperty("java.class.path"),
+            true);
+
+    assertThat(result.getExitCode()).isZero();
+    assertThat(result.getOutput())
+        .doesNotContain("Instrumentation.appendToBootstrapClassLoaderSearch has been called");
+  }
+
   // this tests the case where someone adds the contents of opentelemetry-javaagent.jar by mistake
   // to their application's "uber.jar"
   //

--- a/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
+++ b/javaagent/src/test/java/io/opentelemetry/javaagent/IntegrationTestUtils.java
@@ -157,6 +157,13 @@ public class IntegrationTestUtils {
     throw new IllegalStateException("Agent jar not found");
   }
 
+  static String getAgentJarPath() {
+    String agentArgument = getAgentArgument();
+    int optionsIndex = agentArgument.indexOf('=');
+    return agentArgument.substring(
+        "-javaagent:".length(), optionsIndex == -1 ? agentArgument.length() : optionsIndex);
+  }
+
   public static int runOnSeparateJvm(
       String mainClassName,
       String[] jvmArgs,
@@ -184,20 +191,34 @@ public class IntegrationTestUtils {
       String classpath,
       boolean printOutputStreams)
       throws Exception {
+    return runOnSeparateJvmAndCaptureOutput(
+            mainClassName, jvmArgs, mainMethodArgs, envVars, classpath, printOutputStreams)
+        .getExitCode();
+  }
+
+  static ProcessResult runOnSeparateJvmAndCaptureOutput(
+      String mainClassName,
+      String[] jvmArgs,
+      String[] mainMethodArgs,
+      Map<String, String> envVars,
+      String classpath,
+      boolean printOutputStreams)
+      throws Exception {
+    List<String> vmArgsList = new ArrayList<>(asList(jvmArgs));
+    vmArgsList.add(getAgentArgument());
+
+    List<String> arguments = new ArrayList<>(vmArgsList);
+    arguments.add("-cp");
+    arguments.add(classpath);
+    arguments.add(mainClassName);
+    arguments.addAll(asList(mainMethodArgs));
 
     String separator = System.getProperty("file.separator");
     String path = System.getProperty("java.home") + separator + "bin" + separator + "java";
 
-    List<String> vmArgsList = new ArrayList<>(asList(jvmArgs));
-    vmArgsList.add(getAgentArgument());
-
     List<String> commands = new ArrayList<>();
     commands.add(path);
-    commands.addAll(vmArgsList);
-    commands.add("-cp");
-    commands.add(classpath);
-    commands.add(mainClassName);
-    commands.addAll(asList(mainMethodArgs));
+    commands.addAll(arguments);
     ProcessBuilder processBuilder = new ProcessBuilder(commands.toArray(new String[0]));
     processBuilder.environment().putAll(envVars);
 
@@ -215,7 +236,8 @@ public class IntegrationTestUtils {
     outputGobbler.join();
     errorGobbler.join();
 
-    return process.exitValue();
+    return new ProcessResult(
+        process.exitValue(), outputGobbler.getOutput() + errorGobbler.getOutput());
   }
 
   private static void waitFor(Process process, long timeout, TimeUnit unit)
@@ -241,6 +263,7 @@ public class IntegrationTestUtils {
     final InputStream stream;
     final String type;
     final boolean print;
+    final StringBuilder output = new StringBuilder();
 
     private StreamGobbler(InputStream stream, String type, boolean print) {
       this.stream = stream;
@@ -254,6 +277,7 @@ public class IntegrationTestUtils {
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream, UTF_8));
         String line = null;
         while ((line = reader.readLine()) != null) {
+          output.append(line).append(System.lineSeparator());
           if (print) {
             logger.info("{}> {}", type, line);
           }
@@ -261,6 +285,28 @@ public class IntegrationTestUtils {
       } catch (IOException e) {
         logger.warn("Error gobbling.", e);
       }
+    }
+
+    private String getOutput() {
+      return output.toString();
+    }
+  }
+
+  static class ProcessResult {
+    private final int exitCode;
+    private final String output;
+
+    private ProcessResult(int exitCode, String output) {
+      this.exitCode = exitCode;
+      this.output = output;
+    }
+
+    int getExitCode() {
+      return exitCode;
+    }
+
+    String getOutput() {
+      return output;
     }
   }
 


### PR DESCRIPTION
When the agent JAR is already on the bootstrap class path, the JVM can load the premain entry point without another bootstrap path mutation. Skipping Instrumentation.appendToBootstrapClassLoaderSearch in that case avoids invalidating JDK 25 AOT linkage while preserving manifest validation and normal agent initialization.

A deployment can launch with `java -Xbootclasspath/a:opentelemetry-javaagent.jar -javaagent:opentelemetry-javaagent.jar ...`; putting the JAR on the bootstrap class path does not eagerly load its classes or activate the agent. For AOT cache creation, record/create without an active `-javaagent`, include `--add-modules=java.instrument` and the same bootstrap path in every phase, and use `-XX:+DisableAttachMechanism`; add `-javaagent` in production. Virtual fields on cached classes loaded before premain fall back to weak maps, while agent initialization and transformations still happen in production.