### PR TITLE
Document consistency patterns from Redis reviews

### DIFF
--- a/.github/agents/knowledge/javaagent-module-patterns.md
+++ b/.github/agents/knowledge/javaagent-module-patterns.md
@@ -504,12 +504,10 @@ sufficient for optimization.
 - Reference the advice class using `getClass().getName() + "$InnerClassName"` — not
   `this.getClass().getName() + "$InnerClassName"`, `InnerClassName.class.getName()`,
   `OuterClass.class.getName()`, or a string literal.
-  Any `.class.getName()` reference — whether to the inner advice class or the outer
-  instrumentation class — causes class loading in the agent's class loader, where library
-  types used by the advice are unavailable (causing `NoClassDefFoundError`).
-  `getClass().getName()` avoids this because it is a virtual call on the already-loaded
-  instance, not a class literal. Omit the redundant `this.` qualifier and use the shorter
-  repository convention.
+  Do not use `.class.getName()` to construct an advice class name in `transform()`. Resolving the
+  class literal loads the advice class in the agent class loader, where library types referenced
+  by the advice may be unavailable (causing `NoClassDefFoundError`). Omit the redundant `this.`
+  qualifier and use the shorter repository convention.
 
 ## CallDepth (Preventing Recursive Instrumentation)
 

--- a/.github/agents/knowledge/testing-general-patterns.md
+++ b/.github/agents/knowledge/testing-general-patterns.md
@@ -12,6 +12,14 @@
 - Do not use AssertJ `.as(...)` descriptions or `.withFailMessage(...)` in tests.
   Prefer direct assertions whose failure output shows the unexpected values.
 
+### Scala assertion imports
+
+In Scala tests, import `assertThat` from `org.assertj.core.api.Assertions`. Qualify
+`OpenTelemetryAssertions.assertThat(...)` where the OpenTelemetry-specific assertion is needed,
+and import individual helpers such as `equalTo` separately. Scala does not expose AssertJ's
+inherited Java static methods through `OpenTelemetryAssertions`, so the Java convention of using
+that class as the single `assertThat` entry point does not apply.
+
 ## Parameterized Tests
 
 - When the same test logic is repeated for multiple input/output cases, prefer

--- a/.github/agents/knowledge/testing-semconv-stability.md
+++ b/.github/agents/knowledge/testing-semconv-stability.md
@@ -31,9 +31,9 @@ All methods are in `io.opentelemetry.instrumentation.api.internal.SemconvStabili
 
 ## Gradle Test Task Setup
 
-Every instrumentation module with Semconv versioning **must** define a `testStableSemconv` task.
-Only add it to modules whose tests actually exercise semconv attributes — not to sibling
-submodules (e.g. unit-test modules) that don't touch semconv.
+Every Gradle project whose tests exercise semconv attributes **must** define its own
+`testStableSemconv` task. This includes `javaagent-unit-tests` projects whose tests branch on an
+`emitOld*()` or `emitStable*()` accessor.
 
 A `testBothSemconv` task (testing the `/dup` mode) is **only required for the RPC domain**.
 Database, code, and service-peer domains do not need a `testBothSemconv` task — only


### PR DESCRIPTION
Captures three reusable rules identified while auditing Redis instrumentation consistency changes.

- Require each Gradle project whose tests exercise semconv attributes to define its own `testStableSemconv` task, including applicable `javaagent-unit-tests` projects.
- Preserve Scala’s AssertJ import pattern instead of applying the Java-only single-entry-point convention.
- Scope `.class.getName()` restrictions to advice class names constructed in `transform()`.