### PR TITLE
Cache repeated reflective method lookups

### DIFF
--- a/.github/agents/knowledge/java-reflection.md
+++ b/.github/agents/knowledge/java-reflection.md
@@ -6,11 +6,23 @@ Prefer a direct Java call when supported library versions expose a compatible me
 Java access works. This gives the compiler and muzzle a clear view of the dependency. Use reflection
 only when compatibility, access, or runtime discovery requires it.
 
+Before treating a lookup as runtime-class-dependent, identify the member's actual declaring type.
+A receiver typed as `Object`, or existing code that calls `receiver.getClass()`, does not prove that
+each implementation needs a separate lookup. Check whether a stable interface or base class
+declares the member. A `Method` obtained from that type can invoke compatible implementations.
+
 ## Cache repeated lookup
 
 Flag production Java code that repeats the same reflective method lookup on a path that may execute
 more than once. Resolve the method once and cache the resulting `Method` or `MethodHandle`. Use a
 `static final` field when the declaring class is fixed.
+
+When a fixed declaring type is optional or unavailable at compile time, load it once by name without
+initializing it and cache the nullable method in a `static final` field. In javaagent code, first
+verify the helper-loading strategy. An injected helper or isolated instrumentation-module helper is
+scoped to the instrumented class loader and can load an application type through its defining class
+loader. A bootstrap or otherwise shared helper cannot assume that one application class is valid
+for every caller.
 
 When the lookup depends on the runtime class, use `ClassValue` instead of a static map keyed by
 `Class<?>`. Static maps can keep application classloaders alive. Cache missing methods too when
@@ -24,6 +36,8 @@ initialization.
 | Situation | Preferred approach |
 | --- | --- |
 | Supported versions expose a compatible member and normal access works | Direct Java call |
+| A fixed declaring type is optional or unavailable at compile time | Static cached `Method` or `MethodHandle` resolved by class name |
+| The declaring type or required method metadata depends on the concrete runtime class | `ClassValue` containing the cached accessor |
 | The exact signature is known and typed or adapted invocation helps, or several member kinds need one invocation abstraction | Cached `MethodHandle` |
 | Access requires a target-associated lookup, or `CallSite` linking is part of the design | `MethodHandle` |
 | Setup performs a one-time call, construction, or field access | `Method`, `Constructor`, or `Field` |

--- a/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
+++ b/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
@@ -83,6 +83,19 @@ public class DubboUnknownServiceHelper {
   private static final VirtualField<RpcInvocation, Boolean> UNKNOWN_SERVICE_SPAN_RECORDED =
       VirtualField.find(RpcInvocation.class, Boolean.class);
 
+  private static final ClassValue<Method> statusCodeMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("getStatusCode");
+          } catch (NoSuchMethodException ignored) {
+            return null;
+          }
+        }
+      };
+
   /**
    * Creates an unknown service span when {@code DubboProtocol.getInvoker()} throws because the
    * requested service is not registered in the exporter map. This handles the Dubbo protocol
@@ -253,7 +266,10 @@ public class DubboUnknownServiceHelper {
       return false;
     }
     try {
-      Method statusMethod = throwable.getClass().getMethod("getStatusCode");
+      Method statusMethod = statusCodeMethod.get(throwable.getClass());
+      if (statusMethod == null) {
+        return false;
+      }
       Object status = statusMethod.invoke(throwable);
       return status instanceof Integer && (Integer) status == 404;
     } catch (ReflectiveOperationException ignored) {

--- a/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
+++ b/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
@@ -244,17 +244,9 @@ public class DubboUnknownServiceHelper {
     return message != null && message.contains("Not found exported service");
   }
 
-  /**
-   * Returns {@code true} if the throwable is a Dubbo Triple 404 (service not found). The class
-   * check uses the name string because {@code HttpStatusException} is not available at compile time
-   * against Dubbo 2.7.
-   */
+  /** Returns {@code true} if the throwable is a Dubbo Triple 404 (service not found). */
   static boolean isTripleNotFoundFailure(Throwable throwable) {
-    if (!"org.apache.dubbo.remoting.http12.exception.HttpStatusException"
-        .equals(throwable.getClass().getName())) {
-      return false;
-    }
-    if (statusCodeMethod == null || !statusCodeMethod.getDeclaringClass().isInstance(throwable)) {
+    if (statusCodeMethod == null || throwable.getClass() != statusCodeMethod.getDeclaringClass()) {
       return false;
     }
     try {

--- a/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
+++ b/instrumentation/apache-dubbo-2.7/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apachedubbo/v2_7/DubboUnknownServiceHelper.java
@@ -83,18 +83,7 @@ public class DubboUnknownServiceHelper {
   private static final VirtualField<RpcInvocation, Boolean> UNKNOWN_SERVICE_SPAN_RECORDED =
       VirtualField.find(RpcInvocation.class, Boolean.class);
 
-  private static final ClassValue<Method> statusCodeMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("getStatusCode");
-          } catch (NoSuchMethodException ignored) {
-            return null;
-          }
-        }
-      };
+  @Nullable private static final Method statusCodeMethod = findStatusCodeMethod();
 
   /**
    * Creates an unknown service span when {@code DubboProtocol.getInvoker()} throws because the
@@ -265,15 +254,28 @@ public class DubboUnknownServiceHelper {
         .equals(throwable.getClass().getName())) {
       return false;
     }
+    if (statusCodeMethod == null || !statusCodeMethod.getDeclaringClass().isInstance(throwable)) {
+      return false;
+    }
     try {
-      Method statusMethod = statusCodeMethod.get(throwable.getClass());
-      if (statusMethod == null) {
-        return false;
-      }
-      Object status = statusMethod.invoke(throwable);
+      Object status = statusCodeMethod.invoke(throwable);
       return status instanceof Integer && (Integer) status == 404;
     } catch (ReflectiveOperationException ignored) {
       return false;
+    }
+  }
+
+  @Nullable
+  private static Method findStatusCodeMethod() {
+    try {
+      Class<?> exceptionClass =
+          Class.forName(
+              "org.apache.dubbo.remoting.http12.exception.HttpStatusException",
+              false,
+              DubboUnknownServiceHelper.class.getClassLoader());
+      return exceptionClass.getMethod("getStatusCode");
+    } catch (ReflectiveOperationException | LinkageError | SecurityException ignored) {
+      return null;
     }
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
@@ -30,19 +30,6 @@ import net.bytebuddy.asm.Advice;
  * specific instrumentations may override this value.
  */
 class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
-  private static final ClassValue<Method> filterMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("filter", ContainerRequestContext.class);
-          } catch (NoSuchMethodException ignored) {
-            return null;
-          }
-        }
-      };
-
   @Override
   protected String abortAdviceName() {
     return getClass().getName() + "$ContainerRequestContextAdvice";
@@ -50,6 +37,18 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
 
   @SuppressWarnings("unused")
   public static class ContainerRequestContextAdvice {
+    private static final ClassValue<Method> filterMethod =
+        new ClassValue<Method>() {
+          @Nullable
+          @Override
+          protected Method computeValue(Class<?> type) {
+            try {
+              return type.getMethod("filter", ContainerRequestContext.class);
+            } catch (NoSuchMethodException ignored) {
+              return null;
+            }
+          }
+        };
 
     public static class AdviceScope {
       private final Context context;

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
@@ -37,6 +37,8 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
 
   @SuppressWarnings("unused")
   public static class ContainerRequestContextAdvice {
+    // HandlerData inspects annotations on the concrete filter method, so one Method from
+    // ContainerRequestFilter cannot be reused for every implementation.
     private static final ClassValue<Method> filterMethod =
         new ClassValue<Method>() {
           @Nullable

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
@@ -30,6 +30,19 @@ import net.bytebuddy.asm.Advice;
  * specific instrumentations may override this value.
  */
 class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+  private static final ClassValue<Method> filterMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("filter", ContainerRequestContext.class);
+          } catch (NoSuchMethodException ignored) {
+            return null;
+          }
+        }
+      };
+
   @Override
   protected String abortAdviceName() {
     return getClass().getName() + "$ContainerRequestContextAdvice";
@@ -86,14 +99,7 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
         return null;
       }
 
-      Method method = null;
-      try {
-        method = filterClass.getMethod("filter", ContainerRequestContext.class);
-      } catch (NoSuchMethodException ignored) {
-        // Unable to find the filter method.  This should not be reachable because the context
-        // can only be aborted inside the filter method
-      }
-
+      Method method = filterMethod.get(filterClass);
       if (method == null) {
         return null;
       }

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v2_0/annotations/DefaultRequestContextInstrumentation.java
@@ -52,6 +52,11 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
           }
         };
 
+    @Nullable
+    public static Method getFilterMethod(Class<?> filterClass) {
+      return filterMethod.get(filterClass);
+    }
+
     public static class AdviceScope {
       private final Context context;
       private final Scope scope;
@@ -100,7 +105,7 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
         return null;
       }
 
-      Method method = filterMethod.get(filterClass);
+      Method method = getFilterMethod(filterClass);
       if (method == null) {
         return null;
       }

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
@@ -30,19 +30,6 @@ import net.bytebuddy.asm.Advice;
  * specific instrumentations may override this value.
  */
 class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
-  private static final ClassValue<Method> filterMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("filter", ContainerRequestContext.class);
-          } catch (NoSuchMethodException ignored) {
-            return null;
-          }
-        }
-      };
-
   @Override
   protected String abortAdviceName() {
     return getClass().getName() + "$ContainerRequestContextAdvice";
@@ -50,6 +37,18 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
 
   @SuppressWarnings("unused")
   public static class ContainerRequestContextAdvice {
+    private static final ClassValue<Method> filterMethod =
+        new ClassValue<Method>() {
+          @Nullable
+          @Override
+          protected Method computeValue(Class<?> type) {
+            try {
+              return type.getMethod("filter", ContainerRequestContext.class);
+            } catch (NoSuchMethodException ignored) {
+              return null;
+            }
+          }
+        };
 
     public static class AdviceScope {
       private final Jaxrs3HandlerData handlerData;

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
@@ -37,6 +37,8 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
 
   @SuppressWarnings("unused")
   public static class ContainerRequestContextAdvice {
+    // HandlerData inspects annotations on the concrete filter method, so one Method from
+    // ContainerRequestFilter cannot be reused for every implementation.
     private static final ClassValue<Method> filterMethod =
         new ClassValue<Method>() {
           @Nullable

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
@@ -52,6 +52,11 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
           }
         };
 
+    @Nullable
+    public static Method getFilterMethod(Class<?> filterClass) {
+      return filterMethod.get(filterClass);
+    }
+
     public static class AdviceScope {
       private final Jaxrs3HandlerData handlerData;
       private final Context context;
@@ -98,7 +103,7 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
       if (filterClass == null) {
         return null;
       }
-      Method method = filterMethod.get(filterClass);
+      Method method = getFilterMethod(filterClass);
       if (method == null) {
         return null;
       }

--- a/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-3.0/jaxrs-3.0-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jaxrs/v3_0/annotations/DefaultRequestContextInstrumentation.java
@@ -30,6 +30,19 @@ import net.bytebuddy.asm.Advice;
  * specific instrumentations may override this value.
  */
 class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrumentation {
+  private static final ClassValue<Method> filterMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("filter", ContainerRequestContext.class);
+          } catch (NoSuchMethodException ignored) {
+            return null;
+          }
+        }
+      };
+
   @Override
   protected String abortAdviceName() {
     return getClass().getName() + "$ContainerRequestContextAdvice";
@@ -84,13 +97,7 @@ class DefaultRequestContextInstrumentation extends AbstractRequestContextInstrum
       if (filterClass == null) {
         return null;
       }
-      Method method = null;
-      try {
-        method = filterClass.getMethod("filter", ContainerRequestContext.class);
-      } catch (NoSuchMethodException ignored) {
-        // Unable to find the filter method.  This should not be reachable because the context
-        // can only be aborted inside the filter method
-      }
+      Method method = filterMethod.get(filterClass);
       if (method == null) {
         return null;
       }

--- a/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
+++ b/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
@@ -32,14 +32,20 @@ class NettyStreamInstrumentation implements TypeInstrumentation {
   public static class OpenAdvice {
     @Nullable private static final Method remoteAddressMethod = findRemoteAddressMethod();
 
+    @Nullable
+    public static Method getRemoteAddressMethod() {
+      return remoteAddressMethod;
+    }
+
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.FieldValue("channel") Object channel)
         throws ReflectiveOperationException {
       if (channel == null) {
         return;
       }
-      if (remoteAddressMethod != null) {
-        SocketAddress remoteAddress = (SocketAddress) remoteAddressMethod.invoke(channel);
+      Method method = getRemoteAddressMethod();
+      if (method != null) {
+        SocketAddress remoteAddress = (SocketAddress) method.invoke(channel);
         MongoConnectionPeer.capture(remoteAddress);
       }
     }

--- a/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
+++ b/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
@@ -30,18 +30,7 @@ class NettyStreamInstrumentation implements TypeInstrumentation {
 
   @SuppressWarnings("unused")
   public static class OpenAdvice {
-    private static final ClassValue<Method> remoteAddressMethod =
-        new ClassValue<Method>() {
-          @Nullable
-          @Override
-          protected Method computeValue(Class<?> type) {
-            try {
-              return type.getMethod("remoteAddress");
-            } catch (NoSuchMethodException ignored) {
-              return null;
-            }
-          }
-        };
+    @Nullable private static final Method remoteAddressMethod = findRemoteAddressMethod();
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.FieldValue("channel") Object channel)
@@ -49,10 +38,20 @@ class NettyStreamInstrumentation implements TypeInstrumentation {
       if (channel == null) {
         return;
       }
-      Method method = remoteAddressMethod.get(channel.getClass());
-      if (method != null) {
-        SocketAddress remoteAddress = (SocketAddress) method.invoke(channel);
+      if (remoteAddressMethod != null) {
+        SocketAddress remoteAddress = (SocketAddress) remoteAddressMethod.invoke(channel);
         MongoConnectionPeer.capture(remoteAddress);
+      }
+    }
+
+    @Nullable
+    private static Method findRemoteAddressMethod() {
+      try {
+        Class<?> channelClass =
+            Class.forName("io.netty.channel.Channel", false, OpenAdvice.class.getClassLoader());
+        return channelClass.getMethod("remoteAddress");
+      } catch (ReflectiveOperationException | LinkageError | SecurityException ignored) {
+        return null;
       }
     }
   }

--- a/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
+++ b/instrumentation/mongo/mongo-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/mongo/v4_0/NettyStreamInstrumentation.java
@@ -9,7 +9,9 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import java.lang.reflect.Method;
 import java.net.SocketAddress;
+import javax.annotation.Nullable;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -28,6 +30,18 @@ class NettyStreamInstrumentation implements TypeInstrumentation {
 
   @SuppressWarnings("unused")
   public static class OpenAdvice {
+    private static final ClassValue<Method> remoteAddressMethod =
+        new ClassValue<Method>() {
+          @Nullable
+          @Override
+          protected Method computeValue(Class<?> type) {
+            try {
+              return type.getMethod("remoteAddress");
+            } catch (NoSuchMethodException ignored) {
+              return null;
+            }
+          }
+        };
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void onExit(@Advice.FieldValue("channel") Object channel)
@@ -35,9 +49,11 @@ class NettyStreamInstrumentation implements TypeInstrumentation {
       if (channel == null) {
         return;
       }
-      SocketAddress remoteAddress =
-          (SocketAddress) channel.getClass().getMethod("remoteAddress").invoke(channel);
-      MongoConnectionPeer.capture(remoteAddress);
+      Method method = remoteAddressMethod.get(channel.getClass());
+      if (method != null) {
+        SocketAddress remoteAddress = (SocketAddress) method.invoke(channel);
+        MongoConnectionPeer.capture(remoteAddress);
+      }
     }
   }
 }

--- a/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/ClientConnectionsEntryInstrumentation.java
+++ b/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/ClientConnectionsEntryInstrumentation.java
@@ -17,6 +17,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.redisson.client.RedisClient;
+import org.redisson.connection.ConnectionManager;
 
 class ClientConnectionsEntryInstrumentation implements TypeInstrumentation {
 
@@ -50,7 +51,7 @@ class ClientConnectionsEntryInstrumentation implements TypeInstrumentation {
         @Advice.Argument(2) int poolMaxSize,
         @Advice.Argument(3) int subscriptionPoolMinSize,
         @Advice.Argument(4) int subscriptionPoolMaxSize,
-        @Advice.Argument(5) Object connectionManager,
+        @Advice.Argument(5) ConnectionManager connectionManager,
         @Advice.FieldValue("freeConnectionsCounter") Object freeConnectionsCounter,
         @Advice.FieldValue("freeConnections") Collection<?> freeConnections,
         @Advice.FieldValue("freeSubscribeConnectionsCounter")

--- a/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
+++ b/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.redisson.config.BaseMasterSlaveServersConfig;
+import org.redisson.connection.ConnectionManager;
 import org.redisson.pubsub.AsyncSemaphore;
 
 class RedissonConnectionPoolAccessor {
@@ -18,36 +20,9 @@ class RedissonConnectionPoolAccessor {
   @Nullable private static final Field counterField = findAsyncSemaphoreField("counter");
   @Nullable private static final Method queueSizeMethod;
   @Nullable private static final Field listenersField;
-  private static final ClassValue<Method> getConfigMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("getConfig");
-          } catch (NoSuchMethodException | SecurityException ignored) {
-            return null;
-          }
-        }
-      };
-  private static final ClassValue<Method> subscriptionMinimumIdleMethod =
-      new ClassValue<Method>() {
-        @Nullable
-        @Override
-        protected Method computeValue(Class<?> type) {
-          try {
-            return type.getMethod("getSubscriptionConnectionMinimumIdleSize");
-          } catch (NoSuchMethodException ignored) {
-            try {
-              return type.getMethod("getSlaveSubscriptionConnectionMinimumIdleSize");
-            } catch (NoSuchMethodException | SecurityException ignore) {
-              return null;
-            }
-          } catch (SecurityException ignored) {
-            return null;
-          }
-        }
-      };
+
+  @Nullable
+  private static final Method subscriptionMinimumIdleMethod = findSubscriptionMinimumIdleMethod();
 
   static {
     Method method = null;
@@ -90,20 +65,32 @@ class RedissonConnectionPoolAccessor {
     return null;
   }
 
-  static int getSubscriptionMinimumIdleSize(Object connectionManager, int fallback) {
+  static int getSubscriptionMinimumIdleSize(ConnectionManager connectionManager, int fallback) {
     try {
-      Method configGetter = getConfigMethod.get(connectionManager.getClass());
-      if (configGetter == null) {
+      if (subscriptionMinimumIdleMethod == null) {
         return fallback;
       }
-      Object config = configGetter.invoke(connectionManager);
-      Method getter = subscriptionMinimumIdleMethod.get(config.getClass());
-      if (getter == null) {
-        return fallback;
-      }
-      return ((Number) getter.invoke(config)).intValue();
+      BaseMasterSlaveServersConfig<?> config = connectionManager.getConfig();
+      return ((Number) subscriptionMinimumIdleMethod.invoke(config)).intValue();
     } catch (ReflectiveOperationException | RuntimeException ignored) {
       return fallback;
+    }
+  }
+
+  @Nullable
+  private static Method findSubscriptionMinimumIdleMethod() {
+    try {
+      return BaseMasterSlaveServersConfig.class.getMethod(
+          "getSubscriptionConnectionMinimumIdleSize");
+    } catch (NoSuchMethodException ignored) {
+      try {
+        return BaseMasterSlaveServersConfig.class.getMethod(
+            "getSlaveSubscriptionConnectionMinimumIdleSize");
+      } catch (NoSuchMethodException | SecurityException ignore) {
+        return null;
+      }
+    } catch (SecurityException ignored) {
+      return null;
     }
   }
 

--- a/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
+++ b/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
@@ -18,6 +18,36 @@ class RedissonConnectionPoolAccessor {
   @Nullable private static final Field counterField = findAsyncSemaphoreField("counter");
   @Nullable private static final Method queueSizeMethod;
   @Nullable private static final Field listenersField;
+  private static final ClassValue<Method> getConfigMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("getConfig");
+          } catch (NoSuchMethodException | SecurityException ignored) {
+            return null;
+          }
+        }
+      };
+  private static final ClassValue<Method> subscriptionMinimumIdleMethod =
+      new ClassValue<Method>() {
+        @Nullable
+        @Override
+        protected Method computeValue(Class<?> type) {
+          try {
+            return type.getMethod("getSubscriptionConnectionMinimumIdleSize");
+          } catch (NoSuchMethodException ignored) {
+            try {
+              return type.getMethod("getSlaveSubscriptionConnectionMinimumIdleSize");
+            } catch (NoSuchMethodException | SecurityException ignoredAgain) {
+              return null;
+            }
+          } catch (SecurityException ignored) {
+            return null;
+          }
+        }
+      };
 
   static {
     Method method = null;
@@ -62,12 +92,14 @@ class RedissonConnectionPoolAccessor {
 
   static int getSubscriptionMinimumIdleSize(Object connectionManager, int fallback) {
     try {
-      Object config = connectionManager.getClass().getMethod("getConfig").invoke(connectionManager);
-      Method getter;
-      try {
-        getter = config.getClass().getMethod("getSubscriptionConnectionMinimumIdleSize");
-      } catch (NoSuchMethodException ignored) {
-        getter = config.getClass().getMethod("getSlaveSubscriptionConnectionMinimumIdleSize");
+      Method configGetter = getConfigMethod.get(connectionManager.getClass());
+      if (configGetter == null) {
+        return fallback;
+      }
+      Object config = configGetter.invoke(connectionManager);
+      Method getter = subscriptionMinimumIdleMethod.get(config.getClass());
+      if (getter == null) {
+        return fallback;
       }
       return ((Number) getter.invoke(config)).intValue();
     } catch (ReflectiveOperationException | RuntimeException ignored) {

--- a/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
+++ b/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonConnectionPoolAccessor.java
@@ -40,7 +40,7 @@ class RedissonConnectionPoolAccessor {
           } catch (NoSuchMethodException ignored) {
             try {
               return type.getMethod("getSlaveSubscriptionConnectionMinimumIdleSize");
-            } catch (NoSuchMethodException | SecurityException ignoredAgain) {
+            } catch (NoSuchMethodException | SecurityException ignore) {
               return null;
             }
           } catch (SecurityException ignored) {

--- a/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonSingletons.java
+++ b/instrumentation/redisson/redisson-metrics-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/redissonmetrics/v2_3/RedissonSingletons.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.redisson.client.RedisClient;
+import org.redisson.connection.ConnectionManager;
 
 public class RedissonSingletons {
 
@@ -25,7 +26,7 @@ public class RedissonSingletons {
       Collection<?> regularFreeConnections,
       int subscriptionMinIdle,
       int subscriptionMax,
-      Object connectionManager,
+      ConnectionManager connectionManager,
       Object subscriptionCounter,
       Collection<?> subscriptionFreeConnections) {
     if (subscriptionMax > 0) {


### PR DESCRIPTION
Fixes #20094 by caching repeated reflective method lookups in the JAX-RS, MongoDB, Dubbo, and Redisson instrumentations.

- Resolves methods once from stable declaring interfaces or classes where possible.
- Uses `ClassValue` only for JAX-RS filter methods, where concrete implementation metadata is required.
- Clarifies the reflection guidance for choosing direct calls, static caches, and runtime-class caches.