### PR TITLE
Use SDK clock for SQS batch Create spans

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
@@ -178,8 +178,8 @@ public final class SqsImpl {
         preparedEntries.add(entry.clone());
         continue;
       }
+      // These spans provide creation contexts for message propagation and linking.
       Context creationContext = producerCreateInstrumenter.start(parentContext, createRequest);
-      // These synthetic spans provide creation contexts without measuring message creation.
       producerCreateInstrumenter.end(creationContext, createRequest, null, null);
       // A no-op tracer can pass shouldStart() but return a context with an invalid span.
       if (!Span.fromContext(creationContext).getSpanContext().isValid()) {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/SqsImpl.java
@@ -26,7 +26,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil;
 import io.opentelemetry.instrumentation.api.internal.Timer;
 import java.lang.reflect.Field;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -179,16 +178,9 @@ public final class SqsImpl {
         preparedEntries.add(entry.clone());
         continue;
       }
-      Instant timestamp = Instant.now();
-      Context creationContext =
-          InstrumenterUtil.startAndEnd(
-              producerCreateInstrumenter,
-              parentContext,
-              createRequest,
-              null,
-              null,
-              timestamp,
-              timestamp);
+      Context creationContext = producerCreateInstrumenter.start(parentContext, createRequest);
+      // These synthetic spans provide creation contexts without measuring message creation.
+      producerCreateInstrumenter.end(creationContext, createRequest, null, null);
       // A no-op tracer can pass shouldStart() but return a context with an invalid span.
       if (!Span.fromContext(creationContext).getSpanContext().isValid()) {
         preparedEntries.add(entry.clone());

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -500,9 +500,6 @@ public abstract class AbstractSqsTracingTest {
                                           Attributes.of(MESSAGING_MESSAGE_ID, messageIds.get(1)),
                                           Attributes.of(MESSAGING_MESSAGE_ID, messageIds.get(2)));
                                 })));
-    assertThat(createSpans)
-        .allSatisfy(
-            span -> assertThat(span.getEndEpochNanos()).isEqualTo(span.getStartEpochNanos()));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/AbstractSqsTracingTest.java
@@ -500,6 +500,11 @@ public abstract class AbstractSqsTracingTest {
                                           Attributes.of(MESSAGING_MESSAGE_ID, messageIds.get(1)),
                                           Attributes.of(MESSAGING_MESSAGE_ID, messageIds.get(2)));
                                 })));
+    assertThat(createSpans)
+        .allSatisfy(
+            span ->
+                assertThat(span.getEndEpochNanos())
+                    .isGreaterThanOrEqualTo(span.getStartEpochNanos()));
   }
 
   @Test

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
@@ -237,9 +237,9 @@ public final class SqsImpl {
         continue;
       }
 
+      // These spans provide creation contexts for message propagation and linking.
       io.opentelemetry.context.Context creationContext =
           producerCreateInstrumenter.start(creationParentContext, createRequest);
-      // These synthetic spans provide creation contexts without measuring message creation.
       producerCreateInstrumenter.end(creationContext, createRequest, null, null);
       // A no-op tracer can pass shouldStart() but return a context with an invalid span.
       if (!Span.fromContext(creationContext).getSpanContext().isValid()) {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/SqsImpl.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -238,16 +237,10 @@ public final class SqsImpl {
         continue;
       }
 
-      Instant timestamp = Instant.now();
       io.opentelemetry.context.Context creationContext =
-          InstrumenterUtil.startAndEnd(
-              producerCreateInstrumenter,
-              creationParentContext,
-              createRequest,
-              null,
-              null,
-              timestamp,
-              timestamp);
+          producerCreateInstrumenter.start(creationParentContext, createRequest);
+      // These synthetic spans provide creation contexts without measuring message creation.
+      producerCreateInstrumenter.end(creationContext, createRequest, null, null);
       // A no-op tracer can pass shouldStart() but return a context with an invalid span.
       if (!Span.fromContext(creationContext).getSpanContext().isValid()) {
         continue;

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -351,9 +351,6 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     span.hasName("create testSdkSqs")
         .hasKind(SpanKind.PRODUCER)
         .hasNoParent()
-        .satisfies(
-            spanData ->
-                assertThat(spanData.getEndEpochNanos()).isEqualTo(spanData.getStartEpochNanos()))
         .hasAttributesSatisfyingExactly(
             equalTo(MESSAGING_SYSTEM, AWS_SQS),
             equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),

--- a/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/testing/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/AbstractAws2SqsTracingTest.java
@@ -351,6 +351,10 @@ public abstract class AbstractAws2SqsTracingTest extends AbstractAws2SqsBaseTest
     span.hasName("create testSdkSqs")
         .hasKind(SpanKind.PRODUCER)
         .hasNoParent()
+        .satisfies(
+            spanData ->
+                assertThat(spanData.getEndEpochNanos())
+                    .isGreaterThanOrEqualTo(spanData.getStartEpochNanos()))
         .hasAttributesSatisfyingExactly(
             equalTo(MESSAGING_SYSTEM, AWS_SQS),
             equalTo(MESSAGING_DESTINATION_NAME, "testSdkSqs"),


### PR DESCRIPTION
Use ordinary instrumenter start/end calls for per-message SQS batch Create spans in AWS SDK 1.11 and 2.2, so both timestamps come **from the OpenTelemetry SDK clock**.

I think alignment with SDK clock is more important than them being strictly zero-duration.