### PR TITLE
Give database server targets value semantics

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTarget.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTarget.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db.internal;
 
+import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 /**
@@ -17,10 +18,16 @@ import javax.annotation.Nullable;
  * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
  * at any time.
  */
-public class DbServerTarget {
+@AutoValue
+public abstract class DbServerTarget {
 
-  private final String address;
-  @Nullable private final Integer port;
+  /**
+   * Creates a target from already parsed and sanitized attribute values without further
+   * normalization. Use {@link #builder()} when collecting raw endpoints.
+   */
+  public static DbServerTarget create(String address, @Nullable Integer port) {
+    return new AutoValue_DbServerTarget(address, port);
+  }
 
   /**
    * Returns a builder for a target whose endpoints listen on {@code defaultPort} unless they are
@@ -56,25 +63,19 @@ public class DbServerTarget {
         || path.indexOf('#') >= 0) {
       return null;
     }
-    return new DbServerTarget(path, null);
+    return create(path, null);
   }
 
-  DbServerTarget(String address, @Nullable Integer port) {
-    this.address = address;
-    this.port = port;
-  }
+  DbServerTarget() {}
 
   /** Returns the value for {@code server.address}. */
-  public String getAddress() {
-    return address;
-  }
+  public abstract String getAddress();
 
   /**
-   * Returns the value for {@code server.port}, or {@code null} when the target listens on its
-   * default port or already carries its ports inside {@link #getAddress()}.
+   * Returns the value for {@code server.port}, or {@code null} when no separate port is reported.
+   * Targets built with {@link DbServerTargetBuilder} omit default ports and ports already carried
+   * inside {@link #getAddress()}.
    */
   @Nullable
-  public Integer getPort() {
-    return port;
-  }
+  public abstract Integer getPort();
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetBuilder.java
@@ -176,7 +176,7 @@ public class DbServerTargetBuilder {
   }
 
   private DbServerTarget target(String address, @Nullable Integer port) {
-    return new DbServerTarget(suffix == null ? address : address + "/" + suffix, port);
+    return DbServerTarget.create(suffix == null ? address : address + "/" + suffix, port);
   }
 
   private static String renderHostAndPort(String host, int port) {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/internal/DbServerTargetTest.java
@@ -22,6 +22,38 @@ class DbServerTargetTest {
 
   private static final int DEFAULT_PORT = 9042;
 
+  @Test
+  void alreadyParsedTargetPreservesDefaultPort() {
+    DbServerTarget target = DbServerTarget.create("cassandra.example.com", DEFAULT_PORT);
+
+    assertThat(target.getAddress()).isEqualTo("cassandra.example.com");
+    assertThat(target.getPort()).isEqualTo(DEFAULT_PORT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"host1\\instance,host2", "/var/run/db.sock,host2:5432"})
+  void alreadyParsedTargetPreservesSpecialAddressGroup(String address) {
+    DbServerTarget target = DbServerTarget.create(address, null);
+
+    assertThat(target.getAddress()).isEqualTo(address);
+    assertThat(target.getPort()).isNull();
+  }
+
+  @Test
+  void targetsHaveValueEquality() {
+    DbServerTarget target = DbServerTarget.create("cassandra.example.com", 19042);
+
+    assertThat(builder().addEndpoint("cassandra.example.com", 19042).build())
+        .isEqualTo(target)
+        .hasSameHashCodeAs(target);
+    assertThat(DbServerTarget.create("cassandra.example.com", null))
+        .isEqualTo(DbServerTarget.create("cassandra.example.com", null))
+        .hasSameHashCodeAs(DbServerTarget.create("cassandra.example.com", null))
+        .isNotEqualTo(target);
+    assertThat(DbServerTarget.create("cassandra.example.com", DEFAULT_PORT)).isNotEqualTo(target);
+    assertThat(DbServerTarget.create("other.example.com", 19042)).isNotEqualTo(target);
+  }
+
   @ParameterizedTest
   @MethodSource("unixSocketPaths")
   void unixSocketPreservesAcceptedPathAndHasNoPort(String path) {


### PR DESCRIPTION
Extract the shared `DbServerTarget` value object from #19846 so it can merge independently. Structural equality lets `DbInfo` compare targets by address and port.

`DbServerTarget.create(address, port)` preserves already-parsed, sanitized values without further normalization. Existing builder/getter signatures, endpoint validation, and default-port omission are unchanged.