### PR TITLE
Add Bedrock guardrail ID span attribute

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -60,8 +60,9 @@ testing {
       dependencies {
         implementation(project())
         implementation(project(":instrumentation:aws-sdk:aws-sdk-2.2:testing"))
+        compileOnly("software.amazon.awssdk:bedrockruntime:2.26.5")
         val version = baseVersion("2.25.63").orLatest()
-        implementation("software.amazon.awssdk:bedrockruntime:$version")
+        runtimeOnly("software.amazon.awssdk:bedrockruntime:$version")
       }
     }
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -418,6 +418,7 @@ public final class AwsSdkInstrumenterFactory {
         builder -> {
           builder
               .addAttributesExtractor(GenAiAttributesExtractor.create(getter))
+              .addAttributesExtractor(new BedrockRuntimeAttributesExtractor())
               .addOperationMetrics(GenAiClientMetrics.get());
           setGenAiClientExceptionEventExtractor(builder);
         },

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAccess.java
@@ -69,6 +69,12 @@ final class BedrockRuntimeAccess {
 
   @Nullable
   @NoMuzzle
+  static String getGuardrailIdentifier(ExecutionAttributes executionAttributes) {
+    return enabled ? BedrockRuntimeImpl.getGuardrailIdentifier(executionAttributes) : null;
+  }
+
+  @Nullable
+  @NoMuzzle
   static String getOperationName(ExecutionAttributes executionAttributes) {
     return enabled ? BedrockRuntimeImpl.getOperationName(executionAttributes) : null;
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import javax.annotation.Nullable;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+
+class BedrockRuntimeAttributesExtractor
+    implements AttributesExtractor<ExecutionAttributes, Response> {
+
+  // copied from AwsIncubatingAttributes
+  private static final AttributeKey<String> AWS_BEDROCK_GUARDRAIL_ID =
+      stringKey("aws.bedrock.guardrail.id");
+
+  @Override
+  public void onStart(
+      AttributesBuilder attributes,
+      Context parentContext,
+      ExecutionAttributes executionAttributes) {
+    attributes.put(
+        AWS_BEDROCK_GUARDRAIL_ID, BedrockRuntimeAccess.getGuardrailIdentifier(executionAttributes));
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      ExecutionAttributes executionAttributes,
+      @Nullable Response response,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeImpl.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.awscore.eventstream.EventStreamResponseHandler;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.SdkResponse;
 import software.amazon.awssdk.core.async.SdkPublisher;
@@ -178,6 +180,29 @@ public final class BedrockRuntimeImpl {
     }
     if (request instanceof InvokeModelWithResponseStreamRequest) {
       return ((InvokeModelWithResponseStreamRequest) request).modelId();
+    }
+    return null;
+  }
+
+  @Nullable
+  static String getGuardrailIdentifier(ExecutionAttributes executionAttributes) {
+    SdkRequest request = executionAttributes.getAttribute(SDK_REQUEST_ATTRIBUTE);
+    String guardrailIdentifier =
+        request.getValueForField("guardrailIdentifier", String.class).orElse(null);
+    if (guardrailIdentifier != null) {
+      return guardrailIdentifier;
+    }
+
+    Object guardrailConfig = request.getValueForField("guardrailConfig", Object.class).orElse(null);
+    if (!(guardrailConfig instanceof SdkPojo)) {
+      return null;
+    }
+
+    for (SdkField<?> field : ((SdkPojo) guardrailConfig).sdkFields()) {
+      if (field.memberName().equals("guardrailIdentifier")) {
+        Object value = field.getValueOrDefault(guardrailConfig);
+        return value instanceof String ? (String) value : null;
+      }
     }
     return null;
   }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractorTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2.internal;
+
+import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testLatestDeps;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_BEDROCK_GUARDRAIL_ID;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkField;
+import software.amazon.awssdk.core.SdkPojo;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelWithResponseStreamRequest;
+
+class BedrockRuntimeAttributesExtractorTest {
+
+  private final BedrockRuntimeAttributesExtractor extractor =
+      new BedrockRuntimeAttributesExtractor();
+
+  @ParameterizedTest
+  @MethodSource("invokeModelRequests")
+  void extractsTopLevelGuardrailIdentifier(SdkRequest request) {
+    assertThat(extract(request).get(AWS_BEDROCK_GUARDRAIL_ID)).isEqualTo("guardrail-id");
+  }
+
+  private static Stream<Arguments> invokeModelRequests() {
+    return Stream.of(
+        argumentSet(
+            "InvokeModel",
+            InvokeModelRequest.builder()
+                .guardrailIdentifier("guardrail-id")
+                .guardrailVersion("1")
+                .build()),
+        argumentSet(
+            "InvokeModelWithResponseStream",
+            InvokeModelWithResponseStreamRequest.builder()
+                .guardrailIdentifier("guardrail-id")
+                .guardrailVersion("1")
+                .build()));
+  }
+
+  @Test
+  void extractsNestedGuardrailIdentifier() {
+    SdkRequest request = mock(SdkRequest.class);
+    SdkPojo guardrailConfig = mock(SdkPojo.class);
+    @SuppressWarnings("unchecked")
+    SdkField<String> guardrailIdentifierField = mock(SdkField.class);
+    when(request.getValueForField("guardrailIdentifier", String.class))
+        .thenReturn(Optional.empty());
+    when(request.getValueForField("guardrailConfig", Object.class))
+        .thenReturn(Optional.of(guardrailConfig));
+    when(guardrailConfig.sdkFields()).thenReturn(singletonList(guardrailIdentifierField));
+    when(guardrailIdentifierField.memberName()).thenReturn("guardrailIdentifier");
+    when(guardrailIdentifierField.getValueOrDefault(guardrailConfig)).thenReturn("guardrail-id");
+
+    assertThat(extract(request).get(AWS_BEDROCK_GUARDRAIL_ID)).isEqualTo("guardrail-id");
+  }
+
+  @ParameterizedTest
+  @MethodSource("converseRequests")
+  void extractsGuardrailIdentifierFromConverseRequest(SdkRequest request)
+      throws ReflectiveOperationException {
+    assumeTrue(testLatestDeps());
+
+    SdkRequest requestWithGuardrail = withGuardrailConfiguration(request);
+
+    assertThat(extract(requestWithGuardrail).get(AWS_BEDROCK_GUARDRAIL_ID))
+        .isEqualTo("guardrail-id");
+  }
+
+  private static Stream<Arguments> converseRequests() {
+    return Stream.of(
+        argumentSet("Converse", ConverseRequest.builder().modelId("model-id").build()),
+        argumentSet("ConverseStream", ConverseStreamRequest.builder().modelId("model-id").build()));
+  }
+
+  @Test
+  void omitsGuardrailIdentifierWhenNotConfigured() {
+    SdkRequest request = mock(SdkRequest.class);
+    when(request.getValueForField("guardrailIdentifier", String.class))
+        .thenReturn(Optional.empty());
+    when(request.getValueForField("guardrailConfig", Object.class)).thenReturn(Optional.empty());
+
+    assertThat(extract(request).asMap()).isEmpty();
+  }
+
+  private Attributes extract(SdkRequest request) {
+    ExecutionAttributes executionAttributes =
+        new ExecutionAttributes()
+            .putAttribute(TracingExecutionInterceptor.SDK_REQUEST_ATTRIBUTE, request);
+    AttributesBuilder attributes = Attributes.builder();
+    extractor.onStart(attributes, Context.root(), executionAttributes);
+    return attributes.build();
+  }
+
+  private static SdkRequest withGuardrailConfiguration(SdkRequest request)
+      throws ReflectiveOperationException {
+    String configClassName =
+        request instanceof ConverseStreamRequest
+            ? "GuardrailStreamConfiguration"
+            : "GuardrailConfiguration";
+    Class<?> configClass =
+        Class.forName("software.amazon.awssdk.services.bedrockruntime.model." + configClassName);
+    Class<?> configBuilderClass =
+        Class.forName(
+            "software.amazon.awssdk.services.bedrockruntime.model." + configClassName + "$Builder");
+    Object configBuilder = configClass.getMethod("builder").invoke(null);
+    configBuilderClass
+        .getMethod("guardrailIdentifier", String.class)
+        .invoke(configBuilder, "guardrail-id");
+    configBuilderClass.getMethod("guardrailVersion", String.class).invoke(configBuilder, "1");
+    Object config = configBuilderClass.getMethod("build").invoke(configBuilder);
+
+    SdkRequest.Builder requestBuilder = request.toBuilder();
+    Class<?> requestBuilderClass = Class.forName(request.getClass().getName() + "$Builder");
+    requestBuilderClass.getMethod("guardrailConfig", configClass).invoke(requestBuilder, config);
+    return requestBuilder.build();
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractorTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/testBedrockRuntime/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/BedrockRuntimeAttributesExtractorTest.java
@@ -29,6 +29,8 @@ import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.GuardrailStreamConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelWithResponseStreamRequest;
 
@@ -78,20 +80,15 @@ class BedrockRuntimeAttributesExtractorTest {
 
   @ParameterizedTest
   @MethodSource("converseRequests")
-  void extractsGuardrailIdentifierFromConverseRequest(SdkRequest request)
-      throws ReflectiveOperationException {
+  void extractsGuardrailIdentifierFromConverseRequest(boolean streaming) {
     assumeTrue(testLatestDeps());
 
-    SdkRequest requestWithGuardrail = withGuardrailConfiguration(request);
-
-    assertThat(extract(requestWithGuardrail).get(AWS_BEDROCK_GUARDRAIL_ID))
+    assertThat(extract(LatestConverseRequests.create(streaming)).get(AWS_BEDROCK_GUARDRAIL_ID))
         .isEqualTo("guardrail-id");
   }
 
   private static Stream<Arguments> converseRequests() {
-    return Stream.of(
-        argumentSet("Converse", ConverseRequest.builder().modelId("model-id").build()),
-        argumentSet("ConverseStream", ConverseStreamRequest.builder().modelId("model-id").build()));
+    return Stream.of(argumentSet("Converse", false), argumentSet("ConverseStream", true));
   }
 
   @Test
@@ -113,27 +110,29 @@ class BedrockRuntimeAttributesExtractorTest {
     return attributes.build();
   }
 
-  private static SdkRequest withGuardrailConfiguration(SdkRequest request)
-      throws ReflectiveOperationException {
-    String configClassName =
-        request instanceof ConverseStreamRequest
-            ? "GuardrailStreamConfiguration"
-            : "GuardrailConfiguration";
-    Class<?> configClass =
-        Class.forName("software.amazon.awssdk.services.bedrockruntime.model." + configClassName);
-    Class<?> configBuilderClass =
-        Class.forName(
-            "software.amazon.awssdk.services.bedrockruntime.model." + configClassName + "$Builder");
-    Object configBuilder = configClass.getMethod("builder").invoke(null);
-    configBuilderClass
-        .getMethod("guardrailIdentifier", String.class)
-        .invoke(configBuilder, "guardrail-id");
-    configBuilderClass.getMethod("guardrailVersion", String.class).invoke(configBuilder, "1");
-    Object config = configBuilderClass.getMethod("build").invoke(configBuilder);
+  // Keep references to types introduced after the floor version isolated from floor-version runs.
+  private static final class LatestConverseRequests {
+    private static SdkRequest create(boolean streaming) {
+      if (streaming) {
+        return ConverseStreamRequest.builder()
+            .modelId("model-id")
+            .guardrailConfig(
+                GuardrailStreamConfiguration.builder()
+                    .guardrailIdentifier("guardrail-id")
+                    .guardrailVersion("1")
+                    .build())
+            .build();
+      }
+      return ConverseRequest.builder()
+          .modelId("model-id")
+          .guardrailConfig(
+              GuardrailConfiguration.builder()
+                  .guardrailIdentifier("guardrail-id")
+                  .guardrailVersion("1")
+                  .build())
+          .build();
+    }
 
-    SdkRequest.Builder requestBuilder = request.toBuilder();
-    Class<?> requestBuilderClass = Class.forName(request.getClass().getName() + "$Builder");
-    requestBuilderClass.getMethod("guardrailConfig", configClass).invoke(requestBuilder, config);
-    return requestBuilder.build();
+    private LatestConverseRequests() {}
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2BedrockRuntimeTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_BEDROCK_GUARDRAIL_ID;
 import static io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes.GEN_AI_PROVIDER_NAME;
@@ -1422,6 +1423,8 @@ public abstract class AbstractAws2BedrockRuntimeTest {
         InvokeModelRequest.builder()
             .modelId(modelId)
             .body(SdkBytes.fromByteArray(generator.getBytes()))
+            .guardrailIdentifier("guardrail-id")
+            .guardrailVersion("1")
             .build();
 
     InvokeModelResponse response = client.invokeModel(request);
@@ -1443,6 +1446,7 @@ public abstract class AbstractAws2BedrockRuntimeTest {
                                 equalTo(GEN_AI_PROVIDER_NAME, AWS_BEDROCK),
                                 equalTo(GEN_AI_OPERATION_NAME, TEXT_COMPLETION),
                                 equalTo(GEN_AI_REQUEST_MODEL, modelId),
+                                equalTo(AWS_BEDROCK_GUARDRAIL_ID, "guardrail-id"),
                                 equalTo(GEN_AI_REQUEST_MAX_TOKENS, 10),
                                 satisfies(
                                     GEN_AI_REQUEST_TEMPERATURE,


### PR DESCRIPTION
## Why

This is part of the effort of catching Java instrumentation up to GenAI semantic conventions.

The AWS Bedrock GenAI semantic conventions define `aws.bedrock.guardrail.id`, but the Java AWS SDK instrumentation does not currently emit it. This prevents operators from correlating a traced invocation with guardrail that is in effect versus not.

## What

- Emit `aws.bedrock.guardrail.id` at span start for InvokeModel, InvokeModelWithResponseStream, Converse, and ConverseStream requests.
- Add extraction coverage for top level, nested, missing, floor version, and latest dependency requests.
- Extend the shared recorded Bedrock integration test to assert the attribute.

## Why the approach

This PR improves auditability while failing open with backward compatibility.
* This PR is doing so by using a Bedrock specific attributes extractor and keeps access to newer AWS SDK field APIs behind the existing `BedrockRuntimeAccess`. Nested Converse fields are read through `SdkPojo`, avoiding direct links to request types unavailable before 2.25.63.
* Missing values are omitted and do not affect request execution.

## Validation

Unit tests
- `:instrumentation:aws-sdk:aws-sdk-2.2:library:testBedrockRuntime --tests io.opentelemetry.instrumentation.awssdk.v2_2.internal.BedrockRuntimeAttributesExtractorTest` passed against the supported Bedrock SDK floor, covering top-level, nested, and missing guardrail identifiers.
- The same focused test passed with `-PtestLatestDeps=true`, covering real `ConverseRequest` and `ConverseStreamRequest` guardrail configurations from the latest AWS SDK.

Integration test
- `:instrumentation:aws-sdk:aws-sdk-2.2:library:testBedrockRuntime --tests io.opentelemetry.instrumentation.awssdk.v2_2.internal.Aws2BedrockRuntimeTest.testInvokeModelAmazonTitan` passed; the recorded library-instrumentation span contained `aws.bedrock.guardrail.id=guardrail-id`.

End-to-end (E2E) test
- `:instrumentation:aws-sdk:aws-sdk-2.2:javaagent:testBedrockRuntime --tests io.opentelemetry.instrumentation.awssdk.v2_2.internal.Aws2BedrockRuntimeTest.testInvokeModelAmazonTitan` passed through the packaged Java agent.

Compatibility regression
- `:instrumentation:aws-sdk:aws-sdk-2.2:library:testCoreOnly --tests io.opentelemetry.instrumentation.awssdk.v2_2.Aws2ClientDynamodbTest` passed with AWS SDK core 2.2.0, verifying that applications without Bedrock do not link against newer SDK APIs.

Formatting
- `:instrumentation:aws-sdk:aws-sdk-2.2:library:spotlessCheck` passed.
