### PR TITLE
Capture events in telemetry metadata

### DIFF
--- a/instrumentation-docs/readme.md
+++ b/instrumentation-docs/readme.md
@@ -184,6 +184,15 @@ public class SpringWebInstrumentationModule extends InstrumentationModule
   - List of span kinds the instrumentation module generates, including the attributes and their types.
   - Emitted inline under each telemetry `when` block (spans are not yet part of the definitions catalog).
   - Separate `when` blocks distinguish spans emitted by default vs via configuration options.
+- events (referenced via `event_refs`)
+  - Each telemetry `when` block lists `event_refs`: the ids of event definitions the module emits.
+  - Each id resolves to an entry in the top-level `definitions.events` catalog.
+  - An event is a log record carrying an event name, for example the GenAI message events or the
+    exception events emitted when `otel.semconv.exception.signal.preview=logs` is set.
+  - Each definition records the event `name`, its `severity` (omitted when the instrumentation does
+    not set one) and its attributes.
+  - This is the _generated_ representation, produced automatically from collected telemetry. There is
+    no author-time catalog and no manual authoring path for events.
 
 ### Definitions catalog
 
@@ -207,6 +216,11 @@ definitions:
       data_type: HISTOGRAM
       unit: s
       attributes: [...]
+  events:
+    db.client.operation.exception-1a2b3c4d:  # <event name>-<short content hash>
+      name: db.client.operation.exception
+      severity: WARN
+      attributes: [...]
 libraries:
 - name: java-http-client
   configuration_refs:
@@ -215,6 +229,8 @@ libraries:
   - when: default
     metric_refs:
     - http.client.request.duration-1a2b3c4d
+    event_refs:
+    - db.client.operation.exception-1a2b3c4d
 ```
 
 Configuration ids are the curated ids from the shared registry (see below) for shared options, or the
@@ -370,19 +386,27 @@ name is determined by the instrumentation module name: `io.opentelemetry.{instru
 We will implement gatherers for the schemaUrl and scope attributes when instrumentations start
 implementing them.
 
-### Spans and Metrics
+### Spans, Metrics and Events
 
 In order to identify what telemetry is emitted from instrumentations, we can hook into the
-`InstrumentationTestRunner` class and collect the metrics and spans generated during runs. We can then
-leverage the `afterTestClass()` in the Agent and library test runners to then write this information
-into temporary files. When we analyze the instrumentation modules, we can read these files and
-generate the telemetry section of the instrumentation-list.yaml file.
+`InstrumentationTestRunner` class and collect the metrics, spans and events generated during runs. We
+can then leverage the `afterTestClass()` in the Agent and library test runners to then write this
+information into temporary files. When we analyze the instrumentation modules, we can read these
+files and generate the telemetry section of the instrumentation-list.yaml file.
 
-The data is written into a `.telemetry` directory in the root of each instrumentation module. This
-data will be excluded from git and just generated on demand.
+The data is written into a `.telemetry` directory in the root of each instrumentation module, as
+`metrics-*.yaml`, `spans-*.yaml`, `events-*.yaml` and `scope-*.yaml`. This data will be excluded from
+git and just generated on demand.
 
 Each file has a `when` value along with the list of metrics that indicates whether the telemetry is
 emitted by default or via a configuration option.
+
+Spans and metrics are collected inside the `waitAndAssertTraces` / `waitAndAssertMetrics` assertion
+helpers, so they are only captured when a test asserts on them. Events are instead swept up after
+every test, so they are captured regardless of how the test asserted on them. A log record counts as
+an event when it carries an event name, set either via `LogRecordBuilder.setEventName(...)` or via an
+`event.name` attribute; ordinary log records, such as those produced by the logging library bridges,
+are ignored.
 
 #### Manual Telemetry Documentation
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/DocGeneratorApplication.java
@@ -47,7 +47,7 @@ public class DocGeneratorApplication {
           "# each module references them by id via `metric_refs` and `configuration_refs`.\n");
       writer.write(
           "# For more information see: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/13468\n\n");
-      writer.write("file_format: 0.6\n\n");
+      writer.write("file_format: 0.7\n\n");
       YamlHelper.generateInstrumentationYaml(modules, writer);
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/InstrumentationAnalyzer.java
@@ -8,12 +8,14 @@ package io.opentelemetry.instrumentation.docs;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationMetadata;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
 import io.opentelemetry.instrumentation.docs.internal.TelemetryMerger;
 import io.opentelemetry.instrumentation.docs.parsers.EmittedScopeParser;
+import io.opentelemetry.instrumentation.docs.parsers.EventParser;
 import io.opentelemetry.instrumentation.docs.parsers.GradleParser;
 import io.opentelemetry.instrumentation.docs.parsers.MetricParser;
 import io.opentelemetry.instrumentation.docs.parsers.ModuleParser;
@@ -24,6 +26,7 @@ import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,6 +111,14 @@ class InstrumentationAnalyzer {
     Map<String, List<EmittedMetrics.Metric>> emittedMetrics =
         MetricParser.getMetrics(module, fileManager);
     Map<String, List<EmittedSpans.Span>> emittedSpans = SpanParser.getSpans(module, fileManager);
+
+    // Events are collected from tests only, there is no manual authoring path for them. They still
+    // honor override_telemetry, which means "ignore the auto-generated .telemetry files".
+    Map<String, List<EmittedEvents.Event>> emittedEvents =
+        metadata != null && metadata.getOverrideTelemetry()
+            ? new HashMap<>()
+            : EventParser.getEvents(module, fileManager);
+    module.setEvents(emittedEvents);
 
     if (metadata != null && !metadata.getAdditionalTelemetry().isEmpty()) {
       TelemetryMerger.MergedTelemetryData merged =

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/EmittedEvents.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/EmittedEvents.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.internal;
+
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Representation of events emitted by an instrumentation. Includes context about whether emitted by
+ * default or via a configuration option. This class is internal and is hence not for public use.
+ * Its APIs are unstable and can change at any time.
+ */
+public class EmittedEvents {
+  // Condition in which the telemetry is emitted (ex: default, or configuration option names).
+  private String when;
+
+  @JsonProperty("events_by_scope")
+  private List<EventsByScope> eventsByScope;
+
+  public EmittedEvents() {
+    this.when = "";
+    this.eventsByScope = emptyList();
+  }
+
+  public EmittedEvents(String when, List<EventsByScope> eventsByScope) {
+    this.when = when;
+    this.eventsByScope = eventsByScope;
+  }
+
+  public String getWhen() {
+    return when;
+  }
+
+  public void setWhen(String when) {
+    this.when = when;
+  }
+
+  @JsonProperty("events_by_scope")
+  public List<EventsByScope> getEventsByScope() {
+    return eventsByScope;
+  }
+
+  @JsonProperty("events_by_scope")
+  public void setEventsByScope(List<EventsByScope> events) {
+    this.eventsByScope = events;
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class EventsByScope {
+    private String scope;
+    private List<Event> events;
+
+    public EventsByScope(String scopeName, List<Event> events) {
+      this.scope = scopeName;
+      this.events = events;
+    }
+
+    public EventsByScope() {
+      this.scope = "";
+      this.events = emptyList();
+    }
+
+    public String getScope() {
+      return scope;
+    }
+
+    public void setScope(String scope) {
+      this.scope = scope;
+    }
+
+    public List<Event> getEvents() {
+      return events;
+    }
+
+    public void setEvents(List<Event> events) {
+      this.events = events;
+    }
+  }
+
+  /**
+   * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+   * any time.
+   */
+  public static class Event {
+    private String name;
+
+    @Nullable private String severity;
+
+    private List<TelemetryAttribute> attributes;
+
+    public Event(String name, @Nullable String severity, List<TelemetryAttribute> attributes) {
+      this.name = name;
+      this.severity = severity;
+      this.attributes = attributes;
+    }
+
+    public Event() {
+      this.name = "";
+      this.attributes = new ArrayList<>();
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    @Nullable
+    public String getSeverity() {
+      return severity;
+    }
+
+    public void setSeverity(@Nullable String severity) {
+      this.severity = severity;
+    }
+
+    public List<TelemetryAttribute> getAttributes() {
+      return attributes;
+    }
+
+    public void setAttributes(List<TelemetryAttribute> attributes) {
+      this.attributes = attributes;
+    }
+  }
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/internal/InstrumentationModule.java
@@ -31,6 +31,7 @@ public class InstrumentationModule {
   private InstrumentationScopeInfo scopeInfo;
   private Map<String, List<EmittedMetrics.Metric>> metrics;
   private Map<String, List<EmittedSpans.Span>> spans;
+  private Map<String, List<EmittedEvents.Event>> events;
   private boolean hasStandaloneLibrary;
   private boolean hasJavaAgent;
 
@@ -53,6 +54,7 @@ public class InstrumentationModule {
     this.group = requireNonNullElse(builder.group, builder.instrumentationName);
     this.metrics = requireNonNullElseGet(builder.metrics, HashMap::new);
     this.spans = requireNonNullElseGet(builder.spans, HashMap::new);
+    this.events = requireNonNullElseGet(builder.events, HashMap::new);
     this.hasStandaloneLibrary = builder.hasStandaloneLibrary;
     this.hasJavaAgent = builder.hasJavaAgent;
     this.metadata = builder.metadata;
@@ -118,6 +120,10 @@ public class InstrumentationModule {
     return spans;
   }
 
+  public Map<String, List<EmittedEvents.Event>> getEvents() {
+    return events;
+  }
+
   public void setAgentTargetVersions(Set<String> agentTargetVersions) {
     this.agentTargetVersions = agentTargetVersions;
   }
@@ -150,6 +156,10 @@ public class InstrumentationModule {
     this.spans = spans;
   }
 
+  public void setEvents(Map<String, List<EmittedEvents.Event>> events) {
+    this.events = events;
+  }
+
   /**
    * This class is internal and is hence not for public use. Its APIs are unstable and can change at
    * any time.
@@ -165,6 +175,7 @@ public class InstrumentationModule {
     @Nullable private Set<String> agentTargetVersions;
     @Nullable private Map<String, List<EmittedMetrics.Metric>> metrics;
     @Nullable private Map<String, List<EmittedSpans.Span>> spans;
+    @Nullable private Map<String, List<EmittedEvents.Event>> events;
     private boolean hasStandaloneLibrary;
     private boolean hasJavaAgent;
 
@@ -243,6 +254,12 @@ public class InstrumentationModule {
     @CanIgnoreReturnValue
     public Builder spans(Map<String, List<EmittedSpans.Span>> spans) {
       this.spans = spans;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder events(Map<String, List<EmittedEvents.Event>> events) {
+      this.events = events;
       return this;
     }
 

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedEventParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EmittedEventParser.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import static io.opentelemetry.instrumentation.docs.parsers.TelemetryParser.normalizeWhenCondition;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import io.opentelemetry.instrumentation.docs.utils.YamlHelper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+/**
+ * This class is responsible for parsing events-* files from the `.telemetry` directory of an
+ * instrumentation module and converting them into the {@link EmittedEvents} format.
+ */
+public class EmittedEventParser {
+  private static final Logger logger = Logger.getLogger(EmittedEventParser.class.getName());
+
+  /**
+   * Looks for event files in the .telemetry directory, and combines them into a single map.
+   *
+   * @param instrumentationDirectory the directory to traverse
+   * @return contents of aggregated files
+   */
+  public static Map<String, EmittedEvents> getEventsByScopeFromFiles(
+      Path rootDir, String instrumentationDirectory) throws JsonProcessingException {
+    Map<String, StringBuilder> eventsByScope = new HashMap<>();
+    Path telemetryDir = rootDir.resolve(instrumentationDirectory).resolve(".telemetry");
+
+    if (Files.exists(telemetryDir) && Files.isDirectory(telemetryDir)) {
+      try (Stream<Path> files = Files.list(telemetryDir)) {
+        files
+            .filter(path -> path.getFileName().toString().startsWith("events-"))
+            .forEach(
+                path -> {
+                  String content = FileManager.readFileToString(path);
+                  if (content != null) {
+                    String whenKey = normalizeWhenCondition(content);
+
+                    eventsByScope.putIfAbsent(whenKey, new StringBuilder("events_by_scope:\n"));
+
+                    // Skip the events_by_scope line so we can aggregate into one list
+                    int eventIndex = content.indexOf("events_by_scope:\n");
+                    if (eventIndex != -1) {
+                      String contentAfter =
+                          content.substring(eventIndex + "events_by_scope:\n".length());
+                      eventsByScope.get(whenKey).append(contentAfter);
+                    }
+                  }
+                });
+      } catch (IOException e) {
+        logger.severe(
+            "Error reading event files from " + instrumentationDirectory + ": " + e.getMessage());
+      }
+    }
+
+    return parseEvents(eventsByScope);
+  }
+
+  /**
+   * Takes in a raw string representation of the aggregated EmittedEvents yaml map, separated by the
+   * `when`, indicating the conditions under which the telemetry is emitted. deduplicates by name
+   * and then returns a new map.
+   *
+   * @param input raw string representation of EmittedEvents yaml
+   * @return {@code Map<String, EmittedEvents>} where the key is the `when` condition
+   */
+  private static Map<String, EmittedEvents> parseEvents(Map<String, StringBuilder> input)
+      throws JsonProcessingException {
+    Map<String, EmittedEvents> result = new HashMap<>();
+
+    for (Map.Entry<String, StringBuilder> entry : input.entrySet()) {
+      String when = entry.getKey().strip();
+      StringBuilder content = entry.getValue();
+
+      EmittedEvents events = YamlHelper.emittedEventsParser(content.toString());
+      if (events.getEventsByScope().isEmpty()) {
+        continue;
+      }
+
+      Map<String, Map<String, AggregatedEvent>> eventsByScopeAndName = new HashMap<>();
+
+      for (EmittedEvents.EventsByScope eventsByScopeEntry : events.getEventsByScope()) {
+        Map<String, AggregatedEvent> eventsByName =
+            eventsByScopeAndName.computeIfAbsent(
+                eventsByScopeEntry.getScope(), s -> new HashMap<>());
+
+        for (EmittedEvents.Event event : eventsByScopeEntry.getEvents()) {
+          AggregatedEvent aggregated =
+              eventsByName.computeIfAbsent(event.getName(), n -> new AggregatedEvent());
+          aggregated.severityIfAbsent(event.getSeverity());
+
+          if (event.getAttributes() != null) {
+            for (TelemetryAttribute attr : event.getAttributes()) {
+              aggregated.attributes.add(new TelemetryAttribute(attr.getName(), attr.getType()));
+            }
+          }
+        }
+      }
+
+      result.put(when, getEmittedEvents(eventsByScopeAndName, when));
+    }
+
+    return result;
+  }
+
+  /**
+   * Takes in a map of aggregated events by scope and name, and returns an {@link EmittedEvents}
+   * object with deduplicated events.
+   *
+   * @param eventsByScopeAndName the map of aggregated events by scope and event name
+   * @param when the condition under which the telemetry is emitted
+   * @return an {@link EmittedEvents} object with deduplicated events
+   */
+  private static EmittedEvents getEmittedEvents(
+      Map<String, Map<String, AggregatedEvent>> eventsByScopeAndName, String when) {
+    List<EmittedEvents.EventsByScope> deduplicatedEventsByScope = new ArrayList<>();
+
+    for (Map.Entry<String, Map<String, AggregatedEvent>> scopeEntry :
+        eventsByScopeAndName.entrySet()) {
+      List<EmittedEvents.Event> deduplicatedEvents = new ArrayList<>();
+
+      for (Map.Entry<String, AggregatedEvent> eventEntry : scopeEntry.getValue().entrySet()) {
+        AggregatedEvent aggregated = eventEntry.getValue();
+        deduplicatedEvents.add(
+            new EmittedEvents.Event(
+                eventEntry.getKey(), aggregated.severity, new ArrayList<>(aggregated.attributes)));
+      }
+
+      deduplicatedEventsByScope.add(
+          new EmittedEvents.EventsByScope(scopeEntry.getKey(), deduplicatedEvents));
+    }
+
+    return new EmittedEvents(when, deduplicatedEventsByScope);
+  }
+
+  /** Accumulates the severity and the union of attributes seen for one event name. */
+  private static class AggregatedEvent {
+    @Nullable String severity;
+    final Set<TelemetryAttribute> attributes = new LinkedHashSet<>();
+
+    void severityIfAbsent(@Nullable String severity) {
+      if (this.severity == null) {
+        this.severity = severity;
+      }
+    }
+  }
+
+  private EmittedEventParser() {}
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EventParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/EventParser.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * This class is responsible for parsing event files from the `.telemetry` directory of an
+ * instrumentation module and filtering them by scope.
+ */
+public class EventParser {
+
+  /**
+   * Pull events from the `.telemetry` directory, filter them by scope, and return them keyed by the
+   * `when` condition.
+   *
+   * @param module the instrumentation module to extract events for
+   * @param fileManager the file manager to access the filesystem
+   * @throws JsonProcessingException if there is an error processing the JSON from the event files
+   */
+  public static Map<String, List<EmittedEvents.Event>> getEvents(
+      InstrumentationModule module, FileManager fileManager) throws JsonProcessingException {
+    Map<String, EmittedEvents> events =
+        EmittedEventParser.getEventsByScopeFromFiles(fileManager.rootDir(), module.getSrcPath());
+
+    if (events.isEmpty()) {
+      return new HashMap<>();
+    }
+
+    return filterEventsByScope(events, module.getScopeInfo().getName());
+  }
+
+  /**
+   * Filters events by scope and aggregates attributes for each event name.
+   *
+   * @param eventsByScope the map of events by scope
+   * @param scopeName the name of the scope to filter events for
+   * @return a map of filtered events by `when`
+   */
+  private static Map<String, List<EmittedEvents.Event>> filterEventsByScope(
+      Map<String, EmittedEvents> eventsByScope, String scopeName) {
+
+    Map<String, List<EmittedEvents.Event>> result = new HashMap<>();
+
+    for (Map.Entry<String, EmittedEvents> entry : eventsByScope.entrySet()) {
+      EmittedEvents events = entry.getValue();
+      if (events == null || events.getEventsByScope() == null) {
+        continue;
+      }
+
+      Map<String, AggregatedEvent> eventsByName = new HashMap<>();
+      for (EmittedEvents.EventsByScope scopeEvents : events.getEventsByScope()) {
+        if (!TelemetryParser.scopeIsValid(scopeEvents.getScope(), scopeName)) {
+          continue;
+        }
+        for (EmittedEvents.Event event : scopeEvents.getEvents()) {
+          AggregatedEvent aggregated =
+              eventsByName.computeIfAbsent(event.getName(), n -> new AggregatedEvent());
+          aggregated.severityIfAbsent(event.getSeverity());
+          addEventAttributes(event, aggregated.attributes);
+        }
+      }
+
+      if (eventsByName.isEmpty()) {
+        continue;
+      }
+
+      List<EmittedEvents.Event> filteredEvents = new ArrayList<>();
+      for (Map.Entry<String, AggregatedEvent> eventEntry : eventsByName.entrySet()) {
+        AggregatedEvent aggregated = eventEntry.getValue();
+        filteredEvents.add(
+            new EmittedEvents.Event(
+                eventEntry.getKey(), aggregated.severity, new ArrayList<>(aggregated.attributes)));
+      }
+      result.put(events.getWhen(), filteredEvents);
+    }
+
+    return result;
+  }
+
+  private static void addEventAttributes(
+      EmittedEvents.Event event, Set<TelemetryAttribute> attributes) {
+    if (event.getAttributes() == null) {
+      return;
+    }
+
+    for (TelemetryAttribute attr : event.getAttributes()) {
+      if (!TelemetryParser.isExcludedAttribute(attr.getName())) {
+        attributes.add(new TelemetryAttribute(attr.getName(), attr.getType()));
+      }
+    }
+  }
+
+  /** Accumulates the severity and the union of attributes seen for one event name. */
+  private static class AggregatedEvent {
+    @Nullable String severity;
+    final Set<TelemetryAttribute> attributes = new HashSet<>();
+
+    void severityIfAbsent(@Nullable String severity) {
+      if (this.severity == null) {
+        this.severity = severity;
+      }
+    }
+  }
+
+  private EventParser() {}
+}

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/SpanParser.java
@@ -23,19 +23,6 @@ import java.util.Set;
  */
 public class SpanParser {
 
-  // We want to ignore test related attributes
-  private static final List<String> EXCLUDED_ATTRIBUTES =
-      List.of(
-          "asdf",
-          "x-test-",
-          "test-parameter",
-          "test-baggage-",
-          "test_message",
-          "Test_Message",
-          "Test-Message",
-          "some-client-key",
-          "some-server-key");
-
   /**
    * Pull spans from the `.telemetry` directory, filter them by scope, and set them in the module.
    *
@@ -120,8 +107,7 @@ public class SpanParser {
       }
 
       for (TelemetryAttribute attr : span.getAttributes()) {
-        boolean excluded = EXCLUDED_ATTRIBUTES.stream().anyMatch(ex -> attr.getName().contains(ex));
-        if (!excluded) {
+        if (!TelemetryParser.isExcludedAttribute(attr.getName())) {
           attributes.add(new TelemetryAttribute(attr.getName(), attr.getType()));
         }
       }

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/parsers/TelemetryParser.java
@@ -9,10 +9,25 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Map.entry;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 class TelemetryParser {
+
+  // Attributes that only exist because of how the tests are written, and should not be documented
+  // as telemetry the instrumentation emits.
+  private static final List<String> EXCLUDED_ATTRIBUTES =
+      List.of(
+          "asdf",
+          "x-test-",
+          "test-parameter",
+          "test-baggage-",
+          "test_message",
+          "Test_Message",
+          "Test-Message",
+          "some-client-key",
+          "some-server-key");
 
   // Key is the scope of the module being analyzed, value is a set of additional allowed scopes.
   private static final Map<String, Set<String>> scopeAllowList;
@@ -75,6 +90,17 @@ class TelemetryParser {
   static boolean scopeIsValid(String telemetryScope, String moduleScope) {
     return telemetryScope.equals(moduleScope)
         || scopeAllowList.getOrDefault(moduleScope, emptySet()).contains(telemetryScope);
+  }
+
+  /**
+   * Checks whether the given attribute name is test scaffolding rather than real instrumentation
+   * telemetry, and should therefore be left out of the generated documentation.
+   *
+   * @param attributeName the name of the attribute
+   * @return true if the attribute should be excluded, false otherwise
+   */
+  static boolean isExcludedAttribute(String attributeName) {
+    return EXCLUDED_ATTRIBUTES.stream().anyMatch(attributeName::contains);
   }
 
   /**

--- a/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
+++ b/instrumentation-docs/src/main/java/io/opentelemetry/instrumentation/docs/utils/YamlHelper.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
 import io.opentelemetry.instrumentation.docs.internal.DeclarativeSchema;
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedScope;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
@@ -166,6 +167,7 @@ public class YamlHelper {
     // Get telemetry grouping lists
     Set<String> telemetryGroups = new TreeSet<>(module.getMetrics().keySet());
     telemetryGroups.addAll(module.getSpans().keySet());
+    telemetryGroups.addAll(module.getEvents().keySet());
 
     if (!telemetryGroups.isEmpty()) {
       List<Map<String, Object>> telemetryList = new ArrayList<>();
@@ -195,7 +197,15 @@ public class YamlHelper {
           telemetryEntry.put("spans", spanList);
         }
 
-        if (!spanList.isEmpty() || !metricRefs.isEmpty()) {
+        Set<String> eventRefs = new TreeSet<>();
+        for (EmittedEvents.Event event : module.getEvents().getOrDefault(group, emptyList())) {
+          eventRefs.add(catalog.eventId(event));
+        }
+        if (!eventRefs.isEmpty()) {
+          telemetryEntry.put("event_refs", new ArrayList<>(eventRefs));
+        }
+
+        if (!spanList.isEmpty() || !metricRefs.isEmpty() || !eventRefs.isEmpty()) {
           telemetryList.add(telemetryEntry);
         }
       }
@@ -350,6 +360,16 @@ public class YamlHelper {
     return innerMetricMap;
   }
 
+  private static Map<String, Object> getEventMap(EmittedEvents.Event event) {
+    Map<String, Object> innerEventMap = new LinkedHashMap<>();
+    innerEventMap.put("name", event.getName());
+    if (event.getSeverity() != null) {
+      innerEventMap.put("severity", event.getSeverity());
+    }
+    innerEventMap.put("attributes", getSortedAttributeMaps(event.getAttributes()));
+    return innerEventMap;
+  }
+
   private static Map<String, Object> getSpanMap(EmittedSpans.Span span) {
     Map<String, Object> innerMetricMap = new LinkedHashMap<>();
     innerMetricMap.put("span_kind", span.getSpanKind());
@@ -377,6 +397,10 @@ public class YamlHelper {
 
   public static EmittedSpans emittedSpansParser(String input) throws JsonProcessingException {
     return mapper.readValue(input, EmittedSpans.class);
+  }
+
+  public static EmittedEvents emittedEventsParser(String input) throws JsonProcessingException {
+    return mapper.readValue(input, EmittedEvents.class);
   }
 
   /**
@@ -407,6 +431,18 @@ public class YamlHelper {
             String id = metric.getName() + "-" + shortHash(canonical);
             catalog.metricCanonicalToId.put(canonical, id);
             catalog.metricDefs.put(id, def);
+          }
+        }
+      }
+
+      for (List<EmittedEvents.Event> events : module.getEvents().values()) {
+        for (EmittedEvents.Event event : events) {
+          Map<String, Object> def = getEventMap(event);
+          String canonical = canonicalize(def);
+          if (!catalog.eventCanonicalToId.containsKey(canonical)) {
+            String id = event.getName() + "-" + shortHash(canonical);
+            catalog.eventCanonicalToId.put(canonical, id);
+            catalog.eventDefs.put(id, def);
           }
         }
       }
@@ -508,20 +544,28 @@ public class YamlHelper {
   }
 
   /**
-   * Holds the shared metric and configuration definitions and the lookups needed to resolve a
-   * module's metric/config back to its catalog id. This class is internal and is hence not for
-   * public use.
+   * Holds the shared metric, event and configuration definitions and the lookups needed to resolve
+   * a module's metric/event/config back to its catalog id. This class is internal and is hence not
+   * for public use.
    */
   private static final class DefinitionCatalog {
     final Map<String, Map<String, Object>> metricDefs = new TreeMap<>();
+    final Map<String, Map<String, Object>> eventDefs = new TreeMap<>();
     final Map<String, Map<String, Object>> configDefs = new TreeMap<>();
     final Map<String, String> metricCanonicalToId = new HashMap<>();
+    final Map<String, String> eventCanonicalToId = new HashMap<>();
     final Map<String, String> configCanonicalToId = new HashMap<>();
 
     String metricId(EmittedMetrics.Metric metric) {
       return requireNonNull(
           metricCanonicalToId.get(canonicalize(getMetricsMap(metric))),
           "metric not present in definitions catalog");
+    }
+
+    String eventId(EmittedEvents.Event event) {
+      return requireNonNull(
+          eventCanonicalToId.get(canonicalize(getEventMap(event))),
+          "event not present in definitions catalog");
     }
 
     String configId(ConfigurationOption configuration) {
@@ -541,6 +585,9 @@ public class YamlHelper {
       }
       if (!metricDefs.isEmpty()) {
         definitions.put("metrics", metricDefs);
+      }
+      if (!eventDefs.isEmpty()) {
+        definitions.put("events", eventDefs);
       }
       return definitions;
     }

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedEventParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EmittedEventParserTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("NullAway")
+class EmittedEventParserTest {
+
+  @Test
+  void getEventsFromFilesCombinesFilesCorrectly(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    String file1Content =
+        """
+        when: default
+        events_by_scope:
+          - scope: io.opentelemetry.openai-java-1.1
+            events:
+              - name: gen_ai.user.message
+                attributes:
+                  - name: gen_ai.provider.name
+                    type: STRING
+      """;
+
+    String file2Content =
+        """
+        when: default
+        events_by_scope:
+          - scope: io.opentelemetry.openai-java-1.1
+            events:
+              - name: gen_ai.choice
+                attributes:
+                  - name: gen_ai.provider.name
+                    type: STRING
+              - name: gen_ai.user.message
+                attributes:
+                  - name: gen_ai.system
+                    type: STRING
+      """;
+
+    Files.writeString(telemetryDir.resolve("events-1.yaml"), file1Content);
+    Files.writeString(telemetryDir.resolve("events-2.yaml"), file2Content);
+    // duplicate contents to test deduplication
+    Files.writeString(telemetryDir.resolve("events-3.yaml"), file2Content);
+
+    Map<String, EmittedEvents> result = EmittedEventParser.getEventsByScopeFromFiles(tempDir, "");
+
+    EmittedEvents events = result.get("default");
+    assertThat(events.getEventsByScope()).hasSize(1);
+
+    List<EmittedEvents.Event> openAiEvents = events.getEventsByScope().get(0).getEvents();
+    // deduplicated by name across the three files
+    assertThat(openAiEvents)
+        .extracting(EmittedEvents.Event::getName)
+        .containsExactlyInAnyOrder("gen_ai.user.message", "gen_ai.choice");
+
+    EmittedEvents.Event userMessage =
+        openAiEvents.stream()
+            .filter(event -> event.getName().equals("gen_ai.user.message"))
+            .findFirst()
+            .orElse(null);
+    // attributes are unioned across files
+    assertThat(userMessage.getAttributes())
+        .extracting(TelemetryAttribute::getName)
+        .containsExactlyInAnyOrder("gen_ai.provider.name", "gen_ai.system");
+  }
+
+  @Test
+  void getEventsFromFilesSeparatesWhenConditionsAndKeepsSeverity(@TempDir Path tempDir)
+      throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    String defaultContent =
+        """
+        when: default
+        events_by_scope:
+          - scope: io.opentelemetry.jdbc
+            events:
+              - name: package.info
+                attributes:
+      """;
+
+    String configuredContent =
+        """
+        when: otel.semconv.exception.signal.preview=logs
+        events_by_scope:
+          - scope: io.opentelemetry.jdbc
+            events:
+              - name: db.client.operation.exception
+                severity: WARN
+                attributes:
+                  - name: exception.type
+                    type: STRING
+      """;
+
+    Files.writeString(telemetryDir.resolve("events-1.yaml"), defaultContent);
+    Files.writeString(telemetryDir.resolve("events-2.yaml"), configuredContent);
+
+    Map<String, EmittedEvents> result = EmittedEventParser.getEventsByScopeFromFiles(tempDir, "");
+
+    assertThat(result.keySet())
+        .containsExactlyInAnyOrder("default", "otel.semconv.exception.signal.preview=logs");
+
+    EmittedEvents.Event exceptionEvent =
+        result
+            .get("otel.semconv.exception.signal.preview=logs")
+            .getEventsByScope()
+            .get(0)
+            .getEvents()
+            .get(0);
+    assertThat(exceptionEvent.getName()).isEqualTo("db.client.operation.exception");
+    assertThat(exceptionEvent.getSeverity()).isEqualTo("WARN");
+
+    EmittedEvents.Event packageInfo =
+        result.get("default").getEventsByScope().get(0).getEvents().get(0);
+    assertThat(packageInfo.getName()).isEqualTo("package.info");
+    assertThat(packageInfo.getSeverity()).isNull();
+  }
+
+  @Test
+  void getEventsFromFilesHandlesNonexistentDirectory(@TempDir Path tempDir) throws IOException {
+    Map<String, EmittedEvents> result =
+        EmittedEventParser.getEventsByScopeFromFiles(tempDir, "nonexistent");
+    assertThat(result).isEmpty();
+  }
+}

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EventParserTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/parsers/EventParserTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.docs.parsers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
+import io.opentelemetry.instrumentation.docs.internal.InstrumentationModule;
+import io.opentelemetry.instrumentation.docs.internal.TelemetryAttribute;
+import io.opentelemetry.instrumentation.docs.utils.FileManager;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@SuppressWarnings("NullAway")
+class EventParserTest {
+
+  private static InstrumentationModule module(String instrumentationName, String scopeName) {
+    InstrumentationModule module =
+        new InstrumentationModule.Builder(instrumentationName).srcPath("").build();
+    module.setScopeInfo(InstrumentationScopeInfo.create(scopeName));
+    return module;
+  }
+
+  @Test
+  void getEventsFiltersOutOtherScopes(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    Files.writeString(
+        telemetryDir.resolve("events-1.yaml"),
+        """
+        when: default
+        events_by_scope:
+          - scope: io.opentelemetry.openai-java-1.1
+            events:
+              - name: gen_ai.choice
+                attributes:
+                  - name: gen_ai.provider.name
+                    type: STRING
+          - scope: io.opentelemetry.sdk.metrics
+            events:
+              - name: some.sdk.event
+                attributes:
+          - scope: test
+            events:
+              - name: test.event
+                attributes:
+      """);
+
+    Map<String, List<EmittedEvents.Event>> result =
+        EventParser.getEvents(
+            module("openai-java-1.1", "io.opentelemetry.openai-java-1.1"),
+            new FileManager(tempDir));
+
+    assertThat(result.get("default"))
+        .extracting(EmittedEvents.Event::getName)
+        .containsExactly("gen_ai.choice");
+  }
+
+  @Test
+  void getEventsExcludesTestAttributesAndKeepsSeverity(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    Files.writeString(
+        telemetryDir.resolve("events-1.yaml"),
+        """
+        when: otel.semconv.exception.signal.preview=logs
+        events_by_scope:
+          - scope: io.opentelemetry.grpc-1.6
+            events:
+              - name: rpc.client.operation.exception
+                severity: WARN
+                attributes:
+                  - name: exception.type
+                    type: STRING
+                  - name: test-baggage-key-1
+                    type: STRING
+                  - name: x-test-request
+                    type: STRING_ARRAY
+      """);
+
+    Map<String, List<EmittedEvents.Event>> result =
+        EventParser.getEvents(
+            module("grpc-1.6", "io.opentelemetry.grpc-1.6"), new FileManager(tempDir));
+
+    List<EmittedEvents.Event> events = result.get("otel.semconv.exception.signal.preview=logs");
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).getSeverity()).isEqualTo("WARN");
+    assertThat(events.get(0).getAttributes())
+        .extracting(TelemetryAttribute::getName)
+        .containsExactly("exception.type");
+  }
+
+  @Test
+  void getEventsIncludesAllowListedScopes(@TempDir Path tempDir) throws IOException {
+    Path telemetryDir = Files.createDirectories(tempDir.resolve(".telemetry"));
+
+    // armeria-grpc emits through the grpc-1.6 instrumenter, which is allow-listed for it
+    Files.writeString(
+        telemetryDir.resolve("events-1.yaml"),
+        """
+        when: default
+        events_by_scope:
+          - scope: io.opentelemetry.grpc-1.6
+            events:
+              - name: rpc.client.operation.exception
+                severity: WARN
+                attributes:
+                  - name: exception.type
+                    type: STRING
+      """);
+
+    Map<String, List<EmittedEvents.Event>> result =
+        EventParser.getEvents(
+            module("armeria-grpc-1.14", "io.opentelemetry.armeria-grpc-1.14"),
+            new FileManager(tempDir));
+
+    assertThat(result.get("default"))
+        .extracting(EmittedEvents.Event::getName)
+        .containsExactly("rpc.client.operation.exception");
+  }
+
+  @Test
+  void getEventsReturnsEmptyWhenNoEventFiles(@TempDir Path tempDir) throws IOException {
+    Map<String, List<EmittedEvents.Event>> result =
+        EventParser.getEvents(
+            module("openai-java-1.1", "io.opentelemetry.openai-java-1.1"),
+            new FileManager(tempDir));
+    assertThat(result).isEmpty();
+  }
+}

--- a/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
+++ b/instrumentation-docs/src/test/java/io/opentelemetry/instrumentation/docs/utils/YamlHelperTest.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationOption;
 import io.opentelemetry.instrumentation.docs.internal.ConfigurationType;
+import io.opentelemetry.instrumentation.docs.internal.EmittedEvents;
 import io.opentelemetry.instrumentation.docs.internal.EmittedMetrics;
 import io.opentelemetry.instrumentation.docs.internal.EmittedSpans;
 import io.opentelemetry.instrumentation.docs.internal.InstrumentationClassification;
@@ -559,6 +560,114 @@ class YamlHelperTest {
         """;
 
     assertThat(result).isEqualTo(expectedYaml);
+  }
+
+  @Test
+  void testEventParsing() throws Exception {
+    List<InstrumentationModule> modules = new ArrayList<>();
+
+    EmittedEvents.Event exceptionEvent =
+        new EmittedEvents.Event(
+            "db.client.operation.exception",
+            "WARN",
+            List.of(
+                new TelemetryAttribute("db.system.name", "STRING"),
+                new TelemetryAttribute("exception.type", "STRING")));
+
+    // an event with no severity, to confirm the key is omitted rather than emitted as null
+    EmittedEvents.Event packageInfo =
+        new EmittedEvents.Event(
+            "package.info", null, List.of(new TelemetryAttribute("package.name", "STRING")));
+
+    modules.add(
+        new InstrumentationModule.Builder()
+            .srcPath("instrumentation/mylib/mylib-core-2.3")
+            .instrumentationName("mylib-2.3")
+            .namespace("mylib")
+            .hasStandaloneLibrary(true)
+            .group("mylib")
+            .events(Map.of("default", List.of(exceptionEvent, packageInfo)))
+            .build());
+
+    String result = generateInstrumentationYaml(modules);
+    String expectedYaml =
+        """
+        definitions:
+          events:
+            db.client.operation.exception-e1a80bbd:
+              name: db.client.operation.exception
+              severity: WARN
+              attributes:
+              - name: db.system.name
+                type: STRING
+              - name: exception.type
+                type: STRING
+            package.info-ba4a9905:
+              name: package.info
+              attributes:
+              - name: package.name
+                type: STRING
+        libraries:
+        - name: mylib-2.3
+          source_path: instrumentation/mylib/mylib-core-2.3
+          scope:
+            name: io.opentelemetry.mylib-2.3
+          has_standalone_library: true
+          telemetry:
+          - when: default
+            event_refs:
+            - db.client.operation.exception-e1a80bbd
+            - package.info-ba4a9905
+        """;
+
+    assertThat(result).isEqualTo(expectedYaml);
+  }
+
+  @Test
+  void testEventOnlyTelemetryGroupIsEmitted() throws Exception {
+    // A `when` group carrying only events must not be suppressed.
+    EmittedEvents.Event event = new EmittedEvents.Event("gen_ai.choice", null, emptyList());
+
+    List<InstrumentationModule> modules =
+        List.of(
+            new InstrumentationModule.Builder("mylib-1.0")
+                .srcPath("instrumentation/mylib-1.0")
+                .events(Map.of("otel.semconv.exception.signal.preview=logs", List.of(event)))
+                .build());
+
+    String result = generateInstrumentationYaml(modules);
+
+    assertThat(result).contains("- when: otel.semconv.exception.signal.preview=logs");
+    assertThat(result).contains("event_refs:");
+  }
+
+  @Test
+  void testSharedEventDefinitionIsDeduplicatedAcrossModules() throws Exception {
+    // The exception events are emitted identically by many modules; catalog them once.
+    EmittedEvents.Event event =
+        new EmittedEvents.Event(
+            "exception", "WARN", List.of(new TelemetryAttribute("exception.type", "STRING")));
+
+    List<InstrumentationModule> modules = new ArrayList<>();
+    for (String name : List.of("alpha-1.0", "beta-1.0")) {
+      modules.add(
+          new InstrumentationModule.Builder(name)
+              .srcPath("instrumentation/" + name)
+              .events(Map.of("default", List.of(event)))
+              .build());
+    }
+
+    String result = generateInstrumentationYaml(modules);
+
+    long definitionCount =
+        result
+            .lines()
+            .filter(l -> l.trim().startsWith("exception-") && l.trim().endsWith(":"))
+            .count();
+    long refCount = result.lines().filter(l -> l.trim().startsWith("- exception-")).count();
+
+    assertThat(definitionCount).isEqualTo(1);
+    assertThat(refCount).isEqualTo(2);
   }
 
   @Test

--- a/instrumentation/runtime-telemetry/library/src/testJava17/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrExtension.java
+++ b/instrumentation/runtime-telemetry/library/src/testJava17/java/io/opentelemetry/instrumentation/runtimetelemetry/JfrExtension.java
@@ -90,7 +90,7 @@ class JfrExtension implements BeforeEachCallback, AfterEachCallback {
       String path = new File("").getAbsolutePath();
 
       MetaDataCollector.writeTelemetryToFiles(
-          path, metricsByScope, emptyMap(), instrumentationScopes);
+          path, metricsByScope, emptyMap(), emptyMap(), instrumentationScopes);
     }
   }
 

--- a/smoke-tests/src/main/java/io/opentelemetry/smoketest/SmokeTestRunner.java
+++ b/smoke-tests/src/main/java/io/opentelemetry/smoketest/SmokeTestRunner.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.smoketest;
 
+import static java.util.Collections.emptyMap;
+
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.testing.InstrumentationTestRunner;
 import io.opentelemetry.instrumentation.testing.internal.MetaDataCollector;
@@ -48,7 +50,7 @@ public class SmokeTestRunner extends InstrumentationTestRunner {
       String path = new File("").getAbsolutePath();
 
       MetaDataCollector.writeTelemetryToFiles(
-          path, metricsByScope, tracesByScope, instrumentationScopes);
+          path, metricsByScope, tracesByScope, emptyMap(), instrumentationScopes);
     }
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/AgentTestRunner.java
@@ -74,7 +74,7 @@ public class AgentTestRunner extends InstrumentationTestRunner {
       String path = new File("").getAbsolutePath();
 
       MetaDataCollector.writeTelemetryToFiles(
-          path, metricsByScope, tracesByScope, instrumentationScopes);
+          path, metricsByScope, tracesByScope, eventsByScope, instrumentationScopes);
     }
 
     // additional library ignores are ignored during tests, because they can make it really

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/InstrumentationTestRunner.java
@@ -15,7 +15,9 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributeType;
 import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
+import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.testing.internal.CollectedEvent;
 import io.opentelemetry.instrumentation.testing.util.TelemetryDataUtil;
 import io.opentelemetry.instrumentation.testing.util.ThrowingRunnable;
 import io.opentelemetry.instrumentation.testing.util.ThrowingSupplier;
@@ -54,6 +56,10 @@ import org.awaitility.core.ConditionTimeoutException;
  */
 public abstract class InstrumentationTestRunner {
 
+  private static final String EVENT_NAME_ATTRIBUTE_KEY = "event.name";
+  private static final AttributeKey<String> EVENT_NAME_ATTRIBUTE =
+      AttributeKey.stringKey(EVENT_NAME_ATTRIBUTE_KEY);
+
   private final OpenTelemetry openTelemetry;
   // Lazy initialized so that test runners can load without triggering Instrumenter construction
   // in the OpenTelemetry API bridging tests where some of the newer OpenTelemetry APIs used by
@@ -69,6 +75,13 @@ public abstract class InstrumentationTestRunner {
   protected Map<
           InstrumentationScopeInfo, Map<SpanKind, Map<InternalAttributeKeyImpl<?>, AttributeType>>>
       tracesByScope = new HashMap<>();
+
+  /**
+   * Stores events by scope, where each scope contains a map of event names to the accumulated shape
+   * of that event. This is used to collect metadata about the events emitted during tests.
+   */
+  protected Map<InstrumentationScopeInfo, Map<String, CollectedEvent>> eventsByScope =
+      new HashMap<>();
 
   protected InstrumentationTestRunner(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
@@ -278,6 +291,70 @@ public abstract class InstrumentationTestRunner {
         }
       }
     }
+  }
+
+  /**
+   * Collects the events emitted so far, if telemetry metadata collection is enabled. Called after
+   * every test, so that events are captured whether or not the test asserted on them.
+   */
+  public void collectEmittedEventsIfEnabled() {
+    if (Boolean.getBoolean("collectMetadata")) {
+      collectEmittedEvents(getExportedLogRecords());
+    }
+  }
+
+  private void collectEmittedEvents(List<LogRecordData> logRecords) {
+    for (LogRecordData logRecord : logRecords) {
+      String eventName = eventName(logRecord);
+      if (eventName == null) {
+        // Not an event, just an ordinary log record (for example from a logging library bridge).
+        continue;
+      }
+
+      Map<String, CollectedEvent> scopeMap =
+          this.eventsByScope.computeIfAbsent(
+              logRecord.getInstrumentationScopeInfo(), s -> new HashMap<>());
+      CollectedEvent event = scopeMap.computeIfAbsent(eventName, e -> new CollectedEvent());
+
+      Severity severity = logRecord.getSeverity();
+      if (severity != null && severity != Severity.UNDEFINED_SEVERITY_NUMBER) {
+        event.setSeverityIfAbsent(severity.name());
+      }
+
+      for (AttributeKey<?> key : logRecord.getAttributes().asMap().keySet()) {
+        if (!(key instanceof InternalAttributeKeyImpl)) {
+          // We only collect internal attributes, so skip any non-internal attributes.
+          continue;
+        }
+        if (EVENT_NAME_ATTRIBUTE_KEY.equals(key.getKey())) {
+          // This attribute carries the event's identity, it is not one of its attributes.
+          continue;
+        }
+        event.addAttributeKey((InternalAttributeKeyImpl<?>) key);
+      }
+
+      InstrumentationScopeInfo scopeInfo = logRecord.getInstrumentationScopeInfo();
+      if (!scopeInfo.getName().equals("test")) {
+        instrumentationScopes.add(scopeInfo);
+      }
+    }
+  }
+
+  /**
+   * Returns the name of the event the given log record represents, or {@code null} if it is not an
+   * event.
+   *
+   * <p>Instrumentation names events in one of two ways: newer code calls {@code
+   * LogRecordBuilder.setEventName(String)}, while older code sets an {@code event.name} attribute.
+   * Both are recognized here.
+   */
+  @Nullable
+  private static String eventName(LogRecordData logRecord) {
+    String eventName = logRecord.getEventName();
+    if (eventName == null || eventName.isEmpty()) {
+      eventName = logRecord.getAttributes().get(EVENT_NAME_ATTRIBUTE);
+    }
+    return eventName == null || eventName.isEmpty() ? null : eventName;
   }
 
   public List<LogRecordData> waitForLogRecords(int numberOfLogRecords) {

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/LibraryTestRunner.java
@@ -132,7 +132,7 @@ public class LibraryTestRunner extends InstrumentationTestRunner {
       String path = new File("").getAbsolutePath();
 
       MetaDataCollector.writeTelemetryToFiles(
-          path, metricsByScope, tracesByScope, instrumentationScopes);
+          path, metricsByScope, tracesByScope, eventsByScope, instrumentationScopes);
     }
   }
 

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/CollectedEvent.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/CollectedEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.testing.internal;
+
+import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Accumulates the documented shape of a single event (a log record carrying an event name) across
+ * all the times it was emitted during a test class: its severity and the union of its attributes.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public final class CollectedEvent {
+
+  @Nullable private String severity;
+  private final Set<InternalAttributeKeyImpl<?>> attributeKeys = new LinkedHashSet<>();
+
+  /**
+   * Records the severity of an emission. The first non-null severity seen wins; severity is fixed
+   * per emission site, so later emissions cannot disagree in practice.
+   */
+  public void setSeverityIfAbsent(String severity) {
+    if (this.severity == null) {
+      this.severity = severity;
+    }
+  }
+
+  @Nullable
+  public String getSeverity() {
+    return severity;
+  }
+
+  public void addAttributeKey(InternalAttributeKeyImpl<?> key) {
+    attributeKeys.add(key);
+  }
+
+  /** Returns the union of the attribute keys seen on this event, each carrying its own type. */
+  public Set<InternalAttributeKeyImpl<?>> getAttributeKeys() {
+    return attributeKeys;
+  }
+}

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/MetaDataCollector.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/internal/MetaDataCollector.java
@@ -10,6 +10,7 @@ import io.opentelemetry.api.internal.InternalAttributeKeyImpl;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.testing.internal.jackson.annotation.JsonInclude;
 import io.opentelemetry.testing.internal.jackson.annotation.JsonProperty;
 import io.opentelemetry.testing.internal.jackson.dataformat.yaml.YAMLFactory;
 import io.opentelemetry.testing.internal.jackson.dataformat.yaml.YAMLGenerator;
@@ -58,12 +59,14 @@ public class MetaDataCollector {
       Map<InstrumentationScopeInfo, Map<String, MetricData>> metricsByScope,
       Map<InstrumentationScopeInfo, Map<SpanKind, Map<InternalAttributeKeyImpl<?>, AttributeType>>>
           spansByScopeAndKind,
+      Map<InstrumentationScopeInfo, Map<String, CollectedEvent>> eventsByScope,
       Set<InstrumentationScopeInfo> instrumentationScopes)
       throws IOException {
 
     String moduleRoot = extractInstrumentationPath(path);
     writeMetricData(moduleRoot, metricsByScope);
     writeSpanData(moduleRoot, spansByScopeAndKind);
+    writeEventData(moduleRoot, eventsByScope);
     writeScopeData(moduleRoot, instrumentationScopes);
   }
 
@@ -143,6 +146,56 @@ public class MetaDataCollector {
     }
 
     YAML.writeValue(spansPath.toFile(), spanData);
+  }
+
+  private static void writeEventData(
+      String instrumentationPath,
+      Map<InstrumentationScopeInfo, Map<String, CollectedEvent>> eventsByScope)
+      throws IOException {
+
+    if (eventsByScope.isEmpty()) {
+      return;
+    }
+
+    Path eventsPath =
+        Paths.get(instrumentationPath, TMP_DIR, "events-" + UUID.randomUUID() + ".yaml");
+
+    String config = System.getProperty("metadataConfig");
+    String when = (config != null && !config.isEmpty()) ? config : "default";
+
+    EventsData eventsData = new EventsData();
+    eventsData.when = when;
+    eventsData.eventsByScope = new ArrayList<>();
+
+    for (Map.Entry<InstrumentationScopeInfo, Map<String, CollectedEvent>> entry :
+        eventsByScope.entrySet()) {
+      ScopeEvents scopeEvents = new ScopeEvents();
+      scopeEvents.scope = entry.getKey().getName();
+      scopeEvents.events = new ArrayList<>();
+
+      entry
+          .getValue()
+          .forEach(
+              (eventName, collectedEvent) -> {
+                Event event = new Event();
+                event.name = eventName;
+                event.severity = collectedEvent.getSeverity();
+                event.attributes = new ArrayList<>();
+
+                for (InternalAttributeKeyImpl<?> key : collectedEvent.getAttributeKeys()) {
+                  AttributeInfo attr = new AttributeInfo();
+                  attr.name = key.getKey();
+                  attr.type = key.getType().toString();
+                  event.attributes.add(attr);
+                }
+
+                scopeEvents.events.add(event);
+              });
+
+      eventsData.eventsByScope.add(scopeEvents);
+    }
+
+    YAML.writeValue(eventsPath.toFile(), eventsData);
   }
 
   private static void writeMetricData(
@@ -270,6 +323,27 @@ public class MetaDataCollector {
   static class Span {
     @JsonProperty("span_kind")
     public String spanKind;
+
+    public List<AttributeInfo> attributes;
+  }
+
+  static class EventsData {
+    public String when;
+
+    @JsonProperty("events_by_scope")
+    public List<ScopeEvents> eventsByScope;
+  }
+
+  static class ScopeEvents {
+    public String scope;
+    public List<Event> events;
+  }
+
+  static class Event {
+    public String name;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String severity;
 
     public List<AttributeInfo> attributes;
   }

--- a/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
+++ b/testing-common/src/main/java/io/opentelemetry/instrumentation/testing/junit/InstrumentationExtension.java
@@ -51,6 +51,11 @@ public abstract class InstrumentationExtension
 
   @Override
   public void afterEach(ExtensionContext context) throws Exception {
+    // Unlike spans and metrics, which are collected inside the assertion helpers, events are swept
+    // up here so that they are captured regardless of how the test asserted on them. Exported data
+    // is cleared in beforeEach, so everything emitted by this test is still available.
+    testRunner.collectEmittedEventsIfEnabled();
+
     ContextStorage storage = ContextStorage.get();
     ContextStorageCloser.close(storage);
   }


### PR DESCRIPTION
Captures and documents events emitted by tests along with the other signals

tested on my fork and the result has the genai events: https://github.com/jaydeluca/opentelemetry-java-instrumentation/pull/36/changes#diff-d4a9a82e2e49dddcd092fd546bd57ce2537c32079541611c164a0848fe61e2c1R5195-R5220

