### PR TITLE
Use otelbot App tokens for automation pushes

### DIFF
--- a/.github/workflows/auto-license-report.yml
+++ b/.github/workflows/auto-license-report.yml
@@ -81,9 +81,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.check-patch.outputs.exists == 'true'
         with:
-          token: ${{ steps.otelbot-token.outputs.token }}
-          # zizmor: ignore[artipacked] App credentials are required by the push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Use CLA approved bot
         if: steps.check-patch.outputs.exists == 'true'
@@ -91,7 +89,10 @@ jobs:
 
       - name: Apply patch and push
         if: steps.check-patch.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
+          gh auth setup-git
           git apply "${{ runner.temp }}/patch"
           git add licenses
           git commit -m "Update license report"

--- a/.github/workflows/auto-update-otel-sdk.yml
+++ b/.github/workflows/auto-update-otel-sdk.yml
@@ -37,7 +37,7 @@ jobs:
                              | sed 's/^v//')
 
           matches=$(gh pr list \
-                        --author app/otelbot \
+                        --head "otelbot/update-opentelemetry-sdk-to-${latest_version}" \
                         --state open \
                         --search "in:title \"Update the OpenTelemetry SDK version to $latest_version\"")
           if [ ! -z "$matches" ]
@@ -50,8 +50,6 @@ jobs:
           echo "already-opened=$already_opened" >> $GITHUB_OUTPUT
 
   update-otel-sdk:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     if: |
       needs.check-versions.outputs.current-version != needs.check-versions.outputs.latest-version &&
@@ -61,8 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Update version
         env:
@@ -95,8 +92,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request against main
@@ -110,6 +108,7 @@ jobs:
           body="Update the OpenTelemetry SDK version to \`$VERSION\`."
           branch="otelbot/update-opentelemetry-sdk-to-${VERSION}"
 
+          gh auth setup-git
           git checkout -b $branch
           git add -u
           git add licenses

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   backport:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -25,8 +23,7 @@ jobs:
         with:
           # history is needed to run git cherry-pick below
           fetch-depth: 0
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Use CLA approved bot
         run: .github/scripts/use-cla-approved-bot.sh
@@ -34,16 +31,18 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Create pull request
         env:
           NUMBER: ${{ github.event.inputs.number }}
-          # pull requests from secrets.GITHUB_TOKEN do not run workflows
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
+          gh auth setup-git
           commit=$(gh pr view $NUMBER --json mergeCommit --jq .mergeCommit.oid)
           title=$(gh pr view $NUMBER --json title --jq .title)
 
@@ -52,11 +51,6 @@ jobs:
           git checkout -b $branch
           git cherry-pick $commit
 
-          # note this push will fail if the backport contains any workflow files
-          # because secrets.GITHUB_TOKEN doesn't have this permission
-          # supporting this would require another access token with content write
-          # and workflow write permissions
-          # so for now at least PRs that update workflow files need to be backported manually
           git push --set-upstream origin $branch
 
           gh pr create \

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -12,8 +12,6 @@ concurrency:
 jobs:
   draft:
     if: github.repository == 'open-telemetry/opentelemetry-java-instrumentation'
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     environment: protected
     steps:
@@ -22,8 +20,7 @@ jobs:
           # need full history and tags so the release-notes script can resolve
           # the previous release tag (e.g. v2.27.0) when computing the commit range
           fetch-depth: 0
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Install Copilot CLI
         run: |
@@ -50,8 +47,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request against main
@@ -71,6 +69,7 @@ jobs:
           )
           branch="otelbot/draft-release-notes-${GITHUB_RUN_ID}"
 
+          gh auth setup-git
           git checkout -b $branch
           git add CHANGELOG.md
           git commit -m "$message"

--- a/.github/workflows/flaky-test-remediation.yml
+++ b/.github/workflows/flaky-test-remediation.yml
@@ -69,8 +69,6 @@ jobs:
     if: needs.analyze.outputs.has_candidate == 'true'
     runs-on: ubuntu-latest
     environment: protected
-    permissions:
-      contents: write
     env:
       SELECTED_JSON: ${{ needs.analyze.outputs.selected_json }}
       TEST_CLASS: ${{ needs.analyze.outputs.class }}
@@ -81,8 +79,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Copilot inspects recent commits while diagnosing the flake
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
@@ -161,19 +158,23 @@ jobs:
             ${{ env.OUT_DIR }}/**
           if-no-files-found: ignore
 
-      - name: Push branch
-        if: steps.changes.outputs.committed == 'true'
-        env:
-          STEPS_BRANCH_OUTPUTS_NAME: ${{ steps.branch.outputs.name }}
-        run: git push -f origin "${STEPS_BRANCH_OUTPUTS_NAME}"
-
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         if: steps.changes.outputs.committed == 'true'
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
+
+      - name: Push branch
+        if: steps.changes.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          STEPS_BRANCH_OUTPUTS_NAME: ${{ steps.branch.outputs.name }}
+        run: |
+          gh auth setup-git
+          git push -f origin "${STEPS_BRANCH_OUTPUTS_NAME}"
 
       - name: Create PR
         if: steps.changes.outputs.committed == 'true'
@@ -191,8 +192,7 @@ jobs:
         with:
           ref: otelbot/flaky-test-remediation-progress
           path: progress
-          # zizmor: ignore[artipacked] Credentials are required by the progress branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Use CLA approved bot
         if: steps.changes.outputs.committed == 'true'
@@ -203,7 +203,10 @@ jobs:
       - name: Record attempt
         if: steps.changes.outputs.committed == 'true'
         working-directory: progress
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
+          gh auth setup-git
           if grep -Fxq "$TEST_CLASS" attempted.txt; then
             echo "$TEST_CLASS already recorded"
           else

--- a/.github/workflows/metadata-update.yml
+++ b/.github/workflows/metadata-update.yml
@@ -101,7 +101,7 @@ jobs:
           STEPS_FINDBRANCH_OUTPUTS_BRANCH: ${{ steps.findbranch.outputs.branch }}
         run: |
           BRANCH_NAME="${STEPS_FINDBRANCH_OUTPUTS_BRANCH}"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          gh auth setup-git
           git commit -m "chore: update instrumentation list [automated]"
           # Metadata collection can run for hours, allowing workflow files on main to change after
           # checkout. GitHub then rejects pushing the stale branch without workflows: write, even
@@ -115,7 +115,6 @@ jobs:
             exit 1
           fi
           git push --force origin "$BRANCH_NAME"
-          git remote set-url origin "https://github.com/${{ github.repository }}.git"
 
       - name: Create PR if needed
         if: steps.diffcheck.outputs.has_diff == 'true'

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -7,14 +7,11 @@ permissions:
 
 jobs:
   prepare-patch-release:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - run: |
           if [[ ! $GITHUB_REF_NAME =~ ^release/v[0-9]+\.[0-9]+\.x$ ]]; then
@@ -57,8 +54,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request
@@ -69,6 +67,7 @@ jobs:
           message="Prepare release $VERSION"
           branch="otelbot/prepare-release-${VERSION}"
 
+          gh auth setup-git
           git checkout -b $branch
           git commit -a -m "$message"
           git push --set-upstream origin $branch

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -26,8 +26,6 @@ jobs:
           fi
 
   create-pull-request-against-release-branch:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     needs:
       - prereqs
@@ -37,10 +35,9 @@ jobs:
           # history is needed to allow fast-forward push below in case
           # re-running this workflow after merging additional PRs to main
           fetch-depth: 0
-          # zizmor: ignore[artipacked] Credentials are required by the branch pushes below.
-          persist-credentials: true
+          persist-credentials: false
 
-      - name: Create release branch
+      - name: Set release branch variables
         run: |
           version=$(.github/scripts/get-version.sh)
           version=${version//-SNAPSHOT/}
@@ -50,8 +47,6 @@ jobs:
             echo "unexpected version: $version"
             exit 1
           fi
-
-          git push origin HEAD:$release_branch_name
 
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "RELEASE_BRANCH_NAME=$release_branch_name" >> $GITHUB_ENV
@@ -74,8 +69,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request against the release branch
@@ -86,6 +82,8 @@ jobs:
           message="Prepare release $VERSION"
           branch="otelbot/prepare-release-${VERSION}"
 
+          gh auth setup-git
+          git push origin HEAD:$RELEASE_BRANCH_NAME
           git checkout -b $branch
           git commit -a -m "$message"
           git push --set-upstream origin $branch
@@ -95,16 +93,13 @@ jobs:
             --base $RELEASE_BRANCH_NAME
 
   create-pull-request-against-main:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     needs:
       - prereqs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Set environment variables
         run: |
@@ -136,8 +131,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request against main
@@ -149,6 +145,7 @@ jobs:
           body="Update version to \`$NEXT_VERSION\`."
           branch="otelbot/update-version-to-${NEXT_VERSION}"
 
+          gh auth setup-git
           git checkout -b $branch
           git commit -a -m "$message"
           git push --set-upstream origin $branch

--- a/.github/workflows/release-update-cloudfoundry-index.yml
+++ b/.github/workflows/release-update-cloudfoundry-index.yml
@@ -13,8 +13,6 @@ permissions:
 
 jobs:
   update-cloudfoundry-index-yml:
-    permissions:
-      contents: write # for git push to PR branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -29,8 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: 'cloudfoundry'
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: create working branch
         run: git checkout -b otelbot/cloudfoundry-${{ github.run_number }}-${{ github.run_attempt }}
@@ -46,8 +43,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: create pr with repo changes
@@ -55,6 +53,7 @@ jobs:
           # pull requests from secrets.GITHUB_TOKEN do not run workflows
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         run: |
+          gh auth setup-git
           git add index.yml
           if git diff-index --quiet --cached HEAD ; then
             echo "index.yml already current"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,8 +206,6 @@ jobs:
     uses: ./.github/workflows/documentation-synchronization-audit.yml
 
   post-release-updates:
-    permissions:
-      contents: write # for git push to PR branch
     runs-on: ubuntu-latest
     needs:
       - release
@@ -228,8 +226,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Merge change log to main
         env:
@@ -277,8 +274,9 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request against main
@@ -291,6 +289,7 @@ jobs:
           body="Post-release updates for \`$VERSION\`."
           branch="otelbot/update-apidiff-baseline-to-released-version-${VERSION}"
 
+          gh auth setup-git
           git checkout -b $branch
           git add CHANGELOG.md
           git add docs/apidiffs

--- a/.github/workflows/update-latest-dep-versions.yml
+++ b/.github/workflows/update-latest-dep-versions.yml
@@ -56,6 +56,7 @@ jobs:
           private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Create pull request
         if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/update-latest-dep-versions.yml
+++ b/.github/workflows/update-latest-dep-versions.yml
@@ -11,14 +11,11 @@ permissions:
 
 jobs:
   update-latest-dep-versions:
-    permissions:
-      contents: write  # for git push to PR branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Free disk space
         run: .github/scripts/gha-free-disk-space.sh
@@ -55,8 +52,9 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ vars.OTELBOT_JAVA_INSTRUMENTATION_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_JAVA_INSTRUMENTATION_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Create pull request
@@ -69,6 +67,7 @@ jobs:
           body="Auto-generated update of pinned latest dependency versions used by \`testLatestDeps\` builds."
           branch="otelbot/update-latest-dep-versions"
 
+          gh auth setup-git
           git checkout -b $branch
           git add .github/config/latest-dep-versions.json
           git commit -m "$message"


### PR DESCRIPTION
Uses the repository-specific otelbot GitHub App token for automated pull request branches. This lets normal pull request workflows run and allows backports and latest-dependency updates to include workflow files.

All affected workflows stop persisting checkout credentials and configure Git through `gh auth setup-git`.