### PR TITLE
Increase max telemetry size for smoke tests

### DIFF
--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/TelemetryRetriever.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/TelemetryRetriever.java
@@ -35,7 +35,11 @@ public class TelemetryRetriever implements AutoCloseable {
   private boolean closed;
 
   public TelemetryRetriever(int backendPort, Duration telemetryTimeout) {
-    client = WebClient.of("http://localhost:" + backendPort);
+    client =
+        WebClient.builder("http://localhost:" + backendPort)
+            // by default response size is limited to 10MiB
+            .maxResponseLength(50 * 1024 * 1024)
+            .build();
     this.telemetryTimeout = telemetryTimeout;
   }
 


### PR DESCRIPTION
https://community.develocity.cloud/s/sv3tfdeyeaopk/tests/task/:instrumentation:kafka:kafka-connect-2.6:testing:test/details/io.opentelemetry.instrumentation.kafkaconnect.v2_6.PostgresKafkaConnectSinkTaskTest/testSingleMessage()?expanded-stacktrace=WyIwLTEiLCIwIl0&top-execution=1
Apparently armeria client has a 10MiB response size limit that is exceeded in kafka connect tests.