### PR TITLE
Update fake backend

### DIFF
--- a/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
+++ b/examples/distro/smoke-tests/src/test/java/com/example/javaagent/smoketest/SmokeTest.java
@@ -62,7 +62,7 @@ abstract class SmokeTest {
   static void setup() {
     backend =
         new GenericContainer<>(
-                "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20221127.3559314891")
+                "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20260825.32803070924")
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)

--- a/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
+++ b/examples/extension/src/test/java/com/example/javaagent/smoketest/IntegrationTest.java
@@ -67,7 +67,7 @@ abstract class IntegrationTest {
   static void setup() {
     backend =
         new GenericContainer<>(
-                "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20250811.16876216352")
+                "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20260825.32803070924")
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forPort(8080))
             .withNetwork(network)

--- a/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
+++ b/instrumentation/kafka/kafka-connect-2.6/testing/src/test/java/io/opentelemetry/instrumentation/kafkaconnect/v2_6/KafkaConnectSinkTaskBaseTest.java
@@ -353,7 +353,7 @@ abstract class KafkaConnectSinkTaskBaseTest implements TelemetryRetrieverProvide
     backend =
         new GenericContainer<>(
                 DockerImageName.parse(
-                    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20250811.16876216352"))
+                    "ghcr.io/open-telemetry/opentelemetry-java-instrumentation/smoke-test-fake-backend:20260825.32803070924"))
             .withExposedPorts(BACKEND_PORT)
             .withNetwork(network)
             .withNetworkAliases(BACKEND_ALIAS)


### PR DESCRIPTION
Update fake backend version to what is used in smoke tests in the hope that it will help against https://community.develocity.cloud/s/6boxbt22z6vb4/tests/task/:instrumentation:kafka:kafka-connect-2.6:testing:test/details/io.opentelemetry.instrumentation.kafkaconnect.v2_6.MongoKafkaConnectSinkTaskTest/testSingleMessage()?page=eyJvdXRwdXQiOnsiMCI6NX19&top-execution=1