### PR TITLE
Add an opt-in JDK 25 AOT startup benchmark

### DIFF
--- a/benchmark-overhead/README.md
+++ b/benchmark-overhead/README.md
@@ -7,6 +7,7 @@
 - [Automation](#automation)
 - [Setup and Usage](#setup-and-usage)
 - [Visualization](#visualization)
+- [JDK 25 AOT startup comparison](#jdk-25-aot-startup-comparison)
 
 This directory will contain tools and utilities
 that help us to measure the performance overhead introduced by
@@ -113,3 +114,58 @@ cd benchmark-overhead
 None yet. Help wanted! Our goal is to have the results and a rich UI running in the
 `gh-pages` branch similar to [earlier tools](https://breedx-splk.github.io/iguanodon/web/).
 Please help us make this happen.
+
+## JDK 25 AOT startup comparison
+
+The opt-in `aotStartupBenchmark` task compares the existing small Spring smoke application on HotSpot JDK 25 in four configurations: normal and AOT, each with and without the Java agent. It does not run in ordinary tests or the nightly overhead workflow, and has no performance pass/fail thresholds.
+
+Use JDK 21 or newer for Gradle and Docker with Linux containers. The benchmark uses a pinned JDK 25 Spring smoke image, two container CPUs, a 1 GiB container memory limit, and `-Xmx512m`. Run it on an otherwise idle machine.
+
+Build the current agent from the repository root:
+
+```sh
+./gradlew :javaagent:shadowJar
+```
+
+Then run the standalone benchmark, passing the exact local agent JAR:
+
+```sh
+cd benchmark-overhead
+./gradlew aotStartupBenchmark \
+  -PaotBenchmarkAgentJar=/absolute/path/to/opentelemetry-javaagent-VERSION.jar
+```
+
+On Windows, use `.\gradlew.bat` and a quoted Windows path:
+
+```powershell
+Set-Location benchmark-overhead
+.\gradlew.bat aotStartupBenchmark "-PaotBenchmarkAgentJar=C:\path\to\opentelemetry-javaagent-VERSION.jar"
+```
+
+Each invocation collects fresh observations even when compiled classes are up to date. Defaults are two discarded starts and twenty measured starts per variant. For a short functional run, add `-PaotBenchmarkWarmups=0 -PaotBenchmarkSamples=1`. Both options count fresh JVM starts, not warmup within a running JVM.
+
+The benchmark creates separate no-agent and agent-compatible caches without an active agent. It packages the image's exploded classes and resources into a JAR once so all four configurations use the same flat class path. Cache preparation, diagnostic preflight, and image pulls are outside the measurements. Images without the expected flat layout are rejected rather than silently benchmarking a cache of only JDK classes.
+
+Within each pair, only AOT options differ. Both agent configurations preload the agent JAR on the bootstrap class path and add `java.instrument`; the no-agent configurations do neither. The normal agent configuration is therefore the AOT-compatible recipe without a cache, not an ordinary `-javaagent`-only launch. Field injection uses its enabled default. Instrumentation remains active, but traces, metrics, and logs exporters are all `none`; this measures neither telemetry delivery nor collector overhead.
+
+Every AOT sample requires cache use. Separate untimed runs confirm AOT-linked classes, archived application-class loading, and agent transformation. Timed runs omit agent debug, class-load and instrumentation tracing, and expensive cache verification.
+
+Starts run serially in rotating order. Every sample must return HTTP 200 and `Hi!` from `/greeting`; a failure aborts the benchmark and retains diagnostics without producing a comparison. Samples are not retried or filtered as outliers.
+
+Results are written to `build/reports/aot-startup/<run-id>/`:
+
+- `samples.csv` contains discarded and measured observations.
+- `metadata.properties` records exact commands, image/JDK identity, agent hash/version, repository state, resource limits, sample counts, and cache preparation costs.
+- `summary.md` compares medians and interquartile ranges and calculates absolute and percentage AOT reductions within each pair.
+- `startup.svg` is a presentation-ready grouped chart with a shared zero-based axis and interquartile ranges.
+- Preparation, preflight, and per-sample logs accompany the report.
+
+The primary metric is **JVM uptime at Spring startup completion**, from Spring's `JVM running for` log field. It includes `premain()` and work before Spring's own timer starts. It is not an isolated agent-installation measurement or an exact OS-process lifetime. Spring initialization and container-to-HTTP time are secondary metrics; the latter includes Docker and harness overhead.
+
+These are fresh-process starts with warmed filesystem/image caches, not cold-machine starts. Results apply to this small Spring workload and the recorded environment. They do not establish throughput, JIT warmup, or the benefit for larger services. Read both seconds saved and percentage reduction: a smaller relative benefit with an agent does not necessarily mean less absolute time saved.
+
+To exercise only the parser, configuration, statistics, and report tests without Docker:
+
+```sh
+./gradlew test --tests 'io.opentelemetry.startup.*Test'
+```

--- a/benchmark-overhead/build.gradle.kts
+++ b/benchmark-overhead/build.gradle.kts
@@ -36,5 +36,24 @@ dependencies {
 tasks {
   test {
     useJUnitPlatform()
+    exclude("**/AotStartupBenchmark.class")
   }
+}
+
+tasks.register<Test>("aotStartupBenchmark") {
+  description = "Measures JDK 25 Spring startup with and without AOT and the Java agent."
+  group = "verification"
+  testClassesDirs = sourceSets.test.get().output.classesDirs
+  classpath = sourceSets.test.get().runtimeClasspath
+  useJUnitPlatform()
+  include("**/AotStartupBenchmark.class")
+  maxParallelForks = 1
+  outputs.upToDateWhen { false }
+  outputs.cacheIf { false }
+  systemProperty("aot.benchmark.enabled", "true")
+  systemProperty("aot.benchmark.output", layout.buildDirectory.dir("reports/aot-startup").get().asFile.absolutePath)
+  systemProperty("aot.benchmark.agent", providers.gradleProperty("aotBenchmarkAgentJar").orElse("").get())
+  systemProperty("aot.benchmark.samples", providers.gradleProperty("aotBenchmarkSamples").orElse("20").get())
+  systemProperty("aot.benchmark.warmups", providers.gradleProperty("aotBenchmarkWarmups").orElse("2").get())
+  testLogging.showStandardStreams = true
 }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/AotStartupBenchmark.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/AotStartupBenchmark.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@EnabledIfSystemProperty(named = "aot.benchmark.enabled", matches = "true")
+class AotStartupBenchmark {
+  private static final String IMAGE =
+      "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/"
+          + "smoke-test-spring-boot:jdk25-20251116.19402383847";
+  private static final String APPLICATION =
+      "io.opentelemetry.smoketest.springboot.SpringbootApplication";
+  private static final long MEMORY_BYTES = 1024L * 1024 * 1024;
+  private static final long NANO_CPUS = 2_000_000_000L;
+  private static final Duration TIMEOUT = Duration.ofMinutes(2);
+
+  @Test
+  void compareStartup() throws Exception {
+    Path agent = Path.of(requiredProperty("aot.benchmark.agent")).toAbsolutePath();
+    if (!Files.isRegularFile(agent)) {
+      throw new IllegalArgumentException("Agent JAR does not exist: " + agent);
+    }
+    int samples = count("aot.benchmark.samples", 1);
+    int warmups = count("aot.benchmark.warmups", 0);
+    String runId = Instant.now().toString().replace(':', '-') + "-" + UUID.randomUUID();
+    Path directory = Path.of(requiredProperty("aot.benchmark.output")).resolve(runId);
+    Files.createDirectories(directory);
+    StartupReport report = new StartupReport(directory);
+    Properties metadata = metadata(agent, samples, warmups);
+    metadata.setProperty("status", "incomplete");
+    saveMetadata(directory, metadata);
+    System.out.println("AOT startup results: " + directory);
+
+    List<StartupSample> observations = new ArrayList<>();
+    DockerClient docker = DockerClientFactory.instance().client();
+    String volume = "otel-aot-startup-" + UUID.randomUUID();
+    docker.createVolumeCmd().withName(volume).exec();
+    try {
+      String imageId = prepare(docker, volume, agent, directory, metadata);
+      saveMetadata(directory, metadata);
+      for (Variant variant : List.of(Variant.AOT_NO_AGENT, Variant.AOT_AGENT)) {
+        sample(imageId, volume, variant, 0, 0, true, true, directory, observations, report);
+      }
+      for (int round = 0; round < warmups + samples; round++) {
+        for (int order = 0; order < Variant.values().length; order++) {
+          Variant variant = Variant.values()[(round + order) % Variant.values().length];
+          sample(
+              imageId,
+              volume,
+              variant,
+              round + 1,
+              order + 1,
+              round < warmups,
+              false,
+              directory,
+              observations,
+              report);
+        }
+      }
+      report.writeSummary(observations, metadata);
+      metadata.setProperty("status", "complete");
+      saveMetadata(directory, metadata);
+    } finally {
+      docker.removeVolumeCmd(volume).exec();
+    }
+  }
+
+  private static String prepare(
+      DockerClient docker, String volume, Path agent, Path directory, Properties metadata)
+      throws Exception {
+    try (GenericContainer<?> preparation =
+        container(IMAGE, volume)
+            .withCopyFileToContainer(MountableFile.forHostPath(agent), "/tmp/agent.jar")
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource("aot-startup/prepare.sh"), "/tmp/prepare.sh")
+            .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("/bin/bash"))
+            .withCommand(
+                "-c", "sed -i 's/\\r$//' /tmp/prepare.sh && exec /bin/bash /tmp/prepare.sh")
+            .waitingFor(
+                Wait.forLogMessage(".*BENCHMARK_CACHES_READY.*", 1)
+                    .withStartupTimeout(Duration.ofMinutes(6)))) {
+      try {
+        preparation.start();
+        var image = docker.inspectImageCmd(preparation.getContainerInfo().getImageId()).exec();
+        String imageId = image.getId();
+        metadata.setProperty("image.id", imageId);
+        metadata.setProperty("image.digests", String.valueOf(image.getRepoDigests()));
+        metadata.setProperty("image.architecture", image.getArch());
+        metadata.setProperty("image.os", image.getOs());
+        for (String file :
+            List.of(
+                "java-version.log",
+                "spring-version.log",
+                "cache.properties",
+                "no-agent-record.log",
+                "no-agent-create.log",
+                "agent-record.log",
+                "agent-create.log")) {
+          preparation.copyFileFromContainer(
+              "/benchmark/" + file, directory.resolve(file).toString());
+        }
+        String version = Files.readString(directory.resolve("java-version.log"), UTF_8).strip();
+        assertThat(version).contains("25.").doesNotContain("OpenJ9");
+        metadata.setProperty("jvm.version", version);
+        metadata.setProperty(
+            "spring.version",
+            Files.readString(directory.resolve("spring-version.log"), UTF_8).strip());
+        try (InputStream in = Files.newInputStream(directory.resolve("cache.properties"))) {
+          metadata.load(in);
+        }
+        return imageId;
+      } finally {
+        if (preparation.getContainerId() != null) {
+          Files.writeString(directory.resolve("preparation.log"), preparation.getLogs(), UTF_8);
+        }
+      }
+    }
+  }
+
+  private static void sample(
+      String image,
+      String volume,
+      Variant variant,
+      int round,
+      int order,
+      boolean discarded,
+      boolean preflight,
+      Path directory,
+      List<StartupSample> observations,
+      StartupReport report)
+      throws Exception {
+    String name =
+        preflight ? "preflight-" + variant.id() : round + "-" + order + "-" + variant.id();
+    try (GenericContainer<?> application =
+            container(image, volume)
+                .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("java"))
+                .withCommand(arguments(variant, preflight).toArray(String[]::new))
+                .withExposedPorts(8080)
+                .withStartupAttempts(1)
+                .waitingFor(
+                    Wait.forLogMessage(".*Started SpringbootApplication in.*", 1)
+                        .withStartupTimeout(TIMEOUT));
+        HttpClient client = HttpClient.newBuilder().connectTimeout(TIMEOUT).build()) {
+      boolean success = false;
+      int writtenSamples = observations.size();
+      try {
+        long started = System.nanoTime();
+        application.start();
+        HttpRequest request =
+            HttpRequest.newBuilder(
+                    URI.create(
+                        "http://"
+                            + application.getHost()
+                            + ":"
+                            + application.getMappedPort(8080)
+                            + "/greeting"))
+                .timeout(TIMEOUT)
+                .GET()
+                .build();
+        HttpResponse<String> response =
+            client.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
+        double httpSeconds = (System.nanoTime() - started) / 1_000_000_000.0;
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("Hi!");
+        String logs = application.getLogs();
+        StartupTimings timings = StartupTimings.parse(logs);
+        if (variant.agent()) {
+          assertThat(logs).contains("opentelemetry-javaagent - version:");
+        } else {
+          assertThat(logs).doesNotContain("opentelemetry-javaagent - version:");
+        }
+        if (preflight) {
+          assertThat(logs)
+              .contains("Opened AOT cache")
+              .contains("Using AOT-linked classes: true")
+              .contains(APPLICATION + " source: shared objects file");
+          if (variant.agent()) {
+            assertThat(logs)
+                .contains(
+                    "Transformed io.opentelemetry.smoketest.springboot.controller.WebController")
+                .doesNotContain(
+                    "Instrumentation.appendToBootstrapClassLoaderSearch has been called");
+          }
+        } else {
+          observations.add(
+              new StartupSample(
+                  variant,
+                  round,
+                  order,
+                  discarded,
+                  "ok",
+                  timings.springSeconds(),
+                  timings.jvmSeconds(),
+                  httpSeconds));
+          System.out.printf(
+              "%s %s: JVM %.3f s, Spring %.3f s%n",
+              name,
+              discarded ? "discarded" : "measured",
+              timings.jvmSeconds(),
+              timings.springSeconds());
+        }
+        success = true;
+      } finally {
+        if (!success && !preflight) {
+          observations.add(
+              new StartupSample(
+                  variant, round, order, discarded, "failed", Double.NaN, Double.NaN, Double.NaN));
+        }
+        if (observations.size() > writtenSamples) {
+          report.writeSamples(observations.subList(writtenSamples, observations.size()));
+        }
+        if (application.getContainerId() != null) {
+          Files.writeString(directory.resolve(name + ".log"), application.getLogs(), UTF_8);
+        }
+      }
+    }
+  }
+
+  private static GenericContainer<?> container(String image, String volume) {
+    return new GenericContainer<>(DockerImageName.parse(image))
+        .withEnv("JAVA_TOOL_OPTIONS", "")
+        .withEnv("JDK_JAVA_OPTIONS", "")
+        .withEnv("_JAVA_OPTIONS", "")
+        .withEnv("OTEL_TRACES_EXPORTER", "none")
+        .withEnv("OTEL_METRICS_EXPORTER", "none")
+        .withEnv("OTEL_LOGS_EXPORTER", "none")
+        .withCreateContainerCmdModifier(
+            cmd ->
+                cmd.getHostConfig()
+                    .withBinds(new Bind(volume, new Volume("/benchmark")))
+                    .withMemory(MEMORY_BYTES)
+                    .withMemorySwap(MEMORY_BYTES)
+                    .withNanoCPUs(NANO_CPUS));
+  }
+
+  static List<String> arguments(Variant variant, boolean preflight) {
+    List<String> arguments = new ArrayList<>();
+    arguments.add("-Xmx512m");
+    if (variant.agent()) {
+      arguments.add("--add-modules=java.instrument");
+      arguments.add("-Xbootclasspath/a:/benchmark/agent.jar");
+      arguments.add("-javaagent:/benchmark/agent.jar");
+      arguments.add("-Dotel.javaagent.debug=" + preflight);
+    }
+    if (variant.aot()) {
+      arguments.add("-XX:AOTMode=on");
+      arguments.add("-XX:AOTCache=/benchmark/" + (variant.agent() ? "agent" : "no-agent") + ".aot");
+    }
+    if (preflight) {
+      arguments.add("-XX:+UnlockDiagnosticVMOptions");
+      arguments.add("-XX:+VerifySharedSpaces");
+      arguments.add("-Xlog:aot=debug,class+load=info");
+      arguments.add("-Djdk.instrument.traceUsage=true");
+    }
+    arguments.add("-cp");
+    arguments.add("/benchmark/application.jar:/app/libs/*");
+    arguments.add(APPLICATION);
+    return arguments;
+  }
+
+  private static Properties metadata(Path agent, int samples, int warmups) throws Exception {
+    Properties metadata = new Properties();
+    metadata.setProperty("image.reference", IMAGE);
+    metadata.setProperty("agent.path", agent.toString());
+    try (JarFile jar = new JarFile(agent.toFile())) {
+      String version = jar.getManifest().getMainAttributes().getValue("Implementation-Version");
+      if (version == null) {
+        throw new IllegalArgumentException("Agent JAR has no Implementation-Version");
+      }
+      metadata.setProperty("agent.version", version);
+    }
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    try (InputStream in = Files.newInputStream(agent)) {
+      byte[] buffer = new byte[8192];
+      int count;
+      while ((count = in.read(buffer)) != -1) {
+        digest.update(buffer, 0, count);
+      }
+    }
+    metadata.setProperty("agent.sha256", HexFormat.of().formatHex(digest.digest()));
+    metadata.setProperty("repository.revision", git("rev-parse", "HEAD"));
+    metadata.setProperty(
+        "repository.dirty", Boolean.toString(!git("status", "--porcelain").isEmpty()));
+    metadata.setProperty("samples", Integer.toString(samples));
+    metadata.setProperty("warmups", Integer.toString(warmups));
+    metadata.setProperty("cpus", "2");
+    metadata.setProperty("memory.bytes", Long.toString(MEMORY_BYTES));
+    metadata.setProperty("heap", "-Xmx512m");
+    metadata.setProperty("host.os", System.getProperty("os.name"));
+    metadata.setProperty("host.architecture", System.getProperty("os.arch"));
+    metadata.setProperty(
+        "exporters", "traces=none, metrics=none, logs=none; instrumentation enabled");
+    for (Variant variant : Variant.values()) {
+      metadata.setProperty(
+          "command." + variant.id(), "java " + String.join(" ", arguments(variant, false)));
+    }
+    metadata.setProperty(
+        "reproduction.command",
+        "From benchmark-overhead: ./gradlew aotStartupBenchmark "
+            + "\"-PaotBenchmarkAgentJar="
+            + agent
+            + "\" -PaotBenchmarkSamples="
+            + samples
+            + " -PaotBenchmarkWarmups="
+            + warmups);
+    return metadata;
+  }
+
+  private static String git(String... arguments) throws IOException, InterruptedException {
+    List<String> command = new ArrayList<>(List.of("git", "--no-pager"));
+    command.addAll(List.of(arguments));
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes(), UTF_8).strip();
+    if (process.waitFor() != 0) {
+      throw new IOException("Git metadata command failed: " + output);
+    }
+    return output;
+  }
+
+  private static void saveMetadata(Path directory, Properties metadata) throws IOException {
+    try (OutputStream out = Files.newOutputStream(directory.resolve("metadata.properties"))) {
+      metadata.store(out, "AOT startup benchmark");
+    }
+  }
+
+  private static String requiredProperty(String name) {
+    String value = System.getProperty(name);
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("Missing required benchmark property: " + name);
+    }
+    return value;
+  }
+
+  private static int count(String name, int minimum) {
+    int value = Integer.parseInt(requiredProperty(name));
+    if (value < minimum) {
+      throw new IllegalArgumentException(name + " must be at least " + minimum);
+    }
+    return value;
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/AotStartupConfigurationTest.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/AotStartupConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AotStartupConfigurationTest {
+  @Test
+  void aotIsTheOnlyDifferenceWithinEachPair() {
+    for (Variant variant : List.of(Variant.AOT_NO_AGENT, Variant.AOT_AGENT)) {
+      List<String> arguments = new ArrayList<>(AotStartupBenchmark.arguments(variant, false));
+      assertThat(arguments).contains("-XX:AOTMode=on");
+      arguments.removeIf(argument -> argument.startsWith("-XX:AOT"));
+      assertThat(arguments)
+          .isEqualTo(
+              AotStartupBenchmark.arguments(
+                  variant.agent() ? Variant.NORMAL_AGENT : Variant.NORMAL_NO_AGENT, false));
+    }
+  }
+
+  @Test
+  void noAgentPairHasNoAgentOrBootstrapPreload() {
+    for (Variant variant : List.of(Variant.NORMAL_NO_AGENT, Variant.AOT_NO_AGENT)) {
+      assertThat(AotStartupBenchmark.arguments(variant, false))
+          .noneMatch(argument -> argument.contains("agent.jar"))
+          .doesNotContain("--add-modules=java.instrument");
+    }
+  }
+
+  @Test
+  void timedRunsLeaveFieldInjectionEnabledAndOmitDiagnostics() {
+    for (Variant variant : Variant.values()) {
+      assertThat(AotStartupBenchmark.arguments(variant, false))
+          .noneMatch(argument -> argument.contains("field-injection"))
+          .noneMatch(argument -> argument.startsWith("-Xlog:"))
+          .noneMatch(argument -> argument.contains("traceUsage"))
+          .doesNotContain("-Dotel.javaagent.debug=true", "-XX:+VerifySharedSpaces", "-Xshare:off");
+    }
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReport.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReport.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class StartupReport {
+  private static final String CSV_HEADER =
+      "variant,round,order,discarded,status,spring_seconds,jvm_seconds,http_seconds\n";
+  private static final int CHART_WIDTH = 900;
+  private static final int CHART_HEIGHT = 520;
+  private static final int CHART_LEFT = 90;
+  private static final int CHART_RIGHT = 35;
+  private static final int CHART_TOP = 100;
+  private static final int CHART_BOTTOM = 95;
+  private static final Pattern JDK_VERSION = Pattern.compile("openjdk version \"([^\"]+)\"");
+  private static final Pattern SPRING_VERSION =
+      Pattern.compile("spring-boot-([0-9][A-Za-z0-9.\\-]*)\\.jar");
+
+  private final Path directory;
+
+  StartupReport(Path directory) throws IOException {
+    this.directory = directory;
+    Files.createDirectories(directory);
+  }
+
+  void writeSamples(List<StartupSample> samples) throws IOException {
+    if (samples.isEmpty()) {
+      return;
+    }
+    Path file = directory.resolve("samples.csv");
+    boolean header = !Files.exists(file) || Files.size(file) == 0;
+    StringBuilder output = new StringBuilder();
+    if (header) {
+      output.append(CSV_HEADER);
+    }
+    for (StartupSample sample : samples) {
+      output
+          .append(csv(sample.variant().id()))
+          .append(',')
+          .append(sample.round())
+          .append(',')
+          .append(sample.order())
+          .append(',')
+          .append(sample.discarded())
+          .append(',')
+          .append(csv(sample.status()))
+          .append(',')
+          .append(Double.toString(sample.springSeconds()))
+          .append(',')
+          .append(Double.toString(sample.jvmSeconds()))
+          .append(',')
+          .append(Double.toString(sample.httpSeconds()))
+          .append('\n');
+    }
+    Files.writeString(
+        file,
+        output,
+        UTF_8,
+        java.nio.file.StandardOpenOption.CREATE,
+        java.nio.file.StandardOpenOption.APPEND);
+  }
+
+  void writeSummary(List<StartupSample> samples, Properties metadata) throws IOException {
+    List<StartupSample> measured = validate(samples);
+    Map<Variant, Statistics> statistics = statistics(measured);
+    Files.writeString(
+        directory.resolve("summary.md"), renderSummary(statistics, samples, metadata), UTF_8);
+    Files.writeString(directory.resolve("startup.svg"), renderChart(statistics, metadata), UTF_8);
+  }
+
+  static double quantile(List<Double> values, double quantile) {
+    if (values.isEmpty() || quantile < 0 || quantile > 1) {
+      throw new IllegalArgumentException("Quantile requires non-empty values and q in [0, 1]");
+    }
+    List<Double> sorted = values.stream().sorted().toList();
+    double position = (sorted.size() - 1) * quantile;
+    int lower = (int) position;
+    int upper = Math.min(lower + 1, sorted.size() - 1);
+    return sorted.get(lower) + (sorted.get(upper) - sorted.get(lower)) * (position - lower);
+  }
+
+  private static List<StartupSample> validate(List<StartupSample> samples) {
+    if (samples.isEmpty()) {
+      throw new IllegalArgumentException("Cannot summarize an empty benchmark");
+    }
+    EnumSet<Variant> variants = EnumSet.noneOf(Variant.class);
+    EnumMap<Variant, Integer> counts = new EnumMap<>(Variant.class);
+    List<StartupSample> measured = new ArrayList<>();
+    for (StartupSample sample : samples) {
+      if (!sample.status().equals("ok")) {
+        throw new IllegalArgumentException("Cannot summarize a failed startup sample");
+      }
+      if (!validDuration(sample.springSeconds())
+          || !validDuration(sample.jvmSeconds())
+          || !validDuration(sample.httpSeconds())
+          || sample.jvmSeconds() < sample.springSeconds()) {
+        throw new IllegalArgumentException("Cannot summarize invalid startup timings");
+      }
+      variants.add(sample.variant());
+      if (!sample.discarded()) {
+        measured.add(sample);
+        counts.merge(sample.variant(), 1, Integer::sum);
+      }
+    }
+    if (!variants.equals(EnumSet.allOf(Variant.class))) {
+      throw new IllegalArgumentException("Summary requires every benchmark variant");
+    }
+    if (counts.size() != Variant.values().length
+        || counts.values().stream().distinct().count() != 1) {
+      throw new IllegalArgumentException("Summary requires equal measured counts per variant");
+    }
+    return measured;
+  }
+
+  private static boolean validDuration(double duration) {
+    return Double.isFinite(duration) && duration > 0;
+  }
+
+  private static Map<Variant, Statistics> statistics(List<StartupSample> samples) {
+    EnumMap<Variant, Statistics> result = new EnumMap<>(Variant.class);
+    for (Variant variant : Variant.values()) {
+      List<StartupSample> rows =
+          samples.stream().filter(sample -> sample.variant() == variant).toList();
+      result.put(
+          variant,
+          new Statistics(
+              values(rows, Metric.JVM), values(rows, Metric.SPRING), values(rows, Metric.HTTP)));
+    }
+    return result;
+  }
+
+  private static List<Double> values(List<StartupSample> samples, Metric metric) {
+    return samples.stream()
+        .map(
+            sample ->
+                switch (metric) {
+                  case JVM -> sample.jvmSeconds();
+                  case SPRING -> sample.springSeconds();
+                  case HTTP -> sample.httpSeconds();
+                })
+        .toList();
+  }
+
+  private static String renderSummary(
+      Map<Variant, Statistics> statistics, List<StartupSample> samples, Properties metadata) {
+    StringBuilder result = new StringBuilder();
+    result.append("# JDK 25 AOT startup benchmark\n\n");
+    result.append(
+        "Primary metric: JVM uptime at Spring startup completion, including agent premain and "
+            + "work before Spring's timer starts. Values are seconds.\n\n");
+    result.append("Environment: ").append(environmentCaption(metadata)).append("\n\n");
+    result.append(
+        "| Variant | Measured | Discarded | JVM median | JVM p25 | JVM p75 | Spring median | "
+            + "Spring p25 | Spring p75 | HTTP median | HTTP p25 | HTTP p75 |\n");
+    result.append(
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    int measuredCount = statistics.get(Variant.NORMAL_NO_AGENT).jvm().size();
+    for (Variant variant : Variant.values()) {
+      Statistics stats = statistics.get(variant);
+      long discarded =
+          samples.stream()
+              .filter(sample -> sample.variant() == variant && sample.discarded())
+              .count();
+      result
+          .append("| ")
+          .append(variant.label())
+          .append(" | ")
+          .append(measuredCount)
+          .append(" | ")
+          .append(discarded)
+          .append(" | ")
+          .append(format(stats.jvm().median()))
+          .append(" | ")
+          .append(format(stats.jvm().p25()))
+          .append(" | ")
+          .append(format(stats.jvm().p75()))
+          .append(" | ")
+          .append(format(stats.spring().median()))
+          .append(" | ")
+          .append(format(stats.spring().p25()))
+          .append(" | ")
+          .append(format(stats.spring().p75()))
+          .append(" | ")
+          .append(format(stats.http().median()))
+          .append(" | ")
+          .append(format(stats.http().p25()))
+          .append(" | ")
+          .append(format(stats.http().p75()))
+          .append(" |\n");
+    }
+    result.append("\n## Paired AOT reductions\n\n");
+    result.append("| Pair | Normal median | AOT median | Seconds saved | Reduction |\n");
+    result.append("| --- | ---: | ---: | ---: | ---: |\n");
+    appendReduction(
+        result,
+        "No agent",
+        statistics.get(Variant.NORMAL_NO_AGENT),
+        statistics.get(Variant.AOT_NO_AGENT));
+    appendReduction(
+        result,
+        "With agent",
+        statistics.get(Variant.NORMAL_AGENT),
+        statistics.get(Variant.AOT_AGENT));
+    appendInterpretation(
+        result,
+        statistics.get(Variant.NORMAL_NO_AGENT),
+        statistics.get(Variant.AOT_NO_AGENT),
+        statistics.get(Variant.NORMAL_AGENT),
+        statistics.get(Variant.AOT_AGENT));
+    result.append("\n## Caveats\n\n");
+    result.append(
+        "- Repeated fresh-process starts with warmed filesystem and image caches; this is not "
+            + "cold-machine startup or a JVM warmup benchmark.\n");
+    result.append(
+        "- The workload is the pinned small Spring smoke application. Container-to-HTTP time "
+            + "includes Docker and harness overhead and is secondary.\n");
+    result.append(
+        "- The normal agent case uses the AOT-compatible bootstrap preload without an AOT cache; "
+            + "the comparison is not an isolated transformer-installation measurement.\n");
+    result.append(
+        "- Traces, metrics, and logs exporters are disabled while instrumentation and the SDK "
+            + "remain active.\n");
+    result.append(
+        "- Image pull, application packaging, cache training/creation, and diagnostics are "
+            + "excluded from timed startup samples.\n");
+    String command = metadata.getProperty("reproduction.command");
+    if (command != null) {
+      result.append("\nReproduction: `").append(command).append("`\n");
+    }
+    return result.toString();
+  }
+
+  private static void appendReduction(
+      StringBuilder result, String label, Statistics normal, Statistics aot) {
+    double saved = normal.jvm().median() - aot.jvm().median();
+    result
+        .append("| ")
+        .append(label)
+        .append(" | ")
+        .append(format(normal.jvm().median()))
+        .append(" | ")
+        .append(format(aot.jvm().median()))
+        .append(" | ")
+        .append(format(saved))
+        .append(" | ")
+        .append(format(saved / normal.jvm().median() * 100))
+        .append("% |\n");
+  }
+
+  private static void appendInterpretation(
+      StringBuilder result,
+      Statistics normalNoAgent,
+      Statistics aotNoAgent,
+      Statistics normalAgent,
+      Statistics aotAgent) {
+    double noAgentSaved = normalNoAgent.jvm().median() - aotNoAgent.jvm().median();
+    double agentSaved = normalAgent.jvm().median() - aotAgent.jvm().median();
+    double noAgentReduction = noAgentSaved / normalNoAgent.jvm().median() * 100;
+    double agentReduction = agentSaved / normalAgent.jvm().median() * 100;
+    result.append("\nMeasured result: ");
+    if (noAgentSaved > 0 && agentSaved > 0 && agentReduction < noAgentReduction) {
+      result
+          .append("AOT's relative reduction was smaller with the agent (")
+          .append(format(agentReduction))
+          .append("% versus ")
+          .append(format(noAgentReduction))
+          .append("% without it), while the absolute time saved was larger (")
+          .append(format(agentSaved))
+          .append(" seconds versus ")
+          .append(format(noAgentSaved))
+          .append(" seconds).\n");
+    } else if (noAgentSaved < 0 || agentSaved < 0) {
+      result
+          .append("AOT was slower than normal in ")
+          .append(noAgentSaved < 0 && agentSaved < 0 ? "both" : "one")
+          .append(" comparison pair")
+          .append(noAgentSaved < 0 && agentSaved < 0 ? "s" : "")
+          .append("; the signed reductions above retain that result.\n");
+    } else {
+      result
+          .append("AOT saved ")
+          .append(format(noAgentSaved))
+          .append(" seconds without the agent and ")
+          .append(format(agentSaved))
+          .append(
+              " seconds with the agent; the paired reductions above are the measured result.\n");
+    }
+  }
+
+  private static String renderChart(Map<Variant, Statistics> statistics, Properties metadata) {
+    double max = 0;
+    for (Statistics stats : statistics.values()) {
+      max = Math.max(max, stats.jvm().p75());
+    }
+    max = Math.max(max * 1.2, 1);
+    int plotWidth = CHART_WIDTH - CHART_LEFT - CHART_RIGHT;
+    int plotHeight = CHART_HEIGHT - CHART_TOP - CHART_BOTTOM;
+    StringBuilder svg =
+        new StringBuilder()
+            .append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            .append(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\""
+                    + CHART_WIDTH
+                    + "\" height=\""
+                    + CHART_HEIGHT
+                    + "\" viewBox=\"0 0 "
+                    + CHART_WIDTH
+                    + " "
+                    + CHART_HEIGHT
+                    + "\">\n")
+            .append("<title>JDK 25 JVM uptime at Spring startup completion</title>\n")
+            .append(
+                "<style>text{font-family:Arial,sans-serif;fill:#202124} .bar{fill:#4c78a8} "
+                    + ".iqr{stroke:#202124;stroke-width:3} .grid{stroke:#d9d9d9}</style>\n")
+            .append("<text x=\"")
+            .append(CHART_WIDTH / 2)
+            .append(
+                "\" y=\"25\" text-anchor=\"middle\" font-size=\"20\">JDK 25 JVM uptime at Spring startup completion</text>\n");
+    svg.append("<text x=\"")
+        .append(CHART_WIDTH / 2)
+        .append("\" y=\"47\" text-anchor=\"middle\" font-size=\"11\">")
+        .append(xml(environmentCaption(metadata)))
+        .append("</text>\n");
+    svg.append("<text x=\"")
+        .append(CHART_WIDTH / 2)
+        .append(
+            "\" y=\"67\" text-anchor=\"middle\" font-size=\"12\">bars: median; labels: measured count; lines: p25-p75 (IQR)</text>\n");
+    for (int tick = 0; tick <= 4; tick++) {
+      double value = max * tick / 4;
+      int y = CHART_TOP + plotHeight - (int) Math.round(value / max * plotHeight);
+      svg.append("<line class=\"grid\" x1=\"")
+          .append(CHART_LEFT)
+          .append("\" x2=\"")
+          .append(CHART_WIDTH - CHART_RIGHT)
+          .append("\" y1=\"")
+          .append(y)
+          .append("\" y2=\"")
+          .append(y)
+          .append("\"/>\n");
+      svg.append("<text x=\"")
+          .append(CHART_LEFT - 10)
+          .append("\" y=\"")
+          .append(y + 5)
+          .append("\" text-anchor=\"end\" font-size=\"12\">")
+          .append(format(value))
+          .append("</text>\n");
+    }
+    int groupWidth = plotWidth / 2;
+    int barWidth = 110;
+    int[] centers = {CHART_LEFT + groupWidth / 2, CHART_LEFT + groupWidth + groupWidth / 2};
+    Variant[][] groups = {
+      {Variant.NORMAL_NO_AGENT, Variant.AOT_NO_AGENT},
+      {Variant.NORMAL_AGENT, Variant.AOT_AGENT}
+    };
+    for (int group = 0; group < groups.length; group++) {
+      Statistics normal = statistics.get(groups[group][0]);
+      Statistics aot = statistics.get(groups[group][1]);
+      svg.append("<text x=\"")
+          .append(centers[group])
+          .append("\" y=\"84\" text-anchor=\"middle\" font-size=\"12\">AOT: ")
+          .append(format(normal.jvm().median() - aot.jvm().median()))
+          .append(" s saved (")
+          .append(
+              format((normal.jvm().median() - aot.jvm().median()) / normal.jvm().median() * 100))
+          .append("%)</text>\n");
+      svg.append("<text x=\"")
+          .append(centers[group])
+          .append("\" y=\"")
+          .append(CHART_HEIGHT - 50)
+          .append("\" text-anchor=\"middle\" font-size=\"14\">")
+          .append(group == 0 ? "Without agent" : "With agent")
+          .append("</text>\n");
+      for (int index = 0; index < groups[group].length; index++) {
+        Variant variant = groups[group][index];
+        Statistics stats = statistics.get(variant);
+        int center = centers[group] + (index == 0 ? -barWidth / 2 - 12 : barWidth / 2 + 12);
+        int x = center - barWidth / 2;
+        int y = CHART_TOP + plotHeight - (int) Math.round(stats.jvm().median() / max * plotHeight);
+        int base = CHART_TOP + plotHeight;
+        int p25 = CHART_TOP + plotHeight - (int) Math.round(stats.jvm().p25() / max * plotHeight);
+        int p75 = CHART_TOP + plotHeight - (int) Math.round(stats.jvm().p75() / max * plotHeight);
+        svg.append("<rect class=\"bar\" data-variant=\"")
+            .append(variant.id())
+            .append("\" data-median=\"")
+            .append(format(stats.jvm().median()))
+            .append("\" x=\"")
+            .append(x)
+            .append("\" y=\"")
+            .append(y)
+            .append("\" width=\"")
+            .append(barWidth)
+            .append("\" height=\"")
+            .append(base - y)
+            .append("\"/>\n");
+        svg.append("<line class=\"iqr\" data-variant=\"")
+            .append(variant.id())
+            .append("\" x1=\"")
+            .append(center)
+            .append("\" x2=\"")
+            .append(center)
+            .append("\" y1=\"")
+            .append(p75)
+            .append("\" y2=\"")
+            .append(p25)
+            .append("\"/>\n");
+        svg.append("<text x=\"")
+            .append(center)
+            .append("\" y=\"")
+            .append(Math.max(y - 8, CHART_TOP + 12))
+            .append("\" text-anchor=\"middle\" font-size=\"11\">")
+            .append(format(stats.jvm().median()))
+            .append(" s (n=")
+            .append(stats.jvm().size())
+            .append(")</text>\n");
+        svg.append("<text x=\"")
+            .append(center)
+            .append("\" y=\"")
+            .append(base + 20)
+            .append("\" text-anchor=\"middle\" font-size=\"12\">")
+            .append(variant.aot() ? "AOT" : "Normal")
+            .append("</text>\n");
+      }
+    }
+    svg.append("<text x=\"")
+        .append(CHART_LEFT - 55)
+        .append("\" y=\"")
+        .append(CHART_TOP + plotHeight / 2)
+        .append("\" text-anchor=\"middle\" font-size=\"13\" transform=\"rotate(-90 ")
+        .append(CHART_LEFT - 55)
+        .append(" ")
+        .append(CHART_TOP + plotHeight / 2)
+        .append(")\">JVM uptime at Spring startup completion (seconds)</text>\n");
+    return svg.append("</svg>\n").toString();
+  }
+
+  private static String environmentCaption(Properties metadata) {
+    String jdk = extract(JDK_VERSION, metadata.getProperty("jvm.version"), "unknown");
+    String spring = extract(SPRING_VERSION, metadata.getProperty("spring.version"), "unknown");
+    String agent = metadata.getProperty("agent.version", "unknown");
+    String cpus = metadata.getProperty("cpus", "unknown");
+    String memory = metadata.getProperty("memory.bytes");
+    String memoryLabel =
+        memory == null
+            ? "unknown memory"
+            : String.format(
+                Locale.ROOT, "%.0f GiB", Double.parseDouble(memory) / (1024 * 1024 * 1024));
+    String heap = metadata.getProperty("heap", "unknown heap");
+    return "JDK "
+        + jdk
+        + "; Spring Boot "
+        + spring
+        + "; agent "
+        + agent
+        + "; resources "
+        + cpus
+        + " CPU / "
+        + memoryLabel
+        + " / "
+        + heap
+        + "; traces/metrics/logs exporters disabled; instrumentation active";
+  }
+
+  private static String extract(Pattern pattern, String value, String fallback) {
+    if (value == null) {
+      return fallback;
+    }
+    Matcher matcher = pattern.matcher(value);
+    return matcher.find() ? matcher.group(1) : fallback;
+  }
+
+  private static String xml(String value) {
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;");
+  }
+
+  static String csv(String value) {
+    if (value.indexOf(',') < 0 && value.indexOf('"') < 0 && value.indexOf('\n') < 0) {
+      return value;
+    }
+    return '"' + value.replace("\"", "\"\"") + '"';
+  }
+
+  private static String format(double value) {
+    return String.format(Locale.ROOT, "%.3f", value);
+  }
+
+  private enum Metric {
+    SPRING,
+    JVM,
+    HTTP
+  }
+
+  private record Statistics(Values jvm, Values spring, Values http) {
+    Statistics(List<Double> jvm, List<Double> spring, List<Double> http) {
+      this(new Values(jvm), new Values(spring), new Values(http));
+    }
+  }
+
+  private record Values(List<Double> values) {
+    int size() {
+      return values.size();
+    }
+
+    double median() {
+      return quantile(values, 0.5);
+    }
+
+    double p25() {
+      return quantile(values, 0.25);
+    }
+
+    double p75() {
+      return quantile(values, 0.75);
+    }
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReport.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReport.java
@@ -275,7 +275,7 @@ final class StartupReport {
     double noAgentReduction = noAgentSaved / normalNoAgent.jvm().median() * 100;
     double agentReduction = agentSaved / normalAgent.jvm().median() * 100;
     result.append("\nMeasured result: ");
-    if (noAgentSaved > 0 && agentSaved > 0 && agentReduction < noAgentReduction) {
+    if (noAgentSaved > 0 && agentSaved > noAgentSaved && agentReduction < noAgentReduction) {
       result
           .append("AOT's relative reduction was smaller with the agent (")
           .append(format(agentReduction))

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StartupReportTest {
+  @TempDir Path temporaryDirectory;
+
+  @Test
+  void writesIncrementalSamplesAndSummaryAndChart() throws Exception {
+    StartupReport report = new StartupReport(temporaryDirectory);
+    List<StartupSample> samples = samples();
+
+    report.writeSamples(samples.subList(0, 4));
+    report.writeSamples(samples.subList(4, samples.size()));
+    Properties metadata = new Properties();
+    metadata.setProperty("reproduction.command", "run --value=a&b");
+    metadata.setProperty(
+        "jvm.version", "openjdk version \"25.0.1\" 2025-10-21 LTS\nOpenJDK Runtime Environment");
+    metadata.setProperty("spring.version", "/app/libs/spring-boot-2.6.15.jar");
+    metadata.setProperty("agent.version", "2.32.0-SNAPSHOT");
+    metadata.setProperty("cpus", "2");
+    metadata.setProperty("memory.bytes", "1073741824");
+    metadata.setProperty("heap", "-Xmx512m");
+    report.writeSummary(samples, metadata);
+
+    String csv = Files.readString(temporaryDirectory.resolve("samples.csv"));
+    assertThat(csv.lines()).hasSize(samples.size() + 1);
+    assertThat(csv).contains("normal-no-agent,0,1,true,ok,1.0,2.0,2.5");
+    assertThat(Files.readString(temporaryDirectory.resolve("summary.md")))
+        .contains("| AOT, no agent | 2 | 1 |")
+        .contains("| With agent | 2.250 | 2.750 | -0.500 | -22.222% |")
+        .contains(
+            "Environment: JDK 25.0.1; Spring Boot 2.6.15; agent 2.32.0-SNAPSHOT; resources 2 CPU / 1 GiB / -Xmx512m; traces/metrics/logs exporters disabled; instrumentation active")
+        .contains("AOT was slower than normal in both comparison pairs")
+        .contains("run --value=a&b");
+    String svg = Files.readString(temporaryDirectory.resolve("startup.svg"));
+    assertThat(svg)
+        .contains("JDK 25 JVM uptime at Spring startup completion")
+        .contains("JVM uptime at Spring startup completion (seconds)")
+        .contains(
+            "JDK 25.0.1; Spring Boot 2.6.15; agent 2.32.0-SNAPSHOT; resources 2 CPU / 1 GiB / -Xmx512m; traces/metrics/logs exporters disabled; instrumentation active")
+        .contains("2.250 s (n=2)")
+        .contains("AOT: -0.500 s saved (-22.222%)")
+        .contains("data-variant=\"normal-no-agent\" data-median=\"2.250\"")
+        .contains("data-variant=\"aot-no-agent\" data-median=\"2.750\"")
+        .contains("class=\"iqr\"");
+  }
+
+  @Test
+  void describesSmallerRelativeGainAndLargerAbsoluteSavingWithAgent() throws Exception {
+    StartupReport report = new StartupReport(temporaryDirectory);
+
+    report.writeSummary(fasterSamples(), new Properties());
+
+    assertThat(Files.readString(temporaryDirectory.resolve("summary.md")))
+        .contains(
+            "AOT's relative reduction was smaller with the agent (30.000% versus 50.000% without it), while the absolute time saved was larger (3.000 seconds versus 2.000 seconds).");
+  }
+
+  @Test
+  void reportsSlowerAotWithoutDiscardingTheResult() throws Exception {
+    StartupReport report = new StartupReport(temporaryDirectory);
+    List<StartupSample> samples = samples();
+    samples =
+        samples.stream()
+            .map(
+                sample ->
+                    sample.variant() == Variant.AOT_NO_AGENT && !sample.discarded()
+                        ? new StartupSample(
+                            sample.variant(),
+                            sample.round(),
+                            sample.order(),
+                            false,
+                            "ok",
+                            sample.springSeconds(),
+                            3.0,
+                            sample.httpSeconds())
+                        : sample)
+            .toList();
+
+    report.writeSummary(samples, new Properties());
+
+    assertThat(Files.readString(temporaryDirectory.resolve("summary.md")))
+        .contains("| No agent | 2.250 | 3.000 | -0.750 | -33.333% |");
+  }
+
+  @Test
+  void rejectsFailedOrUnevenResults() throws Exception {
+    StartupReport report = new StartupReport(temporaryDirectory);
+    List<StartupSample> samples = samples();
+    List<StartupSample> failed = new ArrayList<>(samples);
+    failed.set(
+        1,
+        new StartupSample(
+            Variant.NORMAL_NO_AGENT, 1, 1, false, "failed", Double.NaN, Double.NaN, Double.NaN));
+
+    assertThatThrownBy(() -> report.writeSummary(failed, new Properties()))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> report.writeSummary(samples.subList(0, samples.size() - 1), new Properties()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void usesLinearQuantilesAndEscapesCsvValues() {
+    assertThat(StartupReport.quantile(List.of(1.0, 2.0, 4.0, 8.0), 0.25)).isEqualTo(1.75);
+    assertThat(StartupReport.csv("a,\"b")).isEqualTo("\"a,\"\"b\"");
+  }
+
+  private static List<StartupSample> samples() {
+    List<StartupSample> samples = new ArrayList<>();
+    for (Variant variant : Variant.values()) {
+      double jvm = variant.aot() ? (variant.agent() ? 2.5 : 2.5) : 2.0;
+      samples.add(new StartupSample(variant, 0, 1, true, "ok", 1.0, jvm, 2.5));
+      samples.add(new StartupSample(variant, 1, 1, false, "ok", 1.0, jvm, 2.5));
+      samples.add(new StartupSample(variant, 2, 1, false, "ok", 1.5, jvm + 0.5, 3.0));
+    }
+    return samples;
+  }
+
+  private static List<StartupSample> fasterSamples() {
+    List<StartupSample> samples = new ArrayList<>();
+    for (Variant variant : Variant.values()) {
+      double normal = variant.agent() ? 10 : 4;
+      double aot = variant.aot() ? (variant.agent() ? 7 : 2) : normal;
+      samples.add(new StartupSample(variant, 0, 1, true, "ok", 1, normal, 2));
+      samples.add(new StartupSample(variant, 1, 1, false, "ok", 1, aot, 2));
+      samples.add(new StartupSample(variant, 2, 1, false, "ok", 1, aot, 2));
+    }
+    return samples;
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
@@ -64,11 +64,22 @@ class StartupReportTest {
   void describesSmallerRelativeGainAndLargerAbsoluteSavingWithAgent() throws Exception {
     StartupReport report = new StartupReport(temporaryDirectory);
 
-    report.writeSummary(fasterSamples(), new Properties());
+    report.writeSummary(fasterSamples(7), new Properties());
 
     assertThat(Files.readString(temporaryDirectory.resolve("summary.md")))
         .contains(
             "AOT's relative reduction was smaller with the agent (30.000% versus 50.000% without it), while the absolute time saved was larger (3.000 seconds versus 2.000 seconds).");
+  }
+
+  @Test
+  void doesNotClaimLargerAbsoluteSavingWhenOnlyRelativeGainIsSmaller() throws Exception {
+    StartupReport report = new StartupReport(temporaryDirectory);
+
+    report.writeSummary(fasterSamples(9), new Properties());
+
+    assertThat(Files.readString(temporaryDirectory.resolve("summary.md")))
+        .contains(
+            "AOT saved 2.000 seconds without the agent and 1.000 seconds with the agent; the paired reductions above are the measured result.");
   }
 
   @Test
@@ -132,11 +143,11 @@ class StartupReportTest {
     return samples;
   }
 
-  private static List<StartupSample> fasterSamples() {
+  private static List<StartupSample> fasterSamples(double agentAot) {
     List<StartupSample> samples = new ArrayList<>();
     for (Variant variant : Variant.values()) {
       double normal = variant.agent() ? 10 : 4;
-      double aot = variant.aot() ? (variant.agent() ? 7 : 2) : normal;
+      double aot = variant.aot() ? (variant.agent() ? agentAot : 2) : normal;
       samples.add(new StartupSample(variant, 0, 1, true, "ok", 1, normal, 2));
       samples.add(new StartupSample(variant, 1, 1, false, "ok", 1, aot, 2));
       samples.add(new StartupSample(variant, 2, 1, false, "ok", 1, aot, 2));

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupReportTest.java
@@ -135,7 +135,7 @@ class StartupReportTest {
   private static List<StartupSample> samples() {
     List<StartupSample> samples = new ArrayList<>();
     for (Variant variant : Variant.values()) {
-      double jvm = variant.aot() ? (variant.agent() ? 2.5 : 2.5) : 2.0;
+      double jvm = variant.aot() ? 2.5 : 2.0;
       samples.add(new StartupSample(variant, 0, 1, true, "ok", 1.0, jvm, 2.5));
       samples.add(new StartupSample(variant, 1, 1, false, "ok", 1.0, jvm, 2.5));
       samples.add(new StartupSample(variant, 2, 1, false, "ok", 1.5, jvm + 0.5, 3.0));

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupSample.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupSample.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+record StartupSample(
+    Variant variant,
+    int round,
+    int order,
+    boolean discarded,
+    String status,
+    double springSeconds,
+    double jvmSeconds,
+    double httpSeconds) {
+
+  StartupSample {
+    if (!status.equals("ok") && !status.equals("failed")) {
+      throw new IllegalArgumentException("Startup sample status must be ok or failed: " + status);
+    }
+    if (status.equals("failed")
+        && (!Double.isNaN(springSeconds)
+            || !Double.isNaN(jvmSeconds)
+            || !Double.isNaN(httpSeconds))) {
+      throw new IllegalArgumentException("Failed startup samples must have NaN durations");
+    }
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimings.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimings.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+record StartupTimings(double springSeconds, double jvmSeconds) {
+  private static final Pattern STARTUP_LINE =
+      Pattern.compile(
+          ".*Started\\s+SpringbootApplication\\s+in\\s+"
+              + "([0-9]+(?:\\.[0-9]+)?)\\s+seconds\\s+"
+              + "\\(JVM running for\\s+([0-9]+(?:\\.[0-9]+)?)(?:\\s+seconds)?\\).*");
+
+  static StartupTimings parse(String logs) {
+    StartupTimings result = null;
+    for (String line : logs.lines().toList()) {
+      if (!line.contains("Started SpringbootApplication")) {
+        continue;
+      }
+      Matcher matcher = STARTUP_LINE.matcher(line);
+      if (!matcher.matches()) {
+        throw new IllegalArgumentException("Malformed Spring startup timing line: " + line);
+      }
+      if (result != null) {
+        throw new IllegalArgumentException("Multiple Spring startup timing lines");
+      }
+      double springSeconds = Double.parseDouble(matcher.group(1));
+      double jvmSeconds = Double.parseDouble(matcher.group(2));
+      if (!Double.isFinite(springSeconds)
+          || !Double.isFinite(jvmSeconds)
+          || springSeconds <= 0
+          || jvmSeconds <= 0
+          || jvmSeconds < springSeconds) {
+        throw new IllegalArgumentException("Invalid Spring startup timings: " + line);
+      }
+      result = new StartupTimings(springSeconds, jvmSeconds);
+    }
+    if (result == null) {
+      throw new IllegalArgumentException("Missing Spring startup timing line");
+    }
+    return result;
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimings.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimings.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.startup;
 
+import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +18,9 @@ record StartupTimings(double springSeconds, double jvmSeconds) {
 
   static StartupTimings parse(String logs) {
     StartupTimings result = null;
-    for (String line : logs.lines().toList()) {
+    Iterator<String> lines = logs.lines().iterator();
+    while (lines.hasNext()) {
+      String line = lines.next();
       if (!line.contains("Started SpringbootApplication")) {
         continue;
       }

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimingsTest.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/StartupTimingsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class StartupTimingsTest {
+  @Test
+  void parsesThePinnedSpringLogFormat() {
+    StartupTimings timings =
+        StartupTimings.parse(
+            "INFO Started SpringbootApplication in 1.25 seconds (JVM running for 2.5)\n");
+
+    assertThat(timings).isEqualTo(new StartupTimings(1.25, 2.5));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidLogs")
+  void rejectsMissingMalformedDuplicateAndInvalidTimings(String logs) {
+    assertThatThrownBy(() -> StartupTimings.parse(logs))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static Stream<Arguments> invalidLogs() {
+    return Stream.of(
+        Arguments.argumentSet("missing", "Spring is ready"),
+        Arguments.argumentSet(
+            "malformed", "Started SpringbootApplication in 1.25 seconds (process running for 2.5)"),
+        Arguments.argumentSet(
+            "duplicate",
+            "Started SpringbootApplication in 1.25 seconds (JVM running for 2.5)\n"
+                + "Started SpringbootApplication in 1.30 seconds (JVM running for 2.6)"),
+        Arguments.argumentSet(
+            "jvm shorter", "Started SpringbootApplication in 2.5 seconds (JVM running for 1.25)"),
+        Arguments.argumentSet(
+            "zero", "Started SpringbootApplication in 0 seconds (JVM running for 1.25)"));
+  }
+}

--- a/benchmark-overhead/src/test/java/io/opentelemetry/startup/Variant.java
+++ b/benchmark-overhead/src/test/java/io/opentelemetry/startup/Variant.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.startup;
+
+enum Variant {
+  NORMAL_NO_AGENT(false, false, "Normal, no agent", "normal-no-agent"),
+  AOT_NO_AGENT(true, false, "AOT, no agent", "aot-no-agent"),
+  NORMAL_AGENT(false, true, "Normal, agent", "normal-agent"),
+  AOT_AGENT(true, true, "AOT, agent", "aot-agent");
+
+  private final boolean aot;
+  private final boolean agent;
+  private final String label;
+  private final String id;
+
+  Variant(boolean aot, boolean agent, String label, String id) {
+    this.aot = aot;
+    this.agent = agent;
+    this.label = label;
+    this.id = id;
+  }
+
+  public boolean agent() {
+    return agent;
+  }
+
+  public boolean aot() {
+    return aot;
+  }
+
+  public String label() {
+    return label;
+  }
+
+  public String id() {
+    return id;
+  }
+}

--- a/benchmark-overhead/src/test/resources/aot-startup/prepare.sh
+++ b/benchmark-overhead/src/test/resources/aot-startup/prepare.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+work=/benchmark
+application=io.opentelemetry.smoketest.springboot.SpringbootApplication
+pid=
+
+stop_training() {
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid"
+    wait "$pid" || true
+  fi
+}
+trap stop_training EXIT
+
+if [[ ! -d /app/classes || ! -d /app/resources || ! -d /app/libs ]]; then
+  echo "Expected the pinned Spring smoke image with /app/classes, /app/resources, and /app/libs."
+  echo "A nested Spring Boot launcher does not provide the flat class path this benchmark requires."
+  exit 1
+fi
+
+jar --create --file "$work/application.jar" -C /app/classes . -C /app/resources .
+cp -p /tmp/agent.jar "$work/agent.jar"
+app=(-cp "$work/application.jar:/app/libs/*" "$application")
+java -version >"$work/java-version.log" 2>&1
+printf '%s\n' /app/libs/spring-boot-*.jar >"$work/spring-version.log"
+
+for variant in no-agent agent; do
+  common=(-Xmx512m)
+  if [[ "$variant" == agent ]]; then
+    common+=(--add-modules=java.instrument "-Xbootclasspath/a:$work/agent.jar")
+  fi
+  started=$(date +%s%N)
+  java "${common[@]}" -XX:AOTMode=record "-XX:AOTConfiguration=$work/$variant.aotconf" \
+    "${app[@]}" >"$work/$variant-record.log" 2>&1 &
+  pid=$!
+  for _ in $(seq 1 480); do
+    if grep -q "Started SpringbootApplication in" "$work/$variant-record.log"; then
+      break
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      cat "$work/$variant-record.log"
+      wait "$pid"
+      exit 1
+    fi
+    sleep 0.25
+  done
+  if ! grep -q "Started SpringbootApplication in" "$work/$variant-record.log"; then
+    cat "$work/$variant-record.log"
+    echo "Timed out during $variant training"
+    exit 1
+  fi
+  kill -TERM "$pid"
+  status=0
+  wait "$pid" || status=$?
+  pid=
+  if [[ "$status" != 0 && "$status" != 143 ]]; then
+    cat "$work/$variant-record.log"
+    exit "$status"
+  fi
+  [[ -s "$work/$variant.aotconf" ]]
+  echo "cache.$variant.record.millis=$(( ($(date +%s%N) - started) / 1000000 ))" >>"$work/cache.properties"
+  started=$(date +%s%N)
+  if ! java "${common[@]}" -XX:+DisableAttachMechanism -XX:AOTMode=create \
+    "-XX:AOTConfiguration=$work/$variant.aotconf" "-XX:AOTCache=$work/$variant.aot" \
+    -cp "$work/application.jar:/app/libs/*" >"$work/$variant-create.log" 2>&1; then
+    cat "$work/$variant-create.log"
+    exit 1
+  fi
+  [[ -s "$work/$variant.aot" ]]
+  echo "cache.$variant.create.millis=$(( ($(date +%s%N) - started) / 1000000 ))" >>"$work/cache.properties"
+  echo "cache.$variant.bytes=$(stat -c %s "$work/$variant.aot")" >>"$work/cache.properties"
+done
+
+echo BENCHMARK_CACHES_READY
+# Keep the container available for copying diagnostics and metadata out.
+exec sleep infinity


### PR DESCRIPTION
Adds an opt-in benchmark for the small Linux Spring smoke application. It compares normal and JDK 25 ahead-of-time cache launches with and without the Java agent, without adding the benchmark to ordinary tests or automated performance gates.

Run it with a locally built agent JAR:

```sh
./gradlew :javaagent:shadowJar
cd benchmark-overhead
./gradlew aotStartupBenchmark -PaotBenchmarkAgentJar=/absolute/path/to/opentelemetry-javaagent-VERSION.jar
```

Each run starts fresh processes in rotating order and checks the AOT cache and application response before recording samples. Reports include raw samples, environment metadata, median and interquartile range comparisons, a Markdown summary, and an SVG chart. The primary metric is JVM uptime when Spring startup completes, including `premain()` and work before Spring's timer.

Both agent variants put the agent JAR on the bootstrap class path and enable `java.instrument`. The baseline is therefore the same launch without an AOT cache, not a plain `-javaagent` launch. Instrumentation and the SDK stay active while all exporters are disabled.

Recorded 20-sample medians show JVM uptime dropping from **1.658 s to 1.022 s without the agent** and from **4.481 s to 3.554 s with the agent**. This saves about **0.64 s without the agent** and **0.93 s with it**.

![JDK 25 JVM uptime at Spring startup completion, comparing normal and AOT runs with and without the Java agent](https://github.com/user-attachments/assets/c596e49f-a514-493d-9eb8-503c41e0a4cb)

The recorded run used JDK 25.0.1, Spring Boot 2.6.15, 2 CPUs, 1 GiB memory, and 20 measured starts per configuration after two discarded starts. The README contains full reproduction details and caveats.
