### PR TITLE
Prevent stale legacy MongoDB SRV targets

### DIFF
--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettings.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettings.java
@@ -75,6 +75,7 @@ public class MongoClusterSettings {
 
   public static void built(ClusterSettings.Builder builder, ClusterSettings settings) {
     MongoServerTarget scopedSrvTarget = legacySrvTarget.get();
+    legacySrvTarget.remove();
     Configuration configuration =
         scopedSrvTarget == null
             ? BUILDER_CONFIGURATION.get(builder)

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettings.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettings.java
@@ -112,9 +112,10 @@ public class MongoClusterSettings {
     if (target == null) {
       return null;
     }
-    MongoServerTarget previous = legacySrvTarget.get();
+    // The legacy driver builds ClusterSettings before it can invoke user callbacks, so this target
+    // is consumed before a reentrant MongoClient construction can replace it.
     legacySrvTarget.set(target);
-    return new LegacySrvTargetScope(previous);
+    return new LegacySrvTargetScope();
   }
 
   @Nullable
@@ -171,18 +172,10 @@ public class MongoClusterSettings {
    */
   public static class LegacySrvTargetScope {
 
-    @Nullable private final MongoServerTarget previous;
-
-    private LegacySrvTargetScope(@Nullable MongoServerTarget previous) {
-      this.previous = previous;
-    }
+    private LegacySrvTargetScope() {}
 
     public void close() {
-      if (previous == null) {
-        legacySrvTarget.remove();
-      } else {
-        legacySrvTarget.set(previous);
-      }
+      legacySrvTarget.remove();
     }
   }
 

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettingsTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettingsTest.java
@@ -75,6 +75,28 @@ class MongoClusterSettingsTest {
     }
   }
 
+  @Test
+  void legacySrvTargetIsConsumedBeforeNonSrvReentry() {
+    LegacySrvTargetScope outerScope =
+        requireNonNull(
+            MongoClusterSettings.openLegacySrvTargetScope(
+                "mongodb+srv://outer.example.com/database"));
+    try {
+      assertThat(configuredTarget(directBuilder()).getAddress())
+          .isEqualTo("mongodb+srv://outer.example.com");
+
+      assertThat(
+              MongoClusterSettings.openLegacySrvTargetScope(
+                  "mongodb://nested.example.com/database"))
+          .isNull();
+      MongoServerTarget target = configuredTarget(directBuilder());
+      assertThat(target.getAddress()).isEqualTo("direct.example");
+      assertThat(target.getPort()).isEqualTo(27018);
+    } finally {
+      outerScope.close();
+    }
+  }
+
   private static ClusterSettings.Builder directBuilder() {
     ClusterSettings.Builder builder = ClusterSettings.builder();
     List<ServerAddress> hosts = singletonList(new ServerAddress("direct.example", 27018));

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettingsTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoClusterSettingsTest.java
@@ -5,8 +5,14 @@
 
 package io.opentelemetry.instrumentation.mongo.v3_1.internal;
 
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterSettings;
+import io.opentelemetry.instrumentation.mongo.v3_1.internal.MongoClusterSettings.LegacySrvTargetScope;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class MongoClusterSettingsTest {
@@ -38,5 +44,48 @@ class MongoClusterSettingsTest {
         .isNull();
     assertThat(MongoClusterSettings.srvConnectionString("mongodb://cluster0.example.com")).isNull();
     assertThat(MongoClusterSettings.srvConnectionString(null)).isNull();
+  }
+
+  @Test
+  void nestedLegacySrvTargetDoesNotRestoreConsumedOuterTarget() {
+    LegacySrvTargetScope outerScope =
+        requireNonNull(
+            MongoClusterSettings.openLegacySrvTargetScope(
+                "mongodb+srv://outer.example.com/database"));
+    try {
+      assertThat(configuredTarget(directBuilder()).getAddress())
+          .isEqualTo("mongodb+srv://outer.example.com");
+
+      LegacySrvTargetScope innerScope =
+          requireNonNull(
+              MongoClusterSettings.openLegacySrvTargetScope(
+                  "mongodb+srv://inner.example.com/database"));
+      try {
+        assertThat(configuredTarget(directBuilder()).getAddress())
+            .isEqualTo("mongodb+srv://inner.example.com");
+      } finally {
+        innerScope.close();
+      }
+
+      MongoServerTarget target = configuredTarget(directBuilder());
+      assertThat(target.getAddress()).isEqualTo("direct.example");
+      assertThat(target.getPort()).isEqualTo(27018);
+    } finally {
+      outerScope.close();
+    }
+  }
+
+  private static ClusterSettings.Builder directBuilder() {
+    ClusterSettings.Builder builder = ClusterSettings.builder();
+    List<ServerAddress> hosts = singletonList(new ServerAddress("direct.example", 27018));
+    builder.hosts(hosts);
+    MongoClusterSettings.hosts(builder, hosts);
+    return builder;
+  }
+
+  private static MongoServerTarget configuredTarget(ClusterSettings.Builder builder) {
+    ClusterSettings settings = builder.build();
+    MongoClusterSettings.built(builder, settings);
+    return requireNonNull(MongoClusterSettings.configuredTarget(settings));
   }
 }


### PR DESCRIPTION
Consumes each legacy MongoDB SRV target when the driver builds `ClusterSettings` instead of restoring it when the scope closes. This prevents a completed outer scope from leaking its target into a later settings build.