### PR TITLE
Make host ID resource detection opt-in for the Java agent

### DIFF
--- a/instrumentation/resources/library/README.md
+++ b/instrumentation/resources/library/README.md
@@ -40,6 +40,9 @@ Implemented attributes:
 
 - `host.id`
 
+The Java agent disables this provider by default. Enable it by setting
+`otel.resource.providers.host-id.enabled=true`.
+
 ### Operating System
 
 Provider: `io.opentelemetry.instrumentation.resources.OsResource`

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResourceProvider.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResourceProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.resources;
 
+import com.google.auto.service.AutoService;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
@@ -16,6 +17,7 @@ import io.opentelemetry.sdk.resources.Resource;
  * href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/host.md#non-privileged-machine-id-lookup">the
  * semantic conventions</a>
  */
+@AutoService(ResourceProvider.class)
 public final class HostIdResourceProvider implements ConditionalResourceProvider {
 
   // copied from HostIncubatingAttributes

--- a/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ResourceProviderRegistrationTest.java
+++ b/instrumentation/resources/library/src/test/java/io/opentelemetry/instrumentation/resources/ResourceProviderRegistrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+class ResourceProviderRegistrationTest {
+
+  @Test
+  void resourceProvidersAreRegistered() {
+    assertThat(ServiceLoader.load(ResourceProvider.class))
+        .filteredOn(
+            provider ->
+                provider
+                    .getClass()
+                    .getPackage()
+                    .getName()
+                    .equals("io.opentelemetry.instrumentation.resources"))
+        .extracting(provider -> provider.getClass().getSimpleName())
+        .containsExactlyInAnyOrder(
+            "ContainerResourceProvider",
+            "HostIdResourceProvider",
+            "HostResourceProvider",
+            "JarServiceNameDetector",
+            "ManifestResourceProvider",
+            "OsResourceProvider",
+            "ProcessResourceProvider",
+            "ProcessRuntimeResourceProvider");
+  }
+}

--- a/instrumentation/resources/metadata.yaml
+++ b/instrumentation/resources/metadata.yaml
@@ -14,3 +14,8 @@ configurations:
       by default.
     type: boolean
     default: false
+  # No declarative_name: the declarative resource detector schema has no host ID toggle.
+  - name: otel.resource.providers.host-id.enabled
+    description: Enables host ID resource detection in the Java agent.
+    type: boolean
+    default: false

--- a/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
+++ b/instrumentation/spring/spring-boot-autoconfigure/src/test/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfigurationTest.java
@@ -133,6 +133,7 @@ class OpenTelemetryAutoConfigurationTest {
                                   "io.opentelemetry.contrib.aws.resource.LambdaResourceProvider",
                                   "io.opentelemetry.contrib.gcp.resource.GCPResourceProvider",
                                   "io.opentelemetry.contrib.cloudfoundry.resources.CloudFoundryResourceProvider",
+                                  "io.opentelemetry.instrumentation.resources.HostIdResourceProvider",
                                   "io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizerTest$Provider");
                         }));
   }

--- a/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/ResourceProviderRegistrationTest.java
+++ b/instrumentation/spring/spring-boot-resources/javaagent/src/test/java/io/opentelemetry/instrumentation/spring/resources/ResourceProviderRegistrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.spring.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+class ResourceProviderRegistrationTest {
+
+  @Test
+  void resourceProvidersAreRegistered() {
+    assertThat(ServiceLoader.load(ResourceProvider.class))
+        .filteredOn(
+            provider ->
+                provider
+                    .getClass()
+                    .getPackage()
+                    .getName()
+                    .equals("io.opentelemetry.instrumentation.spring.resources"))
+        .extracting(provider -> provider.getClass().getSimpleName())
+        .containsExactlyInAnyOrder(
+            "SpringBootServiceNameDetector", "SpringBootServiceVersionDetector");
+  }
+}

--- a/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/resources/ResourceProviderRegistrationTest.java
+++ b/javaagent-tooling/src/test/java/io/opentelemetry/javaagent/tooling/resources/ResourceProviderRegistrationTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.tooling.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+class ResourceProviderRegistrationTest {
+
+  @Test
+  void resourceProvidersAreRegistered() {
+    assertThat(ServiceLoader.load(ResourceProvider.class))
+        .filteredOn(
+            provider ->
+                provider
+                    .getClass()
+                    .getPackage()
+                    .getName()
+                    .equals("io.opentelemetry.javaagent.tooling.resources"))
+        .extracting(provider -> provider.getClass().getSimpleName())
+        .containsExactlyInAnyOrder("DistroResourceProvider");
+  }
+}

--- a/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizer.java
+++ b/sdk-autoconfigure-support/src/main/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizer.java
@@ -53,6 +53,8 @@ public class ResourceProviderPropertiesCustomizer implements AutoConfigurationCu
     DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
         "io.opentelemetry.contrib.cloudfoundry.resources.CloudFoundryResourceProvider",
         "cloudfoundry");
+    DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
+        "io.opentelemetry.instrumentation.resources.HostIdResourceProvider", "host-id");
     // for testing
     DISABLED_BY_DEFAULT_RESOURCE_PROVIDERS.put(
         "io.opentelemetry.instrumentation.resources.internal.ResourceProviderPropertiesCustomizerTest$Provider",

--- a/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
+++ b/sdk-autoconfigure-support/src/test/java/io/opentelemetry/instrumentation/resources/internal/ResourceProviderPropertiesCustomizerTest.java
@@ -6,8 +6,12 @@
 package io.opentelemetry.instrumentation.resources.internal;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
@@ -16,19 +20,24 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.SdkAutoconfigureAccess;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.assertj.core.util.Strings;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceProviderPropertiesCustomizerTest {
 
+  private static final String HOST_ID_RESOURCE_PROVIDER =
+      "io.opentelemetry.instrumentation.resources.HostIdResourceProvider";
   private static final String PROVIDER_CLASS_NAME = Provider.class.getName();
 
   public static class Provider implements ResourceProvider {
@@ -70,6 +79,26 @@ class ResourceProviderPropertiesCustomizerTest {
     } else {
       assertThat(attributes.get(stringKey("key"))).isNull();
     }
+  }
+
+  @Test
+  void hostIdResourceProviderDisabledByDefault() {
+    assertThat(disabledProviders(emptyMap())).contains(HOST_ID_RESOURCE_PROVIDER);
+  }
+
+  @Test
+  void hostIdResourceProviderCanBeEnabled() {
+    assertThat(disabledProviders(singletonMap("otel.resource.providers.host-id.enabled", "true")))
+        .doesNotContain(HOST_ID_RESOURCE_PROVIDER);
+  }
+
+  private static List<String> disabledProviders(Map<String, String> config) {
+    Map<String, String> customized =
+        new ResourceProviderPropertiesCustomizer()
+            .customize(DefaultConfigProperties.createFromMap(config));
+    return asList(
+        requireNonNull(customized.get(ResourceProviderPropertiesCustomizer.DISABLED_KEY))
+            .split(","));
   }
 
   private static Stream<Arguments> enabledTestCases() {


### PR DESCRIPTION
Registers `HostIdResourceProvider` with the Java agent while keeping it disabled by default. Enable `host.id` detection with:

```properties
otel.resource.providers.host-id.enabled=true
```

Adds module-local `ServiceLoader` contract tests for every production module that provides first-party resource providers.