### PR TITLE
Simplify adding unit tests for the javaagent modules

### DIFF
--- a/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
+++ b/conventions/src/main/kotlin/io.opentelemetry.instrumentation.javaagent-testing.gradle.kts
@@ -145,6 +145,11 @@ afterEvaluate {
     val failOnContextLeakOverride = failOnContextLeakProperty.get()
     val testIndyEnabled = testIndyProperty.get()
 
+    val suite = testing.suites.findByName(name) as? JvmTestSuite
+    if (suite != null && suite.name.endsWith("unitTests", true)) {
+      return@configureEach
+    }
+
     jvmArgumentProviders.add(
       JavaagentTestArgumentsProvider(
         agentShadowJar,


### PR DESCRIPTION
Test suites ending with `unitTests` are run without the agent and without removing the agent classes from the classpath.
```
testing {
  suites {
    register<JvmTestSuite>("unitTests") {
      dependencies {
        implementation(project())
      }
    }
  }
}
...
tasks {
  check {
    dependsOn(testing.suites)
  }
}
```