### PR TITLE
Support adding comments to exclude muzzle configs from docs

### DIFF
--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -339,7 +339,7 @@ We parse gradle files in order to determine several pieces of metadata:
 Every `pass { ... }` block contributes a line to `javaagent_target_versions`. Some pass blocks exist
 only to verify a sub-range or an alternate dependency set, and publishing their version range
 alongside the module's real range is misleading. Add a `// instrumentation-docs:ignore` comment
-immediately after `pass {` inside such a block to leave it out of the generated documentation:
+inside such a block to leave it out of the generated documentation:
 
 ```kotlin
 muzzle {
@@ -358,7 +358,8 @@ muzzle {
 }
 ```
 
-Place the comment on the first line of the block body. A comment above `pass {` is not honored.
+The comment must appear inside the `pass` block; placing it first is recommended. A comment above
+`pass {` is not honored.
 The marker has no effect on muzzle itself, only on the generated `instrumentation-list.yaml`.
 
 ### Scope

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -334,6 +334,34 @@ We parse gradle files in order to determine several pieces of metadata:
 - Standalone Library versions are identified, but we do not try and parse version ranges
 - Minimum Java version is determined by the `otelJava` configurations
 
+#### Excluding a muzzle directive from the docs
+
+Every `pass { ... }` block contributes a line to `javaagent_target_versions`. Some pass blocks exist
+only to verify a sub-range or an alternate dependency set, and publishing their version range
+alongside the module's real range is misleading. Add an `// instrumentation-docs:ignore` comment
+inside such a block to leave it out of the generated documentation:
+
+```kotlin
+muzzle {
+  pass {
+    group.set("com.couchbase.client")
+    module.set("java-client")
+    versions.set("[2,3)")
+  }
+  pass {
+    // instrumentation-docs:ignore - verification only, the [2,3) directive above is the range we document
+    name.set("Pre-2.6 network instrumentation")
+    group.set("com.couchbase.client")
+    module.set("java-client")
+    versions.set("[2,2.6)")
+  }
+}
+```
+
+The comment must be inside the block body. A comment placed on the line above `pass {` is not
+honored, since it reads as a trailing comment on the preceding block. The marker has no effect on
+muzzle itself, only on the generated `instrumentation-list.yaml`.
+
 ### Scope
 
 For now, the scope name is the only value that is implemented in our instrumentations. The scope

--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -338,8 +338,8 @@ We parse gradle files in order to determine several pieces of metadata:
 
 Every `pass { ... }` block contributes a line to `javaagent_target_versions`. Some pass blocks exist
 only to verify a sub-range or an alternate dependency set, and publishing their version range
-alongside the module's real range is misleading. Add an `// instrumentation-docs:ignore` comment
-inside such a block to leave it out of the generated documentation:
+alongside the module's real range is misleading. Add a `// instrumentation-docs:ignore` comment
+immediately after `pass {` inside such a block to leave it out of the generated documentation:
 
 ```kotlin
 muzzle {
@@ -358,9 +358,8 @@ muzzle {
 }
 ```
 
-The comment must be inside the block body. A comment placed on the line above `pass {` is not
-honored, since it reads as a trailing comment on the preceding block. The marker has no effect on
-muzzle itself, only on the generated `instrumentation-list.yaml`.
+Place the comment on the first line of the block body. A comment above `pass {` is not honored.
+The marker has no effect on muzzle itself, only on the generated `instrumentation-list.yaml`.
 
 ### Scope
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
@@ -29,7 +29,8 @@ public class GradleParser {
   private static final Pattern variablePattern =
       Pattern.compile("val\\s+(\\w+)\\s*=\\s*\"([^\"]+)\"");
 
-  private static final Pattern muzzlePassBlockStartPattern = Pattern.compile("\\bpass\\s*\\{");
+  private static final Pattern muzzlePassBlockPattern =
+      Pattern.compile("pass\\s*\\{(.*?)}", Pattern.DOTALL);
 
   private static final Pattern coreJdkPattern = Pattern.compile("coreJdk\\.set\\(true\\)");
 
@@ -77,10 +78,12 @@ public class GradleParser {
   private static DependencyInfo parseMuzzle(
       String gradleFileContents, Map<String, String> variables) {
     Set<String> results = new HashSet<>();
+    Matcher passBlockMatcher = muzzlePassBlockPattern.matcher(gradleFileContents);
 
     Integer minJavaVersion = parseMinJavaVersion(gradleFileContents);
 
-    for (String passBlock : extractPassBlocks(gradleFileContents)) {
+    while (passBlockMatcher.find()) {
+      String passBlock = passBlockMatcher.group(1);
       if (docsIgnorePattern.matcher(passBlock).find()) {
         continue;
       }
@@ -103,47 +106,6 @@ public class GradleParser {
       }
     }
     return new DependencyInfo(results, minJavaVersion);
-  }
-
-  /**
-   * Extracts the body of each muzzle "pass { ... }" block. Braces are matched by depth rather than
-   * with a regex so that a block containing a brace, such as a comment referencing {@code
-   * io.opentelemetry.context.{Context,Scope}}, is captured in full instead of being truncated at
-   * that brace.
-   *
-   * @param gradleFileContents Contents of a Gradle build file as a String
-   * @return The body of each pass block, in the order they appear
-   */
-  private static List<String> extractPassBlocks(String gradleFileContents) {
-    List<String> passBlocks = new ArrayList<>();
-    Matcher blockStartMatcher = muzzlePassBlockStartPattern.matcher(gradleFileContents);
-    int searchFrom = 0;
-
-    while (blockStartMatcher.find(searchFrom)) {
-      int bodyStart = blockStartMatcher.end();
-      int depth = 1;
-      int position = bodyStart;
-
-      while (position < gradleFileContents.length() && depth > 0) {
-        char c = gradleFileContents.charAt(position);
-        if (c == '{') {
-          depth++;
-        } else if (c == '}') {
-          depth--;
-        }
-        position++;
-      }
-
-      if (depth != 0) {
-        // unbalanced braces, the file is not something we can reason about
-        break;
-      }
-
-      passBlocks.add(gradleFileContents.substring(bodyStart, position - 1));
-      searchFrom = position;
-    }
-
-    return passBlocks;
   }
 
   @Nullable

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/GradleParser.java
@@ -29,10 +29,17 @@ public class GradleParser {
   private static final Pattern variablePattern =
       Pattern.compile("val\\s+(\\w+)\\s*=\\s*\"([^\"]+)\"");
 
-  private static final Pattern muzzlePassBlockPattern =
-      Pattern.compile("pass\\s*\\{(.*?)}", Pattern.DOTALL);
+  private static final Pattern muzzlePassBlockStartPattern = Pattern.compile("\\bpass\\s*\\{");
 
   private static final Pattern coreJdkPattern = Pattern.compile("coreJdk\\.set\\(true\\)");
+
+  /**
+   * Marker comment that excludes a muzzle directive from the generated documentation. Some pass
+   * blocks only exist to verify a sub-range or an alternate dependency set, and publishing their
+   * version range alongside the module's real range is misleading.
+   */
+  private static final Pattern docsIgnorePattern =
+      Pattern.compile("//\\s*instrumentation-docs:ignore");
 
   private static final Pattern ifBlockPattern =
       Pattern.compile("if\\s*\\([^)]*\\)\\s*\\{.*?}", Pattern.DOTALL);
@@ -70,12 +77,13 @@ public class GradleParser {
   private static DependencyInfo parseMuzzle(
       String gradleFileContents, Map<String, String> variables) {
     Set<String> results = new HashSet<>();
-    Matcher passBlockMatcher = muzzlePassBlockPattern.matcher(gradleFileContents);
 
     Integer minJavaVersion = parseMinJavaVersion(gradleFileContents);
 
-    while (passBlockMatcher.find()) {
-      String passBlock = passBlockMatcher.group(1);
+    for (String passBlock : extractPassBlocks(gradleFileContents)) {
+      if (docsIgnorePattern.matcher(passBlock).find()) {
+        continue;
+      }
 
       if (coreJdkPattern.matcher(passBlock).find()) {
         if (minJavaVersion != null) {
@@ -95,6 +103,47 @@ public class GradleParser {
       }
     }
     return new DependencyInfo(results, minJavaVersion);
+  }
+
+  /**
+   * Extracts the body of each muzzle "pass { ... }" block. Braces are matched by depth rather than
+   * with a regex so that a block containing a brace, such as a comment referencing {@code
+   * io.opentelemetry.context.{Context,Scope}}, is captured in full instead of being truncated at
+   * that brace.
+   *
+   * @param gradleFileContents Contents of a Gradle build file as a String
+   * @return The body of each pass block, in the order they appear
+   */
+  private static List<String> extractPassBlocks(String gradleFileContents) {
+    List<String> passBlocks = new ArrayList<>();
+    Matcher blockStartMatcher = muzzlePassBlockStartPattern.matcher(gradleFileContents);
+    int searchFrom = 0;
+
+    while (blockStartMatcher.find(searchFrom)) {
+      int bodyStart = blockStartMatcher.end();
+      int depth = 1;
+      int position = bodyStart;
+
+      while (position < gradleFileContents.length() && depth > 0) {
+        char c = gradleFileContents.charAt(position);
+        if (c == '{') {
+          depth++;
+        } else if (c == '}') {
+          depth--;
+        }
+        position++;
+      }
+
+      if (depth != 0) {
+        // unbalanced braces, the file is not something we can reason about
+        break;
+      }
+
+      passBlocks.add(gradleFileContents.substring(bodyStart, position - 1));
+      searchFrom = position;
+    }
+
+    return passBlocks;
   }
 
   @Nullable

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/GradleParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/GradleParserTest.java
@@ -112,11 +112,19 @@ class GradleParserTest {
                 versions.set("[2,2.6)")
                 assertInverse.set(true)
               }
+              pass {
+                group.set("com.couchbase.client")
+                module.set("java-client")
+                versions.set("[3,4)")
+                assertInverse.set(true)
+              }
             }""";
 
     DependencyInfo info =
         GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
-    assertThat(info.versions()).containsExactly("com.couchbase.client:java-client:[2,3)");
+    assertThat(info.versions())
+        .containsExactlyInAnyOrder(
+            "com.couchbase.client:java-client:[2,3)", "com.couchbase.client:java-client:[3,4)");
   }
 
   @Test
@@ -133,51 +141,6 @@ class GradleParserTest {
     DependencyInfo info =
         GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
     assertThat(info.versions()).isEmpty();
-  }
-
-  @Test
-  void testDocsIgnoreHonoredAfterCommentContainingBraces() {
-    String gradleBuildFileContent =
-        """
-            muzzle {
-              pass {
-                group.set("com.azure")
-                module.set("azure-core")
-                versions.set("[1.53.0,)")
-                // this module references the application's io.opentelemetry.context.{Context,Scope}
-                // instrumentation-docs:ignore - verification only
-                excludeInstrumentationName("azure-core-1.53-context")
-              }
-            }""";
-
-    DependencyInfo info =
-        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
-    assertThat(info.versions()).isEmpty();
-  }
-
-  @Test
-  void testExtractMuzzleVersions_CommentContainingBracesDoesNotTruncateBlock() {
-    String gradleBuildFileContent =
-        """
-            muzzle {
-              pass {
-                // this module references the application's io.opentelemetry.context.{Context,Scope}
-                group.set("com.azure")
-                module.set("azure-core")
-                versions.set("[1.53.0,)")
-              }
-              pass {
-                group.set("com.azure")
-                module.set("azure-core-amqp")
-                versions.set("[2.0.0,)")
-              }
-            }""";
-
-    DependencyInfo info =
-        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
-    assertThat(info.versions())
-        .containsExactlyInAnyOrder(
-            "com.azure:azure-core:[1.53.0,)", "com.azure:azure-core-amqp:[2.0.0,)");
   }
 
   @Test

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/GradleParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/GradleParserTest.java
@@ -94,6 +94,111 @@ class GradleParserTest {
   }
 
   @Test
+  void testDocsIgnoreSkipsPassBlock() {
+    String gradleBuildFileContent =
+        """
+            muzzle {
+              pass {
+                group.set("com.couchbase.client")
+                module.set("java-client")
+                versions.set("[2,3)")
+                assertInverse.set(true)
+              }
+              pass {
+                // instrumentation-docs:ignore - verification only
+                name.set("Pre-2.6 network instrumentation")
+                group.set("com.couchbase.client")
+                module.set("java-client")
+                versions.set("[2,2.6)")
+                assertInverse.set(true)
+              }
+            }""";
+
+    DependencyInfo info =
+        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
+    assertThat(info.versions()).containsExactly("com.couchbase.client:java-client:[2,3)");
+  }
+
+  @Test
+  void testDocsIgnoreSkipsCoreJdkPassBlock() {
+    String gradleBuildFileContent =
+        """
+            muzzle {
+              pass {
+                // instrumentation-docs:ignore
+                coreJdk.set(true)
+              }
+            }""";
+
+    DependencyInfo info =
+        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
+    assertThat(info.versions()).isEmpty();
+  }
+
+  @Test
+  void testDocsIgnoreHonoredAfterCommentContainingBraces() {
+    String gradleBuildFileContent =
+        """
+            muzzle {
+              pass {
+                group.set("com.azure")
+                module.set("azure-core")
+                versions.set("[1.53.0,)")
+                // this module references the application's io.opentelemetry.context.{Context,Scope}
+                // instrumentation-docs:ignore - verification only
+                excludeInstrumentationName("azure-core-1.53-context")
+              }
+            }""";
+
+    DependencyInfo info =
+        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
+    assertThat(info.versions()).isEmpty();
+  }
+
+  @Test
+  void testExtractMuzzleVersions_CommentContainingBracesDoesNotTruncateBlock() {
+    String gradleBuildFileContent =
+        """
+            muzzle {
+              pass {
+                // this module references the application's io.opentelemetry.context.{Context,Scope}
+                group.set("com.azure")
+                module.set("azure-core")
+                versions.set("[1.53.0,)")
+              }
+              pass {
+                group.set("com.azure")
+                module.set("azure-core-amqp")
+                versions.set("[2.0.0,)")
+              }
+            }""";
+
+    DependencyInfo info =
+        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
+    assertThat(info.versions())
+        .containsExactlyInAnyOrder(
+            "com.azure:azure-core:[1.53.0,)", "com.azure:azure-core-amqp:[2.0.0,)");
+  }
+
+  @Test
+  void testDocsIgnoreAbovePassBlockIsNotHonored() {
+    String gradleBuildFileContent =
+        """
+            muzzle {
+              // instrumentation-docs:ignore
+              pass {
+                group.set("com.couchbase.client")
+                module.set("java-client")
+                versions.set("[2,2.6)")
+              }
+            }""";
+
+    DependencyInfo info =
+        GradleParser.parseGradleFile(gradleBuildFileContent, InstrumentationType.JAVAAGENT);
+    assertThat(info.versions()).containsExactly("com.couchbase.client:java-client:[2,2.6)");
+  }
+
+  @Test
   void testExtractMuzzleVersions_MultiplePassBlocks() {
     String gradleBuildFileContent =
         """

--- a/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
+++ b/instrumentation/couchbase/couchbase-2.0/javaagent/build.gradle.kts
@@ -14,6 +14,7 @@ muzzle {
     excludeInstrumentationName("couchbase-2.0-network")
   }
   pass {
+    // instrumentation-docs:ignore - verification only, the directive above is the range we document
     name.set("Pre-2.6 network instrumentation")
     group.set("com.couchbase.client")
     module.set("java-client")


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/20088#discussion_r3977891687

Adds a way for us to add a comment to ignore certain muzzle blocks from being included in the instrumentation-list.yaml output