### PR TITLE
Capture ClickHouse network peers

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTarget.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTarget.java
@@ -9,11 +9,16 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 /**
- * The logical server a database client was configured to talk to, rendered as {@code
- * server.address} and {@code server.port}.
+ * A database endpoint set rendered as an address and a port.
  *
- * <p>A target stays the same across routing, node selection, and retries, so it is derived from
- * client configuration rather than from the endpoint that served an individual operation.
+ * <p>A target usually names the logical server a database client was configured to talk to,
+ * rendered as {@code server.address} and {@code server.port}. Such a target stays the same across
+ * routing, node selection, and retries, so it is derived from client configuration rather than from
+ * the endpoint that served an individual operation.
+ *
+ * <p>An instrumentation that knows which endpoint served an individual operation renders that one
+ * endpoint the same way and reports it as {@code network.peer.address} and {@code
+ * network.peer.port}.
  *
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
@@ -68,13 +73,13 @@ public abstract class DbServerTarget {
 
   DbServerTarget() {}
 
-  /** Returns the value for {@code server.address}. */
+  /** Returns the value for {@code server.address}, or for {@code network.peer.address}. */
   public abstract String getAddress();
 
   /**
-   * Returns the value for {@code server.port}, or {@code null} when no separate port is reported.
-   * Targets built with {@link DbServerTargetBuilder} omit default ports and ports already carried
-   * inside {@link #getAddress()}.
+   * Returns the value for {@code server.port}, or for {@code network.peer.port}, or {@code null}
+   * when no separate port is reported. Targets built with {@link DbServerTargetBuilder} omit
+   * default ports and ports already carried inside {@link #getAddress()}.
    */
   @Nullable
   public abstract Integer getPort();

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -13,7 +13,9 @@ import javax.annotation.Nullable;
 
 /**
  * Collects the endpoints a database client was configured with and renders them as a single {@link
- * DbServerTarget}.
+ * DbServerTarget}. A caller that knows which single endpoint served an operation collects that one
+ * endpoint instead, and reports the result as {@code network.peer.address} and {@code
+ * network.peer.port}.
  *
  * <p>Every endpoint is validated as a host name, an IPv4 literal, or an IPv6 literal without any
  * name resolution. When one endpoint cannot be validated the whole target is dropped, because a

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseAttributesGetter.java
@@ -79,4 +79,16 @@ class ClickHouseAttributesGetter implements SqlClientAttributesGetter<ClickHouse
     }
     return request.getPort();
   }
+
+  @Nullable
+  @Override
+  public String getNetworkPeerAddress(ClickHouseDbRequest request, @Nullable Void response) {
+    return emitStableDatabaseSemconv() ? request.getPeerAddress() : null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(ClickHouseDbRequest request, @Nullable Void response) {
+    return emitStableDatabaseSemconv() ? request.getPeerPort() : null;
+  }
 }

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
@@ -11,14 +11,19 @@ import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class ClickHouseDbRequest {
+  @Nullable private volatile DbServerTarget peer;
 
   public static ClickHouseDbRequest create(
       @Nullable String host,
       @Nullable Integer port,
+      @Nullable DbServerTarget peer,
       @Nullable DbServerTarget serverTarget,
       @Nullable String namespace,
       String sql) {
-    return new AutoValue_ClickHouseDbRequest(host, port, serverTarget, namespace, sql);
+    ClickHouseDbRequest request =
+        new AutoValue_ClickHouseDbRequest(host, port, serverTarget, namespace, sql);
+    request.peer = peer;
+    return request;
   }
 
   @Nullable
@@ -26,6 +31,22 @@ public abstract class ClickHouseDbRequest {
 
   @Nullable
   public abstract Integer getPort();
+
+  @Nullable
+  public final String getPeerAddress() {
+    DbServerTarget peer = this.peer;
+    return peer == null ? null : peer.getAddress();
+  }
+
+  @Nullable
+  public final Integer getPeerPort() {
+    DbServerTarget peer = this.peer;
+    return peer == null ? null : peer.getPort();
+  }
+
+  public final void setPeer(@Nullable DbServerTarget peer) {
+    this.peer = peer;
+  }
 
   @Nullable
   public abstract DbServerTarget getServerTarget();

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseDbRequest.java
@@ -11,6 +11,8 @@ import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class ClickHouseDbRequest {
+  // The selected peer can change as an operation retries. It is intentionally excluded from
+  // AutoValue's equality, hash code, and string representations.
   @Nullable private volatile DbServerTarget peer;
 
   public static ClickHouseDbRequest create(

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
@@ -6,12 +6,17 @@
 package io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5;
 
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
 /** Container used to carry state between enter and exit advices */
 public class ClickHouseScope {
+  private static final ContextKey<ClickHouseDbRequest> REQUEST_KEY =
+      ContextKey.named("clickhouse-db-request");
+
   private final ClickHouseDbRequest clickHouseDbRequest;
   private final Context context;
   private final Scope scope;
@@ -37,8 +42,22 @@ public class ClickHouseScope {
       return null;
     }
 
-    Context context = instrumenter.start(parentContext, clickHouseDbRequest);
+    Context context =
+        instrumenter
+            .start(parentContext, clickHouseDbRequest)
+            .with(REQUEST_KEY, clickHouseDbRequest);
     return new ClickHouseScope(clickHouseDbRequest, context, context.makeCurrent(), instrumenter);
+  }
+
+  @Nullable
+  public static ClickHouseDbRequest currentRequest() {
+    return Context.current().get(REQUEST_KEY);
+  }
+
+  public void endOnCompletion(CompletableFuture<?> future) {
+    scope.close();
+    future.whenComplete(
+        (result, throwable) -> instrumenter.end(context, clickHouseDbRequest, null, throwable));
   }
 
   public void end(@Nullable Throwable throwable) {

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 /** Container used to carry state between enter and exit advices */
 public class ClickHouseScope {
   private static final ContextKey<ClickHouseDbRequest> REQUEST_KEY =
-      ContextKey.named("clickhouse-db-request");
+      ContextKey.named("opentelemetry-clickhouse-db-request");
 
   private final ClickHouseDbRequest clickHouseDbRequest;
   private final Context context;

--- a/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
+++ b/instrumentation/clickhouse/clickhouse-client-common-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/client/common/v0_5/ClickHouseScope.java
@@ -8,6 +8,7 @@ package io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
@@ -58,6 +59,22 @@ public class ClickHouseScope {
     scope.close();
     future.whenComplete(
         (result, throwable) -> instrumenter.end(context, clickHouseDbRequest, null, throwable));
+  }
+
+  public void endOnCompletion(CompletableFuture<?> future, Runnable beforeEnd) {
+    scope.close();
+    future.whenComplete(
+        (result, throwable) -> {
+          try {
+            beforeEnd.run();
+          } finally {
+            instrumenter.end(context, clickHouseDbRequest, null, throwable);
+          }
+        });
+  }
+
+  public void setPeer(@Nullable DbServerTarget peer) {
+    clickHouseDbRequest.setPeer(peer);
   }
 
   public void end(@Nullable Throwable throwable) {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -60,10 +60,13 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
       }
 
       ClickHouseNode server = clickHouseRequest.getServer();
+      String host = server.getHost();
+      int port = server.getPort();
       ClickHouseDbRequest request =
           ClickHouseDbRequest.create(
-              server.getHost(),
-              server.getPort(),
+              host,
+              port,
+              ClickHouseClientV1Singletons.peerServerTarget(host, port),
               ClickHouseClientV1Singletons.serverTarget(clickHouseRequest),
               server.getDatabase().orElse(ClickHouseDefaults.DATABASE.getDefaultValue().toString()),
               ClickHouseRequestAccess.getQuery(clickHouseRequest));

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv1.v0_5;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
@@ -23,9 +24,11 @@ import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
@@ -77,6 +80,8 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Argument(0) ClickHouseRequest<?> clickHouseRequest,
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable Object result,
         @Advice.Enter @Nullable ClickHouseScope scope) {
 
       CallDepth callDepth = CallDepth.forClass(ClickHouseClient.class);
@@ -84,7 +89,34 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
         return;
       }
 
-      scope.end(throwable);
+      if (emitStableDatabaseSemconv() && throwable == null && result instanceof CompletableFuture) {
+        scope.endOnCompletion(
+            (CompletableFuture<?>) result, new PeerUpdater(scope, clickHouseRequest));
+      } else {
+        updatePeer(scope, clickHouseRequest);
+        scope.end(throwable);
+      }
+    }
+
+    public static void updatePeer(ClickHouseScope scope, ClickHouseRequest<?> clickHouseRequest) {
+      ClickHouseNode server = clickHouseRequest.getServer();
+      scope.setPeer(
+          ClickHouseClientV1Singletons.peerServerTarget(server.getHost(), server.getPort()));
+    }
+  }
+
+  public static class PeerUpdater implements Runnable {
+    private final ClickHouseScope scope;
+    private final ClickHouseRequest<?> clickHouseRequest;
+
+    public PeerUpdater(ClickHouseScope scope, ClickHouseRequest<?> clickHouseRequest) {
+      this.scope = scope;
+      this.clickHouseRequest = clickHouseRequest;
+    }
+
+    @Override
+    public void run() {
+      ExecuteAndWaitAdvice.updatePeer(scope, clickHouseRequest);
     }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Instrumentation.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
@@ -81,7 +80,7 @@ class ClickHouseClientV1Instrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
         @Advice.Argument(0) ClickHouseRequest<?> clickHouseRequest,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable Object result,
+        @Advice.Return @Nullable Object result,
         @Advice.Enter @Nullable ClickHouseScope scope) {
 
       CallDepth callDepth = CallDepth.forClass(ClickHouseClient.class);

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -61,6 +61,11 @@ public class ClickHouseClientV1Singletons {
     return uncapturedServerTarget(request);
   }
 
+  @Nullable
+  public static DbServerTarget peerServerTarget(String host, int port) {
+    return DbServerTarget.builder(-1).addEndpoint(extractPeerHost(host), port).build();
+  }
+
   public static void captureConfiguredNodes(
       ClickHouseNodes nodes, Collection<ClickHouseNode> configuredNodes) {
     NODES_SERVER_TARGET.set(nodes, createServerTarget(configuredNodes));
@@ -139,6 +144,31 @@ public class ClickHouseClientV1Singletons {
         node.getConfig().isSsl() ? protocol.getDefaultSecurePort() : protocol.getDefaultPort();
     builder.addEndpoint(host, node.getPort(), defaultPort);
     return true;
+  }
+
+  @Nullable
+  private static String extractPeerHost(String host) {
+    if (host.indexOf('/') >= 0
+        || host.indexOf('?') >= 0
+        || host.indexOf('#') >= 0
+        || host.indexOf(',') >= 0
+        || host.indexOf('=') >= 0
+        || host.indexOf('%') >= 0
+        || host.indexOf('[') >= 0
+        || host.indexOf(']') >= 0
+        || hasWhitespace(host)) {
+      return null;
+    }
+    return host.indexOf('@') < 0 ? host : null;
+  }
+
+  private static boolean hasWhitespace(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      if (Character.isWhitespace(value.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static class CapturedServerTarget {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Singletons.java
@@ -63,7 +63,7 @@ public class ClickHouseClientV1Singletons {
 
   @Nullable
   public static DbServerTarget peerServerTarget(String host, int port) {
-    return DbServerTarget.builder(-1).addEndpoint(extractPeerHost(host), port).build();
+    return DbServerTarget.builder(-1).addEndpoint(host, port).build();
   }
 
   public static void captureConfiguredNodes(
@@ -144,31 +144,6 @@ public class ClickHouseClientV1Singletons {
         node.getConfig().isSsl() ? protocol.getDefaultSecurePort() : protocol.getDefaultPort();
     builder.addEndpoint(host, node.getPort(), defaultPort);
     return true;
-  }
-
-  @Nullable
-  private static String extractPeerHost(String host) {
-    if (host.indexOf('/') >= 0
-        || host.indexOf('?') >= 0
-        || host.indexOf('#') >= 0
-        || host.indexOf(',') >= 0
-        || host.indexOf('=') >= 0
-        || host.indexOf('%') >= 0
-        || host.indexOf('[') >= 0
-        || host.indexOf(']') >= 0
-        || hasWhitespace(host)) {
-      return null;
-    }
-    return host.indexOf('@') < 0 ? host : null;
-  }
-
-  private static boolean hasWhitespace(String value) {
-    for (int i = 0; i < value.length(); i++) {
-      if (Character.isWhitespace(value.charAt(i))) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private static class CapturedServerTarget {

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/com/clickhouse/client/TestClickHouseClient.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/com/clickhouse/client/TestClickHouseClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.clickhouse.client;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class TestClickHouseClient implements ClickHouseClient {
+  private final ClickHouseConfig config = new ClickHouseConfig();
+  private final CompletableFuture<ClickHouseResponse> response = new CompletableFuture<>();
+  private ClickHouseRequest<?> request;
+
+  @Override
+  public CompletableFuture<ClickHouseResponse> execute(ClickHouseRequest<?> request) {
+    this.request = request.seal();
+    return response;
+  }
+
+  @Override
+  public ClickHouseConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  public void close() {}
+
+  public void failOverTo(ClickHouseNode server) {
+    ClickHouseNode currentServer = request.getServer();
+    request.changeServer(currentServer, server);
+  }
+
+  public void complete() {
+    response.complete(null);
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -122,6 +124,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -136,6 +143,8 @@ class ClickHouseClientV1Test {
         DB_SYSTEM_NAME,
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
   }
@@ -287,6 +296,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -307,6 +321,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -346,6 +365,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -387,6 +411,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from non_existent_table"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -403,6 +432,8 @@ class ClickHouseClientV1Test {
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
         ERROR_TYPE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
     if (emitStableDatabaseSemconv()) {
@@ -445,6 +476,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -481,6 +517,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -523,6 +564,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -543,6 +589,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -600,6 +651,11 @@ class ClickHouseClientV1Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(:val1)(:val2)(:val3)"),
                             equalTo(
@@ -620,6 +676,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where s=:val"),
@@ -669,6 +730,11 @@ class ClickHouseClientV1Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where s={s:String}"),

--- a/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v1-0.5/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv1/v0_5/ClickHouseClientV1Test.java
@@ -33,6 +33,7 @@ import com.clickhouse.client.ClickHouseParameterizedQuery;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.ClickHouseResponseSummary;
+import com.clickhouse.client.TestClickHouseClient;
 import com.clickhouse.data.ClickHouseFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -481,6 +482,49 @@ class ClickHouseClientV1Test {
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                            equalTo(
+                                DB_QUERY_SUMMARY,
+                                emitStableDatabaseSemconv() ? "select test_table" : null),
+                            equalTo(
+                                maybeStable(DB_OPERATION),
+                                emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testAsyncExecuteUsesFinalServer() {
+    ClickHouseNode initialServer = ClickHouseNode.of("http://initial.example:8124/default");
+    ClickHouseNode finalServer = ClickHouseNode.of("http://final.example:9123/default");
+    TestClickHouseClient client = new TestClickHouseClient();
+
+    CompletableFuture<ClickHouseResponse> response =
+        client.read(initialServer).query("select * from " + TABLE_NAME).execute();
+
+    client.failOverTo(finalServer);
+    if (emitStableDatabaseSemconv()) {
+      assertThat(testing.spans()).isEmpty();
+    }
+    client.complete();
+    response.join();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "select test_table"
+                                : "SELECT " + DATABASE_NAME)
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                            equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                            equalTo(SERVER_ADDRESS, "initial.example"),
+                            equalTo(SERVER_PORT, 8124),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? "final.example" : null),
+                            equalTo(NETWORK_PEER_PORT, emitStableDatabaseSemconv() ? 9123L : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
 import static io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8.ClickHouseClientV2Singletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
@@ -15,13 +16,15 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.clickhouse.client.api.Client;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTarget;
 import io.opentelemetry.javaagent.bootstrap.CallDepth;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8.ClickHouseClientV2Singletons.CurrentServerInfo;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -64,19 +67,17 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
         return null;
       }
 
-      AddressAndPort addressAndPort = ClickHouseClientV2Singletons.getAddressAndPort(client);
-      if (addressAndPort == null) {
-        String endpoint = client.getEndpoints().stream().findFirst().orElse(null);
-        addressAndPort = ClickHouseClientV2Singletons.setAddressAndPort(client, endpoint);
-      }
+      DbServerTarget serverTarget = ClickHouseClientV2Singletons.configuredServerTarget(client);
+      CurrentServerInfo currentServerInfo = ClickHouseClientV2Singletons.currentServerInfo(client);
 
       String database = client.getConfiguration().get("database");
       Context parentContext = currentContext();
       ClickHouseDbRequest request =
           ClickHouseDbRequest.create(
-              addressAndPort.getAddress(),
-              addressAndPort.getPort(),
-              ClickHouseClientV2Singletons.configuredServerTarget(client),
+              currentServerInfo.getAddress(),
+              currentServerInfo.getPort(),
+              currentServerInfo.getPeer(),
+              serverTarget,
               database,
               sqlQuery);
 
@@ -86,13 +87,18 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
+        @Advice.Return @Nullable CompletableFuture<?> future,
         @Advice.Enter @Nullable ClickHouseScope scope) {
       CallDepth callDepth = CallDepth.forClass(Client.class);
       if (callDepth.decrementAndGet() > 0 || scope == null) {
         return;
       }
 
-      scope.end(throwable);
+      if (!emitStableDatabaseSemconv() || throwable != null || future == null) {
+        scope.end(throwable);
+      } else {
+        scope.endOnCompletion(future);
+      }
     }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.clickhouse.client.api.Client;
@@ -28,7 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
@@ -45,7 +45,8 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
             .and(named("query"))
             .and(takesArgument(0, String.class))
             .and(takesArgument(1, isSubTypeOf(Map.class)))
-            .and(takesArgument(2, named("com.clickhouse.client.api.query.QuerySettings"))),
+            .and(takesArgument(2, named("com.clickhouse.client.api.query.QuerySettings")))
+            .and(returns(isSubTypeOf(CompletableFuture.class))),
         getClass().getName() + "$QueryAdvice");
   }
 
@@ -88,19 +89,17 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable Object result,
+        @Advice.Return @Nullable CompletableFuture<?> future,
         @Advice.Enter @Nullable ClickHouseScope scope) {
       CallDepth callDepth = CallDepth.forClass(Client.class);
       if (callDepth.decrementAndGet() > 0 || scope == null) {
         return;
       }
 
-      if (!emitStableDatabaseSemconv()
-          || throwable != null
-          || !(result instanceof CompletableFuture)) {
+      if (!emitStableDatabaseSemconv() || throwable != null || future == null) {
         scope.end(throwable);
       } else {
-        scope.endOnCompletion((CompletableFuture<?>) result);
+        scope.endOnCompletion(future);
       }
     }
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Instrumentation.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
@@ -87,17 +88,19 @@ class ClickHouseClientV2Instrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
     public static void onExit(
         @Advice.Thrown @Nullable Throwable throwable,
-        @Advice.Return @Nullable CompletableFuture<?> future,
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable Object result,
         @Advice.Enter @Nullable ClickHouseScope scope) {
       CallDepth callDepth = CallDepth.forClass(Client.class);
       if (callDepth.decrementAndGet() > 0 || scope == null) {
         return;
       }
 
-      if (!emitStableDatabaseSemconv() || throwable != null || future == null) {
+      if (!emitStableDatabaseSemconv()
+          || throwable != null
+          || !(result instanceof CompletableFuture)) {
         scope.end(throwable);
       } else {
-        scope.endOnCompletion(future);
+        scope.endOnCompletion((CompletableFuture<?>) result);
       }
     }
   }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2InstrumentationModule.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -21,6 +21,7 @@ public class ClickHouseClientV2InstrumentationModule extends InstrumentationModu
 
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
-    return singletonList(new ClickHouseClientV2Instrumentation());
+    return asList(
+        new ClickHouseClientV2Instrumentation(), new ClickHouseClientV2RequestInstrumentation());
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2RequestInstrumentation.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2RequestInstrumentation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.clickhouse.clientv2.v0_8;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
+import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseScope;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class ClickHouseClientV2RequestInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.clickhouse.client.api.internal.HttpAPIClientHelper");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        namedOneOf("executeRequest", "executeMultiPartRequest", "createRequest")
+            .and(
+                takesArgument(
+                    0,
+                    namedOneOf(
+                        "com.clickhouse.client.ClickHouseNode",
+                        "com.clickhouse.client.api.transport.Endpoint"))),
+        getClass().getName() + "$RequestAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class RequestAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(@Advice.Argument(0) Object endpoint) throws Exception {
+      ClickHouseDbRequest request = ClickHouseScope.currentRequest();
+      if (request != null) {
+        ClickHouseClientV2Singletons.capturePeer(request, endpoint);
+      }
+    }
+  }
+}

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -81,11 +81,7 @@ public class ClickHouseClientV2Singletons {
     Class<?> selectedNodeClass = selectedNode.getClass();
     String host = (String) selectedNodeClass.getMethod("getHost").invoke(selectedNode);
     int port = (Integer) selectedNodeClass.getMethod("getPort").invoke(selectedNode);
-    EndpointTarget extracted = EndpointTarget.parse(host);
-    request.setPeer(
-        extracted == null
-            ? null
-            : DbServerTarget.builder(-1).addEndpoint(extracted.address, port).build());
+    request.setPeer(DbServerTarget.builder(-1).addEndpoint(host, port).build());
   }
 
   public static class CurrentServerInfo {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -108,12 +108,14 @@ public class ClickHouseClientV2Singletons {
       }
       String endpoint = endpoints.iterator().next();
       EndpointTarget extracted = EndpointTarget.parse(endpoint);
+      int peerPort =
+          extracted == null
+              ? -1
+              : extracted.port == null ? extracted.defaultPort() : extracted.port;
       DbServerTarget peer =
           extracted == null
               ? null
-              : DbServerTarget.builder(extracted.defaultPort())
-                  .addEndpoint(extracted.address, extracted.port == null ? -1 : extracted.port)
-                  .build();
+              : DbServerTarget.builder(-1).addEndpoint(extracted.address, peerPort).build();
       return new CurrentServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), peer);
     }
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -15,6 +15,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
+import java.lang.reflect.Method;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -26,6 +27,15 @@ public class ClickHouseClientV2Singletons {
       VirtualField.find(Client.class, DbServerTarget.class);
   private static final VirtualField<Client, CurrentServerInfo> CURRENT_SERVER_INFO_FIELD =
       VirtualField.find(Client.class, CurrentServerInfo.class);
+  // the selected node is a ClickHouseNode or a transport Endpoint depending on the library version,
+  // so its accessors are resolved reflectively once per class
+  private static final ClassValue<PeerAccessor> PEER_ACCESSOR =
+      new ClassValue<PeerAccessor>() {
+        @Override
+        protected PeerAccessor computeValue(Class<?> type) {
+          return PeerAccessor.create(type);
+        }
+      };
 
   static {
     instrumenter =
@@ -78,10 +88,37 @@ public class ClickHouseClientV2Singletons {
 
   public static void capturePeer(ClickHouseDbRequest request, Object selectedNode)
       throws Exception {
-    Class<?> selectedNodeClass = selectedNode.getClass();
-    String host = (String) selectedNodeClass.getMethod("getHost").invoke(selectedNode);
-    int port = (Integer) selectedNodeClass.getMethod("getPort").invoke(selectedNode);
-    request.setPeer(DbServerTarget.builder(-1).addEndpoint(host, port).build());
+    PEER_ACCESSOR.get(selectedNode.getClass()).capture(request, selectedNode);
+  }
+
+  private static class PeerAccessor {
+    private static final PeerAccessor UNAVAILABLE = new PeerAccessor(null, null);
+
+    @Nullable private final Method getHost;
+    @Nullable private final Method getPort;
+
+    private PeerAccessor(@Nullable Method getHost, @Nullable Method getPort) {
+      this.getHost = getHost;
+      this.getPort = getPort;
+    }
+
+    private static PeerAccessor create(Class<?> selectedNodeClass) {
+      try {
+        return new PeerAccessor(
+            selectedNodeClass.getMethod("getHost"), selectedNodeClass.getMethod("getPort"));
+      } catch (NoSuchMethodException ignored) {
+        return UNAVAILABLE;
+      }
+    }
+
+    private void capture(ClickHouseDbRequest request, Object selectedNode) throws Exception {
+      if (getHost == null || getPort == null) {
+        return;
+      }
+      String host = (String) getHost.invoke(selectedNode);
+      int port = (Integer) getPort.invoke(selectedNode);
+      request.setPeer(DbServerTarget.builder(-1).addEndpoint(host, port).build());
+    }
   }
 
   public static class CurrentServerInfo {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Singletons.java
@@ -12,7 +12,6 @@ import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServ
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbServerTargetBuilder;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.internal.UrlParser;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.semconv.network.internal.AddressAndPort;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseDbRequest;
 import io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5.ClickHouseInstrumenterFactory;
@@ -25,8 +24,8 @@ public class ClickHouseClientV2Singletons {
   private static final Instrumenter<ClickHouseDbRequest, Void> instrumenter;
   private static final VirtualField<Client, DbServerTarget> CONFIGURED_SERVER_TARGET =
       VirtualField.find(Client.class, DbServerTarget.class);
-  private static final VirtualField<Client, AddressAndPort> ADDRESS_AND_PORT =
-      VirtualField.find(Client.class, AddressAndPort.class);
+  private static final VirtualField<Client, CurrentServerInfo> CURRENT_SERVER_INFO_FIELD =
+      VirtualField.find(Client.class, CurrentServerInfo.class);
 
   static {
     instrumenter =
@@ -54,6 +53,15 @@ public class ClickHouseClientV2Singletons {
     return CONFIGURED_SERVER_TARGET.get(client);
   }
 
+  public static CurrentServerInfo currentServerInfo(Client client) {
+    CurrentServerInfo currentServerInfo = CURRENT_SERVER_INFO_FIELD.get(client);
+    if (currentServerInfo == null) {
+      currentServerInfo = CurrentServerInfo.of(client.getEndpoints());
+      CURRENT_SERVER_INFO_FIELD.set(client, currentServerInfo);
+    }
+    return currentServerInfo;
+  }
+
   @Nullable
   static DbServerTarget parseConfiguredServerTarget(Set<String> endpoints) {
     DbServerTargetBuilder builder = DbServerTarget.builder(-1).setSorted(true);
@@ -68,21 +76,61 @@ public class ClickHouseClientV2Singletons {
     return builder.build();
   }
 
-  @Nullable
-  public static AddressAndPort getAddressAndPort(Client client) {
-    return ADDRESS_AND_PORT.get(client);
+  public static void capturePeer(ClickHouseDbRequest request, Object selectedNode)
+      throws Exception {
+    Class<?> selectedNodeClass = selectedNode.getClass();
+    String host = (String) selectedNodeClass.getMethod("getHost").invoke(selectedNode);
+    int port = (Integer) selectedNodeClass.getMethod("getPort").invoke(selectedNode);
+    EndpointTarget extracted = EndpointTarget.parse(host);
+    request.setPeer(
+        extracted == null
+            ? null
+            : DbServerTarget.builder(-1).addEndpoint(extracted.address, port).build());
   }
 
-  public static AddressAndPort setAddressAndPort(Client client, @Nullable String endpoint) {
-    AddressAndPort addressAndPort = new AddressAndPort();
+  public static class CurrentServerInfo {
+    private static final CurrentServerInfo EMPTY = new CurrentServerInfo(null, null, null);
 
-    if (endpoint != null) {
-      addressAndPort.setAddress(UrlParser.getHost(endpoint));
-      addressAndPort.setPort(UrlParser.getPort(endpoint));
+    @Nullable private final String address;
+    @Nullable private final Integer port;
+    @Nullable private final DbServerTarget peer;
+
+    private CurrentServerInfo(
+        @Nullable String address, @Nullable Integer port, @Nullable DbServerTarget peer) {
+      this.address = address;
+      this.port = port;
+      this.peer = peer;
     }
-    ADDRESS_AND_PORT.set(client, addressAndPort);
 
-    return addressAndPort;
+    private static CurrentServerInfo of(Set<String> endpoints) {
+      if (endpoints.isEmpty()) {
+        return EMPTY;
+      }
+      String endpoint = endpoints.iterator().next();
+      EndpointTarget extracted = EndpointTarget.parse(endpoint);
+      DbServerTarget peer =
+          extracted == null
+              ? null
+              : DbServerTarget.builder(extracted.defaultPort())
+                  .addEndpoint(extracted.address, extracted.port == null ? -1 : extracted.port)
+                  .build();
+      return new CurrentServerInfo(UrlParser.getHost(endpoint), UrlParser.getPort(endpoint), peer);
+    }
+
+    @Nullable
+    public String getAddress() {
+      return address;
+    }
+
+    @Nullable
+    public Integer getPort() {
+      return port;
+    }
+
+    @Nullable
+    public DbServerTarget getPeer() {
+      return peer;
+    }
   }
 
   private static class EndpointTarget {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -25,7 +25,6 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
@@ -41,10 +40,8 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -158,95 +155,15 @@ class ClickHouseClientV2Test {
   }
 
   @Test
-  void testRetryReportsContactedEndpoint() throws Exception {
-    assumeTrue(isClassPresent("com.clickhouse.client.api.transport.ClientNodeSelector"));
+  void testCapturedPeerFollowsEachContactedEndpoint() throws Exception {
+    Object request = createDbRequest();
+    assertCapturedPeer(request, null, null);
 
-    int unavailablePort = 1;
-    Client testClient =
-        new Client.Builder()
-            .addEndpoint("http://127.0.0.1:" + unavailablePort)
-            .addEndpoint(Protocol.HTTP, host, port, false)
-            .setDefaultDatabase(DATABASE_NAME)
-            .setUsername(USERNAME)
-            .setPassword(PASSWORD)
-            .setOption("compress", "false")
-            .setConnectTimeout(100)
-            .setMaxRetries(1)
-            .useAsyncRequests(true)
-            .build();
-    cleanup.deferCleanup(testClient);
-    putUnreachableEndpointFirst(testClient, unavailablePort);
+    capturePeer(request, new TestEndpoint("first.example", 9123));
+    assertCapturedPeer(request, "first.example", 9123);
 
-    QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
-    response.close();
-
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
-                        equalTo(maybeStable(DB_NAME), DATABASE_NAME),
-                        equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
-                        equalTo(
-                            NETWORK_PEER_PORT, emitStableDatabaseSemconv() ? (long) port : null),
-                        equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
-                        equalTo(
-                            DB_QUERY_SUMMARY,
-                            emitStableDatabaseSemconv() ? "select test_table" : null),
-                        equalTo(
-                            maybeStable(DB_OPERATION),
-                            emitStableDatabaseSemconv() ? null : "SELECT"))));
-  }
-
-  @Test
-  void testExhaustedRetryReportsLastContactedEndpoint() throws Exception {
-    assumeTrue(isClassPresent("com.clickhouse.client.api.transport.ClientNodeSelector"));
-
-    int firstUnavailablePort = 1;
-    int secondUnavailablePort = 2;
-    Client testClient =
-        new Client.Builder()
-            .addEndpoint("http://127.0.0.1:" + firstUnavailablePort)
-            .addEndpoint("http://127.0.0.1:" + secondUnavailablePort)
-            .setDefaultDatabase(DATABASE_NAME)
-            .setUsername(USERNAME)
-            .setPassword(PASSWORD)
-            .setOption("compress", "false")
-            .setConnectTimeout(100)
-            .setMaxRetries(1)
-            .useAsyncRequests(true)
-            .build();
-    cleanup.deferCleanup(testClient);
-    putUnreachableEndpointFirst(testClient, firstUnavailablePort);
-
-    Throwable thrown = catchThrowable(() -> testClient.query("select * from " + TABLE_NAME).join());
-    assertThat(thrown).isNotNull();
-
-    testing.waitAndAssertTraces(
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasAttributesSatisfyingExactly(
-                        equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
-                        equalTo(maybeStable(DB_NAME), DATABASE_NAME),
-                        equalTo(
-                            NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? "127.0.0.1" : null),
-                        equalTo(
-                            NETWORK_PEER_PORT,
-                            emitStableDatabaseSemconv() ? (long) secondUnavailablePort : null),
-                        equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
-                        equalTo(
-                            DB_QUERY_SUMMARY,
-                            emitStableDatabaseSemconv() ? "select test_table" : null),
-                        equalTo(
-                            maybeStable(DB_OPERATION),
-                            emitStableDatabaseSemconv() ? null : "SELECT"),
-                        equalTo(
-                            ERROR_TYPE,
-                            emitStableDatabaseSemconv()
-                                ? thrown.getCause().getClass().getName()
-                                : null))));
+    capturePeer(request, new TestEndpoint("second.example", 9124));
+    assertCapturedPeer(request, "second.example", 9124);
   }
 
   @Test
@@ -746,43 +663,49 @@ class ClickHouseClientV2Test {
     assertThat(peer.getClass().getMethod("getPort").invoke(peer)).isEqualTo(port);
   }
 
-  private static boolean isClassPresent(String className) {
-    try {
-      Class.forName(className, false, Client.class.getClassLoader());
-      return true;
-    } catch (ClassNotFoundException ignored) {
-      return false;
-    }
+  private static Object createDbRequest() throws Exception {
+    return uniqueMethod(dbRequestClass(), "create")
+        .invoke(
+            null,
+            "initial.example",
+            8123,
+            null,
+            null,
+            DATABASE_NAME,
+            "select * from " + TABLE_NAME);
   }
 
-  private static void putUnreachableEndpointFirst(Client client, int unavailablePort)
-      throws Exception {
-    Field endpointsField = Client.class.getDeclaredField("endpoints");
-    endpointsField.setAccessible(true);
-    List<?> endpoints = (List<?>) endpointsField.get(client);
-    List<Object> orderedEndpoints = new ArrayList<>(endpoints.size());
-    Object unavailableEndpoint = null;
-    for (Object endpoint : endpoints) {
-      int endpointPort = (Integer) endpoint.getClass().getMethod("getPort").invoke(endpoint);
-      if (endpointPort == unavailablePort) {
-        unavailableEndpoint = endpoint;
-      } else {
-        orderedEndpoints.add(endpoint);
+  private static void capturePeer(Object request, Object contactedEndpoint) throws Exception {
+    uniqueMethod(singletons(), "capturePeer").invoke(null, request, contactedEndpoint);
+  }
+
+  /**
+   * Returns the only method of {@code owner} with this name. The parameter types cannot be named
+   * here, because the instrumentation classes are loaded by the agent rather than by the test class
+   * loader.
+   */
+  private static Method uniqueMethod(Class<?> owner, String name) {
+    for (Method method : owner.getDeclaredMethods()) {
+      if (name.equals(method.getName())) {
+        return method;
       }
     }
-    assertThat(unavailableEndpoint).isNotNull();
-    orderedEndpoints.add(0, unavailableEndpoint);
-    endpointsField.set(client, orderedEndpoints);
+    throw new AssertionError(owner.getName() + " has no method named " + name);
+  }
 
-    Class<?> selectorClass =
-        Class.forName(
-            "com.clickhouse.client.api.transport.ClientNodeSelector",
-            true,
-            Client.class.getClassLoader());
-    Object selector = selectorClass.getConstructor(List.class).newInstance(orderedEndpoints);
-    Field selectorField = Client.class.getDeclaredField("nodeSelector");
-    selectorField.setAccessible(true);
-    selectorField.set(client, selector);
+  private static void assertCapturedPeer(Object request, String address, Integer port)
+      throws Exception {
+    Class<?> requestClass = dbRequestClass();
+    assertThat(requestClass.getMethod("getPeerAddress").invoke(request)).isEqualTo(address);
+    assertThat(requestClass.getMethod("getPeerPort").invoke(request)).isEqualTo(port);
+  }
+
+  private static Class<?> dbRequestClass() throws Exception {
+    return Class.forName(
+        "io.opentelemetry.javaagent.instrumentation.clickhouse.client.common.v0_5."
+            + "ClickHouseDbRequest",
+        true,
+        singletons().getClassLoader());
   }
 
   private static Class<?> singletons() throws Exception {
@@ -805,6 +728,29 @@ class ClickHouseClientV2Test {
                       + "ClickHouseClientV2InstrumentationModule",
                   Client.class.getClassLoader());
       return Class.forName(singletonsName, true, instrumentationClassLoader);
+    }
+  }
+
+  /**
+   * Stands in for the node or endpoint object that the ClickHouse client hands to its HTTP helper
+   * for a single attempt. The instrumentation reads the host and the port off it reflectively,
+   * because the library names that object differently across the supported versions.
+   */
+  public static class TestEndpoint {
+    private final String host;
+    private final int port;
+
+    TestEndpoint(String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public int getPort() {
+      return port;
     }
   }
 }

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -319,13 +319,7 @@ class ClickHouseClientV2Test {
 
   @Test
   void testUnsafePeerEndpointIsOmitted() throws Exception {
-    Class<?> singletons = singletons();
-    Class<?> endpointTarget =
-        Class.forName(singletons.getName() + "$EndpointTarget", true, singletons.getClassLoader());
-    Method parse = endpointTarget.getDeclaredMethod("parse", String.class);
-    parse.setAccessible(true);
-
-    assertThat(parse.invoke(null, "http://host.example%3fsecret:8123")).isNull();
+    assertCurrentPeer(new HashSet<>(asList("http://host.example%3fsecret:8123")), null, null);
   }
 
   @Test

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -309,7 +309,9 @@ class ClickHouseClientV2Test {
 
   @Test
   void testUnsafePeerEndpointIsOmitted() throws Exception {
-    Class<?> endpointTarget = Class.forName(singletons().getName() + "$EndpointTarget");
+    Class<?> singletons = singletons();
+    Class<?> endpointTarget =
+        Class.forName(singletons.getName() + "$EndpointTarget", true, singletons.getClassLoader());
     Method parse = endpointTarget.getDeclaredMethod("parse", String.class);
     parse.setAccessible(true);
 

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -271,6 +271,16 @@ class ClickHouseClientV2Test {
     assertServerTarget(new HashSet<>(asList("http://2001:db8::1:9123")), "2001:db8::1", 9123);
   }
 
+  @Test
+  void testInitialPeerUsesEffectivePort() throws Exception {
+    assertCurrentPeer(new HashSet<>(asList("http://single.example")), "single.example", 8123);
+  }
+
+  @Test
+  void testInitialPeerWithoutKnownPortIsOmitted() throws Exception {
+    assertCurrentPeer(new HashSet<>(asList("custom://single.example")), null, null);
+  }
+
   @ParameterizedTest
   @ValueSource(
       strings = {
@@ -719,6 +729,27 @@ class ClickHouseClientV2Test {
     Class<?> serverTargetType = serverTarget.getClass().getSuperclass();
     assertThat(serverTargetType.getMethod("getAddress").invoke(serverTarget)).isEqualTo(address);
     assertThat(serverTargetType.getMethod("getPort").invoke(serverTarget)).isEqualTo(port);
+  }
+
+  private static void assertCurrentPeer(Set<String> endpoints, String address, Integer port)
+      throws Exception {
+    Class<?> singletons = singletons();
+    Class<?> currentServerInfo =
+        Class.forName(
+            singletons.getName() + "$CurrentServerInfo", true, singletons.getClassLoader());
+    Method of = currentServerInfo.getDeclaredMethod("of", Set.class);
+    of.setAccessible(true);
+    Object info = of.invoke(null, endpoints);
+    Object peer = currentServerInfo.getMethod("getPeer").invoke(info);
+
+    if (address == null) {
+      assertThat(peer).isNull();
+      return;
+    }
+
+    assertThat(peer).isNotNull();
+    assertThat(peer.getClass().getMethod("getAddress").invoke(peer)).isEqualTo(address);
+    assertThat(peer.getClass().getMethod("getPort").invoke(peer)).isEqualTo(port);
   }
 
   private static boolean isClassPresent(String className) {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -13,6 +13,8 @@ import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_SUMMARY;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_NAME;
@@ -23,6 +25,7 @@ import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSyste
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ServerException;
@@ -38,8 +41,10 @@ import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtens
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.javaagent.testing.common.AgentClassLoaderAccess;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -127,6 +132,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -141,8 +151,102 @@ class ClickHouseClientV2Test {
         DB_SYSTEM_NAME,
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
+  }
+
+  @Test
+  void testRetryReportsContactedEndpoint() throws Exception {
+    assumeTrue(isClassPresent("com.clickhouse.client.api.transport.ClientNodeSelector"));
+
+    int unavailablePort = 1;
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://127.0.0.1:" + unavailablePort)
+            .addEndpoint(Protocol.HTTP, host, port, false)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .setConnectTimeout(100)
+            .setMaxRetries(1)
+            .useAsyncRequests(true)
+            .build();
+    cleanup.deferCleanup(testClient);
+    putUnreachableEndpointFirst(testClient, unavailablePort);
+
+    QueryResponse response = testClient.query("select * from " + TABLE_NAME).join();
+    response.close();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttributesSatisfyingExactly(
+                        equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                        equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                        equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                        equalTo(
+                            NETWORK_PEER_PORT, emitStableDatabaseSemconv() ? (long) port : null),
+                        equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                        equalTo(
+                            DB_QUERY_SUMMARY,
+                            emitStableDatabaseSemconv() ? "select test_table" : null),
+                        equalTo(
+                            maybeStable(DB_OPERATION),
+                            emitStableDatabaseSemconv() ? null : "SELECT"))));
+  }
+
+  @Test
+  void testExhaustedRetryReportsLastContactedEndpoint() throws Exception {
+    assumeTrue(isClassPresent("com.clickhouse.client.api.transport.ClientNodeSelector"));
+
+    int firstUnavailablePort = 1;
+    int secondUnavailablePort = 2;
+    Client testClient =
+        new Client.Builder()
+            .addEndpoint("http://127.0.0.1:" + firstUnavailablePort)
+            .addEndpoint("http://127.0.0.1:" + secondUnavailablePort)
+            .setDefaultDatabase(DATABASE_NAME)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setOption("compress", "false")
+            .setConnectTimeout(100)
+            .setMaxRetries(1)
+            .useAsyncRequests(true)
+            .build();
+    cleanup.deferCleanup(testClient);
+    putUnreachableEndpointFirst(testClient, firstUnavailablePort);
+
+    Throwable thrown = catchThrowable(() -> testClient.query("select * from " + TABLE_NAME).join());
+    assertThat(thrown).isNotNull();
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasAttributesSatisfyingExactly(
+                        equalTo(maybeStable(DB_SYSTEM), CLICKHOUSE),
+                        equalTo(maybeStable(DB_NAME), DATABASE_NAME),
+                        equalTo(
+                            NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? "127.0.0.1" : null),
+                        equalTo(
+                            NETWORK_PEER_PORT,
+                            emitStableDatabaseSemconv() ? (long) secondUnavailablePort : null),
+                        equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
+                        equalTo(
+                            DB_QUERY_SUMMARY,
+                            emitStableDatabaseSemconv() ? "select test_table" : null),
+                        equalTo(
+                            maybeStable(DB_OPERATION),
+                            emitStableDatabaseSemconv() ? null : "SELECT"),
+                        equalTo(
+                            ERROR_TYPE,
+                            emitStableDatabaseSemconv()
+                                ? thrown.getCause().getClass().getName()
+                                : null))));
   }
 
   @Test
@@ -204,6 +308,15 @@ class ClickHouseClientV2Test {
   }
 
   @Test
+  void testUnsafePeerEndpointIsOmitted() throws Exception {
+    Class<?> endpointTarget = Class.forName(singletons().getName() + "$EndpointTarget");
+    Method parse = endpointTarget.getDeclaredMethod("parse", String.class);
+    parse.setAccessible(true);
+
+    assertThat(parse.invoke(null, "http://host.example%3fsecret:8123")).isNull();
+  }
+
+  @Test
   void testQueryWithStringQuery() throws Exception {
     testing.runWithSpan(
         "parent",
@@ -233,6 +346,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)(?)(?)"),
                             equalTo(
@@ -253,6 +371,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -291,6 +414,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from " + TABLE_NAME),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -327,6 +455,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(maybeStable(DB_STATEMENT), "select * from non_existent_table"),
                             equalTo(
                                 DB_QUERY_SUMMARY,
@@ -343,6 +476,8 @@ class ClickHouseClientV2Test {
         DB_QUERY_SUMMARY,
         DB_NAMESPACE,
         ERROR_TYPE,
+        NETWORK_PEER_ADDRESS,
+        NETWORK_PEER_PORT,
         SERVER_ADDRESS,
         SERVER_PORT);
     if (emitStableDatabaseSemconv()) {
@@ -386,6 +521,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
                             equalTo(
@@ -421,6 +561,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -464,6 +609,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "insert into " + TABLE_NAME + " values(?)"),
                             equalTo(
@@ -484,6 +634,11 @@ class ClickHouseClientV2Test {
                             equalTo(maybeStable(DB_NAME), DATABASE_NAME),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
                             equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " limit ?"),
@@ -530,6 +685,11 @@ class ClickHouseClientV2Test {
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? host : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 maybeStable(DB_STATEMENT),
                                 "select * from " + TABLE_NAME + " where value={param_s: String}"),
                             equalTo(
@@ -552,10 +712,50 @@ class ClickHouseClientV2Test {
       assertThat(serverTarget).isNull();
       return;
     }
+
     assertThat(serverTarget).isNotNull();
     Class<?> serverTargetType = serverTarget.getClass().getSuperclass();
     assertThat(serverTargetType.getMethod("getAddress").invoke(serverTarget)).isEqualTo(address);
     assertThat(serverTargetType.getMethod("getPort").invoke(serverTarget)).isEqualTo(port);
+  }
+
+  private static boolean isClassPresent(String className) {
+    try {
+      Class.forName(className, false, Client.class.getClassLoader());
+      return true;
+    } catch (ClassNotFoundException ignored) {
+      return false;
+    }
+  }
+
+  private static void putUnreachableEndpointFirst(Client client, int unavailablePort)
+      throws Exception {
+    Field endpointsField = Client.class.getDeclaredField("endpoints");
+    endpointsField.setAccessible(true);
+    List<?> endpoints = (List<?>) endpointsField.get(client);
+    List<Object> orderedEndpoints = new ArrayList<>(endpoints.size());
+    Object unavailableEndpoint = null;
+    for (Object endpoint : endpoints) {
+      int endpointPort = (Integer) endpoint.getClass().getMethod("getPort").invoke(endpoint);
+      if (endpointPort == unavailablePort) {
+        unavailableEndpoint = endpoint;
+      } else {
+        orderedEndpoints.add(endpoint);
+      }
+    }
+    assertThat(unavailableEndpoint).isNotNull();
+    orderedEndpoints.add(0, unavailableEndpoint);
+    endpointsField.set(client, orderedEndpoints);
+
+    Class<?> selectorClass =
+        Class.forName(
+            "com.clickhouse.client.api.transport.ClientNodeSelector",
+            true,
+            Client.class.getClassLoader());
+    Object selector = selectorClass.getConstructor(List.class).newInstance(orderedEndpoints);
+    Field selectorField = Client.class.getDeclaredField("nodeSelector");
+    selectorField.setAccessible(true);
+    selectorField.set(client, selector);
   }
 
   private static Class<?> singletons() throws Exception {

--- a/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
+++ b/instrumentation/clickhouse/clickhouse-client-v2-0.8/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/clickhouse/clientv2/v0_8/ClickHouseClientV2Test.java
@@ -659,8 +659,9 @@ class ClickHouseClientV2Test {
     }
 
     assertThat(peer).isNotNull();
-    assertThat(peer.getClass().getMethod("getAddress").invoke(peer)).isEqualTo(address);
-    assertThat(peer.getClass().getMethod("getPort").invoke(peer)).isEqualTo(port);
+    assertThat(peer.getClass().getSuperclass().getMethod("getAddress").invoke(peer))
+        .isEqualTo(address);
+    assertThat(peer.getClass().getSuperclass().getMethod("getPort").invoke(peer)).isEqualTo(port);
   }
 
   private static Object createDbRequest() throws Exception {


### PR DESCRIPTION
Adds `network.peer.address` and `network.peer.port` to stable ClickHouse client v1 and v2 database spans. The attributes identify the endpoint contacted for each request, including the final endpoint contacted after retries, while legacy telemetry remains unchanged.