### PR TITLE
Document reflective method lookup caching

### DIFF
--- a/.github/agents/knowledge/general-rules.md
+++ b/.github/agents/knowledge/general-rules.md
@@ -15,6 +15,7 @@ When a "Knowledge File" is listed, load it from `knowledge/` before reviewing th
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | General      | Logic, correctness, reliability, safety, copy/paste mistakes, incorrect comments                                                                                                                                                                                                                                                                                                                              | Always                                                                                                                                                          | —                                  |
 | Performance  | Precompile production Java regular-expression literals that may be evaluated repeatedly in reusable `static final Pattern` fields                                                                                                                                                                                                                                                                             | Repeated production Java regex literals passed to `String.replaceAll`, `String.matches`, or similar APIs; `String.split` outside the JDK fast path              | —                                  |
+| Performance  | Cache production Java reflective method lookups that may execute repeatedly                                                                                                                                                                                                                                                                                                                                   | Repeated calls to `Class.getMethod`, `Class.getDeclaredMethod`, or equivalent method-handle lookup APIs                                                         | —                                  |
 | Style        | Style guide                                                                                                                                                                                                                                                                                                                                                                                                   | Always                                                                                                                                                          | —                                  |
 | Style        | Reflow avoidable short lines that Spotless creates between consecutive `//` prose-comment lines; allow short lines when the line-length limit requires them                                                                                                                                                                                                                                                   | Multi-line `//` prose comments                                                                                                                                  | —                                  |
 | Style        | Add `// visible for testing` when a production member has broader visibility solely so tests can access it                                                                                                                                                                                                                                                                                                    | Production members accessed directly only by tests                                                                                                              | —                                  |
@@ -78,6 +79,20 @@ only then. That fast path covers a one-character literal that is not a surrogate
 one of `.$|()[{^?*+`, and a backslash followed by one character that is neither a surrogate nor
 an ASCII letter or digit. Calls such as `value.split(",")` and `version.split("\\.")` already
 run an `indexOf` loop with no `Pattern`, so precompiling them makes the code slower.
+
+## [Performance] Cache Reused Reflective Method Lookups
+
+Flag production Java code that repeats the same reflective method lookup on a path
+that may execute more than once. Resolve the method once and cache the resulting
+`Method` or `MethodHandle`. Use a `static final` field when the declaring class
+is fixed. When the lookup depends on the runtime class, use `ClassValue` instead
+of a static map keyed by `Class<?>`. Static maps can keep application class
+loaders alive. Cache missing methods too when supported library versions may not
+provide the method.
+
+Do not apply this rule to test code or a lookup that is provably executed only once
+during initialization. Prefer a direct method call when every supported library
+version exposes the API at compile time.
 
 ## [Javaagent] Best-Effort Suppressed Failures
 


### PR DESCRIPTION
Teaches review agents to flag repeated reflective method lookups in production paths.

The rule recommends a cached `static final Method` or `MethodHandle` for fixed declaring classes and `ClassValue` when the declaring class varies at runtime. It also covers absent-method caching and excludes tests and one-time initialization.

The existing codebase audit is tracked in #20094.