### PR TITLE
Capture observed Redis peers for Lettuce 4

### DIFF
--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/build.gradle.kts
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/build.gradle.kts
@@ -5,13 +5,16 @@ plugins {
 dependencies {
   testImplementation(project(":instrumentation-api-incubator"))
   testImplementation(project(":instrumentation:lettuce:lettuce-4.0:javaagent"))
+  testImplementation(project(":javaagent-extension-api"))
   testImplementation("biz.paluch.redis:lettuce:4.0.Final")
+  testImplementation("io.netty:netty-transport-native-epoll:4.0.56.Final")
 }
 
 tasks {
   val testStableSemconv = register<Test>("testStableSemconv") {
     testClassesDirs = sourceSets.test.get().output.classesDirs
     classpath = sourceSets.test.get().runtimeClasspath
+
     jvmArgs("-Dotel.semconv-stability.opt-in=database")
   }
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_ADDRESS;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_PEER;
+import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_TARGET;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,7 +67,7 @@ class LettuceNetworkAttributesGetterTest {
   void commandRetryUsesLastSelectedAddress() throws UnknownHostException {
     RedisCommand<?, ?, ?> command = command();
     LettuceCommandPeer peer = new LettuceCommandPeer();
-    LettuceSingletons.COMMAND_PEER.set(command, peer);
+    COMMAND_PEER.set(command, peer);
     LettuceSingletons.recordCommandPeer(
         command, new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
     LettuceSingletons.recordCommandPeer(
@@ -82,7 +85,7 @@ class LettuceNetworkAttributesGetterTest {
   void commandUsesDomainSocketPath() {
     DomainSocketAddress address = new DomainSocketAddress("/var/run/redis.sock");
     RedisCommand<?, ?, ?> command = command();
-    LettuceSingletons.COMMAND_PEER.set(command, new LettuceCommandPeer());
+    COMMAND_PEER.set(command, new LettuceCommandPeer());
     Channel channel = mock(Channel.class);
     when(channel.remoteAddress()).thenReturn(address);
     ChannelHandlerContext context = mock(ChannelHandlerContext.class);
@@ -102,7 +105,7 @@ class LettuceNetworkAttributesGetterTest {
     RedisCommand<?, ?, ?> command = new Command<>(CommandType.DEBUG, null);
     LettuceCommandPeer peer = new LettuceCommandPeer();
     peer.record(new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
-    LettuceSingletons.COMMAND_PEER.set(command, peer);
+    COMMAND_PEER.set(command, peer);
 
     LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
 
@@ -113,10 +116,8 @@ class LettuceNetworkAttributesGetterTest {
   @Test
   void commandKeepsConfiguredServerAddressWhenPeerIsUnknown() {
     RedisCommand<?, ?, ?> command = command();
-    LettuceSingletons.COMMAND_ADDRESS.set(
-        command, InetSocketAddress.createUnresolved("redis.example", PORT));
-    LettuceSingletons.COMMAND_TARGET.set(
-        command, RedisServerTarget.ofHostAndPort("redis.example", PORT));
+    COMMAND_ADDRESS.set(command, InetSocketAddress.createUnresolved("redis.example", PORT));
+    COMMAND_TARGET.set(command, RedisServerTarget.ofHostAndPort("redis.example", PORT));
 
     LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
 
@@ -135,7 +136,7 @@ class LettuceNetworkAttributesGetterTest {
 
     LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
 
-    assertThat(LettuceSingletons.COMMAND_PEER.get(command)).isNull();
+    assertThat(COMMAND_PEER.get(command)).isNull();
     assertThat(getter.getNetworkPeerAddress(command, null)).isNull();
     assertThat(getter.getNetworkPeerPort(command, null)).isNull();
   }
@@ -202,7 +203,7 @@ class LettuceNetworkAttributesGetterTest {
 
     LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(context, command);
 
-    assertThat(LettuceSingletons.COMMAND_PEER.get(command)).isNull();
+    assertThat(COMMAND_PEER.get(command)).isNull();
     assertThat(LettuceSingletons.commandPeerAddress(command)).isNull();
   }
 
@@ -279,7 +280,7 @@ class LettuceNetworkAttributesGetterTest {
     RedisCommand<?, ?, ?> command = command();
     LettuceCommandPeer peer = new LettuceCommandPeer();
     peer.record(address);
-    LettuceSingletons.COMMAND_PEER.set(command, peer);
+    COMMAND_PEER.set(command, peer);
     return command;
   }
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_ADDRESS;
 import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_PEER;
-import static io.opentelemetry.javaagent.instrumentation.lettuce.v4_0.LettuceSingletons.COMMAND_TARGET;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -117,7 +116,7 @@ class LettuceNetworkAttributesGetterTest {
   void commandKeepsConfiguredServerAddressWhenPeerIsUnknown() {
     RedisCommand<?, ?, ?> command = command();
     COMMAND_ADDRESS.set(command, InetSocketAddress.createUnresolved("redis.example", PORT));
-    COMMAND_TARGET.set(command, RedisServerTarget.ofHostAndPort("redis.example", PORT));
+    LettuceServerTargets.capture(command, RedisServerTarget.ofHostAndPort("redis.example", PORT));
 
     LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
@@ -63,8 +63,8 @@ class LettuceNetworkAttributesGetterTest {
   @Test
   void commandRetryUsesLastSelectedAddress() throws UnknownHostException {
     RedisCommand<?, ?, ?> command = command();
-    LettuceCommandPeer peerAddress = new LettuceCommandPeer();
-    LettuceSingletons.COMMAND_PEER.set(command, peerAddress);
+    LettuceCommandPeer peer = new LettuceCommandPeer();
+    LettuceSingletons.COMMAND_PEER.set(command, peer);
     LettuceSingletons.recordCommandPeer(
         command, new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
     LettuceSingletons.recordCommandPeer(

--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
@@ -171,7 +171,7 @@ class LettuceNetworkAttributesGetterTest {
   }
 
   @Test
-  void multiCommandWriteDoesNotRecordSelectedAddress() throws UnknownHostException {
+  void multiCommandWriteRecordsSelectedAddressForEachCommand() throws UnknownHostException {
     InetSocketAddress initialAddress =
         new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
     InetSocketAddress writeAddress =
@@ -186,8 +186,8 @@ class LettuceNetworkAttributesGetterTest {
     LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(
         context, asList(firstCommand, secondCommand));
 
-    assertThat(LettuceSingletons.commandPeerAddress(firstCommand)).isEqualTo(initialAddress);
-    assertThat(LettuceSingletons.commandPeerAddress(secondCommand)).isEqualTo(initialAddress);
+    assertThat(LettuceSingletons.commandPeerAddress(firstCommand)).isEqualTo(writeAddress);
+    assertThat(LettuceSingletons.commandPeerAddress(secondCommand)).isEqualTo(writeAddress);
   }
 
   @Test
@@ -204,6 +204,71 @@ class LettuceNetworkAttributesGetterTest {
 
     assertThat(LettuceSingletons.COMMAND_PEER.get(command)).isNull();
     assertThat(LettuceSingletons.commandPeerAddress(command)).isNull();
+  }
+
+  @Test
+  void batchUsesResolvedAddressWhenEveryCommandAgrees() throws UnknownHostException {
+    InetSocketAddress address =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    RedisCommand<?, ?, ?> firstCommand = commandWithPeer(address);
+    RedisCommand<?, ?, ?> secondCommand = commandWithPeer(address);
+    LettuceBatchRequest request =
+        LettuceBatchRequest.create(asList(firstCommand, secondCommand), null, null, null);
+
+    LettuceBatchAttributesGetter getter = new LettuceBatchAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(request, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? "10.1.2.3" : null);
+    assertThat(getter.getNetworkPeerPort(request, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? PORT : null);
+  }
+
+  @Test
+  void batchOmitsPeerWhenCommandsResolveToDifferentAddresses() throws UnknownHostException {
+    RedisCommand<?, ?, ?> firstCommand =
+        commandWithPeer(
+            new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
+    RedisCommand<?, ?, ?> secondCommand =
+        commandWithPeer(
+            new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT));
+    LettuceBatchRequest request =
+        LettuceBatchRequest.create(asList(firstCommand, secondCommand), null, null, null);
+
+    LettuceBatchAttributesGetter getter = new LettuceBatchAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(request, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(request, null)).isNull();
+  }
+
+  @Test
+  void batchOmitsPeerWhenAnyCommandPeerIsUnknown() throws UnknownHostException {
+    InetSocketAddress address =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    RedisCommand<?, ?, ?> firstCommand = commandWithPeer(address);
+    RedisCommand<?, ?, ?> secondCommand = command();
+    LettuceSingletons.initializeCommandPeer(secondCommand);
+    LettuceBatchRequest request =
+        LettuceBatchRequest.create(asList(firstCommand, secondCommand), null, null, null);
+
+    LettuceBatchAttributesGetter getter = new LettuceBatchAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(request, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(request, null)).isNull();
+  }
+
+  @Test
+  void batchOmitsPeerWhenAnyCommandHasNoState() throws UnknownHostException {
+    InetSocketAddress address =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    RedisCommand<?, ?, ?> firstCommand = commandWithPeer(address);
+    RedisCommand<?, ?, ?> secondCommand = command();
+    LettuceBatchRequest request =
+        LettuceBatchRequest.create(asList(firstCommand, secondCommand), null, null, null);
+
+    LettuceBatchAttributesGetter getter = new LettuceBatchAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(request, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(request, null)).isNull();
   }
 
   private static RedisCommand<?, ?, ?> command() {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceNetworkAttributesGetterTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.lambdaworks.redis.protocol.Command;
+import com.lambdaworks.redis.protocol.CommandType;
+import com.lambdaworks.redis.protocol.RedisCommand;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.RedisServerTarget;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LettuceNetworkAttributesGetterTest {
+
+  private static final int PORT = 6379;
+
+  @ParameterizedTest
+  @MethodSource("resolvedAddresses")
+  void commandUsesResolvedSelectedAddress(InetAddress inetAddress, String expectedAddress) {
+    InetSocketAddress address = new InetSocketAddress(inetAddress, PORT);
+    RedisCommand<?, ?, ?> command = commandWithPeer(address);
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(LettuceSingletons.commandPeerAddress(command)).isEqualTo(address);
+    assertThat(getter.getNetworkPeerAddress(command, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? expectedAddress : null);
+    assertThat(getter.getNetworkPeerPort(command, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? PORT : null);
+  }
+
+  @Test
+  void commandDropsUnresolvedSelectedAddress() {
+    RedisCommand<?, ?, ?> command =
+        commandWithPeer(InetSocketAddress.createUnresolved("redis.example", PORT));
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(command, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(command, null)).isNull();
+  }
+
+  @Test
+  void commandRetryUsesLastSelectedAddress() throws UnknownHostException {
+    RedisCommand<?, ?, ?> command = command();
+    LettuceCommandPeer peerAddress = new LettuceCommandPeer();
+    LettuceSingletons.COMMAND_PEER.set(command, peerAddress);
+    LettuceSingletons.recordCommandPeer(
+        command, new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
+    LettuceSingletons.recordCommandPeer(
+        command, new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT));
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(command, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? "10.1.2.4" : null);
+    assertThat(getter.getNetworkPeerPort(command, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? PORT : null);
+  }
+
+  @Test
+  void commandUsesDomainSocketPath() {
+    DomainSocketAddress address = new DomainSocketAddress("/var/run/redis.sock");
+    RedisCommand<?, ?, ?> command = command();
+    LettuceSingletons.COMMAND_PEER.set(command, new LettuceCommandPeer());
+    Channel channel = mock(Channel.class);
+    when(channel.remoteAddress()).thenReturn(address);
+    ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    when(context.channel()).thenReturn(channel);
+
+    LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(context, command);
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+    assertThat(LettuceSingletons.commandPeerAddress(command)).isEqualTo(address);
+    assertThat(getter.getNetworkPeerAddress(command, null))
+        .isEqualTo(emitStableDatabaseSemconv() ? "/var/run/redis.sock" : null);
+    assertThat(getter.getNetworkPeerPort(command, null)).isNull();
+  }
+
+  @Test
+  void commandThatDoesNotExpectResponseDropsSelectedAddress() throws UnknownHostException {
+    RedisCommand<?, ?, ?> command = new Command<>(CommandType.DEBUG, null);
+    LettuceCommandPeer peer = new LettuceCommandPeer();
+    peer.record(new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT));
+    LettuceSingletons.COMMAND_PEER.set(command, peer);
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(getter.getNetworkPeerAddress(command, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(command, null)).isNull();
+  }
+
+  @Test
+  void commandKeepsConfiguredServerAddressWhenPeerIsUnknown() {
+    RedisCommand<?, ?, ?> command = command();
+    LettuceSingletons.COMMAND_ADDRESS.set(
+        command, InetSocketAddress.createUnresolved("redis.example", PORT));
+    LettuceSingletons.COMMAND_TARGET.set(
+        command, RedisServerTarget.ofHostAndPort("redis.example", PORT));
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(getter.getServerAddress(command)).isEqualTo("redis.example");
+    assertThat(getter.getServerPort(command)).isEqualTo(emitStableDatabaseSemconv() ? null : PORT);
+    assertThat(getter.getNetworkPeerAddress(command, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(command, null)).isNull();
+  }
+
+  @Test
+  void completedCommandDropsSelectedAddress() throws UnknownHostException {
+    InetSocketAddress address =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    RedisCommand<?, ?, ?> command = commandWithPeer(address);
+    LettuceSingletons.clearCommandPeer(command);
+
+    LettuceDbAttributesGetter getter = new LettuceDbAttributesGetter();
+
+    assertThat(LettuceSingletons.COMMAND_PEER.get(command)).isNull();
+    assertThat(getter.getNetworkPeerAddress(command, null)).isNull();
+    assertThat(getter.getNetworkPeerPort(command, null)).isNull();
+  }
+
+  @Test
+  void commandIgnoresWriteAfterCompletion() throws UnknownHostException {
+    InetSocketAddress initialAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    InetSocketAddress writeAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT);
+    RedisCommand<?, ?, ?> command = commandWithPeer(initialAddress);
+    LettuceSingletons.finishCommandPeer(command);
+    LettuceSingletons.recordCommandPeer(command, writeAddress);
+
+    assertThat(LettuceSingletons.commandPeerAddress(command)).isEqualTo(initialAddress);
+  }
+
+  @Test
+  void singleBufferedCommandRecordsSelectedAddress() throws UnknownHostException {
+    InetSocketAddress initialAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    InetSocketAddress writeAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT);
+    RedisCommand<?, ?, ?> command = commandWithPeer(initialAddress);
+    Channel channel = mock(Channel.class);
+    when(channel.remoteAddress()).thenReturn(writeAddress);
+    ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    when(context.channel()).thenReturn(channel);
+
+    LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(context, singletonList(command));
+
+    assertThat(LettuceSingletons.commandPeerAddress(command)).isEqualTo(writeAddress);
+  }
+
+  @Test
+  void multiCommandWriteDoesNotRecordSelectedAddress() throws UnknownHostException {
+    InetSocketAddress initialAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), PORT);
+    InetSocketAddress writeAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT);
+    RedisCommand<?, ?, ?> firstCommand = commandWithPeer(initialAddress);
+    RedisCommand<?, ?, ?> secondCommand = commandWithPeer(initialAddress);
+    Channel channel = mock(Channel.class);
+    when(channel.remoteAddress()).thenReturn(writeAddress);
+    ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    when(context.channel()).thenReturn(channel);
+
+    LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(
+        context, asList(firstCommand, secondCommand));
+
+    assertThat(LettuceSingletons.commandPeerAddress(firstCommand)).isEqualTo(initialAddress);
+    assertThat(LettuceSingletons.commandPeerAddress(secondCommand)).isEqualTo(initialAddress);
+  }
+
+  @Test
+  void commandWithoutStateDoesNotGainStateFromWrite() throws UnknownHostException {
+    InetSocketAddress writeAddress =
+        new InetSocketAddress(InetAddress.getByAddress(new byte[] {10, 1, 2, 4}), PORT);
+    RedisCommand<?, ?, ?> command = command();
+    Channel channel = mock(Channel.class);
+    when(channel.remoteAddress()).thenReturn(writeAddress);
+    ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    when(context.channel()).thenReturn(channel);
+
+    LettuceCommandHandlerInstrumentation.WriteAdvice.onEnter(context, command);
+
+    assertThat(LettuceSingletons.COMMAND_PEER.get(command)).isNull();
+    assertThat(LettuceSingletons.commandPeerAddress(command)).isNull();
+  }
+
+  private static RedisCommand<?, ?, ?> command() {
+    return new Command<>(CommandType.GET, null);
+  }
+
+  private static RedisCommand<?, ?, ?> commandWithPeer(SocketAddress address) {
+    RedisCommand<?, ?, ?> command = command();
+    LettuceCommandPeer peer = new LettuceCommandPeer();
+    peer.record(address);
+    LettuceSingletons.COMMAND_PEER.set(command, peer);
+    return command;
+  }
+
+  private static Stream<Arguments> resolvedAddresses() throws UnknownHostException {
+    return Stream.of(
+        argumentSet("ipv4", InetAddress.getByAddress(new byte[] {10, 1, 2, 3}), "10.1.2.3"),
+        argumentSet(
+            "ipv6",
+            InetAddress.getByAddress(
+                new byte[] {0x20, 0x01, 0x0d, (byte) 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+            "2001:db8:0:0:0:0:0:1"));
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/InstrumentationPoints.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/InstrumentationPoints.java
@@ -38,7 +38,7 @@ public class InstrumentationPoints {
       @Nullable Throwable throwable,
       @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
     if (throwable != null) {
-      instrumenter().end(context, command, null, throwable);
+      endCommand(command, context, throwable, asyncCommand);
     } else if (expectsResponse(command)) {
       asyncCommand.handleAsync(
           (value, ex) -> {
@@ -50,12 +50,28 @@ public class InstrumentationPoints {
               // and don't report this as an error
               ex = null;
             }
-            instrumenter().end(context, command, null, ex);
+            endCommand(command, context, ex, asyncCommand);
             return null;
           });
     } else {
       // No response is expected, so we must finish the span now.
-      instrumenter().end(context, command, null, null);
+      endCommand(command, context, null, asyncCommand);
+    }
+  }
+
+  private static void endCommand(
+      RedisCommand<?, ?, ?> command,
+      Context context,
+      @Nullable Throwable throwable,
+      @Nullable AsyncCommand<?, ?, ?> asyncCommand) {
+    LettuceSingletons.finishCommandPeer(command);
+    try {
+      instrumenter().end(context, command, null, throwable);
+    } finally {
+      LettuceSingletons.clearCommandPeer(command);
+      if (asyncCommand != null) {
+        LettuceSingletons.clearCommandPeer(asyncCommand);
+      }
     }
   }
 
@@ -68,6 +84,7 @@ public class InstrumentationPoints {
       return;
     }
 
+    LettuceSingletons.finishCommandPeer(command);
     Throwable error = null;
     if ("completeExceptionally".equals(methodName)) {
       error = commandError;

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandInstrumentation.java
@@ -12,6 +12,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
 import com.lambdaworks.redis.protocol.AsyncCommand;
+import com.lambdaworks.redis.protocol.RedisCommand;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge;
@@ -41,11 +42,14 @@ class LettuceAsyncCommandInstrumentation implements TypeInstrumentation {
   public static class SaveContextAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-    public static void saveContext(@Advice.This AsyncCommand<?, ?, ?> asyncCommand) {
+    public static void saveContext(
+        @Advice.This AsyncCommand<?, ?, ?> asyncCommand,
+        @Advice.Argument(0) RedisCommand<?, ?, ?> command) {
       Context context = Java8BytecodeBridge.currentContext();
       // get the context that submitted this command and attach it, it will be used to run callbacks
       context = context.get(COMMAND_CONTEXT_KEY);
       CONTEXT.set(asyncCommand, context);
+      LettuceSingletons.linkCommandPeer(asyncCommand, command);
     }
   }
 
@@ -63,9 +67,13 @@ class LettuceAsyncCommandInstrumentation implements TypeInstrumentation {
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
-    public static void onExit(@Advice.Enter @Nullable Scope scope) {
+    public static void onExit(
+        @Advice.This AsyncCommand<?, ?, ?> asyncCommand, @Advice.Enter @Nullable Scope scope) {
       if (scope != null) {
         scope.close();
+      }
+      if (asyncCommand.isDone()) {
+        LettuceSingletons.clearCommandPeer(asyncCommand);
       }
     }
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
@@ -94,6 +94,9 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
         @Advice.This AbstractRedisAsyncCommands<?, ?> commands,
         @Advice.Argument(0) RedisCommand<?, ?, ?> command) {
       LettuceSingletons.attachAddress(command, commands.getConnection());
+      // Every buffered command needs its own peer state so a later netty write can record the
+      // address it observed, whether or not this command starts its own span.
+      LettuceSingletons.initializeCommandPeer(command);
       if (LettuceBatchContext.isBatching(commands)) {
         return AdviceScope.captureForBatching(commands);
       }
@@ -103,7 +106,6 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
         return null;
       }
 
-      LettuceSingletons.initializeCommandPeer(command);
       Context context = instrumenter().start(parentContext, command);
       // remember the context that called dispatch, it is used in LettuceAsyncCommandInstrumentation
       context = context.with(COMMAND_CONTEXT_KEY, parentContext);

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncCommandsInstrumentation.java
@@ -103,6 +103,7 @@ class LettuceAsyncCommandsInstrumentation implements TypeInstrumentation {
         return null;
       }
 
+      LettuceSingletons.initializeCommandPeer(command);
       Context context = instrumenter().start(parentContext, command);
       // remember the context that called dispatch, it is used in LettuceAsyncCommandInstrumentation
       context = context.with(COMMAND_CONTEXT_KEY, parentContext);

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchAttributesGetter.java
@@ -73,4 +73,20 @@ class LettuceBatchAttributesGetter implements DbClientAttributesGetter<LettuceBa
     InetSocketAddress serverAddress = request.getServerAddress();
     return serverAddress != null ? serverAddress.getPort() : null;
   }
+
+  @Nullable
+  @Override
+  public String getNetworkPeerAddress(LettuceBatchRequest request, @Nullable Void unused) {
+    return emitStableDatabaseSemconv()
+        ? LettuceCommandPeer.getNetworkPeerAddress(request.getPeerAddress())
+        : null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(LettuceBatchRequest request, @Nullable Void unused) {
+    return emitStableDatabaseSemconv()
+        ? LettuceCommandPeer.getNetworkPeerPort(request.getPeerAddress())
+        : null;
+  }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchRequest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceBatchRequest.java
@@ -8,12 +8,14 @@ package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 import com.lambdaworks.redis.protocol.RedisCommand;
 import io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.RedisServerTarget;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
 
 final class LettuceBatchRequest {
   private final String operationName;
   @Nullable private final Long batchSize;
+  private final List<RedisCommand<?, ?, ?>> commands;
   @Nullable private final InetSocketAddress serverAddress;
   @Nullable private final Integer databaseIndex;
   @Nullable private final RedisServerTarget serverTarget;
@@ -21,11 +23,13 @@ final class LettuceBatchRequest {
   private LettuceBatchRequest(
       String operationName,
       @Nullable Long batchSize,
+      List<RedisCommand<?, ?, ?>> commands,
       @Nullable InetSocketAddress serverAddress,
       @Nullable Integer databaseIndex,
       @Nullable RedisServerTarget serverTarget) {
     this.operationName = operationName;
     this.batchSize = batchSize;
+    this.commands = commands;
     this.serverAddress = serverAddress;
     this.databaseIndex = databaseIndex;
     this.serverTarget = serverTarget;
@@ -39,6 +43,7 @@ final class LettuceBatchRequest {
     return new LettuceBatchRequest(
         operationName(commands),
         commands.size() != 1 ? (long) commands.size() : null,
+        commands,
         serverAddress,
         databaseIndex,
         serverTarget);
@@ -56,6 +61,13 @@ final class LettuceBatchRequest {
   @Nullable
   InetSocketAddress getServerAddress() {
     return serverAddress;
+  }
+
+  @Nullable
+  SocketAddress getPeerAddress() {
+    // Read lazily when the span ends so an outbound write that races the batch dispatch can still
+    // supply the peer.
+    return LettuceSingletons.batchPeerAddress(commands);
   }
 
   @Nullable

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandHandlerInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandHandlerInstrumentation.java
@@ -43,12 +43,13 @@ class LettuceCommandHandlerInstrumentation implements TypeInstrumentation {
     public static void onEnter(
         @Advice.Argument(0) ChannelHandlerContext context, @Advice.Argument(1) Object message) {
       SocketAddress address = context.channel().remoteAddress();
-      if (address != null && message instanceof RedisCommand) {
+      if (address == null) {
+        return;
+      }
+      if (message instanceof RedisCommand) {
         LettuceSingletons.recordCommandPeer((RedisCommand<?, ?, ?>) message, address);
-      } else if (address != null && message instanceof Collection) {
-        Collection<?> commands = (Collection<?>) message;
-        if (commands.size() == 1) {
-          Object command = commands.iterator().next();
+      } else if (message instanceof Collection) {
+        for (Object command : (Collection<?>) message) {
           if (command instanceof RedisCommand) {
             LettuceSingletons.recordCommandPeer((RedisCommand<?, ?, ?>) command, address);
           }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandHandlerInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandHandlerInstrumentation.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.lambdaworks.redis.protocol.RedisCommand;
+import io.netty.channel.ChannelHandlerContext;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.net.SocketAddress;
+import java.util.Collection;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class LettuceCommandHandlerInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return named("com.lambdaworks.redis.protocol.CommandHandler");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        named("write")
+            .and(takesArguments(3))
+            .and(takesArgument(0, named("io.netty.channel.ChannelHandlerContext")))
+            .and(takesArgument(2, named("io.netty.channel.ChannelPromise"))),
+        getClass().getName() + "$WriteAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class WriteAdvice {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter(
+        @Advice.Argument(0) ChannelHandlerContext context, @Advice.Argument(1) Object message) {
+      SocketAddress address = context.channel().remoteAddress();
+      if (address != null && message instanceof RedisCommand) {
+        LettuceSingletons.recordCommandPeer((RedisCommand<?, ?, ?>) message, address);
+      } else if (address != null && message instanceof Collection) {
+        Collection<?> commands = (Collection<?>) message;
+        if (commands.size() == 1) {
+          Object command = commands.iterator().next();
+          if (command instanceof RedisCommand) {
+            LettuceSingletons.recordCommandPeer((RedisCommand<?, ?, ?>) command, address);
+          }
+        }
+      }
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandPeer.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandPeer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import javax.annotation.Nullable;
+
+public class LettuceCommandPeer {
+  private static final String DOMAIN_SOCKET_ADDRESS_CLASS =
+      "io.netty.channel.unix.DomainSocketAddress";
+
+  private static final ClassValue<Method> domainSocketAddressPathMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("path");
+          } catch (NoSuchMethodException | SecurityException ignored) {
+            return null;
+          }
+        }
+      };
+
+  // Completion and outbound writes can race on different threads.
+  @Nullable private SocketAddress address;
+  private boolean finished;
+
+  synchronized void record(SocketAddress address) {
+    if (!finished) {
+      this.address = address;
+    }
+  }
+
+  synchronized void finish() {
+    finished = true;
+  }
+
+  @Nullable
+  synchronized SocketAddress getAddress() {
+    return address;
+  }
+
+  @Nullable
+  static String getNetworkPeerAddress(@Nullable SocketAddress peerAddress) {
+    if (peerAddress instanceof InetSocketAddress) {
+      InetSocketAddress inetPeerAddress = (InetSocketAddress) peerAddress;
+      return inetPeerAddress.isUnresolved() ? null : inetPeerAddress.getAddress().getHostAddress();
+    }
+    if (peerAddress != null
+        && peerAddress.getClass().getName().equals(DOMAIN_SOCKET_ADDRESS_CLASS)) {
+      Method pathMethod = domainSocketAddressPathMethod.get(peerAddress.getClass());
+      if (pathMethod == null) {
+        return null;
+      }
+      try {
+        return (String) pathMethod.invoke(peerAddress);
+      } catch (ReflectiveOperationException
+          | IllegalArgumentException
+          | ClassCastException ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  static Integer getNetworkPeerPort(@Nullable SocketAddress peerAddress) {
+    if (!(peerAddress instanceof InetSocketAddress)) {
+      return null;
+    }
+    InetSocketAddress inetPeerAddress = (InetSocketAddress) peerAddress;
+    return inetPeerAddress.isUnresolved() ? null : inetPeerAddress.getPort();
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandPeer.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandPeer.java
@@ -10,7 +10,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import javax.annotation.Nullable;
 
-public class LettuceCommandPeer {
+final class LettuceCommandPeer {
   private static final String DOMAIN_SOCKET_ADDRESS_CLASS =
       "io.netty.channel.unix.DomainSocketAddress";
 

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandWrapperInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceCommandWrapperInstrumentation.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.lambdaworks.redis.protocol.RedisCommand;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+class LettuceCommandWrapperInstrumentation implements TypeInstrumentation {
+
+  @Override
+  public ElementMatcher<TypeDescription> typeMatcher() {
+    return namedOneOf(
+        "com.lambdaworks.redis.protocol.CommandWrapper",
+        "com.lambdaworks.redis.cluster.ClusterCommand");
+  }
+
+  @Override
+  public void transform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        isConstructor().and(takesArgument(0, named("com.lambdaworks.redis.protocol.RedisCommand"))),
+        getClass().getName() + "$ConstructorAdvice");
+    transformer.applyAdviceToMethod(
+        namedOneOf("complete", "completeExceptionally", "cancel"),
+        getClass().getName() + "$TerminalAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class ConstructorAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    public static void onExit(
+        @Advice.This RedisCommand<?, ?, ?> wrapper,
+        @Advice.Argument(0) RedisCommand<?, ?, ?> command) {
+      LettuceSingletons.linkCommandPeer(wrapper, command);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  public static class TerminalAdvice {
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)
+    public static void onExit(@Advice.This RedisCommand<?, ?, ?> wrapper) {
+      if (wrapper.isDone()) {
+        LettuceSingletons.clearCommandPeer(wrapper);
+      }
+    }
+  }
+}

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceDbAttributesGetter.java
@@ -70,4 +70,20 @@ class LettuceDbAttributesGetter implements DbClientAttributesGetter<RedisCommand
     InetSocketAddress serverAddress = LettuceSingletons.COMMAND_ADDRESS.get(request);
     return serverAddress != null ? serverAddress.getPort() : null;
   }
+
+  @Nullable
+  @Override
+  public String getNetworkPeerAddress(RedisCommand<?, ?, ?> request, @Nullable Void unused) {
+    return emitStableDatabaseSemconv()
+        ? LettuceCommandPeer.getNetworkPeerAddress(LettuceSingletons.commandPeerAddress(request))
+        : null;
+  }
+
+  @Nullable
+  @Override
+  public Integer getNetworkPeerPort(RedisCommand<?, ?, ?> request, @Nullable Void unused) {
+    return emitStableDatabaseSemconv()
+        ? LettuceCommandPeer.getNetworkPeerPort(LettuceSingletons.commandPeerAddress(request))
+        : null;
+  }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceInstrumentationModule.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceInstrumentationModule.java
@@ -24,6 +24,8 @@ public class LettuceInstrumentationModule extends InstrumentationModule {
         new LettuceAbstractRedisClientInstrumentation(),
         new LettuceAsyncCommandInstrumentation(),
         new LettuceAsyncCommandsInstrumentation(),
+        new LettuceCommandHandlerInstrumentation(),
+        new LettuceCommandWrapperInstrumentation(),
         new LettuceConnectionInstrumentation(),
         new LettuceReactiveCommandDispatcherInstrumentation(),
         new LettuceObservableCommandInstrumentation(),

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceObservableCommandInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceObservableCommandInstrumentation.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import rx.Subscriber;
 
 class LettuceObservableCommandInstrumentation implements TypeInstrumentation {
 
@@ -54,10 +55,13 @@ class LettuceObservableCommandInstrumentation implements TypeInstrumentation {
   public static class ConstructorAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-    public static void onExit(@Advice.This RedisCommand<?, ?, ?> command) {
+    public static void onExit(
+        @Advice.This RedisCommand<?, ?, ?> observableCommand,
+        @Advice.Argument(1) Subscriber<?> subscriber) {
+      LettuceSingletons.applySubscriberPeer(observableCommand, subscriber);
       Context context = Java8BytecodeBridge.currentContext();
       if (context.get(COMMAND_CONTEXT_KEY) != null) {
-        CONTEXT.set(command, context);
+        CONTEXT.set(observableCommand, context);
       }
     }
   }
@@ -77,7 +81,11 @@ class LettuceObservableCommandInstrumentation implements TypeInstrumentation {
       }
 
       CONTEXT.set(command, null);
-      InstrumentationPoints.endReactiveCommand(command, context, methodName, commandError);
+      try {
+        InstrumentationPoints.endReactiveCommand(command, context, methodName, commandError);
+      } finally {
+        LettuceSingletons.clearCommandPeer(command);
+      }
       context = context.get(COMMAND_CONTEXT_KEY);
       return context.makeCurrent();
     }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveCommandDispatcherInstrumentation.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveCommandDispatcherInstrumentation.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import rx.Subscriber;
 
 class LettuceReactiveCommandDispatcherInstrumentation implements TypeInstrumentation {
 
@@ -56,21 +57,30 @@ class LettuceReactiveCommandDispatcherInstrumentation implements TypeInstrumenta
 
     public static class AdviceScope {
       private final RedisCommand<?, ?, ?> command;
+      private final Subscriber<?> subscriber;
       private final Context context;
       private final Scope scope;
 
-      public AdviceScope(RedisCommand<?, ?, ?> command, Context context) {
+      public AdviceScope(RedisCommand<?, ?, ?> command, Subscriber<?> subscriber, Context context) {
         this.command = command;
+        this.subscriber = subscriber;
         this.context = context;
         this.scope = context.makeCurrent();
       }
 
       public void end(@Nullable Throwable throwable) {
         scope.close();
-        if (throwable != null) {
-          instrumenter().end(context, command, null, throwable);
-        } else if (!InstrumentationPoints.expectsResponse(command)) {
-          instrumenter().end(context, command, null, null);
+        try {
+          if (throwable != null) {
+            LettuceSingletons.finishCommandPeer(command);
+            instrumenter().end(context, command, null, throwable);
+          } else if (!InstrumentationPoints.expectsResponse(command)) {
+            LettuceSingletons.finishCommandPeer(command);
+            instrumenter().end(context, command, null, null);
+          }
+        } finally {
+          LettuceSingletons.clearCommandPeer(command);
+          LettuceSingletons.clearSubscriberPeer(subscriber);
         }
       }
     }
@@ -79,6 +89,7 @@ class LettuceReactiveCommandDispatcherInstrumentation implements TypeInstrumenta
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static AdviceScope onEnter(
         @Advice.This ReactiveCommandDispatcher<?, ?, ?> dispatcher,
+        @Advice.Argument(0) Subscriber<?> subscriber,
         @Advice.FieldValue(value = "command") @Nullable RedisCommand<?, ?, ?> command,
         @Advice.FieldValue("commandSupplier")
             Supplier<? extends RedisCommand<?, ?, ?>> commandSupplier,
@@ -89,15 +100,18 @@ class LettuceReactiveCommandDispatcherInstrumentation implements TypeInstrumenta
       }
       RedisCommand<?, ?, ?> otelCommand = command == null ? commandSupplier.get() : command;
       LettuceSingletons.attachAddress(otelCommand, connection);
+      LettuceSingletons.clearSubscriberPeer(subscriber);
       if (!instrumenter().shouldStart(parentContext, otelCommand)) {
         return null;
       }
 
+      LettuceSingletons.initializeCommandPeer(otelCommand);
       Context context = instrumenter().start(parentContext, otelCommand);
       // remember the context that called dispatch, it is used in
       // LettuceObservableCommandInstrumentation
       context = context.with(COMMAND_CONTEXT_KEY, parentContext);
-      return new AdviceScope(otelCommand, context);
+      LettuceSingletons.captureSubscriberPeer(subscriber, otelCommand);
+      return new AdviceScope(otelCommand, subscriber, context);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class, inline = false)

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -27,6 +27,7 @@ import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtr
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 import javax.annotation.Nullable;
 import rx.Subscriber;
 
@@ -200,6 +201,26 @@ public class LettuceSingletons {
     }
     LettuceCommandPeer peer = COMMAND_PEER.get(command);
     return peer != null ? peer.getAddress() : null;
+  }
+
+  @Nullable
+  static SocketAddress batchPeerAddress(List<RedisCommand<?, ?, ?>> commands) {
+    // The batch span reports a peer only when every buffered command resolved to the same
+    // address; a batch spanning more than one connection has no single peer to report.
+    SocketAddress batchPeerAddress = null;
+    for (RedisCommand<?, ?, ?> command : commands) {
+      LettuceCommandPeer peer = COMMAND_PEER.get(command);
+      SocketAddress commandPeerAddress = peer != null ? peer.getAddress() : null;
+      if (commandPeerAddress == null) {
+        return null;
+      }
+      if (batchPeerAddress == null) {
+        batchPeerAddress = commandPeerAddress;
+      } else if (!batchPeerAddress.equals(commandPeerAddress)) {
+        return null;
+      }
+    }
+    return batchPeerAddress;
   }
 
   @Nullable

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -26,7 +26,9 @@ import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
 import io.opentelemetry.instrumentation.api.util.VirtualField;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import javax.annotation.Nullable;
+import rx.Subscriber;
 
 public class LettuceSingletons {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.lettuce-4.0";
@@ -47,6 +49,12 @@ public class LettuceSingletons {
 
   public static final VirtualField<RedisChannelHandler<?, ?>, InetSocketAddress>
       CONNECTION_ADDRESS = VirtualField.find(RedisChannelHandler.class, InetSocketAddress.class);
+
+  public static final VirtualField<RedisCommand<?, ?, ?>, LettuceCommandPeer> COMMAND_PEER =
+      VirtualField.find(RedisCommand.class, LettuceCommandPeer.class);
+
+  public static final VirtualField<Subscriber<?>, LettuceCommandPeer> SUBSCRIBER_PEER =
+      VirtualField.find(Subscriber.class, LettuceCommandPeer.class);
 
   public static final VirtualField<RedisCommand<?, ?, ?>, InetSocketAddress> COMMAND_ADDRESS =
       VirtualField.find(RedisCommand.class, InetSocketAddress.class);
@@ -133,6 +141,7 @@ public class LettuceSingletons {
   public static void attachAddress(
       RedisCommand<?, ?, ?> command, StatefulConnection<?, ?> connection) {
     COMMAND_ADDRESS.set(command, serverAddress(connection));
+    COMMAND_PEER.set(command, null);
     COMMAND_DATABASE_INDEX.set(command, databaseIndex(connection));
     // Always overwrite the command target so reused command objects cannot retain stale state.
     LettuceServerTargets.copy(connection, command);
@@ -143,6 +152,54 @@ public class LettuceSingletons {
     return connection instanceof RedisChannelHandler
         ? CONNECTION_ADDRESS.get((RedisChannelHandler<?, ?>) connection)
         : null;
+  }
+
+  public static void initializeCommandPeer(RedisCommand<?, ?, ?> command) {
+    COMMAND_PEER.set(command, new LettuceCommandPeer());
+  }
+
+  public static void linkCommandPeer(RedisCommand<?, ?, ?> wrapper, RedisCommand<?, ?, ?> command) {
+    COMMAND_PEER.set(wrapper, COMMAND_PEER.get(command));
+  }
+
+  public static void captureSubscriberPeer(
+      Subscriber<?> subscriber, RedisCommand<?, ?, ?> command) {
+    SUBSCRIBER_PEER.set(subscriber, COMMAND_PEER.get(command));
+  }
+
+  public static void applySubscriberPeer(RedisCommand<?, ?, ?> command, Subscriber<?> subscriber) {
+    COMMAND_PEER.set(command, SUBSCRIBER_PEER.get(subscriber));
+  }
+
+  public static void clearCommandPeer(RedisCommand<?, ?, ?> command) {
+    COMMAND_PEER.set(command, null);
+  }
+
+  public static void clearSubscriberPeer(Subscriber<?> subscriber) {
+    SUBSCRIBER_PEER.set(subscriber, null);
+  }
+
+  public static void finishCommandPeer(RedisCommand<?, ?, ?> command) {
+    LettuceCommandPeer peer = COMMAND_PEER.get(command);
+    if (peer != null) {
+      peer.finish();
+    }
+  }
+
+  public static void recordCommandPeer(RedisCommand<?, ?, ?> command, SocketAddress address) {
+    LettuceCommandPeer peer = COMMAND_PEER.get(command);
+    if (peer != null) {
+      peer.record(address);
+    }
+  }
+
+  @Nullable
+  static SocketAddress commandPeerAddress(RedisCommand<?, ?, ?> command) {
+    if (!InstrumentationPoints.expectsResponse(command)) {
+      return null;
+    }
+    LettuceCommandPeer peer = COMMAND_PEER.get(command);
+    return peer != null ? peer.getAddress() : null;
   }
 
   @Nullable

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -667,8 +667,10 @@ class LettuceAsyncClientTest {
                             equalTo(maybeStable(DB_OPERATION), scenario.operationName),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, null),
-                            equalTo(NETWORK_PEER_PORT, null),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
@@ -728,8 +730,10 @@ class LettuceAsyncClientTest {
                             equalTo(maybeStable(DB_OPERATION), "PIPELINE SET"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
-                            equalTo(NETWORK_PEER_ADDRESS, null),
-                            equalTo(NETWORK_PEER_PORT, null),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? 2L : null))));

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceAsyncClientTest.java
@@ -16,6 +16,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -46,9 +48,10 @@ import io.opentelemetry.instrumentation.test.utils.PortUtils;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
-import io.opentelemetry.sdk.testing.assertj.AttributeAssertion;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +103,7 @@ class LettuceAsyncClientTest {
           .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
   private static String host;
+  private static String ip;
   private static int port;
   private static int incorrectPort;
   private static String dbUriNonExistent;
@@ -117,10 +121,11 @@ class LettuceAsyncClientTest {
   private static RedisAsyncCommands<String, String> nonDefaultDbCommands;
 
   @BeforeAll
-  static void setUp() {
+  static void setUp() throws UnknownHostException {
     redisServer.start();
     cleanup.deferAfterAll(redisServer::stop);
     host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
 
@@ -239,7 +244,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -262,7 +271,12 @@ class LettuceAsyncClientTest {
                               equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                               equalTo(maybeStable(DB_OPERATION), "SELECT"),
                               equalTo(SERVER_ADDRESS, host),
-                              equalTo(SERVER_PORT, port))),
+                              equalTo(SERVER_PORT, port),
+                              equalTo(
+                                  NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                              equalTo(
+                                  NETWORK_PEER_PORT,
+                                  emitStableDatabaseSemconv() ? Long.valueOf(port) : null))),
           trace ->
               trace.hasSpansSatisfyingExactly(
                   span ->
@@ -273,7 +287,12 @@ class LettuceAsyncClientTest {
                               equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                               equalTo(maybeStable(DB_OPERATION), "SET"),
                               equalTo(SERVER_ADDRESS, host),
-                              equalTo(SERVER_PORT, port))));
+                              equalTo(SERVER_PORT, port),
+                              equalTo(
+                                  NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                              equalTo(
+                                  NETWORK_PEER_PORT,
+                                  emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
     } finally {
       connection.sync().select(0);
       testing.waitForTraces(3);
@@ -311,7 +330,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -376,7 +399,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName("callback1")
                         .hasKind(SpanKind.INTERNAL)
@@ -423,7 +450,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "RANDOMKEY"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -471,7 +502,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "HMSET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))),
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -485,7 +520,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "HGETALL"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -517,18 +556,6 @@ class LettuceAsyncClientTest {
               assertThat(completedExceptionally).isTrue();
             });
 
-    List<AttributeAssertion> assertions =
-        new ArrayList<>(
-            asList(
-                equalTo(maybeStable(DB_SYSTEM), REDIS),
-                equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
-                equalTo(maybeStable(DB_OPERATION), "DEL"),
-                equalTo(SERVER_ADDRESS, host),
-                equalTo(SERVER_PORT, port)));
-    if (emitStableDatabaseSemconv()) {
-      assertions.add(equalTo(ERROR_TYPE, "java.lang.IllegalStateException"));
-    }
-
     testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
@@ -537,7 +564,19 @@ class LettuceAsyncClientTest {
                         .hasKind(SpanKind.CLIENT)
                         .hasStatus(StatusData.error())
                         .hasException(new IllegalStateException("TestException"))
-                        .hasAttributesSatisfyingExactly(assertions)));
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(maybeStable(DB_OPERATION), "DEL"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null),
+                            equalTo(
+                                ERROR_TYPE,
+                                emitStableDatabaseSemconv()
+                                    ? "java.lang.IllegalStateException"
+                                    : null))));
   }
 
   @Test
@@ -580,6 +619,8 @@ class LettuceAsyncClientTest {
                             equalTo(maybeStable(DB_OPERATION), "SADD"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null),
                             equalTo(booleanKey("lettuce.command.cancelled"), experimental(true))),
                 span ->
                     span.hasName("callback")
@@ -626,6 +667,8 @@ class LettuceAsyncClientTest {
                             equalTo(maybeStable(DB_OPERATION), scenario.operationName),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? scenario.batchSize : null),
@@ -649,7 +692,11 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, expectedNonDefaultNamespace()),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -681,6 +728,8 @@ class LettuceAsyncClientTest {
                             equalTo(maybeStable(DB_OPERATION), "PIPELINE SET"),
                             equalTo(SERVER_ADDRESS, host),
                             equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null),
                             equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? 2L : null))));
@@ -715,7 +764,11 @@ class LettuceAsyncClientTest {
                       equalTo(DB_NAMESPACE, expectedNonDefaultNamespace()),
                       equalTo(maybeStable(DB_OPERATION), "SELECT"),
                       equalTo(SERVER_ADDRESS, host),
-                      equalTo(SERVER_PORT, port));
+                      equalTo(SERVER_PORT, port),
+                      equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                      equalTo(
+                          NETWORK_PEER_PORT,
+                          emitStableDatabaseSemconv() ? Long.valueOf(port) : null));
             });
   }
 
@@ -854,7 +907,9 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "DEBUG"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, serverPort))));
+                            equalTo(SERVER_PORT, serverPort),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null))));
   }
 
   @Test
@@ -896,6 +951,8 @@ class LettuceAsyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SHUTDOWN"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, shutdownServerPort))));
+                            equalTo(SERVER_PORT, shutdownServerPort),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null))));
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -165,6 +165,32 @@ class LettuceClusterClientTest {
                                 emitStableDatabaseSemconv() ? authenticatedIp : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) authenticatedPort : null))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "COMMAND " + authenticatedTarget
+                                : "COMMAND")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, null),
+                            equalTo(maybeStable(DB_OPERATION), "COMMAND"),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? authenticatedTarget
+                                    : authenticatedHost),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv() ? null : (long) authenticatedPort),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? authenticatedIp : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv() ? (long) authenticatedPort : null))));
     if (testLatestDeps()) {
       traceAsserts.add(
@@ -285,6 +311,9 @@ class LettuceClusterClientTest {
     StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
     cleanup.deferCleanup(peerConnection);
 
+    testing.waitForTraces(1);
+    testing.clearData();
+
     RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
     String routedKey = keyInSlotRange("routed", SLOT_SPLIT, SlotHash.SLOT_COUNT);
     String firstBatchKey = keyInSlotRange("first-batch", 0, SLOT_SPLIT);
@@ -393,6 +422,9 @@ class LettuceClusterClientTest {
     cleanup.deferCleanup(() -> client.shutdown(0, 15, SECONDS));
     StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
     cleanup.deferCleanup(peerConnection);
+
+    testing.waitForTraces(1);
+    testing.clearData();
 
     RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
     String redirectedKey = keyInSlotRange("redirected", 0, SLOT_SPLIT);

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -218,9 +218,7 @@ class LettuceClusterClientTest {
                                   emitStableDatabaseSemconv() ? authenticatedIp : null),
                               equalTo(
                                   NETWORK_PEER_PORT,
-                                  emitStableDatabaseSemconv()
-                                      ? (long) authenticatedPort
-                                      : null))));
+                                  emitStableDatabaseSemconv() ? (long) authenticatedPort : null))));
     }
     testing.waitAndAssertTraces(traceAsserts);
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -89,10 +89,14 @@ class LettuceClusterClientTest {
           .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
   private static StatefulRedisClusterConnection<String, String> connection;
+  private static TestRedisCluster firstRedisServer;
+  private static TestRedisCluster secondRedisServer;
+  private static StatefulRedisClusterConnection<String, String> peerConnection;
   private static String host;
   private static String ip;
   private static int port;
   private static String configuredTarget;
+  private static String peerConfiguredTarget;
 
   @BeforeAll
   static void setUp() throws Exception {
@@ -112,8 +116,29 @@ class LettuceClusterClientTest {
     connection = client.connect();
     cleanup.deferAfterAll(connection);
 
+    firstRedisServer = new TestRedisCluster();
+    cleanup.deferAfterAll(firstRedisServer);
+    secondRedisServer = new TestRedisCluster();
+    cleanup.deferAfterAll(secondRedisServer);
+
+    RedisURI firstNodeUri =
+        RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
+    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
+    peerConfiguredTarget =
+        "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
+    List<RedisURI> nodeUris =
+        asList(
+            firstNodeUri,
+            RedisURI.create(
+                "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
+    RedisClusterClient peerClient =
+        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
+    cleanup.deferAfterAll(() -> peerClient.shutdown(0, 15, SECONDS));
+    peerConnection = peerClient.connect();
+    cleanup.deferAfterAll(peerConnection);
+
     if (testLatestDeps()) {
-      testing.waitForTraces(1);
+      testing.waitForTraces(2);
     }
   }
 
@@ -152,32 +177,6 @@ class LettuceClusterClientTest {
                             equalTo(maybeStable(DB_SYSTEM), REDIS),
                             equalTo(DB_NAMESPACE, null),
                             equalTo(maybeStable(DB_OPERATION), "AUTH"),
-                            equalTo(
-                                SERVER_ADDRESS,
-                                emitStableDatabaseSemconv()
-                                    ? authenticatedTarget
-                                    : authenticatedHost),
-                            equalTo(
-                                SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : (long) authenticatedPort),
-                            equalTo(
-                                NETWORK_PEER_ADDRESS,
-                                emitStableDatabaseSemconv() ? authenticatedIp : null),
-                            equalTo(
-                                NETWORK_PEER_PORT,
-                                emitStableDatabaseSemconv() ? (long) authenticatedPort : null))),
-        trace ->
-            trace.hasSpansSatisfyingExactly(
-                span ->
-                    span.hasName(
-                            emitStableDatabaseSemconv()
-                                ? "COMMAND " + authenticatedTarget
-                                : "COMMAND")
-                        .hasKind(SpanKind.CLIENT)
-                        .hasAttributesSatisfyingExactly(
-                            equalTo(maybeStable(DB_SYSTEM), REDIS),
-                            equalTo(DB_NAMESPACE, null),
-                            equalTo(maybeStable(DB_OPERATION), "COMMAND"),
                             equalTo(
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv()
@@ -290,30 +289,6 @@ class LettuceClusterClientTest {
 
   @Test
   void testCommandAndBatchUseObservedPeers() throws Exception {
-    TestRedisCluster firstRedisServer = new TestRedisCluster();
-    cleanup.deferCleanup(firstRedisServer);
-    TestRedisCluster secondRedisServer = new TestRedisCluster();
-    cleanup.deferCleanup(secondRedisServer);
-
-    RedisURI firstNodeUri =
-        RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
-    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
-    String peerConfiguredTarget =
-        "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
-    List<RedisURI> nodeUris =
-        asList(
-            firstNodeUri,
-            RedisURI.create(
-                "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
-    RedisClusterClient client =
-        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
-    cleanup.deferCleanup(() -> client.shutdown(0, 15, SECONDS));
-    StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
-    cleanup.deferCleanup(peerConnection);
-
-    testing.waitForTraces(1);
-    testing.clearData();
-
     RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
     String routedKey = keyInSlotRange("routed", SLOT_SPLIT, SlotHash.SLOT_COUNT);
     String firstBatchKey = keyInSlotRange("first-batch", 0, SLOT_SPLIT);
@@ -402,30 +377,6 @@ class LettuceClusterClientTest {
   @Test
   @EnabledIfSystemProperty(named = "testLatestDeps", matches = "true")
   void redirectedCommandUsesLastPeer() throws Exception {
-    TestRedisCluster firstRedisServer = new TestRedisCluster();
-    cleanup.deferCleanup(firstRedisServer);
-    TestRedisCluster secondRedisServer = new TestRedisCluster();
-    cleanup.deferCleanup(secondRedisServer);
-
-    RedisURI firstNodeUri =
-        RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
-    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
-    String peerConfiguredTarget =
-        "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
-    List<RedisURI> nodeUris =
-        asList(
-            firstNodeUri,
-            RedisURI.create(
-                "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
-    RedisClusterClient client =
-        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
-    cleanup.deferCleanup(() -> client.shutdown(0, 15, SECONDS));
-    StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
-    cleanup.deferCleanup(peerConnection);
-
-    testing.waitForTraces(1);
-    testing.clearData();
-
     RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
     String redirectedKey = keyInSlotRange("redirected", 0, SLOT_SPLIT);
     firstRedisServer.redirectSetOnce(redirectedKey, secondRedisServer);

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -123,7 +123,7 @@ class LettuceClusterClientTest {
 
     RedisURI firstNodeUri =
         RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
-    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
+    RedisURI peerAlternateSeed = RedisURI.create("redis://seed.invalid:6379");
     peerConfiguredTarget =
         "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
     List<RedisURI> nodeUris =
@@ -132,7 +132,7 @@ class LettuceClusterClientTest {
             RedisURI.create(
                 "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
     RedisClusterClient peerClient =
-        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
+        new TestRedisClusterClient(asList(peerAlternateSeed, firstNodeUri), nodeUris);
     cleanup.deferAfterAll(() -> peerClient.shutdown(0, 15, SECONDS));
     peerConnection = peerClient.connect();
     cleanup.deferAfterAll(peerConnection);

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -11,18 +11,24 @@ import static io.opentelemetry.instrumentation.testing.util.TestLatestDeps.testL
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_SYSTEM;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DbSystemNameIncubatingValues.REDIS;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.lambdaworks.redis.RedisFuture;
 import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.cluster.RedisClusterClient;
+import com.lambdaworks.redis.cluster.SlotHash;
 import com.lambdaworks.redis.cluster.api.StatefulRedisClusterConnection;
 import com.lambdaworks.redis.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import com.lambdaworks.redis.cluster.models.partitions.Partitions;
@@ -33,9 +39,20 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -51,8 +68,10 @@ import org.testcontainers.utility.DockerImageName;
 class LettuceClusterClientTest {
   private static final Logger logger = LoggerFactory.getLogger(LettuceClusterClientTest.class);
 
-  private static final String NODE_ID = "0000000000000000000000000000000000000000";
+  private static final String FIRST_NODE_ID = "0000000000000000000000000000000000000000";
+  private static final String SECOND_NODE_ID = "1111111111111111111111111111111111111111";
   private static final String PASSWORD = "password";
+  private static final int SLOT_SPLIT = SlotHash.SLOT_COUNT / 2;
 
   @RegisterExtension
   static final InstrumentationExtension testing = AgentInstrumentationExtension.create();
@@ -70,6 +89,7 @@ class LettuceClusterClientTest {
 
   private static StatefulRedisClusterConnection<String, String> connection;
   private static String host;
+  private static String ip;
   private static int port;
   private static String configuredTarget;
 
@@ -79,6 +99,7 @@ class LettuceClusterClientTest {
     cleanup.deferAfterAll(redisServer::stop);
 
     host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
 
     RedisURI nodeUri = RedisURI.create("redis://" + host + ":" + port);
@@ -96,7 +117,7 @@ class LettuceClusterClientTest {
   }
 
   @Test
-  void testAuthenticationUsesConfiguredSeedList() {
+  void testAuthenticationUsesConfiguredSeedList() throws Exception {
     GenericContainer<?> authenticatedRedisServer =
         new GenericContainer<>(CONTAINER_IMAGE)
             .withExposedPorts(6379)
@@ -107,6 +128,7 @@ class LettuceClusterClientTest {
     cleanup.deferCleanup(authenticatedRedisServer::stop);
 
     String authenticatedHost = authenticatedRedisServer.getHost();
+    String authenticatedIp = InetAddress.getByName(authenticatedHost).getHostAddress();
     int authenticatedPort = authenticatedRedisServer.getMappedPort(6379);
     RedisURI nodeUri = RedisURI.create("redis://" + authenticatedHost + ":" + authenticatedPort);
     nodeUri.setPassword(PASSWORD);
@@ -136,7 +158,15 @@ class LettuceClusterClientTest {
                                     : authenticatedHost),
                             equalTo(
                                 SERVER_PORT,
-                                emitStableDatabaseSemconv() ? null : (long) authenticatedPort))));
+                                emitStableDatabaseSemconv() ? null : (long) authenticatedPort),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? authenticatedIp : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? (long) authenticatedPort
+                                    : null))));
     if (testLatestDeps()) {
       traceAsserts.add(
           trace ->
@@ -158,7 +188,15 @@ class LettuceClusterClientTest {
                                       : authenticatedHost),
                               equalTo(
                                   SERVER_PORT,
-                                  emitStableDatabaseSemconv() ? null : (long) authenticatedPort))));
+                                  emitStableDatabaseSemconv() ? null : (long) authenticatedPort),
+                              equalTo(
+                                  NETWORK_PEER_ADDRESS,
+                                  emitStableDatabaseSemconv() ? authenticatedIp : null),
+                              equalTo(
+                                  NETWORK_PEER_PORT,
+                                  emitStableDatabaseSemconv()
+                                      ? (long) authenticatedPort
+                                      : null))));
     }
     testing.waitAndAssertTraces(traceAsserts);
   }
@@ -182,7 +220,12 @@ class LettuceClusterClientTest {
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv() ? configuredTarget : host),
                             equalTo(
-                                SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port))));
+                                SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null))));
   }
 
   @Test
@@ -214,35 +257,323 @@ class LettuceClusterClientTest {
                                 emitStableDatabaseSemconv() ? configuredTarget : host),
                             equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
                             equalTo(
+                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? (long) port : null),
+                            equalTo(
                                 DB_OPERATION_BATCH_SIZE,
                                 emitStableDatabaseSemconv() ? 2L : null))));
   }
 
+  @Test
+  void testCommandAndBatchUseObservedPeers() throws Exception {
+    TestRedisCluster firstRedisServer = new TestRedisCluster();
+    cleanup.deferCleanup(firstRedisServer);
+    TestRedisCluster secondRedisServer = new TestRedisCluster();
+    cleanup.deferCleanup(secondRedisServer);
+
+    RedisURI firstNodeUri =
+        RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
+    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
+    String peerConfiguredTarget =
+        "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
+    List<RedisURI> nodeUris =
+        asList(
+            firstNodeUri,
+            RedisURI.create(
+                "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
+    RedisClusterClient client =
+        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
+    cleanup.deferCleanup(() -> client.shutdown(0, 15, SECONDS));
+    StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
+    cleanup.deferCleanup(peerConnection);
+
+    RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
+    String routedKey = keyInSlotRange("routed", SLOT_SPLIT, SlotHash.SLOT_COUNT);
+    String firstBatchKey = keyInSlotRange("first-batch", 0, SLOT_SPLIT);
+    String secondBatchKey = keyInSlotRange("second-batch", SLOT_SPLIT, SlotHash.SLOT_COUNT);
+    assertThat(asyncCommands.set(routedKey, "value").get(10, SECONDS)).isEqualTo("OK");
+
+    asyncCommands.setAutoFlushCommands(false);
+    cleanup.deferCleanup(() -> asyncCommands.setAutoFlushCommands(true));
+    RedisFuture<String> first = asyncCommands.set(firstBatchKey, "value");
+    RedisFuture<String> second = asyncCommands.set(secondBatchKey, "value");
+    asyncCommands.flushCommands();
+    assertThat(first.get(10, SECONDS)).isEqualTo("OK");
+    assertThat(second.get(10, SECONDS)).isEqualTo("OK");
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv() ? "SET " + peerConfiguredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, null),
+                            equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerConfiguredTarget
+                                    : firstRedisServer.getHost()),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? null
+                                    : (long)
+                                        (testLatestDeps()
+                                            ? secondRedisServer.getPort()
+                                            : firstRedisServer.getPort())),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? secondRedisServer.getHost() : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? (long) secondRedisServer.getPort()
+                                    : null))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv()
+                                ? "PIPELINE SET " + peerConfiguredTarget
+                                : "PIPELINE SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, null),
+                            equalTo(maybeStable(DB_OPERATION), "PIPELINE SET"),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerConfiguredTarget
+                                    : firstRedisServer.getHost()),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? null
+                                    : (long)
+                                        (testLatestDeps()
+                                            ? secondRedisServer.getPort()
+                                            : firstRedisServer.getPort())),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null),
+                            equalTo(
+                                DB_OPERATION_BATCH_SIZE,
+                                emitStableDatabaseSemconv() ? 2L : null))));
+
+    firstRedisServer.assertReceivedSet(firstBatchKey);
+    secondRedisServer.assertReceivedSet(routedKey, secondBatchKey);
+    firstRedisServer.assertNoFailure();
+    secondRedisServer.assertNoFailure();
+  }
+
+  private static String keyInSlotRange(String prefix, int startInclusive, int endExclusive) {
+    for (int i = 0; ; i++) {
+      String key = prefix + "-" + i;
+      int slot = SlotHash.getSlot(key);
+      if (slot >= startInclusive && slot < endExclusive) {
+        return key;
+      }
+    }
+  }
+
   private static class TestRedisClusterClient extends RedisClusterClient {
-    private final RedisURI nodeUri;
+    private final List<RedisURI> nodeUris;
 
     private TestRedisClusterClient(List<RedisURI> seedUris, RedisURI nodeUri) {
+      this(seedUris, asList(nodeUri));
+    }
+
+    private TestRedisClusterClient(List<RedisURI> seedUris, List<RedisURI> nodeUris) {
       super(seedUris);
-      this.nodeUri = nodeUri;
+      this.nodeUris = nodeUris;
     }
 
     @Override
     protected Partitions loadPartitions() {
-      List<Integer> slots = new ArrayList<>(16384);
-      for (int slot = 0; slot < 16384; slot++) {
+      Partitions partitions = new Partitions();
+      if (nodeUris.size() == 1) {
+        partitions.addPartition(
+            newNode(nodeUris.get(0), FIRST_NODE_ID, 0, SlotHash.SLOT_COUNT));
+      } else {
+        partitions.addPartition(newNode(nodeUris.get(0), FIRST_NODE_ID, 0, SLOT_SPLIT));
+        partitions.addPartition(
+            newNode(nodeUris.get(1), SECOND_NODE_ID, SLOT_SPLIT, SlotHash.SLOT_COUNT));
+      }
+      partitions.updateCache();
+      return partitions;
+    }
+
+    private static RedisClusterNode newNode(
+        RedisURI uri, String nodeId, int startInclusive, int endExclusive) {
+      List<Integer> slots = new ArrayList<>(endExclusive - startInclusive);
+      for (int slot = startInclusive; slot < endExclusive; slot++) {
         slots.add(slot);
       }
       RedisClusterNode node = new RedisClusterNode();
-      node.setUri(nodeUri);
-      node.setNodeId(NODE_ID);
+      node.setUri(uri);
+      node.setNodeId(nodeId);
       node.setConnected(true);
       node.setSlots(slots);
       node.setFlags(EnumSet.of(NodeFlag.MASTER));
+      return node;
+    }
+  }
 
-      Partitions partitions = new Partitions();
-      partitions.addPartition(node);
-      partitions.updateCache();
-      return partitions;
+  private static class TestRedisCluster implements AutoCloseable {
+    private final ServerSocket serverSocket;
+    private final Set<Socket> connections = ConcurrentHashMap.newKeySet();
+    private final Set<String> receivedSetKeys = ConcurrentHashMap.newKeySet();
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private final Thread acceptThread;
+    private volatile boolean closed;
+
+    private TestRedisCluster() throws IOException {
+      serverSocket = new ServerSocket(0, 50, InetAddress.getAllByName("127.0.0.1")[0]);
+      acceptThread = new Thread(this::acceptConnections, "test-redis-cluster-accept");
+      acceptThread.setDaemon(true);
+      acceptThread.start();
+    }
+
+    private String getHost() {
+      return serverSocket.getInetAddress().getHostAddress();
+    }
+
+    private int getPort() {
+      return serverSocket.getLocalPort();
+    }
+
+    private void acceptConnections() {
+      while (!closed) {
+        try {
+          Socket socket = serverSocket.accept();
+          connections.add(socket);
+          Thread thread =
+              new Thread(() -> handleConnection(socket), "test-redis-cluster-connection");
+          thread.setDaemon(true);
+          thread.start();
+        } catch (IOException e) {
+          if (!closed) {
+            failure.compareAndSet(null, e);
+          }
+        }
+      }
+    }
+
+    private void handleConnection(Socket socket) {
+      try (DataInputStream input = new DataInputStream(socket.getInputStream())) {
+        OutputStream output = socket.getOutputStream();
+        while (true) {
+          List<String> command = readCommand(input);
+          if (command.isEmpty()) {
+            break;
+          }
+          writeResponse(command, output);
+        }
+      } catch (IOException e) {
+        if (!closed) {
+          failure.compareAndSet(null, e);
+        }
+      } finally {
+        connections.remove(socket);
+      }
+    }
+
+    private void writeResponse(List<String> command, OutputStream output) throws IOException {
+      String name = command.get(0).toUpperCase(Locale.ROOT);
+      if ("CLUSTER".equals(name)
+          && command.size() > 1
+          && "NODES".equals(command.get(1).toUpperCase(Locale.ROOT))) {
+        String nodes =
+            FIRST_NODE_ID
+                + " "
+                + getHost()
+                + ":"
+                + getPort()
+                + " myself,master - 0 0 1 connected 0-16383\n";
+        write(output, "$" + nodes.getBytes(UTF_8).length + "\r\n" + nodes + "\r\n");
+      } else if ("SET".equals(name)) {
+        String key = command.get(1);
+        receivedSetKeys.add(key);
+        write(output, "+OK\r\n");
+      } else if ("CLIENT".equals(name)) {
+        write(output, "+OK\r\n");
+      } else if ("COMMAND".equals(name)) {
+        write(output, "*0\r\n");
+      } else if ("PING".equals(name)) {
+        write(output, "+PONG\r\n");
+      } else {
+        AssertionError error = new AssertionError("Unexpected Redis command: " + command);
+        failure.compareAndSet(null, error);
+        write(output, "-ERR unsupported command\r\n");
+      }
+    }
+
+    private static List<String> readCommand(DataInputStream input) throws IOException {
+      int first = input.read();
+      if (first == -1) {
+        return emptyList();
+      }
+      if (first != '*') {
+        throw new IOException("Expected RESP array");
+      }
+      int argumentCount = Integer.parseInt(readLine(input));
+      List<String> command = new ArrayList<>(argumentCount);
+      for (int i = 0; i < argumentCount; i++) {
+        if (input.read() != '$') {
+          throw new IOException("Expected RESP bulk string");
+        }
+        int length = Integer.parseInt(readLine(input));
+        byte[] value = new byte[length];
+        input.readFully(value);
+        if (input.read() != '\r' || input.read() != '\n') {
+          throw new IOException("Expected RESP line ending");
+        }
+        command.add(new String(value, UTF_8));
+      }
+      return command;
+    }
+
+    private static String readLine(DataInputStream input) throws IOException {
+      ByteArrayOutputStream line = new ByteArrayOutputStream();
+      int value;
+      while ((value = input.read()) != '\r') {
+        if (value == -1) {
+          throw new IOException("Unexpected end of RESP input");
+        }
+        line.write(value);
+      }
+      if (input.read() != '\n') {
+        throw new IOException("Expected RESP line ending");
+      }
+      return new String(line.toByteArray(), US_ASCII);
+    }
+
+    private static void write(OutputStream output, String value) throws IOException {
+      output.write(value.getBytes(UTF_8));
+      output.flush();
+    }
+
+    private void assertNoFailure() {
+      assertThat(failure.get()).isNull();
+    }
+
+    private void assertReceivedSet(String... keys) {
+      assertThat(receivedSetKeys).contains(keys);
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed = true;
+      serverSocket.close();
+      for (Socket connection : new ArrayList<>(connections)) {
+        connection.close();
+      }
     }
   }
 }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -165,9 +165,7 @@ class LettuceClusterClientTest {
                                 emitStableDatabaseSemconv() ? authenticatedIp : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
-                                emitStableDatabaseSemconv()
-                                    ? (long) authenticatedPort
-                                    : null))));
+                                emitStableDatabaseSemconv() ? (long) authenticatedPort : null))));
     if (testLatestDeps()) {
       traceAsserts.add(
           trace ->
@@ -220,10 +218,8 @@ class LettuceClusterClientTest {
                             equalTo(
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv() ? configuredTarget : host),
-                            equalTo(
-                                SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
-                            equalTo(
-                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv() ? (long) port : null))));
@@ -257,8 +253,7 @@ class LettuceClusterClientTest {
                                 SERVER_ADDRESS,
                                 emitStableDatabaseSemconv() ? configuredTarget : host),
                             equalTo(SERVER_PORT, emitStableDatabaseSemconv() ? null : (long) port),
-                            equalTo(
-                                NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
                             equalTo(
                                 NETWORK_PEER_PORT,
                                 emitStableDatabaseSemconv() ? (long) port : null),
@@ -467,8 +462,7 @@ class LettuceClusterClientTest {
     protected Partitions loadPartitions() {
       Partitions partitions = new Partitions();
       if (nodeUris.size() == 1) {
-        partitions.addPartition(
-            newNode(nodeUris.get(0), FIRST_NODE_ID, 0, SlotHash.SLOT_COUNT));
+        partitions.addPartition(newNode(nodeUris.get(0), FIRST_NODE_ID, 0, SlotHash.SLOT_COUNT));
       } else {
         partitions.addPartition(newNode(nodeUris.get(0), FIRST_NODE_ID, 0, SLOT_SPLIT));
         partitions.addPartition(

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceClusterClientTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -372,6 +373,74 @@ class LettuceClusterClientTest {
     secondRedisServer.assertNoFailure();
   }
 
+  // Lettuce 4.0 uses a Guava API that is not available in the test runtime when following
+  // redirects.
+  @Test
+  @EnabledIfSystemProperty(named = "testLatestDeps", matches = "true")
+  void redirectedCommandUsesLastPeer() throws Exception {
+    TestRedisCluster firstRedisServer = new TestRedisCluster();
+    cleanup.deferCleanup(firstRedisServer);
+    TestRedisCluster secondRedisServer = new TestRedisCluster();
+    cleanup.deferCleanup(secondRedisServer);
+
+    RedisURI firstNodeUri =
+        RedisURI.create("redis://" + firstRedisServer.getHost() + ":" + firstRedisServer.getPort());
+    RedisURI alternateSeed = RedisURI.create("redis://seed.invalid:6379");
+    String peerConfiguredTarget =
+        "seed.invalid:6379," + firstRedisServer.getHost() + ":" + firstRedisServer.getPort();
+    List<RedisURI> nodeUris =
+        asList(
+            firstNodeUri,
+            RedisURI.create(
+                "redis://" + secondRedisServer.getHost() + ":" + secondRedisServer.getPort()));
+    RedisClusterClient client =
+        new TestRedisClusterClient(asList(alternateSeed, firstNodeUri), nodeUris);
+    cleanup.deferCleanup(() -> client.shutdown(0, 15, SECONDS));
+    StatefulRedisClusterConnection<String, String> peerConnection = client.connect();
+    cleanup.deferCleanup(peerConnection);
+
+    RedisAdvancedClusterAsyncCommands<String, String> asyncCommands = peerConnection.async();
+    String redirectedKey = keyInSlotRange("redirected", 0, SLOT_SPLIT);
+    firstRedisServer.redirectSetOnce(redirectedKey, secondRedisServer);
+
+    assertThat(asyncCommands.set(redirectedKey, "value").get(10, SECONDS)).isEqualTo("OK");
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(
+                            emitStableDatabaseSemconv() ? "SET " + peerConfiguredTarget : "SET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, null),
+                            equalTo(maybeStable(DB_OPERATION), "SET"),
+                            equalTo(
+                                SERVER_ADDRESS,
+                                emitStableDatabaseSemconv()
+                                    ? peerConfiguredTarget
+                                    : firstRedisServer.getHost()),
+                            equalTo(
+                                SERVER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? null
+                                    : Long.valueOf(secondRedisServer.getPort())),
+                            equalTo(
+                                NETWORK_PEER_ADDRESS,
+                                emitStableDatabaseSemconv() ? secondRedisServer.getHost() : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv()
+                                    ? Long.valueOf(secondRedisServer.getPort())
+                                    : null))));
+
+    firstRedisServer.assertReceivedSet(redirectedKey);
+    secondRedisServer.assertReceivedSet(redirectedKey);
+    firstRedisServer.assertNoFailure();
+    secondRedisServer.assertNoFailure();
+  }
+
   private static String keyInSlotRange(String prefix, int startInclusive, int endExclusive) {
     for (int i = 0; ; i++) {
       String key = prefix + "-" + i;
@@ -429,6 +498,8 @@ class LettuceClusterClientTest {
     private final ServerSocket serverSocket;
     private final Set<Socket> connections = ConcurrentHashMap.newKeySet();
     private final Set<String> receivedSetKeys = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<String, TestRedisCluster> setRedirects =
+        new ConcurrentHashMap<>();
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
     private final Thread acceptThread;
     private volatile boolean closed;
@@ -500,7 +571,20 @@ class LettuceClusterClientTest {
       } else if ("SET".equals(name)) {
         String key = command.get(1);
         receivedSetKeys.add(key);
-        write(output, "+OK\r\n");
+        TestRedisCluster redirect = setRedirects.remove(key);
+        if (redirect == null) {
+          write(output, "+OK\r\n");
+        } else {
+          write(
+              output,
+              "-MOVED "
+                  + SlotHash.getSlot(key)
+                  + " "
+                  + redirect.getHost()
+                  + ":"
+                  + redirect.getPort()
+                  + "\r\n");
+        }
       } else if ("CLIENT".equals(name)) {
         write(output, "+OK\r\n");
       } else if ("COMMAND".equals(name)) {
@@ -552,6 +636,10 @@ class LettuceClusterClientTest {
         throw new IOException("Expected RESP line ending");
       }
       return new String(line.toByteArray(), US_ASCII);
+    }
+
+    private void redirectSetOnce(String key, TestRedisCluster target) {
+      setRedirects.put(key, target);
     }
 
     private static void write(OutputStream output, String value) throws IOException {

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceReactiveClientTest.java
@@ -9,6 +9,8 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.testing.junit.db.SemconvStabilityUtil.maybeStable;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -27,6 +29,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -40,6 +44,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
+import rx.Observable;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
@@ -68,14 +73,16 @@ class LettuceReactiveClientTest {
 
   private static RedisReactiveCommands<String, String> reactiveCommands;
   private static String host;
+  private static String ip;
   private static int port;
 
   @BeforeAll
-  static void setUp() {
+  static void setUp() throws UnknownHostException {
     redisServer.start();
     cleanup.deferAfterAll(redisServer::stop);
 
     host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     String embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
 
@@ -133,7 +140,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -167,7 +178,51 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
+  }
+
+  @Test
+  void resubscribedCommandUsesEachDispatchedPeer() {
+    Observable<String> command = reactiveCommands.get("TESTKEY");
+
+    assertThat(command.toBlocking().single()).isEqualTo("TESTVAL");
+    assertThat(command.toBlocking().single()).isEqualTo("TESTVAL");
+
+    testing.waitAndAssertTraces(
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "GET " + host + ":" + port : "GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(maybeStable(DB_OPERATION), "GET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))),
+        trace ->
+            trace.hasSpansSatisfyingExactly(
+                span ->
+                    span.hasName(emitStableDatabaseSemconv() ? "GET " + host + ":" + port : "GET")
+                        .hasKind(SpanKind.CLIENT)
+                        .hasAttributesSatisfyingExactly(
+                            equalTo(maybeStable(DB_SYSTEM), REDIS),
+                            equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
+                            equalTo(maybeStable(DB_OPERATION), "GET"),
+                            equalTo(SERVER_ADDRESS, host),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   // to make sure instrumentation's chained completion stages won't interfere with user's, while
@@ -208,7 +263,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName("callback")
                         .hasKind(SpanKind.INTERNAL)
@@ -237,7 +296,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "RANDOMKEY"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -262,7 +325,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "COMMAND"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -291,7 +358,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "COMMAND"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -323,7 +394,9 @@ class LettuceReactiveClientTest {
                                   equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                                   equalTo(maybeStable(DB_OPERATION), "SHUTDOWN"),
                                   equalTo(SERVER_ADDRESS, host),
-                                  equalTo(SERVER_PORT, port))));
+                                  equalTo(SERVER_PORT, port),
+                                  equalTo(NETWORK_PEER_ADDRESS, null),
+                                  equalTo(NETWORK_PEER_PORT, null))));
         });
   }
 
@@ -352,7 +425,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName(emitStableDatabaseSemconv() ? "GET " + host + ":" + port : "GET")
                         .hasKind(SpanKind.CLIENT)
@@ -362,7 +439,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -395,7 +476,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName(emitStableDatabaseSemconv() ? "GET " + host + ":" + port : "GET")
                         .hasKind(SpanKind.CLIENT)
@@ -405,7 +490,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -440,7 +529,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port)),
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null)),
                 span ->
                     span.hasName(emitStableDatabaseSemconv() ? "GET " + host + ":" + port : "GET")
                         .hasKind(SpanKind.CLIENT)
@@ -450,7 +543,11 @@ class LettuceReactiveClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   private static void withIsolatedContainer(

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSyncClientTest.java
@@ -14,6 +14,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equal
 import static io.opentelemetry.semconv.DbAttributes.DB_NAMESPACE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_SYSTEM_NAME;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
+import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_ADDRESS;
 import static io.opentelemetry.semconv.ServerAttributes.SERVER_PORT;
 import static io.opentelemetry.semconv.incubating.DbIncubatingAttributes.DB_OPERATION;
@@ -41,6 +43,8 @@ import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
 import io.opentelemetry.instrumentation.testing.junit.AgentInstrumentationExtension;
 import io.opentelemetry.instrumentation.testing.junit.InstrumentationExtension;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +85,7 @@ class LettuceSyncClientTest {
           .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
   private static String host;
+  private static String ip;
   private static int port;
   private static int incorrectPort;
   private static String dbUriNonExistent;
@@ -98,11 +103,12 @@ class LettuceSyncClientTest {
   private static RedisCommands<String, String> syncCommands;
 
   @BeforeAll
-  static void setUp() {
+  static void setUp() throws UnknownHostException {
     redisServer.start();
     cleanup.deferAfterAll(redisServer::stop);
 
     host = redisServer.getHost();
+    ip = InetAddress.getByName(host).getHostAddress();
     port = redisServer.getMappedPort(6379);
     embeddedDbUri = "redis://" + host + ":" + port + "/" + DB_INDEX;
 
@@ -199,16 +205,33 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
 
-    assertDurationMetric(
-        testing,
-        "io.opentelemetry.lettuce-4.0",
-        DB_SYSTEM_NAME,
-        DB_OPERATION_NAME,
-        DB_NAMESPACE,
-        SERVER_ADDRESS,
-        SERVER_PORT);
+    if (emitStableDatabaseSemconv()) {
+      assertDurationMetric(
+          testing,
+          "io.opentelemetry.lettuce-4.0",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_NAMESPACE,
+          SERVER_ADDRESS,
+          SERVER_PORT,
+          NETWORK_PEER_ADDRESS,
+          NETWORK_PEER_PORT);
+    } else {
+      assertDurationMetric(
+          testing,
+          "io.opentelemetry.lettuce-4.0",
+          DB_SYSTEM_NAME,
+          DB_OPERATION_NAME,
+          DB_NAMESPACE,
+          SERVER_ADDRESS,
+          SERVER_PORT);
+    }
   }
 
   @Test
@@ -229,7 +252,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "PING"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @SuppressWarnings("unchecked")
@@ -266,7 +293,9 @@ class LettuceSyncClientTest {
                           equalTo(DB_NAMESPACE, null),
                           equalTo(maybeStable(DB_OPERATION), "SET"),
                           equalTo(SERVER_ADDRESS, configuredTarget),
-                          equalTo(SERVER_PORT, null)));
+                          equalTo(SERVER_PORT, null),
+                          equalTo(NETWORK_PEER_ADDRESS, ip),
+                          equalTo(NETWORK_PEER_PORT, port)));
           if (connectionTelemetryEnabled()) {
             spanAsserts.add(
                 span ->
@@ -316,7 +345,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -335,7 +368,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -354,7 +391,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "GET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -376,7 +417,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "RANDOMKEY"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -396,7 +441,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "LPUSH"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -416,7 +465,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "HMSET"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -438,7 +491,11 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "HGETALL"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, port))));
+                            equalTo(SERVER_PORT, port),
+                            equalTo(NETWORK_PEER_ADDRESS, emitStableDatabaseSemconv() ? ip : null),
+                            equalTo(
+                                NETWORK_PEER_PORT,
+                                emitStableDatabaseSemconv() ? Long.valueOf(port) : null))));
   }
 
   @Test
@@ -478,7 +535,9 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "DEBUG"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, serverPort))));
+                            equalTo(SERVER_PORT, serverPort),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null))));
   }
 
   @Test
@@ -520,6 +579,8 @@ class LettuceSyncClientTest {
                             equalTo(DB_NAMESPACE, emitStableDatabaseSemconv() ? "0" : null),
                             equalTo(maybeStable(DB_OPERATION), "SHUTDOWN"),
                             equalTo(SERVER_ADDRESS, host),
-                            equalTo(SERVER_PORT, shutdownServerPort))));
+                            equalTo(SERVER_PORT, shutdownServerPort),
+                            equalTo(NETWORK_PEER_ADDRESS, null),
+                            equalTo(NETWORK_PEER_PORT, null))));
   }
 }


### PR DESCRIPTION
Adds `network.peer.address` and `network.peer.port` to Lettuce 4.x database spans in stable and duplicate database semantic convention modes. The peer attributes report the last direct Redis peer, while `server.*` keeps the configured target from #20072.

Async and reactive commands preserve the observed peer across reconnects and MOVED/ASK redirects. Batch and multi-command spans report the peer when every buffered command resolves to the same connection, and omit it when a batch spans more than one peer. Fan-out, no-response, and completed-before-write paths still omit peer attributes.

Stacked on #20072. Part of #20010 and #19899.
