### PR TITLE
Restore Develocity cache reads for pull requests

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,10 +76,8 @@ val shouldDisableLocalBuildCache =
   isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 develocity {
-  if (develocityAccessKey.isNotEmpty()) {
-    server = develocityServer
-    projectId = "OpenTelemetry"
-  }
+  server = develocityServer
+  projectId = "OpenTelemetry"
 
   buildScan {
     if (develocityAccessKey.isNotEmpty()) {
@@ -116,9 +114,7 @@ buildCache {
   local {
     isEnabled = !shouldDisableLocalBuildCache
   }
-
   remote(develocity.buildCache) {
-    server = develocityServer
     isPush = isRemoteBuildCachePushEnabled
   }
 }


### PR DESCRIPTION
Configure the Develocity server and OpenTelemetry project for every build so unauthenticated pull request builds address the same remote-cache namespace as `main`.

Pull request builds still receive no access key and `isPush` remains false, so they can read shared cache entries without gaining write access.