### PR TITLE
Document metadata override ordering

### DIFF
--- a/.github/agents/knowledge/metadata-yaml-format.md
+++ b/.github/agents/knowledge/metadata-yaml-format.md
@@ -29,6 +29,10 @@ Each configuration entry includes:
 - `declarative_schema` (optional): Per-item object schema, required when
   `declarative_type: structured_list` (see Structured Lists).
 
+When a module-specific configuration overrides a referenced common configuration, list the
+module-specific entry immediately before the common `ref`. This keeps the override and fallback
+together and makes their precedence clear.
+
 ## Structured Lists
 
 Some declarative configs are **lists of objects** even though their flat form is a scalar/map. The


### PR DESCRIPTION
Documents that a module-specific configuration override should appear immediately before the common metadata reference it overrides. Keeping the override and fallback adjacent makes their precedence clear and matches the established AWS SDK and RocketMQ metadata pattern.