### PR TITLE
Emit schema URLs for database, messaging, and RPC telemetry

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
@@ -20,6 +21,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.instrumentation.api.internal.SemconvStability;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
@@ -38,7 +40,7 @@ import javax.annotation.Nullable;
  * attribute extraction from request/response objects.
  */
 public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
-    implements AttributesExtractor<REQUEST, RESPONSE>, SpanKeyProvider {
+    implements AttributesExtractor<REQUEST, RESPONSE>, SchemaUrlProvider, SpanKeyProvider {
 
   // copied from DbIncubatingAttributes
   private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
@@ -166,5 +168,10 @@ public final class DbClientAttributesExtractor<REQUEST, RESPONSE>
   @Override
   public SpanKey internalGetSpanKey() {
     return SpanKey.DB_CLIENT;
+  }
+
+  @Override
+  public String internalGetSchemaUrl() {
+    return databaseSchemaUrl();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetrics.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -42,6 +43,7 @@ public final class DbConnectionPoolMetrics {
     if (version != null) {
       meterBuilder.setInstrumentationVersion(version);
     }
+    meterBuilder.setSchemaUrl(databaseSchemaUrl());
     return create(meterBuilder.build(), poolName);
   }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.api.incubator.semconv.db;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.stableDbSystemName;
@@ -21,6 +22,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import io.opentelemetry.instrumentation.api.semconv.network.ServerAttributesExtractor;
@@ -41,7 +43,7 @@ import javax.annotation.Nullable;
  * statement parameters are removed.
  */
 public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
-    implements AttributesExtractor<REQUEST, RESPONSE>, SpanKeyProvider {
+    implements AttributesExtractor<REQUEST, RESPONSE>, SchemaUrlProvider, SpanKeyProvider {
 
   // copied from DbIncubatingAttributes
   private static final AttributeKey<String> DB_NAME = AttributeKey.stringKey("db.name");
@@ -215,5 +217,10 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
   @Override
   public SpanKey internalGetSpanKey() {
     return SpanKey.DB_CLIENT;
+  }
+
+  @Override
+  public String internalGetSchemaUrl() {
+    return databaseSchemaUrl();
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractor.java
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.messaging;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldMessagingSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
@@ -17,6 +18,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.config.IncludeExclude;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
 import io.opentelemetry.instrumentation.api.internal.SpanKeyProvider;
 import java.util.ArrayList;
@@ -36,7 +38,7 @@ import javax.annotation.Nullable;
  * attribute extraction from request/response objects.
  */
 public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
-    implements AttributesExtractor<REQUEST, RESPONSE>, SpanKeyProvider {
+    implements AttributesExtractor<REQUEST, RESPONSE>, SchemaUrlProvider, SpanKeyProvider {
 
   // copied from MessagingIncubatingAttributes
   private static final AttributeKey<Long> MESSAGING_BATCH_MESSAGE_COUNT =
@@ -284,5 +286,10 @@ public final class MessagingAttributesExtractor<REQUEST, RESPONSE>
         return SpanKey.CONSUMER_SETTLE;
     }
     throw new IllegalStateException("Can't possibly happen");
+  }
+
+  @Override
+  public String internalGetSchemaUrl() {
+    return messagingSchemaUrl(supportsStableSemconv);
   }
 }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcCommonAttributesExtractor.java
@@ -7,16 +7,18 @@ package io.opentelemetry.instrumentation.api.incubator.semconv.rpc;
 
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitOldRpcSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableRpcSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.rpcSchemaUrl;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import javax.annotation.Nullable;
 
 abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
-    implements AttributesExtractor<REQUEST, RESPONSE> {
+    implements AttributesExtractor<REQUEST, RESPONSE>, SchemaUrlProvider {
 
   static final AttributeKey<String> RPC_METHOD = AttributeKey.stringKey("rpc.method");
   private static final AttributeKey<String> RPC_METHOD_ORIGINAL =
@@ -72,5 +74,10 @@ abstract class RpcCommonAttributesExtractor<REQUEST, RESPONSE>
       }
       attributes.put(ERROR_TYPE, errorType);
     }
+  }
+
+  @Override
+  public final String internalGetSchemaUrl() {
+    return rpcSchemaUrl();
   }
 }

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientAttributesExtractorTest.java
@@ -28,12 +28,23 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
+import io.opentelemetry.semconv.SchemaUrls;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 class DbClientAttributesExtractorTest {
+
+  @Test
+  void shouldProvideSchemaUrl() {
+    AttributesExtractor<Map<String, String>, Void> extractor =
+        DbClientAttributesExtractor.create(new TestAttributesGetter());
+
+    assertThat(((SchemaUrlProvider) extractor).internalGetSchemaUrl())
+        .isEqualTo(emitStableDatabaseSemconv() ? SchemaUrls.V1_44_0 : SchemaUrls.V1_24_0);
+  }
 
   static class TestAttributesGetter implements DbClientAttributesGetter<Map<String, String>, Void> {
     @Override

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetricsTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbConnectionPoolMetricsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.api.incubator.semconv.db;
+
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.testing.internal.AutoCleanupExtension;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.semconv.SchemaUrls;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DbConnectionPoolMetricsTest {
+
+  @RegisterExtension final AutoCleanupExtension cleanup = AutoCleanupExtension.create();
+
+  @Test
+  void shouldSetSchemaUrl() {
+    InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    cleanup.deferCleanup(meterProvider);
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
+
+    DbConnectionPoolMetrics metrics =
+        DbConnectionPoolMetrics.create(openTelemetry, "test", "test-pool");
+    metrics.connectionTimeouts().add(1);
+
+    assertThat(metricReader.collectAllMetrics())
+        .singleElement()
+        .satisfies(
+            metric ->
+                assertThat(metric.getInstrumentationScopeInfo().getSchemaUrl())
+                    .isEqualTo(
+                        emitStableDatabaseSemconv() ? SchemaUrls.V1_44_0 : SchemaUrls.V1_24_0));
+  }
+}

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractorTest.java
@@ -36,6 +36,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
+import io.opentelemetry.semconv.SchemaUrls;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +46,15 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // using deprecated semconv
 class SqlClientAttributesExtractorTest {
+
+  @Test
+  void shouldProvideSchemaUrl() {
+    AttributesExtractor<Map<String, Object>, Void> extractor =
+        SqlClientAttributesExtractor.create(new TestAttributesGetter());
+
+    assertThat(((SchemaUrlProvider) extractor).internalGetSchemaUrl())
+        .isEqualTo(emitStableDatabaseSemconv() ? SchemaUrls.V1_44_0 : SchemaUrls.V1_24_0);
+  }
 
   static class TestAttributesGetter
       implements SqlClientAttributesGetter<Map<String, Object>, Void> {

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/messaging/MessagingAttributesExtractorTest.java
@@ -35,7 +35,9 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.instrumentation.api.internal.SpanKey;
+import io.opentelemetry.semconv.SchemaUrls;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +51,26 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class MessagingAttributesExtractorTest {
+
+  @Test
+  void shouldProvideSchemaUrl() {
+    AttributesExtractor<Map<String, String>, String> extractor =
+        MessagingAttributesExtractor.create(
+            TestGetter.INSTANCE, MessagingOperationType.SEND, "send");
+
+    assertThat(((SchemaUrlProvider) extractor).internalGetSchemaUrl())
+        .isEqualTo(emitStableMessagingSemconv() ? SchemaUrls.V1_43_0 : SchemaUrls.V1_24_0);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void deprecatedExtractorShouldProvideLegacySchemaUrl() {
+    AttributesExtractor<Map<String, String>, String> extractor =
+        MessagingAttributesExtractor.create(TestGetter.INSTANCE, MessageOperation.PUBLISH);
+
+    assertThat(((SchemaUrlProvider) extractor).internalGetSchemaUrl())
+        .isEqualTo(SchemaUrls.V1_24_0);
+  }
 
   @SuppressWarnings("deprecation") // using deprecated semconv
   @ParameterizedTest

--- a/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesExtractorTest.java
+++ b/instrumentation-api-incubator/src/test/java/io/opentelemetry/instrumentation/api/incubator/semconv/rpc/RpcAttributesExtractorTest.java
@@ -21,6 +21,8 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
+import io.opentelemetry.semconv.SchemaUrls;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -89,6 +91,9 @@ class RpcAttributesExtractorTest {
   }
 
   private static void testExtractor(AttributesExtractor<Map<String, String>, Void> extractor) {
+    assertThat(((SchemaUrlProvider) extractor).internalGetSchemaUrl())
+        .isEqualTo(emitStableRpcSemconv() ? SchemaUrls.V1_44_0 : SchemaUrls.V1_37_0);
+
     Map<String, String> request = new HashMap<>();
     request.put("service", "my.Service");
     request.put("method", "Method");

--- a/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
+++ b/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java
@@ -11,6 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.incubator.ExtendedOpenTelemetry;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.semconv.SchemaUrls;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -87,6 +88,10 @@ public final class SemconvStability {
     return emitStableDatabaseSemconv;
   }
 
+  public static String databaseSchemaUrl() {
+    return emitStableDatabaseSemconv ? SchemaUrls.V1_44_0 : SchemaUrls.V1_24_0;
+  }
+
   public static boolean emitOldServicePeerSemconv() {
     return emitOldServicePeerSemconv;
   }
@@ -136,6 +141,10 @@ public final class SemconvStability {
     return emitStableRpcSemconv;
   }
 
+  public static String rpcSchemaUrl() {
+    return emitStableRpcSemconv ? SchemaUrls.V1_44_0 : SchemaUrls.V1_37_0;
+  }
+
   private static final Map<String, String> rpcSystemNameMap = new HashMap<>();
 
   static {
@@ -178,6 +187,12 @@ public final class SemconvStability {
   // conventions are stable.
   public static boolean emitStableMessagingSemconv() { // to be removed in 3.0
     return emitStableMessagingSemconv;
+  }
+
+  public static String messagingSchemaUrl(boolean supportsStableSemconv) {
+    return supportsStableSemconv && emitStableMessagingSemconv
+        ? SchemaUrls.V1_43_0
+        : SchemaUrls.V1_24_0;
   }
 
   private SemconvStability() {}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
@@ -36,6 +38,8 @@ import javax.annotation.Nullable;
  */
 public class EmittedScopeParser {
   private static final Logger logger = Logger.getLogger(EmittedScopeParser.class.getName());
+  private static final Pattern SCHEMA_VERSION =
+      Pattern.compile("^https://opentelemetry\\.io/schemas/(\\d+)\\.(\\d+)\\.(\\d+)$");
 
   @Nullable
   public static InstrumentationScopeInfo getScope(
@@ -89,8 +93,32 @@ public class EmittedScopeParser {
       Set<EmittedScope.Scope> scopes, String scopeName) {
     return scopes.stream()
         .filter(scope -> scopeName.equals(scope.getName()))
-        .min(Comparator.comparingInt(scope -> scope.getSchemaUrl() == null ? 1 : 0))
+        .max(
+            Comparator.comparing(
+                    EmittedScope.Scope::getSchemaUrl,
+                    Comparator.nullsFirst(EmittedScopeParser::compareSchemaUrls))
+                .thenComparing(
+                    EmittedScope.Scope::getVersion,
+                    Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(scope -> String.valueOf(scope.getAttributes())))
         .orElse(null);
+  }
+
+  private static int compareSchemaUrls(String left, String right) {
+    Matcher leftMatcher = SCHEMA_VERSION.matcher(left);
+    Matcher rightMatcher = SCHEMA_VERSION.matcher(right);
+    if (!leftMatcher.matches() || !rightMatcher.matches()) {
+      return left.compareTo(right);
+    }
+    for (int i = 1; i <= 3; i++) {
+      int comparison =
+          Integer.compare(
+              Integer.parseInt(leftMatcher.group(i)), Integer.parseInt(rightMatcher.group(i)));
+      if (comparison != 0) {
+        return comparison;
+      }
+    }
+    return 0;
   }
 
   /**

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -107,7 +107,13 @@ public class EmittedScopeParser {
   private static int compareSchemaUrls(String left, String right) {
     Matcher leftMatcher = SCHEMA_VERSION.matcher(left);
     Matcher rightMatcher = SCHEMA_VERSION.matcher(right);
-    if (!leftMatcher.matches() || !rightMatcher.matches()) {
+    boolean leftMatches = leftMatcher.matches();
+    boolean rightMatches = rightMatcher.matches();
+    int formatComparison = Boolean.compare(leftMatches, rightMatches);
+    if (formatComparison != 0) {
+      return formatComparison;
+    }
+    if (!leftMatches) {
       return left.compareTo(right);
     }
     for (int i = 1; i <= 3; i++) {

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParser.java
@@ -19,6 +19,7 @@ import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfoBuilder;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -118,8 +119,7 @@ public class EmittedScopeParser {
     }
     for (int i = 1; i <= 3; i++) {
       int comparison =
-          Integer.compare(
-              Integer.parseInt(leftMatcher.group(i)), Integer.parseInt(rightMatcher.group(i)));
+          new BigInteger(leftMatcher.group(i)).compareTo(new BigInteger(rightMatcher.group(i)));
       if (comparison != 0) {
         return comparison;
       }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -323,7 +323,7 @@ class EmittedScopeParserTest {
   }
 
   @Test
-  void testGetScopePrefersNewestSchemaUrl(@TempDir Path tempDir) throws IOException {
+  void testGetScopePrefersNewestCanonicalSchemaUrl(@TempDir Path tempDir) throws IOException {
     Path instrumentationDir = tempDir.resolve("test-instrumentation");
     Path telemetryDir = instrumentationDir.resolve(".telemetry");
     Files.createDirectories(telemetryDir);
@@ -336,10 +336,13 @@ class EmittedScopeParserTest {
             schemaUrl: https://opentelemetry.io/schemas/1.9.0
           - name: io.opentelemetry.test-lib-1.0
             version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/1.5.invalid
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
             schemaUrl: null
           - name: io.opentelemetry.test-lib-1.0
             version: 2.14.0
-            schemaUrl: https://opentelemetry.io/schemas/1.44.0
+            schemaUrl: https://opentelemetry.io/schemas/1.10.0
         """;
 
     Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
@@ -351,7 +354,7 @@ class EmittedScopeParserTest {
     InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
 
     assertThat(scopeInfo).isNotNull();
-    assertThat(scopeInfo.getSchemaUrl()).isEqualTo("https://opentelemetry.io/schemas/1.44.0");
+    assertThat(scopeInfo.getSchemaUrl()).isEqualTo("https://opentelemetry.io/schemas/1.10.0");
   }
 
   @Test

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -323,6 +323,38 @@ class EmittedScopeParserTest {
   }
 
   @Test
+  void testGetScopePrefersNewestSchemaUrl(@TempDir Path tempDir) throws IOException {
+    Path instrumentationDir = tempDir.resolve("test-instrumentation");
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    String scopeContent =
+        """
+        scopes:
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/1.9.0
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: null
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/1.44.0
+        """;
+
+    Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
+
+    FileManager fileManager = new FileManager(tempDir);
+    InstrumentationModule module =
+        new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
+
+    InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
+
+    assertThat(scopeInfo).isNotNull();
+    assertThat(scopeInfo.getSchemaUrl()).isEqualTo("https://opentelemetry.io/schemas/1.44.0");
+  }
+
+  @Test
   void testGetScopeMultipleScopesOneMatches(@TempDir Path tempDir) throws IOException {
     Path instrumentationDir = tempDir.resolve("test-instrumentation");
     Path telemetryDir = instrumentationDir.resolve(".telemetry");

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedScopeParserTest.java
@@ -358,6 +358,36 @@ class EmittedScopeParserTest {
   }
 
   @Test
+  void testGetScopeHandlesLargeSchemaVersionComponents(@TempDir Path tempDir) throws IOException {
+    Path instrumentationDir = tempDir.resolve("test-instrumentation");
+    Path telemetryDir = instrumentationDir.resolve(".telemetry");
+    Files.createDirectories(telemetryDir);
+
+    String scopeContent =
+        """
+        scopes:
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/1.10.0
+          - name: io.opentelemetry.test-lib-1.0
+            version: 2.14.0
+            schemaUrl: https://opentelemetry.io/schemas/999999999999999999999999.0.0
+        """;
+
+    Files.writeString(telemetryDir.resolve("scope-abc123.yaml"), scopeContent);
+
+    FileManager fileManager = new FileManager(tempDir);
+    InstrumentationModule module =
+        new InstrumentationModule.Builder("test-lib-1.0").srcPath("test-instrumentation").build();
+
+    InstrumentationScopeInfo scopeInfo = EmittedScopeParser.getScope(fileManager, module);
+
+    assertThat(scopeInfo).isNotNull();
+    assertThat(scopeInfo.getSchemaUrl())
+        .isEqualTo("https://opentelemetry.io/schemas/999999999999999999999999.0.0");
+  }
+
+  @Test
   void testGetScopeMultipleScopesOneMatches(@TempDir Path tempDir) throws IOException {
     Path instrumentationDir = tempDir.resolve("test-instrumentation");
     Path telemetryDir = instrumentationDir.resolve(".telemetry");

--- a/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SpanKeyOmittingAttributesExtractor.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-common-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/common/v2_2/internal/SpanKeyOmittingAttributesExtractor.java
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.awslambdaevents.common.v2_2.internal;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import javax.annotation.Nullable;
 
 /**
@@ -18,7 +19,7 @@ import javax.annotation.Nullable;
  * under the legacy semantic conventions so that their pre-v1.43 suppression behavior is preserved.
  */
 final class SpanKeyOmittingAttributesExtractor<REQUEST, RESPONSE>
-    implements AttributesExtractor<REQUEST, RESPONSE> {
+    implements AttributesExtractor<REQUEST, RESPONSE>, SchemaUrlProvider {
 
   private final AttributesExtractor<REQUEST, RESPONSE> delegate;
 
@@ -39,5 +40,13 @@ final class SpanKeyOmittingAttributesExtractor<REQUEST, RESPONSE>
       @Nullable RESPONSE response,
       @Nullable Throwable error) {
     delegate.onEnd(attributes, context, request, response, error);
+  }
+
+  @Nullable
+  @Override
+  public String internalGetSchemaUrl() {
+    return delegate instanceof SchemaUrlProvider
+        ? ((SchemaUrlProvider) delegate).internalGetSchemaUrl()
+        : null;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v1_11/internal/AwsSdkInstrumenterFactory.java
@@ -12,7 +12,9 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSettleExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -142,6 +144,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingReceiveExceptionEventExtractor(builder);
           if (emitStableMessagingSemconv()) {
             builder.addSpanLinksExtractor(
@@ -172,7 +175,8 @@ public final class AwsSdkInstrumenterFactory {
                 MessagingSpanNameExtractor.create(getter, operationType, PROCESS_OPERATION_NAME))
             .addAttributesExtractors(toSqsRequestExtractors(attributesExtractors()))
             .addAttributesExtractor(messagingAttributeExtractor)
-            .addOperationMetrics(MessagingProcessMetrics.get());
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .setSchemaUrl(messagingSchemaUrl(true));
     if (!messagingReceiveInstrumentationEnabled && emitStableMessagingSemconv()) {
       builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     }
@@ -256,6 +260,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingProducerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingSendExceptionEventExtractor(builder);
           if (emitStableMessagingSemconv()) {
             builder.addSpanLinksExtractor(
@@ -281,6 +286,7 @@ public final class AwsSdkInstrumenterFactory {
             MessagingSpanNameExtractor.create(getter, operationType, CREATE_OPERATION_NAME))
         .addAttributesExtractor(
             messagingAttributesExtractor(getter, operationType, CREATE_OPERATION_NAME))
+        .setSchemaUrl(messagingSchemaUrl(true))
         .buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
@@ -298,6 +304,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingSettleExceptionEventExtractor(builder);
         },
         true);
@@ -312,7 +319,8 @@ public final class AwsSdkInstrumenterFactory {
         builder -> {
           builder
               .addAttributesExtractor(new DynamoDbAttributesExtractor())
-              .addOperationMetrics(DbClientMetrics.get());
+              .addOperationMetrics(DbClientMetrics.get())
+              .setSchemaUrl(databaseSchemaUrl());
           setDbClientExceptionEventExtractor(builder);
         },
         true);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/internal/AwsSdkInstrumenterFactory.java
@@ -13,8 +13,10 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSettleExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.rpc.internal.RpcExceptionEventExtractors.setRpcClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -205,6 +207,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingReceiveExceptionEventExtractor(builder);
           if (emitStableMessagingSemconv()) {
             builder.addSpanLinksExtractor(
@@ -234,7 +237,8 @@ public final class AwsSdkInstrumenterFactory {
             .addAttributesExtractors(toSqsRequestExtractors(consumerAttributesExtractors()))
             .addAttributesExtractor(
                 messagingAttributesExtractor(getter, operationType, PROCESS_OPERATION_NAME))
-            .addOperationMetrics(MessagingProcessMetrics.get());
+            .addOperationMetrics(MessagingProcessMetrics.get())
+            .setSchemaUrl(messagingSchemaUrl(true));
     if (!messagingReceiveInstrumentationEnabled && emitStableMessagingSemconv()) {
       builder.addOperationMetrics(MessagingConsumerMetrics.getConsumedMessages());
     }
@@ -325,6 +329,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingProducerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingSendExceptionEventExtractor(builder);
           if (emitStableMessagingSemconv()) {
             builder.addSpanLinksExtractor(
@@ -351,6 +356,7 @@ public final class AwsSdkInstrumenterFactory {
             MessagingSpanNameExtractor.create(getter, operationType, CREATE_OPERATION_NAME))
         .addAttributesExtractor(
             messagingAttributesExtractor(getter, operationType, CREATE_OPERATION_NAME))
+        .setSchemaUrl(messagingSchemaUrl(true))
         .buildInstrumenter(MessagingSpanKindExtractor.create(operationType));
   }
 
@@ -368,6 +374,7 @@ public final class AwsSdkInstrumenterFactory {
         singletonList(messagingAttributeExtractor),
         builder -> {
           builder.addOperationMetrics(MessagingConsumerMetrics.getForOperationType());
+          builder.setSchemaUrl(messagingSchemaUrl(true));
           setMessagingSettleExceptionEventExtractor(builder);
         },
         true);
@@ -382,7 +389,8 @@ public final class AwsSdkInstrumenterFactory {
         builder -> {
           builder
               .addAttributesExtractor(new DynamoDbAttributesExtractor())
-              .addOperationMetrics(DbClientMetrics.get());
+              .addOperationMetrics(DbClientMetrics.get())
+              .setSchemaUrl(databaseSchemaUrl());
           setDbClientExceptionEventExtractor(builder);
         },
         true);
@@ -402,7 +410,8 @@ public final class AwsSdkInstrumenterFactory {
         builder -> {
           builder
               .addAttributesExtractor(SqlClientAttributesExtractor.create(getter))
-              .addOperationMetrics(DbClientMetrics.get());
+              .addOperationMetrics(DbClientMetrics.get())
+              .setSchemaUrl(databaseSchemaUrl());
           setDbClientExceptionEventExtractor(builder);
         },
         true);

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelProcessMetrics.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelProcessMetrics.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.M
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingTelemetrySignal.CONSUMED_MESSAGES;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingTelemetryState.add;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingTelemetryState.enable;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelMessageTelemetry.messageTelemetry;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -47,6 +48,7 @@ class CamelProcessMetrics {
     if (version != null) {
       meterBuilder.setInstrumentationVersion(version);
     }
+    meterBuilder.setSchemaUrl(messagingSchemaUrl(true));
     return meterBuilder.build();
   }
 

--- a/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
+++ b/instrumentation/camel-2.20/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/camel/v2_20/CamelSingletons.java
@@ -12,6 +12,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingTelemetryState.add;
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingTelemetryState.enable;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 import static io.opentelemetry.javaagent.instrumentation.camel.v2_20.CamelMessageTelemetry.messageTelemetry;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -32,6 +33,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanStatusExtractor;
+import io.opentelemetry.instrumentation.api.internal.SchemaUrlProvider;
 import io.opentelemetry.javaagent.instrumentation.camel.v2_20.decorators.DecoratorRegistry;
 import javax.annotation.Nullable;
 import org.apache.camel.Endpoint;
@@ -80,7 +82,8 @@ class CamelSingletons {
         emitStableMessagingSemconv()
             ? MessagingSpanNameExtractor.create(getter, operationType, operationName)
             : legacySpanNameExtractor;
-    InstrumenterBuilder<CamelRequest, Void> builder = instrumenterBuilder(spanNameExtractor);
+    InstrumenterBuilder<CamelRequest, Void> builder =
+        instrumenterBuilder(spanNameExtractor).setSchemaUrl(messagingSchemaUrl(true));
     if (emitStableMessagingSemconv()) {
       AttributesExtractor<CamelRequest, Void> attributesExtractor =
           MessagingAttributesExtractor.create(getter, operationType, operationName);
@@ -181,7 +184,7 @@ class CamelSingletons {
   }
 
   private static class KeylessAttributesExtractor
-      implements AttributesExtractor<CamelRequest, Void> {
+      implements AttributesExtractor<CamelRequest, Void>, SchemaUrlProvider {
 
     private final AttributesExtractor<CamelRequest, Void> delegate;
 
@@ -202,6 +205,14 @@ class CamelSingletons {
         @Nullable Void unused,
         @Nullable Throwable error) {
       delegate.onEnd(attributes, context, request, null, error);
+    }
+
+    @Nullable
+    @Override
+    public String internalGetSchemaUrl() {
+      return delegate instanceof SchemaUrlProvider
+          ? ((SchemaUrlProvider) delegate).internalGetSchemaUrl()
+          : null;
     }
   }
 

--- a/instrumentation/couchbase/couchbase-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_0/CouchbaseEnvironmentInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_0/CouchbaseEnvironmentInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v3_0;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -39,7 +40,11 @@ class CouchbaseEnvironmentInstrumentation implements TypeInstrumentation {
               ? "io.opentelemetry.couchbase-3.0"
               : "io.opentelemetry.javaagent.couchbase-3.0";
       builder.requestTracer(
-          CouchbaseRequestTracer.create(GlobalOpenTelemetry.getTracer(instrumentationName)));
+          CouchbaseRequestTracer.create(
+              GlobalOpenTelemetry.get()
+                  .tracerBuilder(instrumentationName)
+                  .setSchemaUrl(databaseSchemaUrl())
+                  .build()));
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseEnvironmentInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-3.1/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_1/CouchbaseEnvironmentInstrumentation.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.couchbase.v3_1;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
@@ -48,7 +49,11 @@ class CouchbaseEnvironmentInstrumentation implements TypeInstrumentation {
       }
       builder.requestTracer(
           CouchbaseRequestTracer.create(
-              openTelemetry.getTracer(instrumentationName), legacyBridge));
+              openTelemetry
+                  .tracerBuilder(instrumentationName)
+                  .setSchemaUrl(databaseSchemaUrl())
+                  .build(),
+              legacyBridge));
     }
 
     @SuppressWarnings("EffectivelyPrivate")

--- a/instrumentation/couchbase/couchbase-3.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_2/CouchbaseRequestTracer.java
+++ b/instrumentation/couchbase/couchbase-3.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/couchbase/v3_2/CouchbaseRequestTracer.java
@@ -7,6 +7,7 @@ package io.opentelemetry.javaagent.instrumentation.couchbase.v3_2;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableDatabaseSemconv;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_ADDRESS;
 import static io.opentelemetry.semconv.NetworkAttributes.NETWORK_PEER_PORT;
@@ -34,7 +35,10 @@ public final class CouchbaseRequestTracer implements RequestTracer {
   public static RequestTracer create(OpenTelemetry openTelemetry, boolean clientSpans) {
     return new CouchbaseRequestTracer(
         new CouchbaseTracer(
-            openTelemetry.getTracer("com.couchbase.client.jvm"),
+            openTelemetry
+                .tracerBuilder("com.couchbase.client.jvm")
+                .setSchemaUrl(databaseSchemaUrl())
+                .build(),
             true,
             clientSpans ? CLIENT : INTERNAL,
             false,

--- a/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
+++ b/instrumentation/jdbc/library/src/main/java/io/opentelemetry/instrumentation/jdbc/internal/JdbcInstrumenterFactory.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.instrumentation.jdbc.internal;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 import static java.util.Collections.emptyList;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -67,6 +68,7 @@ public final class JdbcInstrumenterFactory {
             openTelemetry, INSTRUMENTATION_NAME, CodeSpanNameExtractor.create(getter))
         .addAttributesExtractor(CodeAttributesExtractor.create(getter))
         .addAttributesExtractor(new DataSourceDbAttributesExtractor())
+        .setSchemaUrl(databaseSchemaUrl())
         .setEnabled(enabled)
         .buildInstrumenter();
   }

--- a/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-4.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v4_0/LettuceSingletons.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v4_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 
 import com.lambdaworks.redis.ReactiveCommandDispatcher;
 import com.lambdaworks.redis.RedisChannelHandler;
@@ -111,6 +112,7 @@ public class LettuceSingletons {
                 ServicePeerAttributesExtractor.create(
                     netAttributesGetter, GlobalOpenTelemetry.get()))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
+            .setSchemaUrl(databaseSchemaUrl())
             .setEnabled(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "lettuce")
                     .get("connection_telemetry")

--- a/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
+++ b/instrumentation/lettuce/lettuce-5.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/lettuce/v5_0/LettuceSingletons.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.javaagent.instrumentation.lettuce.v5_0;
 
 import static io.opentelemetry.instrumentation.api.incubator.semconv.db.internal.DbExceptionEventExtractors.setDbClientExceptionEventExtractor;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
 
 import io.lettuce.core.RedisChannelHandler;
 import io.lettuce.core.RedisURI;
@@ -115,6 +116,7 @@ public class LettuceSingletons {
                 ServicePeerAttributesExtractor.create(
                     connectNetworkAttributesGetter, GlobalOpenTelemetry.get()))
             .addAttributesExtractor(new LettuceConnectAttributesExtractor())
+            .setSchemaUrl(databaseSchemaUrl())
             .setEnabled(
                 DeclarativeConfigUtil.getInstrumentationConfig(GlobalOpenTelemetry.get(), "lettuce")
                     .get("connection_telemetry")

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/main/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactory.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.i
 import static io.opentelemetry.instrumentation.api.incubator.semconv.messaging.internal.MessagingExceptionEventExtractors.setMessagingSendExceptionEventExtractor;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.messagingSchemaUrl;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -110,6 +111,7 @@ class RocketMqInstrumenterFactory {
                 openTelemetry, INSTRUMENTATION_NAME, request -> "multiple_sources receive")
             .addAttributesExtractor(constant(MESSAGING_SYSTEM, "rocketmq"))
             .addAttributesExtractor(constant(MESSAGING_OPERATION, "receive"))
+            .setSchemaUrl(messagingSchemaUrl(false))
             .buildInstrumenter(SpanKindExtractor.alwaysConsumer());
 
     return new RocketMqConsumerInstrumenter(

--- a/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
+++ b/instrumentation/rocketmq/rocketmq-client-4.8/library/src/test/java/io/opentelemetry/instrumentation/rocketmqclient/v4_8/RocketMqInstrumenterFactoryTest.java
@@ -11,16 +11,19 @@ import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emi
 import static io.opentelemetry.instrumentation.api.internal.SemconvStability.emitStableMessagingSemconv;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.ErrorAttributes.ERROR_TYPE;
+import static io.opentelemetry.semconv.SchemaUrls.V1_24_0;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_NAME;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_ROCKETMQ_NAMESPACE;
 import static io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MESSAGING_SYSTEM;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -79,6 +82,38 @@ class RocketMqInstrumenterFactoryTest {
                             equalTo(
                                 MESSAGING_ROCKETMQ_NAMESPACE,
                                 emitStableMessagingSemconv() ? "" : null))));
+  }
+
+  @Test
+  void usesLegacySchemaForBatchReceiveSpan() {
+    assumeFalse(emitStableMessagingSemconv());
+
+    MessageExt firstMessage = new MessageExt();
+    firstMessage.setTopic("topic");
+    firstMessage.putUserProperty("test-header", "first");
+    MessageExt secondMessage = new MessageExt();
+    secondMessage.setTopic("topic");
+    secondMessage.putUserProperty("test-header", "second");
+    RocketMqConsumerInstrumenter instrumenter =
+        RocketMqInstrumenterFactory.createConsumerInstrumenter(
+            testing.getOpenTelemetry(), IncludeExclude.builder().build(), false);
+
+    RocketMqConsumerInstrumenter.ConsumerContext consumerContext =
+        requireNonNull(
+            instrumenter.start(
+                Context.root(),
+                asList(firstMessage, secondMessage),
+                "consumer-group",
+                "namespace"));
+    instrumenter.end(consumerContext, new ConsumeMessageContext());
+
+    testing.waitForTraces(1);
+    assertThat(testing.spans())
+        .filteredOn(span -> span.getName().equals("multiple_sources receive"))
+        .singleElement()
+        .satisfies(
+            span ->
+                assertThat(span.getInstrumentationScopeInfo().getSchemaUrl()).isEqualTo(V1_24_0));
   }
 
   @Test

--- a/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
+++ b/instrumentation/tomcat/tomcat-jdbc-8.5/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/tomcat/jdbc/v8_5/TomcatConnectionPoolMetrics.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.tomcat.jdbc.v8_5;
 
+import static io.opentelemetry.instrumentation.api.internal.SemconvStability.databaseSchemaUrl;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -104,6 +106,7 @@ public class TomcatConnectionPoolMetrics {
     if (version != null) {
       meterBuilder.setInstrumentationVersion(version);
     }
+    meterBuilder.setSchemaUrl(databaseSchemaUrl());
     return meterBuilder.build();
   }
 


### PR DESCRIPTION
Adds mode-aware schema URLs to database, messaging, and RPC spans and metrics, so backends can identify which semantic convention version each scope emits.

- Database uses v1.24.0 in legacy mode and v1.44.0 in stable and duplicate modes.
- Messaging uses v1.24.0 in legacy mode and v1.43.0 in preview and duplicate modes.
- RPC uses v1.37.0 in legacy mode and v1.44.0 in stable and duplicate modes.
- Composite instrumenters use the higher-level component's schema, such as database rather than RPC or HTTP.
- Instrumentation docs group telemetry by instrumentation scope name. When entries for the same scope use different canonical OpenTelemetry schema URLs, the docs keep the URL with the highest semantic version, regardless of input order.

Part of #11939.