### PR TITLE
Prevent truncation from splitting surrogate pairs

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 
@@ -38,7 +39,7 @@ public final class RedisCommandSanitizer {
   private static final Map<String, CommandSanitizer> SANITIZERS;
   private static final CommandSanitizer DEFAULT = new CommandAndNumArgs(0);
 
-  // max length of the sanitized command, command longer than that will be truncated to this length
+  // max length in UTF-16 code units of the sanitized command
   // visible for testing
   static final int LIMIT = 32 * 1024;
 
@@ -377,9 +378,7 @@ public final class RedisCommandSanitizer {
   }
 
   private static String limit(StringBuilder builder) {
-    if (builder.length() > LIMIT) {
-      builder.delete(LIMIT, builder.length());
-    }
+    truncate(builder, LIMIT);
     return builder.toString();
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizer.java
@@ -39,7 +39,7 @@ public final class RedisCommandSanitizer {
   private static final Map<String, CommandSanitizer> SANITIZERS;
   private static final CommandSanitizer DEFAULT = new CommandAndNumArgs(0);
 
-  // max length in UTF-16 code units of the sanitized command
+  // maximum sanitized command length
   // visible for testing
   static final int LIMIT = 32 * 1024;
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQuery.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
+
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
@@ -61,7 +63,7 @@ public abstract class SqlQuery {
       return querySummary.substring(0, lastSpace);
     }
     // If no space found, truncate at the limit
-    return querySummary.substring(0, QUERY_SUMMARY_MAX_LENGTH);
+    return truncate(querySummary, QUERY_SUMMARY_MAX_LENGTH);
   }
 
   @Nullable

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import io.opentelemetry.instrumentation.api.internal.StringUtils;
 import java.util.regex.Pattern;
 
 %%
@@ -61,7 +62,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  // max length of the sanitized statement - SQLs longer than this will be trimmed
+  // max length in UTF-16 code units of the sanitized statement
   static final int LIMIT = 32 * 1024;
 
   // Match on strings like "IN(?, ?, ...)"
@@ -393,9 +394,7 @@ WHITESPACE           = [ \t\r\n]+
   private class Alter extends DdlOperation {}
 
   private SqlQuery getResult() {
-    if (builder.length() > LIMIT) {
-      builder.delete(LIMIT, builder.length());
-    }
+    StringUtils.truncate(builder, LIMIT);
     String fullStatement = builder.toString();
 
     // Normalize all 'in (?, ?, ...)' statements to in (?) to reduce cardinality

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizer.jflex
@@ -62,7 +62,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  // max length in UTF-16 code units of the sanitized statement
+  // maximum sanitized statement length
   static final int LIMIT = 32 * 1024;
 
   // Match on strings like "IN(?, ?, ...)"

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import io.opentelemetry.instrumentation.api.internal.StringUtils;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Locale;
@@ -67,7 +68,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  // max length of the sanitized statement - SQLs longer than this will be trimmed
+  // max length in UTF-16 code units of the sanitized statement
   static final int LIMIT = 32 * 1024;
 
   // Match on strings like "IN(?, ?, ...)"
@@ -747,9 +748,7 @@ WHITESPACE           = [ \t\r\n]+
   }
 
   private SqlQuery getResult() {
-    if (builder.length() > LIMIT) {
-      builder.delete(LIMIT, builder.length());
-    }
+    StringUtils.truncate(builder, LIMIT);
     String fullStatement = builder.toString();
 
     // Normalize all 'in (?, ?, ...)' statements to in (?) to reduce cardinality

--- a/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
+++ b/instrumentation-api-incubator/src/main/jflex/SqlSanitizerWithSummary.jflex
@@ -68,7 +68,7 @@ WHITESPACE           = [ \t\r\n]+
     }
   }
 
-  // max length in UTF-16 code units of the sanitized statement
+  // maximum sanitized statement length
   static final int LIMIT = 32 * 1024;
 
   // Match on strings like "IN(?, ?, ...)"

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
@@ -240,6 +240,15 @@ class RedisCommandSanitizerTest {
     assertThat(result).startsWith("HMSET hash key0 ? key1 ?");
   }
 
+  @Test
+  void doesNotSplitSurrogatePairWhenTruncating() {
+    String argument = "a".repeat(RedisCommandSanitizer.LIMIT - 5) + "\uD83D\uDE00";
+
+    String result = RedisCommandSanitizer.create(true).sanitize("GET", list(argument));
+
+    assertThat(result).hasSize(RedisCommandSanitizer.LIMIT - 1).endsWith("a");
+  }
+
   static Stream<Arguments> sanitizeArgs() {
     return Stream.of(
         // Connection

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
@@ -242,7 +242,7 @@ class RedisCommandSanitizerTest {
 
   @Test
   void doesNotSplitSurrogatePairWhenTruncating() {
-    String argument = repeat('a', RedisCommandSanitizer.LIMIT - 5) + "\uD83D\uDE00";
+    String argument = repeat('a', RedisCommandSanitizer.LIMIT - 5) + "😀";
 
     String result = RedisCommandSanitizer.create(true).sanitize("GET", list(argument));
 

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/RedisCommandSanitizerTest.java
@@ -242,7 +242,7 @@ class RedisCommandSanitizerTest {
 
   @Test
   void doesNotSplitSurrogatePairWhenTruncating() {
-    String argument = "a".repeat(RedisCommandSanitizer.LIMIT - 5) + "\uD83D\uDE00";
+    String argument = repeat('a', RedisCommandSanitizer.LIMIT - 5) + "\uD83D\uDE00";
 
     String result = RedisCommandSanitizer.create(true).sanitize("GET", list(argument));
 
@@ -329,5 +329,13 @@ class RedisCommandSanitizerTest {
 
   static List<String> list(String... args) {
     return asList(args);
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -296,7 +296,7 @@ class SqlQueryAnalyzerTest {
   void queryTextTruncationDoesNotSplitSurrogatePair() {
     String beforePair = repeat('A', AutoSqlSanitizer.LIMIT - 1);
 
-    SqlQuery result = analyze(beforePair + "\uD83D\uDE00");
+    SqlQuery result = analyze(beforePair + "😀");
 
     assertThat(result.getQueryText()).isEqualTo(beforePair);
   }
@@ -380,8 +380,7 @@ class SqlQueryAnalyzerTest {
   void querySummaryTruncationDoesNotSplitSurrogatePair() {
     String beforePair = repeat('A', 254);
 
-    String summary =
-        SqlQuery.createWithSummary(null, null, beforePair + "\uD83D\uDE00").getQuerySummary();
+    String summary = SqlQuery.createWithSummary(null, null, beforePair + "😀").getQuerySummary();
 
     assertThat(summary).isEqualTo(beforePair);
   }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -282,15 +282,6 @@ class SqlQueryAnalyzerTest {
     for (int i = 0; i < 10000; i++) {
       s.append("SELECT * FROM TABLE WHERE FIELD = 1234 AND ");
     }
-
-    @Test
-    void queryTextTruncationDoesNotSplitSurrogatePair() {
-      String beforePair = "A".repeat(AutoSqlSanitizer.LIMIT - 1);
-
-      SqlQuery result = analyze(beforePair + "\uD83D\uDE00");
-
-      assertThat(result.getQueryText()).isEqualTo(beforePair);
-    }
     SqlQuery result = analyze(s.toString());
     assertThat(result.getQueryText().length()).isLessThanOrEqualTo(AutoSqlSanitizer.LIMIT);
     assertThat(result.getQueryText()).doesNotContain("1234");
@@ -299,6 +290,15 @@ class SqlQueryAnalyzerTest {
     } else {
       assertThat(result.getQuerySummary()).isNull();
     }
+  }
+
+  @Test
+  void queryTextTruncationDoesNotSplitSurrogatePair() {
+    String beforePair = repeat('A', AutoSqlSanitizer.LIMIT - 1);
+
+    SqlQuery result = analyze(beforePair + "\uD83D\uDE00");
+
+    assertThat(result.getQueryText()).isEqualTo(beforePair);
   }
 
   @Test
@@ -363,16 +363,6 @@ class SqlQueryAnalyzerTest {
       if (i > 0) {
         sql.append(", ");
       }
-
-      @Test
-      void querySummaryTruncationDoesNotSplitSurrogatePair() {
-        String beforePair = "A".repeat(254);
-
-        String summary =
-            SqlQuery.createWithSummary(null, null, beforePair + "\uD83D\uDE00").getQuerySummary();
-
-        assertThat(summary).isEqualTo(beforePair);
-      }
       sql.append("very_long_table_name_").append(i);
     }
     String result =
@@ -384,6 +374,16 @@ class SqlQueryAnalyzerTest {
         .isEqualTo(
             "SELECT very_long_table_name_0 very_long_table_name_1 very_long_table_name_2 very_long_table_name_3 very_long_table_name_4 very_long_table_name_5 very_long_table_name_6 very_long_table_name_7 very_long_table_name_8 very_long_table_name_9");
     assertThat(result.length()).isEqualTo(236);
+  }
+
+  @Test
+  void querySummaryTruncationDoesNotSplitSurrogatePair() {
+    String beforePair = repeat('A', 254);
+
+    String summary =
+        SqlQuery.createWithSummary(null, null, beforePair + "\uD83D\uDE00").getQuerySummary();
+
+    assertThat(summary).isEqualTo(beforePair);
   }
 
   @ParameterizedTest
@@ -1414,5 +1414,13 @@ class SqlQueryAnalyzerTest {
         Arguments.of(
             "merge into \"my table\"",
             expect("MERGE", "my table", "merge", "\"my table\"", "merge \"my table\"")));
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlQueryAnalyzerTest.java
@@ -282,6 +282,15 @@ class SqlQueryAnalyzerTest {
     for (int i = 0; i < 10000; i++) {
       s.append("SELECT * FROM TABLE WHERE FIELD = 1234 AND ");
     }
+
+    @Test
+    void queryTextTruncationDoesNotSplitSurrogatePair() {
+      String beforePair = "A".repeat(AutoSqlSanitizer.LIMIT - 1);
+
+      SqlQuery result = analyze(beforePair + "\uD83D\uDE00");
+
+      assertThat(result.getQueryText()).isEqualTo(beforePair);
+    }
     SqlQuery result = analyze(s.toString());
     assertThat(result.getQueryText().length()).isLessThanOrEqualTo(AutoSqlSanitizer.LIMIT);
     assertThat(result.getQueryText()).doesNotContain("1234");
@@ -353,6 +362,16 @@ class SqlQueryAnalyzerTest {
     for (int i = 0; i < 50; i++) {
       if (i > 0) {
         sql.append(", ");
+      }
+
+      @Test
+      void querySummaryTruncationDoesNotSplitSurrogatePair() {
+        String beforePair = "A".repeat(254);
+
+        String summary =
+            SqlQuery.createWithSummary(null, null, beforePair + "\uD83D\uDE00").getQuerySummary();
+
+        assertThat(summary).isEqualTo(beforePair);
       }
       sql.append("very_long_table_name_").append(i);
     }

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+/**
+ * Internal string utilities.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class StringUtils {
+
+  /**
+   * Returns the longest prefix of {@code value} that fits within {@code maxLength} UTF-16 code units
+   * without splitting a valid surrogate pair.
+   */
+  public static String truncate(String value, int maxLength) {
+    if (value.length() <= maxLength) {
+      return value;
+    }
+    return value.substring(0, truncationLength(value, maxLength));
+  }
+
+  /**
+   * Truncates {@code value} to the longest prefix that fits within {@code maxLength} UTF-16 code
+   * units without splitting a valid surrogate pair.
+   */
+  public static void truncate(StringBuilder value, int maxLength) {
+    if (value.length() > maxLength) {
+      value.setLength(truncationLength(value, maxLength));
+    }
+  }
+
+  private static int truncationLength(CharSequence value, int maxLength) {
+    if (maxLength > 0
+        && Character.isHighSurrogate(value.charAt(maxLength - 1))
+        && Character.isLowSurrogate(value.charAt(maxLength))) {
+      return maxLength - 1;
+    }
+    return maxLength;
+  }
+
+  private StringUtils() {}
+}

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
@@ -14,8 +14,8 @@ package io.opentelemetry.instrumentation.api.internal;
 public final class StringUtils {
 
   /**
-   * Returns the longest prefix of {@code value} that fits within {@code maxLength} UTF-16 code
-   * units without splitting a valid surrogate pair.
+   * Returns the longest prefix whose {@link String#length()} does not exceed {@code maxLength}. If
+   * truncating at the limit would split a surrogate pair, the pair is omitted.
    */
   public static String truncate(String value, int maxLength) {
     if (value.length() <= maxLength) {
@@ -25,13 +25,32 @@ public final class StringUtils {
   }
 
   /**
-   * Truncates {@code value} to the longest prefix that fits within {@code maxLength} UTF-16 code
-   * units without splitting a valid surrogate pair.
+   * Truncates {@code value} so that its length does not exceed {@code maxLength}. If the limit
+   * would split a surrogate pair, the pair is omitted.
    */
   public static void truncate(StringBuilder value, int maxLength) {
     if (value.length() > maxLength) {
       value.setLength(truncationLength(value, maxLength));
     }
+  }
+
+  /**
+   * Truncates {@code value} so that its length does not exceed {@code maxLength}. If the limit
+   * would split a surrogate pair, the pair is omitted.
+   */
+  public static void truncate(StringBuffer value, int maxLength) {
+    if (value.length() > maxLength) {
+      value.setLength(truncationLength(value, maxLength));
+    }
+  }
+
+  /**
+   * Appends the longest prefix of {@code value} whose length does not exceed {@code maxLength}. If
+   * the limit would split a surrogate pair, the pair is omitted.
+   */
+  public static void appendTruncated(StringBuilder target, String value, int maxLength) {
+    int length = value.length() <= maxLength ? value.length() : truncationLength(value, maxLength);
+    target.append(value, 0, length);
   }
 
   private static int truncationLength(CharSequence value, int maxLength) {

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/StringUtils.java
@@ -14,8 +14,8 @@ package io.opentelemetry.instrumentation.api.internal;
 public final class StringUtils {
 
   /**
-   * Returns the longest prefix of {@code value} that fits within {@code maxLength} UTF-16 code units
-   * without splitting a valid surrogate pair.
+   * Returns the longest prefix of {@code value} that fits within {@code maxLength} UTF-16 code
+   * units without splitting a valid surrogate pair.
    */
   public static String truncate(String value, int maxLength) {
     if (value.length() <= maxLength) {

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
@@ -39,4 +39,22 @@ class StringUtilsTest {
 
     assertThat(value).hasToString("a");
   }
+
+  @Test
+  void truncateStringBuffer() {
+    StringBuffer value = new StringBuffer("a\uD83D\uDE00b");
+
+    StringUtils.truncate(value, 2);
+
+    assertThat(value).hasToString("a");
+  }
+
+  @Test
+  void appendTruncated() {
+    StringBuilder target = new StringBuilder("prefix:");
+
+    StringUtils.appendTruncated(target, "a\uD83D\uDE00b", 2);
+
+    assertThat(target).hasToString("prefix:a");
+  }
 }

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StringUtilsTest {
+
+  @Test
+  void truncateString() {
+    String unchanged = "abc";
+
+    assertThat(StringUtils.truncate(unchanged, 3)).isSameAs(unchanged);
+    assertThat(StringUtils.truncate(unchanged, 4)).isSameAs(unchanged);
+    assertThat(StringUtils.truncate("abcd", 3)).isEqualTo("abc");
+    assertThat(StringUtils.truncate("ābc", 2)).isEqualTo("āb");
+    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 1)).isEqualTo("a");
+    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 2)).isEqualTo("a");
+    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 3)).isEqualTo("a\uD83D\uDE00");
+    assertThat(StringUtils.truncate("abc", 0)).isEmpty();
+  }
+
+  @Test
+  void truncateStringPreservesMalformedSurrogates() {
+    assertThat(StringUtils.truncate("a\uD83Db", 2)).isEqualTo("a\uD83D");
+    assertThat(StringUtils.truncate("a\uDE00b", 2)).isEqualTo("a\uDE00");
+  }
+
+  @Test
+  void truncateStringBuilder() {
+    StringBuilder value = new StringBuilder("a\uD83D\uDE00b");
+
+    StringUtils.truncate(value, 2);
+
+    assertThat(value).hasToString("a");
+  }
+}

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
@@ -17,12 +17,12 @@ class StringUtilsTest {
 
     assertThat(StringUtils.truncate(unchanged, 3)).isSameAs(unchanged);
     assertThat(StringUtils.truncate(unchanged, 4)).isSameAs(unchanged);
-    assertThat(StringUtils.truncate("abcd", 3)).isEqualTo("abc");
+    assertThat(StringUtils.truncate("abcd", 3)).isEqualTo(unchanged);
     assertThat(StringUtils.truncate("ābc", 2)).isEqualTo("āb");
     assertThat(StringUtils.truncate("a\uD83D\uDE00b", 1)).isEqualTo("a");
     assertThat(StringUtils.truncate("a\uD83D\uDE00b", 2)).isEqualTo("a");
     assertThat(StringUtils.truncate("a\uD83D\uDE00b", 3)).isEqualTo("a\uD83D\uDE00");
-    assertThat(StringUtils.truncate("abc", 0)).isEmpty();
+    assertThat(StringUtils.truncate(unchanged, 0)).isEmpty();
   }
 
   @Test

--- a/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
+++ b/instrumentation-api/src/test/java/io/opentelemetry/instrumentation/api/internal/StringUtilsTest.java
@@ -19,21 +19,24 @@ class StringUtilsTest {
     assertThat(StringUtils.truncate(unchanged, 4)).isSameAs(unchanged);
     assertThat(StringUtils.truncate("abcd", 3)).isEqualTo(unchanged);
     assertThat(StringUtils.truncate("ābc", 2)).isEqualTo("āb");
-    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 1)).isEqualTo("a");
-    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 2)).isEqualTo("a");
-    assertThat(StringUtils.truncate("a\uD83D\uDE00b", 3)).isEqualTo("a\uD83D\uDE00");
+    assertThat(StringUtils.truncate("a😀b", 1)).isEqualTo("a");
+    assertThat(StringUtils.truncate("a😀b", 2)).isEqualTo("a");
+    assertThat(StringUtils.truncate("a😀b", 3)).isEqualTo("a😀");
     assertThat(StringUtils.truncate(unchanged, 0)).isEmpty();
   }
 
   @Test
   void truncateStringPreservesMalformedSurrogates() {
-    assertThat(StringUtils.truncate("a\uD83Db", 2)).isEqualTo("a\uD83D");
-    assertThat(StringUtils.truncate("a\uDE00b", 2)).isEqualTo("a\uDE00");
+    char highSurrogate = (char) 0xd83d;
+    char lowSurrogate = (char) 0xde00;
+
+    assertThat(StringUtils.truncate("a" + highSurrogate + "b", 2)).isEqualTo("a" + highSurrogate);
+    assertThat(StringUtils.truncate("a" + lowSurrogate + "b", 2)).isEqualTo("a" + lowSurrogate);
   }
 
   @Test
   void truncateStringBuilder() {
-    StringBuilder value = new StringBuilder("a\uD83D\uDE00b");
+    StringBuilder value = new StringBuilder("a😀b");
 
     StringUtils.truncate(value, 2);
 
@@ -42,7 +45,7 @@ class StringUtilsTest {
 
   @Test
   void truncateStringBuffer() {
-    StringBuffer value = new StringBuffer("a\uD83D\uDE00b");
+    StringBuffer value = new StringBuffer("a😀b");
 
     StringUtils.truncate(value, 2);
 
@@ -53,7 +56,7 @@ class StringUtilsTest {
   void appendTruncated() {
     StringBuilder target = new StringBuilder("prefix:");
 
-    StringUtils.appendTruncated(target, "a\uD83D\uDE00b", 2);
+    StringUtils.appendTruncated(target, "a😀b", 2);
 
     assertThat(target).hasToString("prefix:a");
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.instrumentation.elasticsearch.rest.v7_0;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -22,7 +24,7 @@ import javax.annotation.Nullable;
  * <p>When the body is not a valid JSON value or sequence of JSON values, this returns {@code null}
  * so that the caller drops the body rather than capturing it raw.
  *
- * <p>Sanitized output longer than 32,768 characters is truncated.
+ * <p>Sanitized output longer than 32,768 UTF-16 code units is truncated.
  */
 final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> {
 
@@ -113,13 +115,15 @@ final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> 
     }
 
     private boolean isFull() {
-      return getBuffer().length() >= MAX_QUERY_LENGTH;
+      StringBuffer output = getBuffer();
+      return output.length() > MAX_QUERY_LENGTH
+          || (output.length() == MAX_QUERY_LENGTH
+              && !Character.isHighSurrogate(output.charAt(MAX_QUERY_LENGTH - 1)));
     }
 
     @Override
     public String toString() {
-      StringBuffer output = getBuffer();
-      return output.substring(0, Math.min(output.length(), MAX_QUERY_LENGTH));
+      return truncate(getBuffer().toString(), MAX_QUERY_LENGTH);
     }
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/main/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizer.java
@@ -24,7 +24,8 @@ import javax.annotation.Nullable;
  * <p>When the body is not a valid JSON value or sequence of JSON values, this returns {@code null}
  * so that the caller drops the body rather than capturing it raw.
  *
- * <p>Sanitized output longer than 32,768 UTF-16 code units is truncated.
+ * <p>Sanitized output is limited to a {@link String#length()} of 32,768 without splitting a
+ * surrogate pair.
  */
 final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> {
 
@@ -123,7 +124,9 @@ final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> 
 
     @Override
     public String toString() {
-      return truncate(getBuffer().toString(), MAX_QUERY_LENGTH);
+      StringBuffer output = getBuffer();
+      truncate(output, MAX_QUERY_LENGTH);
+      return output.toString();
     }
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -65,6 +65,16 @@ class JacksonElasticsearchQuerySanitizerTest {
   }
 
   @Test
+  void doesNotSplitSurrogatePairAtQueryLengthLimit() {
+    String beforePair =
+        "{\""
+            + "a".repeat(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
+    String body = beforePair + "\uD83D\uDE00\":[]}";
+
+    assertThat(sanitize(body)).isEqualTo(beforePair);
+  }
+
+  @Test
   void stopsBeforeOverDepthContentAfterLimit() {
     String exactLimit =
         objectWithEmptyArrayField(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 7);

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -67,11 +67,10 @@ class JacksonElasticsearchQuerySanitizerTest {
   @Test
   void doesNotSplitSurrogatePairAtQueryLengthLimit() {
     String beforePair =
-        "{\""
-            + "a".repeat(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
+        "{\"" + repeat('a', JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
     String body = beforePair + "\uD83D\uDE00\":[]}";
 
-    assertThat(sanitize(body)).isEqualTo(beforePair);
+    assertThat(sanitizer.apply(body)).isEqualTo(beforePair);
   }
 
   @Test
@@ -105,5 +104,13 @@ class JacksonElasticsearchQuerySanitizerTest {
       body.append('a');
     }
     return body.append("\":[]}").toString();
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-7.0/library/src/test/java/io/opentelemetry/instrumentation/elasticsearch/rest/v7_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -68,7 +68,7 @@ class JacksonElasticsearchQuerySanitizerTest {
   void doesNotSplitSurrogatePairAtQueryLengthLimit() {
     String beforePair =
         "{\"" + repeat('a', JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
-    String body = beforePair + "\uD83D\uDE00\":[]}";
+    String body = beforePair + "😀\":[]}";
 
     assertThat(sanitizer.apply(body)).isEqualTo(beforePair);
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -145,6 +145,16 @@ class JacksonElasticsearchQuerySanitizerTest {
   }
 
   @Test
+  void doesNotSplitSurrogatePairAtQueryLengthLimit() {
+    String beforePair =
+        "{\""
+            + "a".repeat(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
+    String body = beforePair + "\uD83D\uDE00\":[]}";
+
+    assertThat(sanitizer.apply(body)).isEqualTo(beforePair);
+  }
+
+  @Test
   void stopsBeforeOverDepthContentAfterLimit() {
     String exactLimit =
         objectWithEmptyArrayField(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 7);

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -147,8 +147,7 @@ class JacksonElasticsearchQuerySanitizerTest {
   @Test
   void doesNotSplitSurrogatePairAtQueryLengthLimit() {
     String beforePair =
-        "{\""
-            + "a".repeat(JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
+        "{\"" + repeat('a', JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
     String body = beforePair + "\uD83D\uDE00\":[]}";
 
     assertThat(sanitizer.apply(body)).isEqualTo(beforePair);
@@ -243,5 +242,13 @@ class JacksonElasticsearchQuerySanitizerTest {
       body.append('a');
     }
     return body.append("\":[]}").toString();
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizerTest.java
@@ -148,7 +148,7 @@ class JacksonElasticsearchQuerySanitizerTest {
   void doesNotSplitSurrogatePairAtQueryLengthLimit() {
     String beforePair =
         "{\"" + repeat('a', JacksonElasticsearchQuerySanitizer.MAX_QUERY_LENGTH - 3);
-    String body = beforePair + "\uD83D\uDE00\":[]}";
+    String body = beforePair + "😀\":[]}";
 
     assertThat(sanitizer.apply(body)).isEqualTo(beforePair);
   }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizer.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.elasticsearch.rest.common.v5_0;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -27,7 +29,7 @@ import javax.annotation.Nullable;
  * <p>When the body is not a valid JSON value or sequence of JSON values, this returns {@code null}
  * so that the caller drops the body rather than capturing it raw.
  *
- * <p>Sanitized output longer than 32,768 characters is truncated.
+ * <p>Sanitized output longer than 32,768 UTF-16 code units is truncated.
  */
 final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> {
 
@@ -136,13 +138,15 @@ final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> 
     }
 
     private boolean isFull() {
-      return getBuffer().length() >= MAX_QUERY_LENGTH;
+      StringBuffer output = getBuffer();
+      return output.length() > MAX_QUERY_LENGTH
+          || (output.length() == MAX_QUERY_LENGTH
+              && !Character.isHighSurrogate(output.charAt(MAX_QUERY_LENGTH - 1)));
     }
 
     @Override
     public String toString() {
-      StringBuffer output = getBuffer();
-      return output.substring(0, Math.min(output.length(), MAX_QUERY_LENGTH));
+      return truncate(getBuffer().toString(), MAX_QUERY_LENGTH);
     }
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizer.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-common-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/elasticsearch/rest/common/v5_0/JacksonElasticsearchQuerySanitizer.java
@@ -29,7 +29,8 @@ import javax.annotation.Nullable;
  * <p>When the body is not a valid JSON value or sequence of JSON values, this returns {@code null}
  * so that the caller drops the body rather than capturing it raw.
  *
- * <p>Sanitized output longer than 32,768 UTF-16 code units is truncated.
+ * <p>Sanitized output is limited to a {@link String#length()} of 32,768 without splitting a
+ * surrogate pair.
  */
 final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> {
 
@@ -146,7 +147,9 @@ final class JacksonElasticsearchQuerySanitizer implements UnaryOperator<String> 
 
     @Override
     public String toString() {
-      return truncate(getBuffer().toString(), MAX_QUERY_LENGTH);
+      StringBuffer output = getBuffer();
+      truncate(output, MAX_QUERY_LENGTH);
+      return output.toString();
     }
   }
 }

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoTelemetryBuilder.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoTelemetryBuilder.java
@@ -37,8 +37,8 @@ public final class MongoTelemetryBuilder {
   }
 
   /**
-   * Sets the max length of recorded queries after normalization. Defaults to {@value
-   * DEFAULT_MAX_NORMALIZED_QUERY_LENGTH}.
+   * Sets the max length in UTF-16 code units of recorded queries after normalization. Defaults to
+   * {@value DEFAULT_MAX_NORMALIZED_QUERY_LENGTH}.
    */
   @CanIgnoreReturnValue
   public MongoTelemetryBuilder setMaxNormalizedQueryLength(int maxNormalizedQueryLength) {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoTelemetryBuilder.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/MongoTelemetryBuilder.java
@@ -37,8 +37,8 @@ public final class MongoTelemetryBuilder {
   }
 
   /**
-   * Sets the max length in UTF-16 code units of recorded queries after normalization. Defaults to
-   * {@value DEFAULT_MAX_NORMALIZED_QUERY_LENGTH}.
+   * Sets the maximum normalized query {@link String#length()}. Defaults to {@value
+   * DEFAULT_MAX_NORMALIZED_QUERY_LENGTH}.
    */
   @CanIgnoreReturnValue
   public MongoTelemetryBuilder setMaxNormalizedQueryLength(int maxNormalizedQueryLength) {

--- a/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetter.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/main/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.mongo.v3_1.internal;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
 import static java.util.Arrays.asList;
 
 import com.mongodb.MongoException;
@@ -238,13 +239,11 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
       new BsonDocumentCodec().encode(jsonWriter, command, EncoderContext.builder().build());
     }
 
-    // If using MongoDB driver >= 3.7, the substring invocation will be a no-op due to use of
+    // If using MongoDB driver >= 3.7, truncation will generally be a no-op due to use of
     // JsonWriterSettings.Builder.maxLength in the static initializer for JSON_WRITER_SETTINGS
-    StringBuilder buf = stringWriter.getBuilder();
-    if (buf.length() <= maxNormalizedQueryLength) {
-      return buf.toString();
-    }
-    return buf.substring(0, maxNormalizedQueryLength);
+    StringBuilder buffer = stringWriter.getBuilder();
+    truncate(buffer, maxNormalizedQueryLength);
+    return buffer.toString();
   }
 
   @Nullable
@@ -276,7 +275,12 @@ class MongoDbAttributesGetter implements DbClientAttributesGetter<CommandStarted
                 .filter(method -> method.getName().equals("maxLength"))
                 .findFirst();
         if (maxLengthMethod.isPresent()) {
-          maxLengthMethod.get().invoke(builder, maxNormalizedQueryLength);
+          // Keep one extra code unit so truncation can detect a surrogate pair across the boundary.
+          int writerMaxLength =
+              maxNormalizedQueryLength == Integer.MAX_VALUE
+                  ? maxNormalizedQueryLength
+                  : maxNormalizedQueryLength + 1;
+          maxLengthMethod.get().invoke(builder, writerMaxLength);
         }
         settings =
             (JsonWriterSettings)

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
@@ -118,12 +118,12 @@ class MongoDbAttributesGetterTest {
 
     String normalized =
         sanitizeQueryAcrossVersions(
-            extractor, new BsonDocument("cmd", new BsonString("aaaaaaaaaa\uD83D\uDE00")));
+            extractor, new BsonDocument("cmd", new BsonString("aaaaaaaaaa😀")));
 
     assertThat(normalized)
+        .hasSizeLessThanOrEqualTo(20)
         .startsWith("{\"cmd\": \"")
-        .endsWith("a")
-        .doesNotContain("\uD83D", "\uDE00");
+        .doesNotContain(String.valueOf((char) 0xd83d), String.valueOf((char) 0xde00));
   }
 
   @ParameterizedTest

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
@@ -118,9 +118,12 @@ class MongoDbAttributesGetterTest {
 
     String normalized =
         sanitizeQueryAcrossVersions(
-            extractor, new BsonDocument("cmd", new BsonString("a".repeat(10) + "\uD83D\uDE00")));
+            extractor, new BsonDocument("cmd", new BsonString("aaaaaaaaaa\uD83D\uDE00")));
 
-    assertThat(normalized).isEqualTo("{\"cmd\": \"" + "a".repeat(10));
+    assertThat(normalized)
+        .startsWith("{\"cmd\": \"")
+        .endsWith("a")
+        .doesNotContain("\uD83D", "\uDE00");
   }
 
   @ParameterizedTest

--- a/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
+++ b/instrumentation/mongo/mongo-3.1/library/src/test/java/io/opentelemetry/instrumentation/mongo/v3_1/internal/MongoDbAttributesGetterTest.java
@@ -112,6 +112,17 @@ class MongoDbAttributesGetterTest {
         .isIn("{\"cmd\": \"c\", \"f1\": [\"?\", \"?", "{\"cmd\": \"c\", \"f1\": [\"?\",");
   }
 
+  @Test
+  void shouldNotSplitSurrogatePairWhenTruncating() {
+    MongoDbAttributesGetter extractor = new MongoDbAttributesGetter(true, 20);
+
+    String normalized =
+        sanitizeQueryAcrossVersions(
+            extractor, new BsonDocument("cmd", new BsonString("a".repeat(10) + "\uD83D\uDE00")));
+
+    assertThat(normalized).isEqualTo("{\"cmd\": \"" + "a".repeat(10));
+  }
+
   @ParameterizedTest
   @MethodSource("errorTypes")
   void getErrorTypeReturnsServerCodeOrFallsBack(Throwable error, String expectedErrorType) {

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -75,8 +75,7 @@ class OpenSearchBodyExtractorTest {
     JacksonJsonpMapper mapper = new JacksonJsonpMapper();
     String beforePair = repeat('a', MAX_QUERY_BODY_LENGTH - 3);
     JsonpSerializable value =
-        (generator, unused) ->
-            generator.writeStartObject().writeKey(beforePair + "\uD83D\uDE00").writeEnd();
+        (generator, unused) -> generator.writeStartObject().writeKey(beforePair + "😀").writeEnd();
 
     String result = OpenSearchBodyExtractor.extract(mapper, value, true);
 

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.spi.JsonProvider;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.NdJsonpSerializable;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 
@@ -76,6 +78,20 @@ class OpenSearchBodyExtractorTest {
     String beforePair = repeat('a', MAX_QUERY_BODY_LENGTH - 3);
     JsonpSerializable value =
         (generator, unused) -> generator.writeStartObject().writeKey(beforePair + "😀").writeEnd();
+
+    String result = OpenSearchBodyExtractor.extract(mapper, value, true);
+
+    assertThat(result).isEqualTo("{\"" + beforePair);
+  }
+
+  @Test
+  void shouldStopNdJsonAfterDroppingSurrogatePairAtQueryBodyLimit() {
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    String beforePair = repeat('a', MAX_QUERY_BODY_LENGTH - 3);
+    JsonpSerializable first =
+        (generator, unused) -> generator.writeStartObject().writeKey(beforePair + "😀").writeEnd();
+    NdJsonpSerializable value =
+        () -> asList(first, singletonMap("message", "next item")).iterator();
 
     String result = OpenSearchBodyExtractor.extract(mapper, value, true);
 

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -19,6 +19,8 @@ import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 
 class OpenSearchBodyExtractorTest {
 
+  private static final int MAX_QUERY_BODY_LENGTH = 32 * 1024;
+
   @Test
   void shouldUseJacksonMapperJsonFactory() {
     JsonFactory jsonFactory =
@@ -66,5 +68,18 @@ class OpenSearchBodyExtractorTest {
         OpenSearchBodyExtractor.extract(mapper, singletonMap("message", "secret"), true);
 
     assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldNotSplitSurrogatePairAtQueryBodyLimit() {
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    String beforePair = "a".repeat(MAX_QUERY_BODY_LENGTH - 3);
+    JsonpSerializable value =
+        (generator, unused) ->
+            generator.writeStartObject().writeKey(beforePair + "\uD83D\uDE00").writeEnd();
+
+    String result = OpenSearchBodyExtractor.extract(mapper, value, true);
+
+    assertThat(result).isEqualTo("{\"" + beforePair);
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractorTest.java
@@ -73,7 +73,7 @@ class OpenSearchBodyExtractorTest {
   @Test
   void shouldNotSplitSurrogatePairAtQueryBodyLimit() {
     JacksonJsonpMapper mapper = new JacksonJsonpMapper();
-    String beforePair = "a".repeat(MAX_QUERY_BODY_LENGTH - 3);
+    String beforePair = repeat('a', MAX_QUERY_BODY_LENGTH - 3);
     JsonpSerializable value =
         (generator, unused) ->
             generator.writeStartObject().writeKey(beforePair + "\uD83D\uDE00").writeEnd();
@@ -81,5 +81,13 @@ class OpenSearchBodyExtractorTest {
     String result = OpenSearchBodyExtractor.extract(mapper, value, true);
 
     assertThat(result).isEqualTo("{\"" + beforePair);
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
   }
 }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
@@ -31,18 +31,18 @@ class OpenSearchBodyExtractor {
     try {
       if (request instanceof NdJsonpSerializable) {
         return serializeNdJson(
-            mapper, (NdJsonpSerializable) request, sanitize, MAX_QUERY_BODY_LENGTH);
+                mapper, (NdJsonpSerializable) request, sanitize, MAX_QUERY_BODY_LENGTH)
+            .value;
       }
 
-      return serialize(mapper, request, sanitize, MAX_QUERY_BODY_LENGTH);
+      return serialize(mapper, request, sanitize, MAX_QUERY_BODY_LENGTH).value;
     } catch (Throwable t) {
       logger.log(FINE, "Failure extracting body", t);
       return null;
     }
   }
 
-  @Nullable
-  private static String serialize(
+  private static SerializationResult serialize(
       JsonpMapper mapper, Object item, boolean sanitize, int maxLength) {
     BoundedStringWriter writer = new BoundedStringWriter(maxLength);
 
@@ -72,27 +72,33 @@ class OpenSearchBodyExtractor {
     }
 
     String result = writer.toString().trim();
-    return result.isEmpty() ? null : result;
+    return new SerializationResult(result.isEmpty() ? null : result, writer.limitReached());
   }
 
-  @Nullable
-  private static String serializeNdJson(
+  private static SerializationResult serializeNdJson(
       JsonpMapper mapper, NdJsonpSerializable value, boolean sanitize, int maxLength) {
     StringBuilder result = new StringBuilder(Math.min(maxLength, 1024));
     Iterator<?> values = value._serializables();
     boolean first = true;
+    boolean limitReached = false;
 
     while (values.hasNext() && result.length() < maxLength) {
       Object item = values.next();
-      String itemStr;
-      int remaining = maxLength - result.length();
-
-      if (item instanceof NdJsonpSerializable && item != value) {
-        itemStr = serializeNdJson(mapper, (NdJsonpSerializable) item, sanitize, remaining);
-      } else {
-        itemStr = serialize(mapper, item, sanitize, remaining);
+      int separatorLength = first ? 0 : QUERY_SEPARATOR.length();
+      int remaining = maxLength - result.length() - separatorLength;
+      if (remaining <= 0) {
+        limitReached = true;
+        break;
       }
 
+      SerializationResult itemResult;
+      if (item instanceof NdJsonpSerializable && item != value) {
+        itemResult = serializeNdJson(mapper, (NdJsonpSerializable) item, sanitize, remaining);
+      } else {
+        itemResult = serialize(mapper, item, sanitize, remaining);
+      }
+
+      String itemStr = itemResult.value;
       if (itemStr != null && !itemStr.isEmpty()) {
         if (!first) {
           appendPrefix(result, QUERY_SEPARATOR, maxLength);
@@ -102,9 +108,13 @@ class OpenSearchBodyExtractor {
         }
         first = false;
       }
+      if (itemResult.limitReached) {
+        limitReached = true;
+        break;
+      }
     }
 
-    return result.length() == 0 ? null : result.toString();
+    return new SerializationResult(result.length() == 0 ? null : result.toString(), limitReached);
   }
 
   private static void appendPrefix(StringBuilder result, String value, int maxLength) {
@@ -178,6 +188,17 @@ class OpenSearchBodyExtractor {
     public String toString() {
       truncate(result, maxLength);
       return result.toString();
+    }
+  }
+
+  private static final class SerializationResult {
+
+    @Nullable private final String value;
+    private final boolean limitReached;
+
+    private SerializationResult(@Nullable String value, boolean limitReached) {
+      this.value = value;
+      this.limitReached = limitReached;
     }
   }
 

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
@@ -22,7 +22,7 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 class OpenSearchBodyExtractor {
 
   private static final Logger logger = Logger.getLogger(OpenSearchBodyExtractor.class.getName());
-  private static final int MAX_QUERY_BODY_LENGTH = 32 * 1024;
+  private static final int MAX_QUERY_BODY_LENGTH = 32 * 1024; // UTF-16 code units
   private static final String QUERY_SEPARATOR = ";";
 
   @Nullable
@@ -123,14 +123,17 @@ class OpenSearchBodyExtractor {
 
     @Override
     public void write(char[] buffer, int offset, int length) {
-      int writeLength = Math.min(length, maxLength + 1 - result.length());
+      int writeLength = Math.min(length, maxLength - result.length());
       result.append(buffer, offset, writeLength);
+      if (writeLength < length && needsOneMoreCodeUnit()) {
+        result.append(buffer[offset + writeLength]);
+      }
       abortIfFull();
     }
 
     @Override
     public void write(int value) {
-      if (result.length() <= maxLength) {
+      if (result.length() < maxLength || needsOneMoreCodeUnit()) {
         result.append((char) value);
       }
       abortIfFull();
@@ -138,16 +141,23 @@ class OpenSearchBodyExtractor {
 
     @Override
     public void write(String value, int offset, int length) {
-      int writeLength = Math.min(length, maxLength + 1 - result.length());
+      int writeLength = Math.min(length, maxLength - result.length());
       result.append(value, offset, offset + writeLength);
+      if (writeLength < length && needsOneMoreCodeUnit()) {
+        result.append(value.charAt(offset + writeLength));
+      }
       abortIfFull();
+    }
+
+    private boolean needsOneMoreCodeUnit() {
+      return maxLength > 0
+          && result.length() == maxLength
+          && Character.isHighSurrogate(result.charAt(maxLength - 1));
     }
 
     private void abortIfFull() {
       if (result.length() > maxLength
-          || (result.length() == maxLength
-              && (maxLength == 0
-                  || !Character.isHighSurrogate(result.charAt(maxLength - 1))))) {
+          || (result.length() == maxLength && !needsOneMoreCodeUnit())) {
         limitReached = true;
         throw new QueryBodyLimitException();
       }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
 import static java.util.logging.Level.FINE;
 
 import jakarta.json.stream.JsonGenerator;
@@ -106,8 +107,7 @@ class OpenSearchBodyExtractor {
   }
 
   private static void appendPrefix(StringBuilder result, String value, int maxLength) {
-    int length = Math.min(value.length(), maxLength - result.length());
-    result.append(value, 0, length);
+    result.append(truncate(value, maxLength - result.length()));
   }
 
   private static final class BoundedStringWriter extends Writer {
@@ -123,14 +123,14 @@ class OpenSearchBodyExtractor {
 
     @Override
     public void write(char[] buffer, int offset, int length) {
-      int writeLength = Math.min(length, maxLength - result.length());
+      int writeLength = Math.min(length, maxLength + 1 - result.length());
       result.append(buffer, offset, writeLength);
       abortIfFull();
     }
 
     @Override
     public void write(int value) {
-      if (result.length() < maxLength) {
+      if (result.length() <= maxLength) {
         result.append((char) value);
       }
       abortIfFull();
@@ -138,13 +138,16 @@ class OpenSearchBodyExtractor {
 
     @Override
     public void write(String value, int offset, int length) {
-      int writeLength = Math.min(length, maxLength - result.length());
+      int writeLength = Math.min(length, maxLength + 1 - result.length());
       result.append(value, offset, offset + writeLength);
       abortIfFull();
     }
 
     private void abortIfFull() {
-      if (result.length() == maxLength) {
+      if (result.length() > maxLength
+          || (result.length() == maxLength
+              && (maxLength == 0
+                  || !Character.isHighSurrogate(result.charAt(maxLength - 1))))) {
         limitReached = true;
         throw new QueryBodyLimitException();
       }
@@ -162,6 +165,7 @@ class OpenSearchBodyExtractor {
 
     @Override
     public String toString() {
+      truncate(result, maxLength);
       return result.toString();
     }
   }

--- a/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
+++ b/instrumentation/opensearch/opensearch-java-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opensearch/v3_0/OpenSearchBodyExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.opensearch.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.StringUtils.appendTruncated;
 import static io.opentelemetry.instrumentation.api.internal.StringUtils.truncate;
 import static java.util.logging.Level.FINE;
 
@@ -22,7 +23,7 @@ import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 class OpenSearchBodyExtractor {
 
   private static final Logger logger = Logger.getLogger(OpenSearchBodyExtractor.class.getName());
-  private static final int MAX_QUERY_BODY_LENGTH = 32 * 1024; // UTF-16 code units
+  private static final int MAX_QUERY_BODY_LENGTH = 32 * 1024;
   private static final String QUERY_SEPARATOR = ";";
 
   @Nullable
@@ -107,7 +108,7 @@ class OpenSearchBodyExtractor {
   }
 
   private static void appendPrefix(StringBuilder result, String value, int maxLength) {
-    result.append(truncate(value, maxLength - result.length()));
+    appendTruncated(result, value, maxLength - result.length());
   }
 
   private static final class BoundedStringWriter extends Writer {


### PR DESCRIPTION
Adds shared Unicode-aware truncation helpers and applies them to SQL and Redis sanitization, MongoDB query attributes, and Elasticsearch/OpenSearch query body extraction.

When a length limit falls between the two UTF-16 code units of a supplementary character, truncation omits the entire character instead of returning an isolated surrogate.

Closes #19873.