### PR TITLE
Fix universal database endpoint cap

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  */
 public class DbServerTargetBuilder {
 
-  private static final int MAX_ENDPOINTS = 5;
+  public static final int MAX_ENDPOINTS = 5;
   private static final int MIN_PORT = 1;
   private static final int MAX_PORT = 65535;
   private static final int MAX_HOST_NAME_LENGTH = 253;

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
  */
 public class DbServerTargetBuilder {
 
-  private static final int DEFAULT_MAX_ENDPOINTS = 5;
+  private static final int MAX_ENDPOINTS = 5;
   private static final int MIN_PORT = 1;
   private static final int MAX_PORT = 65535;
   private static final int MAX_HOST_NAME_LENGTH = 253;
@@ -42,7 +42,6 @@ public class DbServerTargetBuilder {
 
   private final int defaultPort;
   private final List<Endpoint> endpoints = new ArrayList<>();
-  private int maxEndpoints = DEFAULT_MAX_ENDPOINTS;
   private boolean sorted;
   private boolean portAlwaysInline;
   @Nullable private String suffix;
@@ -59,16 +58,6 @@ public class DbServerTargetBuilder {
   @CanIgnoreReturnValue
   public DbServerTargetBuilder setSorted(boolean sorted) {
     this.sorted = sorted;
-    return this;
-  }
-
-  /** Render at most {@code maxEndpoints} endpoints. Default is 5. */
-  @CanIgnoreReturnValue
-  public DbServerTargetBuilder setMaxEndpoints(int maxEndpoints) {
-    if (maxEndpoints < 1) {
-      throw new IllegalArgumentException("maxEndpoints must be positive");
-    }
-    this.maxEndpoints = maxEndpoints;
     return this;
   }
 
@@ -171,7 +160,7 @@ public class DbServerTargetBuilder {
     if (sorted) {
       rendered.sort(String::compareTo);
     }
-    return String.join(",", rendered.subList(0, Math.min(maxEndpoints, rendered.size())));
+    return String.join(",", rendered.subList(0, Math.min(MAX_ENDPOINTS, rendered.size())));
   }
 
   private DbServerTarget target(String address, @Nullable Integer port) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.net.InetAddress;
@@ -227,44 +226,29 @@ class DbServerTargetTest {
   }
 
   @Test
-  void endpointCapIsConfigurable() {
-    DbServerTarget target =
-        builder()
-            .setMaxEndpoints(2)
-            .addEndpoint("a.example.com", -1)
-            .addEndpoint("b.example.com", -1)
-            .addEndpoint("c.example.com", -1)
-            .build();
-
-    assertThat(target).isNotNull();
-    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
-  }
-
-  @Test
-  void endpointCapMustBePositive() {
-    assertThatThrownBy(() -> builder().setMaxEndpoints(0))
-        .isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
   void endpointsAreSortedBeforeTheyAreCapped() {
     DbServerTarget target =
         builder()
             .setSorted(true)
-            .setMaxEndpoints(2)
             .addEndpoint("c.example.com", -1)
             .addEndpoint("a.example.com", -1)
             .addEndpoint("b.example.com", -1)
+            .addEndpoint("e.example.com", -1)
+            .addEndpoint("d.example.com", -1)
+            .addEndpoint("f.example.com", -1)
             .build();
 
     assertThat(target).isNotNull();
-    assertThat(target.getAddress()).isEqualTo("a.example.com,b.example.com");
+    assertThat(target.getAddress())
+        .isEqualTo("a.example.com,b.example.com,c.example.com,d.example.com,e.example.com");
   }
 
   @Test
   void anUnsafeEndpointBeyondTheCapStillDropsTheTarget() {
-    DbServerTargetBuilder builder = builder().setMaxEndpoints(1);
-    builder.addEndpoint("a.example.com", -1);
+    DbServerTargetBuilder builder = builder();
+    for (int i = 1; i <= 5; i++) {
+      builder.addEndpoint("node" + i + ".example.com", -1);
+    }
     builder.addEndpoint("evil host", -1);
 
     assertThat(builder.build()).isNull();

--- a/instrumentation/geode-1.4/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerTargetBuilderTest.java
+++ b/instrumentation/geode-1.4/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerTargetBuilderTest.java
@@ -35,7 +35,7 @@ class GeodeServerTargetBuilderTest {
   }
 
   @Test
-  void locatorDiscoveryKeepsEverySortedLocatorAndServerGroup() {
+  void locatorDiscoveryIsSortedAndLimitedToFive() {
     GeodeServerTargetBuilder builder = new GeodeServerTargetBuilder();
     builder.addLocator("z.example", 10334);
     builder.addLocator("e.example", 10334);
@@ -50,7 +50,7 @@ class GeodeServerTargetBuilderTest {
     assertThat(target.getAddress())
         .isEqualTo(
             "a.example:10334,b.example:10334,c.example:10334,d.example:10334,"
-                + "e.example:10334,z.example:10334/orders");
+                + "e.example:10334/orders");
     assertThat(target.getPort()).isNull();
   }
 

--- a/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerTargetBuilder.java
+++ b/instrumentation/geode-1.4/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/geode/v1_4/GeodeServerTargetBuilder.java
@@ -58,9 +58,6 @@ class GeodeServerTargetBuilder {
   }
 
   private static DbServerTargetBuilder newLocatorBuilder() {
-    return DbServerTarget.builder(DEFAULT_LOCATOR_PORT)
-        .setSorted(true)
-        .setMaxEndpoints(Integer.MAX_VALUE)
-        .setPortAlwaysInline(true);
+    return DbServerTarget.builder(DEFAULT_LOCATOR_PORT).setSorted(true).setPortAlwaysInline(true);
   }
 }


### PR DESCRIPTION
Make the database server target cap a fixed five endpoints across all callers.

Remove `DbServerTargetBuilder.setMaxEndpoints(int)`, apply the fixed cap to Geode locator targets, and update coverage for sorted truncation and validation beyond the cap.